### PR TITLE
[perf] Properly lazy() EmbeddedConsole; reduce console chunk page load by 79%

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -11,14 +11,14 @@ import { Observable } from 'rxjs';
 import {
   HttpSetup,
   NotificationsStart,
-  I18nStart,
   CoreTheme,
   DocLinksStart,
   CoreStart,
 } from '@kbn/core/public';
-import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { EuiWindowEvent } from '@elastic/eui';
 import { ObjectStorageClient } from '../../../../common/types';
 
 import * as localStorageObjectClient from '../../../lib/local_storage_object_client';
@@ -49,7 +49,6 @@ import { Main } from '../main';
 import { EditorContentSpinner } from '../../components';
 
 interface ConsoleDependencies {
-  I18nContext: I18nStart['Context'];
   autocompleteInfo: AutocompleteInfo;
   docLinks: DocLinksStart['links'];
   docLinkVersion: string;
@@ -71,7 +70,6 @@ const loadDependencies = async (
   const {
     docLinks: { DOC_LINK_VERSION, links },
     http,
-    i18n: { Context: I18nContext },
     notifications,
     theme: { theme$ },
   } = core;
@@ -93,7 +91,6 @@ const loadDependencies = async (
 
   autocompleteInfo.mapping.setup(http, settings);
   return {
-    I18nContext,
     autocompleteInfo,
     docLinks: links,
     docLinkVersion: DOC_LINK_VERSION,
@@ -109,15 +106,20 @@ const loadDependencies = async (
   };
 };
 
-type ConsoleWrapperProps = Omit<EmbeddableConsoleDependencies, 'setDispatch'>;
+interface ConsoleWrapperProps extends Omit<EmbeddableConsoleDependencies, 'setDispatch'> {
+  onKeyDown: (this: Window, ev: WindowEventMap['keydown']) => any;
+}
 
-export const ConsoleWrapper: React.FunctionComponent<ConsoleWrapperProps> = (props) => {
+export const ConsoleWrapper = (props: ConsoleWrapperProps) => {
   const [dependencies, setDependencies] = useState<ConsoleDependencies | null>(null);
+  const { core, usageCollection, onKeyDown } = props;
+
   useEffect(() => {
     if (dependencies === null) {
-      loadDependencies(props.core, props.usageCollection).then(setDependencies);
+      loadDependencies(core, usageCollection).then(setDependencies);
     }
-  }, [dependencies, setDependencies, props]);
+  }, [dependencies, setDependencies, core, usageCollection]);
+
   useEffect(() => {
     return () => {
       if (dependencies) {
@@ -129,8 +131,8 @@ export const ConsoleWrapper: React.FunctionComponent<ConsoleWrapperProps> = (pro
   if (!dependencies) {
     return <EditorContentSpinner />;
   }
+
   const {
-    I18nContext,
     autocompleteInfo,
     docLinkVersion,
     docLinks,
@@ -145,33 +147,34 @@ export const ConsoleWrapper: React.FunctionComponent<ConsoleWrapperProps> = (pro
     trackUiMetric,
   } = dependencies;
   return (
-    <I18nContext>
-      <KibanaThemeProvider theme={{ theme$ }}>
-        <ServicesContextProvider
-          value={{
-            docLinkVersion,
-            docLinks,
-            services: {
-              esHostService,
-              storage,
-              history,
-              settings,
-              notifications,
-              trackUiMetric,
-              objectStorageClient,
-              http,
-              autocompleteInfo,
-            },
-            theme$,
-          }}
-        >
-          <RequestContextProvider>
-            <EditorContextProvider settings={settings.toJSON()}>
+    <KibanaRenderContextProvider {...core}>
+      <ServicesContextProvider
+        value={{
+          docLinkVersion,
+          docLinks,
+          services: {
+            esHostService,
+            storage,
+            history,
+            settings,
+            notifications,
+            trackUiMetric,
+            objectStorageClient,
+            http,
+            autocompleteInfo,
+          },
+          theme$,
+        }}
+      >
+        <RequestContextProvider>
+          <EditorContextProvider settings={settings.toJSON()}>
+            <div className="embeddableConsole__content" data-test-subj="consoleEmbeddedBody">
+              <EuiWindowEvent event="keydown" handler={onKeyDown} />
               <Main hideWelcome />
-            </EditorContextProvider>
-          </RequestContextProvider>
-        </ServicesContextProvider>
-      </KibanaThemeProvider>
-    </I18nContext>
+            </div>
+          </EditorContextProvider>
+        </RequestContextProvider>
+      </ServicesContextProvider>
+    </KibanaRenderContextProvider>
   );
 };

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -15,10 +15,10 @@ import {
   EuiPortal,
   EuiScreenReaderOnly,
   EuiThemeProvider,
-  EuiWindowEvent,
   keys,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { dynamic } from '@kbn/shared-ux-utility';
 
 import {
   EmbeddableConsoleProps,
@@ -28,7 +28,6 @@ import {
 import * as store from '../../stores/embeddable_console';
 import { setLoadFromParameter, removeLoadFromParameter } from '../../lib/load_from';
 
-import { ConsoleWrapper } from './console_wrapper';
 import './_index.scss';
 
 const KBN_BODY_CONSOLE_CLASS = 'kbnBody--hasEmbeddableConsole';
@@ -36,6 +35,10 @@ const KBN_BODY_CONSOLE_CLASS = 'kbnBody--hasEmbeddableConsole';
 const landmarkHeading = i18n.translate('console.embeddableConsole.landmarkHeading', {
   defaultMessage: 'Developer console',
 });
+
+const ConsoleWrapper = dynamic(async () => ({
+  default: (await import('./console_wrapper')).ConsoleWrapper,
+}));
 
 export const EmbeddableConsole = ({
   size = 'm',
@@ -121,12 +124,7 @@ export const EmbeddableConsole = ({
               </EuiButton>
             </div>
           </EuiThemeProvider>
-          {isConsoleOpen ? (
-            <div className="embeddableConsole__content" data-test-subj="consoleEmbeddedBody">
-              <EuiWindowEvent event="keydown" handler={onKeyDown} />
-              <ConsoleWrapper core={core} usageCollection={usageCollection} />
-            </div>
-          ) : null}
+          {isConsoleOpen ? <ConsoleWrapper {...{ core, usageCollection, onKeyDown }} /> : null}
         </section>
         <EuiScreenReaderOnly>
           <p aria-live="assertive">

--- a/src/plugins/console/public/application/containers/embeddable/index.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/index.tsx
@@ -6,24 +6,16 @@
  * Side Public License, v 1.
  */
 
-import React, { ComponentType, lazy, Suspense } from 'react';
+import { dynamic } from '@kbn/shared-ux-utility';
+import React from 'react';
 import {
   EmbeddableConsoleProps,
   EmbeddableConsoleDependencies,
 } from '../../../types/embeddable_console';
 
 type EmbeddableConsoleInternalProps = EmbeddableConsoleProps & EmbeddableConsoleDependencies;
+const Console = dynamic(async () => ({
+  default: (await import('./embeddable_console')).EmbeddableConsole,
+}));
 
-const Console = lazy<ComponentType<EmbeddableConsoleInternalProps>>(async () => {
-  return {
-    default: (await import('./embeddable_console')).EmbeddableConsole,
-  };
-});
-
-export const EmbeddableConsole: React.FC<EmbeddableConsoleInternalProps> = (props) => {
-  return (
-    <Suspense fallback={null}>
-      <Console {...props} />
-    </Suspense>
-  );
-};
+export const EmbeddableConsole = (props: EmbeddableConsoleInternalProps) => <Console {...props} />;

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -5,6 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
 import { i18n } from '@kbn/i18n';
 import { Plugin, CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/public';
 import { ENABLE_PERSISTENT_CONSOLE_UI_SETTING_ID } from '@kbn/dev-tools-plugin/public';

--- a/src/plugins/console/tsconfig.json
+++ b/src/plugins/console/tsconfig.json
@@ -29,7 +29,8 @@
     "@kbn/react-kibana-context-theme",
     "@kbn/code-editor",
     "@kbn/monaco",
-    "@kbn/cloud-plugin"
+    "@kbn/cloud-plugin",
+    "@kbn/react-kibana-context-render"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
> I've been working on analyzing and improving Kibana bundling.  This is one of a series of small changes with (relatively) large impact.

## Summary

In Serverless projects, I noticed that `console` was consistently loading large, async chunks on page load:

<img width="1209" alt="Screenshot 2024-03-21 at 10 50 45 AM" src="https://github.com/elastic/kibana/assets/297604/efda493c-0605-4183-8522-2df36ee0e384">

Investigating further, it turns out that while the `EmbeddableConsole` is [loaded asynchronously](https://github.com/elastic/kibana/blob/2cf76fd82e8bc830b9c999b94912aa4700f4128f/src/plugins/console/public/application/containers/embeddable/index.tsx#L17-L29), it consists of two parts: the floating bottom bar (that starts off closed), and the bulk of the console itself.

This amounts to `1.2MB` of total code and assets, of which `217k` is JS code, (in dev mode).

By adding an async load to the `ConsoleWrapper`, we defer loading **`181k`** of JS code utnil someone _actually_ opens the portal.  It also reduces the overall total asset load by **`933k`** by deferring additional resources (css, images, etc).

**Before**: **`1.2MB`** total assets and **`217k`** code.
**After**: **`267k`** total assets and **`45.9k`** code.
**Savings**: **`78%`** and **`79%`**.

### Before

<img width="1620" alt="Screenshot 2024-03-21 at 11 07 48 AM" src="https://github.com/elastic/kibana/assets/297604/19207550-d346-4df8-b66f-8ffbb61a3adc">

### After

<img width="1837" alt="Screenshot 2024-03-21 at 10 41 00 PM" src="https://github.com/elastic/kibana/assets/297604/821f7b13-5caa-400a-abe7-77e97c2bc062">

## Effect

Functionality remains the same, but a large portion (81%) of the console code is deferred until someone interacts with it.

![Mar-21-2024 22-44-40](https://github.com/elastic/kibana/assets/297604/3860264f-a89a-4171-80e7-8d0b959091c3)

## Notes

This PR also introduces the `KibanaRenderingContext` and `dynamic` utilities from @elastic/appex-sharedux.

cc: @TattdCodeMonkey 