### PR TITLE
[Infra] Reduce active alert table column to reduce whitespace

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/service_list/column_header_with_tooltip.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/service_list/column_header_with_tooltip.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiPopover, EuiIcon } from '@elastic/eui';
+import React, { useCallback } from 'react';
+import useToggle from 'react-use/lib/useToggle';
+
+export function ColumnHeaderWithTooltip({
+  label,
+  tooltipContent,
+}: {
+  label: string;
+  tooltipContent: string;
+}) {
+  const [isPopoverOpen, togglePopover] = useToggle(false);
+
+  const onButtonClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      togglePopover();
+    },
+    [togglePopover]
+  );
+
+  return (
+    <EuiFlexGroup gutterSize="xs" alignItems="center">
+      <div>{label}</div>
+      <EuiPopover
+        panelPaddingSize="s"
+        button={
+          <button
+            onClick={onButtonClick}
+            data-test-subj="apmViewTableColumnPopoverButton"
+          >
+            <EuiIcon type="questionInCircle" />
+          </button>
+        }
+        isOpen={isPopoverOpen}
+        closePopover={togglePopover}
+        offset={10}
+        anchorPosition="upCenter"
+        panelStyle={{ maxWidth: 350 }}
+      >
+        {tooltipContent}
+      </EuiPopover>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -57,6 +57,7 @@ import {
   TableSearchBar,
 } from '../../../shared/managed_table';
 import { HealthBadge } from './health_badge';
+import { ColumnHeaderWithTooltip } from './column_header_with_tooltip';
 
 type ServicesDetailedStatisticsAPIResponse =
   APIReturnType<'POST /internal/apm/services/detailed_statistics'>;
@@ -91,10 +92,23 @@ export function getServiceColumns({
       ? [
           {
             field: ServiceInventoryFieldName.AlertsCount,
-            name: i18n.translate('xpack.apm.servicesTable.alertsColumnLabel', {
-              defaultMessage: 'Active alerts',
-            }),
-            width: `${unit * 8}px`,
+            name: (
+              <ColumnHeaderWithTooltip
+                tooltipContent={i18n.translate(
+                  'xpack.apm.servicesTable.tooltip.alertsCount',
+                  {
+                    defaultMessage: 'The count of the active alerts',
+                  }
+                )}
+                label={i18n.translate(
+                  'xpack.apm.servicesTable.alertsColumnLabel',
+                  {
+                    defaultMessage: 'Alerts',
+                  }
+                )}
+              />
+            ),
+            width: `${unit * 6}px`,
             sortable: true,
             render: (_, { serviceName, alertsCount }) => {
               if (!alertsCount) {

--- a/x-pack/plugins/observability_solution/infra/public/common/visualizations/translations.ts
+++ b/x-pack/plugins/observability_solution/infra/public/common/visualizations/translations.ts
@@ -11,6 +11,9 @@ export const METRICS_TOOLTIP = {
   hostCount: i18n.translate('xpack.infra.hostsViewPage.metrics.tooltip.hostCount', {
     defaultMessage: 'Number of hosts returned by your search criteria.',
   }),
+  alertsCount: i18n.translate('xpack.infra.hostsViewPage.metrics.tooltip.alertsCount', {
+    defaultMessage: 'The count of the active alerts',
+  }),
 
   cpuUsage: i18n.translate('xpack.infra.hostsViewPage.metrics.tooltip.cpuUsage', {
     defaultMessage:

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/table/column_header.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/table/column_header.tsx
@@ -14,28 +14,35 @@ interface Props {
   label: string;
   toolTip?: string;
   formula?: string;
+  showDocumentationLink?: boolean;
 }
 
-export const ColumnHeader = React.memo(({ label, toolTip, formula }: Props) => {
-  return (
-    <EuiFlexGroup gutterSize="xs">
-      <div
-        css={css`
-          overflow-wrap: break-word !important;
-          word-break: break-word;
-          min-width: 0;
-          text-overflow: ellipsis;
-          overflow: hidden;
-        `}
-      >
-        {label}
-      </div>
+export const ColumnHeader = React.memo(
+  ({ label, toolTip, formula, showDocumentationLink = true }: Props) => {
+    return (
+      <EuiFlexGroup gutterSize="xs">
+        <div
+          css={css`
+            overflow-wrap: break-word !important;
+            word-break: break-word;
+            min-width: 0;
+            text-overflow: ellipsis;
+            overflow: hidden;
+          `}
+        >
+          {label}
+        </div>
 
-      {toolTip && (
-        <Popover>
-          <TooltipContent formula={formula} description={toolTip} showDocumentationLink />
-        </Popover>
-      )}
-    </EuiFlexGroup>
-  );
-});
+        {toolTip && (
+          <Popover>
+            <TooltipContent
+              formula={formula}
+              description={toolTip}
+              showDocumentationLink={showDocumentationLink}
+            />
+          </Popover>
+        )}
+      </EuiFlexGroup>
+    );
+  }
+);

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/table/column_header.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/table/column_header.tsx
@@ -18,31 +18,29 @@ interface Props {
 }
 
 export const ColumnHeader = React.memo(
-  ({ label, toolTip, formula, showDocumentationLink = true }: Props) => {
-    return (
-      <EuiFlexGroup gutterSize="xs">
-        <div
-          css={css`
-            overflow-wrap: break-word !important;
-            word-break: break-word;
-            min-width: 0;
-            text-overflow: ellipsis;
-            overflow: hidden;
-          `}
-        >
-          {label}
-        </div>
+  ({ label, toolTip, formula, showDocumentationLink = true }: Props) => (
+    <EuiFlexGroup gutterSize="xs">
+      <div
+        css={css`
+          overflow-wrap: break-word !important;
+          word-break: break-word;
+          min-width: 0;
+          text-overflow: ellipsis;
+          overflow: hidden;
+        `}
+      >
+        {label}
+      </div>
 
-        {toolTip && (
-          <Popover>
-            <TooltipContent
-              formula={formula}
-              description={toolTip}
-              showDocumentationLink={showDocumentationLink}
-            />
-          </Popover>
-        )}
-      </EuiFlexGroup>
-    );
-  }
+      {toolTip && (
+        <Popover>
+          <TooltipContent
+            formula={formula}
+            description={toolTip}
+            showDocumentationLink={showDocumentationLink}
+          />
+        </Popover>
+      )}
+    </EuiFlexGroup>
+  )
 );

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_hosts_table.tsx
@@ -27,7 +27,7 @@ import { Sorting, useHostsTableUrlState } from './use_hosts_table_url_state';
 import { useHostsViewContext } from './use_hosts_view';
 import { useMetricsDataViewContext } from './use_metrics_data_view';
 import { ColumnHeader } from '../components/table/column_header';
-import { TABLE_COLUMN_LABEL } from '../translations';
+import { TABLE_COLUMN_LABEL, TABLE_CONTENT_LABEL } from '../translations';
 import { METRICS_TOOLTIP } from '../../../../common/visualizations';
 import { buildCombinedHostsFilter } from '../../../../utils/filters/build';
 
@@ -118,10 +118,6 @@ const sortTableData =
   };
 
 /**
- * Columns translations
- */
-
-/**
  * Build a table columns and items starting from the snapshot nodes.
  */
 export const useHostsTable = () => {
@@ -207,6 +203,8 @@ export const useHostsTable = () => {
     return items.sort(sortTableData(sorting)).slice(startIndex, endIndex);
   }, [items, pagination, sorting]);
 
+  const metricColumnsWidth = displayAlerts ? '11%' : '15%';
+
   const columns: Array<EuiBasicTableColumn<HostNodeRow>> = useMemo(
     () => [
       {
@@ -231,7 +229,14 @@ export const useHostsTable = () => {
       ...(displayAlerts
         ? [
             {
-              name: TABLE_COLUMN_LABEL.alertsCount,
+              name: (
+                <ColumnHeader
+                  label={TABLE_COLUMN_LABEL.alertsCount}
+                  toolTip={METRICS_TOOLTIP.alertsCount}
+                  showDocumentationLink={false}
+                />
+              ),
+              width: '95px',
               field: 'alertsCount',
               sortable: true,
               'data-test-subj': 'hostsView-tableRow-alertsCount',
@@ -240,18 +245,18 @@ export const useHostsTable = () => {
                   return null;
                 }
                 return (
-                  <EuiToolTip position="top" content={TABLE_COLUMN_LABEL.alertsCount}>
+                  <EuiToolTip position="top" content={TABLE_CONTENT_LABEL.activeAlerts}>
                     <EuiBadge
                       iconType="warning"
                       color="danger"
                       onClick={() => {
                         setProperties({ detailsItemId: row.id === detailsItemId ? null : row.id });
                       }}
-                      onClickAriaLabel={TABLE_COLUMN_LABEL.alertsCount}
+                      onClickAriaLabel={TABLE_CONTENT_LABEL.activeAlerts}
                       iconOnClick={() => {
                         setProperties({ detailsItemId: row.id === detailsItemId ? null : row.id });
                       }}
-                      iconOnClickAriaLabel={TABLE_COLUMN_LABEL.alertsCount}
+                      iconOnClickAriaLabel={TABLE_CONTENT_LABEL.activeAlerts}
                     >
                       {alertsCount}
                     </EuiBadge>
@@ -270,7 +275,7 @@ export const useHostsTable = () => {
         render: (title: HostNodeRow['title']) => (
           <EntryTitle title={title} onClick={() => reportHostEntryClick(title)} />
         ),
-        width: '20%',
+        width: displayAlerts ? '15%' : '20%',
       },
       {
         name: (
@@ -280,6 +285,7 @@ export const useHostsTable = () => {
             formula={formulas?.cpuUsage.value}
           />
         ),
+        width: metricColumnsWidth,
         field: 'cpu',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-cpuUsage',
@@ -294,6 +300,7 @@ export const useHostsTable = () => {
             formula={formulas?.normalizedLoad1m.value}
           />
         ),
+        width: metricColumnsWidth,
         field: 'normalizedLoad1m',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-normalizedLoad1m',
@@ -308,6 +315,7 @@ export const useHostsTable = () => {
             formula={formulas?.memoryUsage.value}
           />
         ),
+        width: metricColumnsWidth,
         field: 'memory',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-memoryUsage',
@@ -322,6 +330,7 @@ export const useHostsTable = () => {
             formula={formulas?.memoryFree.value}
           />
         ),
+        width: metricColumnsWidth,
         field: 'memoryFree',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-memoryFree',
@@ -336,6 +345,7 @@ export const useHostsTable = () => {
             formula={formulas?.diskUsage.value}
           />
         ),
+        width: metricColumnsWidth,
         field: 'diskSpaceUsage',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-diskSpaceUsage',
@@ -350,6 +360,7 @@ export const useHostsTable = () => {
             formula={formulas?.rx.value}
           />
         ),
+        width: '10%',
         field: 'rx',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-rx',
@@ -364,6 +375,7 @@ export const useHostsTable = () => {
             formula={formulas?.tx.value}
           />
         ),
+        width: '10%',
         field: 'tx',
         sortable: true,
         'data-test-subj': 'hostsView-tableRow-tx',
@@ -383,6 +395,7 @@ export const useHostsTable = () => {
       reportHostEntryClick,
       setProperties,
       displayAlerts,
+      metricColumnsWidth,
     ]
   );
 

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/translations.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/translations.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 
 export const TABLE_COLUMN_LABEL = {
   alertsCount: i18n.translate('xpack.infra.hostsViewPage.table.alertsColumnHeader', {
-    defaultMessage: 'Active alerts',
+    defaultMessage: 'Alerts',
   }),
 
   title: i18n.translate('xpack.infra.hostsViewPage.table.nameColumnHeader', {
@@ -46,5 +46,11 @@ export const TABLE_COLUMN_LABEL = {
 
   toggleDialogAction: i18n.translate('xpack.infra.hostsViewPage.table.toggleDialogWithDetails', {
     defaultMessage: 'Toggle dialog with details',
+  }),
+};
+
+export const TABLE_CONTENT_LABEL = {
+  activeAlerts: i18n.translate('xpack.infra.hostsViewPage.table.tooltip.activeAlertsExplanation', {
+    defaultMessage: 'Active alerts',
   }),
 };


### PR DESCRIPTION
Closes #178871
## Summary

This PR changed the alerts column title and size in services and hosts view tables. It renames "Active Alerts" to alerts and adds a `?` with a tooltip content "The count of the active alerts"

![image](https://github.com/elastic/kibana/assets/14139027/18b28e74-6ffc-4cc8-a701-db6369ee0b40)

<img width="1920" alt="image" src="https://github.com/elastic/kibana/assets/14139027/070bfe54-77b0-4cd2-87d2-966048666a7c">



## Testing 
- To get host data use metricbeat:
Example dev config 
```
metricbeat.modules:
  - module: system
    metricsets:
      - cpu # CPU usage
      - load # CPU load averages
      - memory # Memory usage
      - network # Network IO
      - process # Per process metrics
      - process_summary # Process summary
      - uptime # System Uptime
      - socket_summary # Socket summary
      - core # Per CPU core usage
      - diskio # Disk IO
      - filesystem # File system usage for each mountpoint
      - fsstat # File system summary metrics
    enabled: true
    period: 1m
    processes: [".*"]
# ......
output.elasticsearch:
  hosts: ["localhost:9200"]

  username: "***"
  password: "***"
processors:
  - add_host_metadata: ~
```
- or the synthtrace scenario:

` node scripts/synthtrace  infra_hosts_with_apm_hosts.ts `

To set up an alert rule use the menu top right in APM service overview: 
<img width="1909" alt="image" src="https://github.com/elastic/kibana/assets/14139027/a565b0a8-aeca-43fd-a205-19eba8d34d62">
To set up an alert rule use the Create Alert inside hosts flyout: 

<img width="1809" alt="image" src="https://github.com/elastic/kibana/assets/14139027/ef5a68f9-4a45-41d4-aef1-5847ff38fc3c">


1. Open Hosts view
   - Check the table with and without active alerts
   

https://github.com/elastic/kibana/assets/14139027/528abe7f-775e-47b1-90a7-2871f841ba79


2. Open APM Services

https://github.com/elastic/kibana/assets/14139027/0a2614f5-e0f8-4fb9-93db-3a4eccf488bf

