### PR TITLE
mark OS.advanced.artifacts.user.ca_cert as unsupported since 8.5

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -911,6 +911,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
   {
     key: 'linux.advanced.artifacts.user.ca_cert',
     first_supported_version: '7.9',
+    last_supported_version: '8.5',
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.artifacts.user.ca_cert',
       {
@@ -921,6 +922,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
   {
     key: 'windows.advanced.artifacts.user.ca_cert',
     first_supported_version: '7.9',
+    last_supported_version: '8.5',
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.artifacts.user.ca_cert',
       {
@@ -931,6 +933,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
   {
     key: 'mac.advanced.artifacts.user.ca_cert',
     first_supported_version: '7.9',
+    last_supported_version: '8.5',
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.artifacts.user.ca_cert',
       {


### PR DESCRIPTION
## Summary

This marks the options `linux.advanced.artifacts.user.ca_cert`, `windows.advanced.artifacts.user.ca_cert`, and `mac.advanced.artifacts.user.ca_cert` as unsupported since after 8.5. Below is a screenshot of what it looks like. @intxgo please confirm if that final version is correct.

<img width="938" alt="image" src="https://github.com/elastic/kibana/assets/56368752/8f09cfac-8c1e-45d9-b57f-4ef6ad2c48aa">

