### PR TITLE
[Embeddables Rebuild] Enhance BuildEmbeddable function 

### DIFF
--- a/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.test.tsx
+++ b/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.test.tsx
@@ -58,7 +58,47 @@ describe('react embeddable renderer', () => {
   it('builds the embeddable', () => {
     const buildEmbeddableSpy = jest.spyOn(testEmbeddableFactory, 'buildEmbeddable');
     render(<ReactEmbeddableRenderer type={'test'} state={{ rawState: { bork: 'blorp?' } }} />);
-    expect(buildEmbeddableSpy).toHaveBeenCalledWith({ bork: 'blorp?' }, expect.any(Function));
+    expect(buildEmbeddableSpy).toHaveBeenCalledWith(
+      { bork: 'blorp?' },
+      expect.any(Function),
+      expect.any(String),
+      undefined
+    );
+  });
+
+  it('builds the embeddable, providing an id', () => {
+    const buildEmbeddableSpy = jest.spyOn(testEmbeddableFactory, 'buildEmbeddable');
+    render(
+      <ReactEmbeddableRenderer
+        type={'test'}
+        maybeId={'12345'}
+        state={{ rawState: { bork: 'blorp?' } }}
+      />
+    );
+    expect(buildEmbeddableSpy).toHaveBeenCalledWith(
+      { bork: 'blorp?' },
+      expect.any(Function),
+      '12345',
+      undefined
+    );
+  });
+
+  it('builds the embeddable, providing a parent', () => {
+    const buildEmbeddableSpy = jest.spyOn(testEmbeddableFactory, 'buildEmbeddable');
+    const parentApi = getMockPresentationContainer();
+    render(
+      <ReactEmbeddableRenderer
+        type={'test'}
+        state={{ rawState: { bork: 'blorp?' } }}
+        parentApi={parentApi}
+      />
+    );
+    expect(buildEmbeddableSpy).toHaveBeenCalledWith(
+      { bork: 'blorp?' },
+      expect.any(Function),
+      expect.any(String),
+      parentApi
+    );
   });
 
   it('renders the given component once it resolves', () => {

--- a/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
+++ b/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
@@ -49,6 +49,7 @@ export const ReactEmbeddableRenderer = <
   const componentPromise = useMemo(
     () =>
       (async () => {
+        const uuid = maybeId ?? generateId();
         const factory = getReactEmbeddableFactory(type) as ReactEmbeddableFactory<
           StateType,
           ApiType
@@ -57,7 +58,6 @@ export const ReactEmbeddableRenderer = <
           apiRegistration: ReactEmbeddableApiRegistration<StateType, ApiType>,
           comparators: EmbeddableStateComparators<StateType>
         ) => {
-          const uuid = maybeId ?? generateId();
           const { unsavedChanges, resetUnsavedChanges, cleanup } =
             startTrackingEmbeddableUnsavedChanges(
               uuid,
@@ -83,7 +83,9 @@ export const ReactEmbeddableRenderer = <
 
         const { api, Component } = await factory.buildEmbeddable(
           factory.deserializeState(state),
-          registerApi
+          registerApi,
+          uuid,
+          parentApi
         );
 
         return React.forwardRef<typeof api>((_, ref) => {

--- a/src/plugins/embeddable/public/react_embeddable_system/types.ts
+++ b/src/plugins/embeddable/public/react_embeddable_system/types.ts
@@ -5,7 +5,11 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { HasSerializableState, SerializedPanelState } from '@kbn/presentation-containers';
+import {
+  HasSerializableState,
+  PresentationContainer,
+  SerializedPanelState,
+} from '@kbn/presentation-containers';
 import { DefaultPresentationPanelApi } from '@kbn/presentation-panel-plugin/public/panel_component/types';
 import { HasType, PublishesUnsavedChanges, PublishingSubject } from '@kbn/presentation-publishing';
 import React, { ReactElement } from 'react';
@@ -42,7 +46,9 @@ export interface ReactEmbeddableFactory<
     buildApi: (
       apiRegistration: ReactEmbeddableApiRegistration<StateType, ApiType>,
       comparators: EmbeddableStateComparators<StateType>
-    ) => ApiType
+    ) => ApiType,
+    uuid: string,
+    parentApi?: PresentationContainer
   ) => Promise<{ Component: React.FC<{}>; api: ApiType }>;
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the `buildEmbeddable` function by providing it the `uuid` and the `parentApi`. This allows access to the parent and the uuid _before_ calling `buildApi`. The implementor isn't required to _use_ these new arguments, but they are passed if needed.

UUIDs are required to initialize drilldowns for React Embeddables after https://github.com/elastic/kibana/pull/178896
