### PR TITLE
[Metric threshold] Fix bug in loading the metric threshold alert details page

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/alerting/metric_threshold/components/alert_details_app_section.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/metric_threshold/components/alert_details_app_section.tsx
@@ -102,7 +102,7 @@ export function AlertDetailsAppSection({
         ),
       },
     ]);
-  }, [alert, rule, ruleLink, setAlertSummaryFields]);
+  }, [rule, ruleLink, setAlertSummaryFields]);
 
   return !!rule.params.criteria ? (
     <EuiFlexGroup direction="column" data-test-subj="metricThresholdAppSection">


### PR DESCRIPTION
Similar https://github.com/elastic/kibana/issues/175922

## Summary

Fix the metric threshold alert details page by removing unnecessary dependencies.

**Note**
This page is disabled behind this feature flag: `xpack.observability.unsafe.alertDetails.metrics.enabled`

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/8acdc250-1260-4a46-ac46-3f4e359b7d8a)|![image](https://github.com/elastic/kibana/assets/12370520/3760b4c9-f714-4d76-9b5f-a3d3323311b1)|