### PR TITLE
[7.17] Upgrade nodemailer dependency 6.6.2 -> 6.9.9 (#176487)

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "nock": "12.0.3",
     "node-fetch": "^2.6.7",
     "node-forge": "^1.3.1",
-    "nodemailer": "^6.6.2",
+    "nodemailer": "^6.9.9",
     "normalize-path": "^3.0.0",
     "object-hash": "^1.3.1",
     "object-path-immutable": "^3.1.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -57,6 +57,7 @@ export const LICENSE_ALLOWED = [
   '(MIT OR CC0-1.0)',
   'MIT',
   'MIT*',
+  'MIT-0',
   'MIT/X11',
   'new BSD, and MIT',
   '(OFL-1.1 AND MIT)',

--- a/x-pack/test/alerting_api_integration/common/config.ts
+++ b/x-pack/test/alerting_api_integration/common/config.ts
@@ -162,7 +162,8 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
           `--xpack.actions.allowedHosts=${JSON.stringify([
             'localhost',
             'some.non.existent.com',
-            'smtp.live.com',
+            'smtp-mail.outlook.com',
+            'slack.com',
           ])}`,
           '--xpack.encryptedSavedObjects.encryptionKey="wuGNaIhoMpk5sO4UBxgr3NyW1sFcLgIf"',
           '--xpack.alerting.invalidateApiKeysTask.interval="15s"',

--- a/yarn.lock
+++ b/yarn.lock
@@ -20562,10 +20562,10 @@ node-source-walk@^6.0.0, node-source-walk@^6.0.1, node-source-walk@^6.0.2:
   dependencies:
     "@babel/parser" "^7.21.8"
 
-nodemailer@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.6.2.tgz#e184c9ed5bee245a3e0bcabc7255866385757114"
-  integrity sha512-YSzu7TLbI+bsjCis/TZlAXBoM4y93HhlIgo0P5oiA2ua9Z4k+E2Fod//ybIzdJxOlXGRcHIh/WaeCBehvxZb/Q==
+nodemailer@^6.9.9:
+  version "6.9.9"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.9.tgz#4549bfbf710cc6addec5064dd0f19874d24248d9"
+  integrity sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==
 
 nopt@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Upgrade nodemailer dependency 6.6.2 -> 6.9.9 (#176487)](https://github.com/elastic/kibana/pull/176487)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sid","email":"siddharthmantri1@gmail.com"},"sourceCommit":{"committedDate":"2024-03-19T16:00:55Z","message":"Upgrade nodemailer dependency 6.6.2 -> 6.9.9 (#176487)\n\nUpdate nodemailer production dependency (6.6.2 -> 6.9.9)\r\n\r\nNodemailer changelog: \r\n- Fixing GHSA:\r\nhttps://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md#699-2024-02-01\r\n- Update hotmail/outlook well known service\r\nhttps://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md#673-2022-03-21\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"bccb0cd4bac837b1cc89c730a66ed2f340ad1361","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","auto-backport","backport:all-open","ci:cloud-deploy","v8.14.0"],"number":176487,"url":"https://github.com/elastic/kibana/pull/176487","mergeCommit":{"message":"Upgrade nodemailer dependency 6.6.2 -> 6.9.9 (#176487)\n\nUpdate nodemailer production dependency (6.6.2 -> 6.9.9)\r\n\r\nNodemailer changelog: \r\n- Fixing GHSA:\r\nhttps://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md#699-2024-02-01\r\n- Update hotmail/outlook well known service\r\nhttps://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md#673-2022-03-21\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"bccb0cd4bac837b1cc89c730a66ed2f340ad1361"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/176487","number":176487,"mergeCommit":{"message":"Upgrade nodemailer dependency 6.6.2 -> 6.9.9 (#176487)\n\nUpdate nodemailer production dependency (6.6.2 -> 6.9.9)\r\n\r\nNodemailer changelog: \r\n- Fixing GHSA:\r\nhttps://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md#699-2024-02-01\r\n- Update hotmail/outlook well known service\r\nhttps://github.com/nodemailer/nodemailer/blob/master/CHANGELOG.md#673-2022-03-21\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"bccb0cd4bac837b1cc89c730a66ed2f340ad1361"}}]}] BACKPORT-->