### PR TITLE
Update GitHub connector RCF to support GitHub App authentication method

### DIFF
--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -93,6 +93,10 @@ const PORT_LABEL = i18n.translate('searchConnectors.nativeConnectors.portLabel',
   defaultMessage: 'Port',
 });
 
+const PERSONAL_ACCESS_TOKEN = 'personal_access_token';
+
+const GITHUB_APP = 'github_app';
+
 export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | undefined> = {
   azure_blob_storage: {
     configuration: {
@@ -772,13 +776,13 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
                 defaultMessage: 'Personal access token',
               }
             ),
-            value: 'personal_access_token',
+            value: PERSONAL_ACCESS_TOKEN,
           },
           {
             label: i18n.translate('searchConnectors.nativeConnectors.github.options.githubApp', {
               defaultMessage: 'GitHub App',
             }),
-            value: 'github_app',
+            value: GITHUB_APP,
           },
         ],
         order: 3,
@@ -788,14 +792,14 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         type: FieldType.STRING,
         ui_restrictions: [],
         validations: [],
-        value: 'personal_access_token',
+        value: PERSONAL_ACCESS_TOKEN,
       },
       token: {
         default_value: null,
         depends_on: [
           {
             field: 'auth_method',
-            value: 'personal_access_token',
+            value: PERSONAL_ACCESS_TOKEN,
           },
         ],
         display: DisplayType.TEXTBOX,
@@ -850,7 +854,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         depends_on: [
           {
             field: 'auth_method',
-            value: 'personal_access_token',
+            value: PERSONAL_ACCESS_TOKEN,
           },
           {
             field: 'repo_type',
@@ -876,7 +880,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         depends_on: [
           {
             field: 'auth_method',
-            value: 'github_app',
+            value: GITHUB_APP,
           },
         ],
         display: DisplayType.NUMERIC,
@@ -898,7 +902,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         depends_on: [
           {
             field: 'auth_method',
-            value: 'github_app',
+            value: GITHUB_APP,
           },
         ],
         display: DisplayType.TEXTAREA,

--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -710,7 +710,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         depends_on: [],
         display: DisplayType.DROPDOWN,
         label: i18n.translate('searchConnectors.nativeConnectors.github.label', {
-          defaultMessage: 'GitHub data source',
+          defaultMessage: 'Data source',
         }),
         options: [
           {
@@ -745,7 +745,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         ],
         display: DisplayType.TEXTBOX,
         label: i18n.translate('searchConnectors.nativeConnectors.github.url.label', {
-          defaultMessage: 'GitHub URL',
+          defaultMessage: 'Server URL',
         }),
         options: [],
         order: 2,
@@ -757,15 +757,50 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         validations: [],
         value: '',
       },
-      token: {
+      auth_method: {
         default_value: null,
         depends_on: [],
+        display: DisplayType.DROPDOWN,
+        label: i18n.translate('searchConnectors.nativeConnectors.github.authMethod.label', {
+          defaultMessage: 'Authentication method',
+        }),
+        options: [
+          {
+            label: i18n.translate('searchConnectors.nativeConnectors.github.options.pat', {
+              defaultMessage: 'Personal access token',
+            }),
+            value: 'pat',
+          },
+          {
+            label: i18n.translate('searchConnectors.nativeConnectors.github.options.githubApp', {
+              defaultMessage: 'GitHub App',
+            }),
+            value: 'github_app',
+          },
+        ],
+        order: 3,
+        required: true,
+        sensitive: false,
+        tooltip: null,
+        type: FieldType.STRING,
+        ui_restrictions: [],
+        validations: [],
+        value: 'pat',
+      },
+      token: {
+        default_value: null,
+        depends_on: [
+          {
+            field: 'auth_method',
+            value: 'pat',
+          },
+        ],
         display: DisplayType.TEXTBOX,
         label: i18n.translate('searchConnectors.nativeConnectors.github.token.label', {
-          defaultMessage: 'GitHub Token',
+          defaultMessage: 'Token',
         }),
         options: [],
-        order: 3,
+        order: 4,
         required: true,
         sensitive: true,
         tooltip: null,
@@ -795,7 +830,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
             value: 'other',
           },
         ],
-        order: 4,
+        order: 5,
         required: true,
         sensitive: false,
         tooltip: i18n.translate('searchConnectors.nativeConnectors.github.repo_type', {
@@ -811,6 +846,10 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         default_value: null,
         depends_on: [
           {
+            field: 'auth_method',
+            value: 'pat',
+          },
+          {
             field: 'repo_type',
             value: 'organization',
           },
@@ -820,9 +859,53 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'Organization Name',
         }),
         options: [],
-        order: 5,
+        order: 6,
         required: true,
         sensitive: false,
+        tooltip: null,
+        type: FieldType.STRING,
+        ui_restrictions: [],
+        validations: [],
+        value: '',
+      },
+      app_id: {
+        default_value: null,
+        depends_on: [
+          {
+            field: 'auth_method',
+            value: 'github_app',
+          },
+        ],
+        display: DisplayType.NUMERIC,
+        label: i18n.translate('searchConnectors.nativeConnectors.github.appID.label', {
+          defaultMessage: 'App ID',
+        }),
+        options: [],
+        order: 7,
+        required: true,
+        sensitive: false,
+        tooltip: null,
+        type: FieldType.INTEGER,
+        ui_restrictions: [],
+        validations: [],
+        value: '',
+      },
+      private_key: {
+        default_value: null,
+        depends_on: [
+          {
+            field: 'auth_method',
+            value: 'github_app',
+          },
+        ],
+        display: DisplayType.TEXTAREA,
+        label: i18n.translate('searchConnectors.nativeConnectors.github.privateKey.label', {
+          defaultMessage: 'App private key',
+        }),
+        options: [],
+        order: 8,
+        required: true,
+        sensitive: true,
         tooltip: null,
         type: FieldType.STRING,
         ui_restrictions: [],
@@ -837,7 +920,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'List of repositories',
         }),
         options: [],
-        order: 6,
+        order: 9,
         required: true,
         sensitive: false,
         tooltip: i18n.translate('searchConnectors.nativeConnectors.github.listOfRepos.tooltip', {
@@ -854,7 +937,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         display: DisplayType.TOGGLE,
         label: ENABLE_SSL_LABEL,
         options: [],
-        order: 7,
+        order: 10,
         required: true,
         sensitive: false,
         tooltip: null,
@@ -874,7 +957,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         display: DisplayType.TEXTBOX,
         label: SSL_CERTIFICATE_LABEL,
         options: [],
-        order: 8,
+        order: 11,
         required: true,
         sensitive: false,
         tooltip: null,
@@ -889,7 +972,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         display: DisplayType.NUMERIC,
         label: RETRIES_PER_REQUEST_LABEL,
         options: [],
-        order: 9,
+        order: 12,
         required: false,
         sensitive: false,
         tooltip: null,
@@ -904,7 +987,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         display: DisplayType.TOGGLE,
         label: USE_TEXT_EXTRACTION_SERVICE_LABEL,
         options: [],
-        order: 10,
+        order: 13,
         required: true,
         sensitive: false,
         tooltip: USE_TEXT_EXTRACTION_SERVICE_TOOLTIP,
@@ -924,7 +1007,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         display: DisplayType.TOGGLE,
         label: ENABLE_DOCUMENT_LEVEL_SECURITY_LABEL,
         options: [],
-        order: 11,
+        order: 14,
         required: true,
         sensitive: false,
         tooltip: i18n.translate(

--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -766,9 +766,12 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         }),
         options: [
           {
-            label: i18n.translate('searchConnectors.nativeConnectors.github.options.personalAccessToken', {
-              defaultMessage: 'Personal access token',
-            }),
+            label: i18n.translate(
+              'searchConnectors.nativeConnectors.github.options.personalAccessToken',
+              {
+                defaultMessage: 'Personal access token',
+              }
+            ),
             value: 'personal_access_token',
           },
           {

--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -766,10 +766,10 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         }),
         options: [
           {
-            label: i18n.translate('searchConnectors.nativeConnectors.github.options.pat', {
+            label: i18n.translate('searchConnectors.nativeConnectors.github.options.personalAccessToken', {
               defaultMessage: 'Personal access token',
             }),
-            value: 'pat',
+            value: 'personal_access_token',
           },
           {
             label: i18n.translate('searchConnectors.nativeConnectors.github.options.githubApp', {
@@ -785,14 +785,14 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         type: FieldType.STRING,
         ui_restrictions: [],
         validations: [],
-        value: 'pat',
+        value: 'personal_access_token',
       },
       token: {
         default_value: null,
         depends_on: [
           {
             field: 'auth_method',
-            value: 'pat',
+            value: 'personal_access_token',
           },
         ],
         display: DisplayType.TEXTBOX,
@@ -847,7 +847,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         depends_on: [
           {
             field: 'auth_method',
-            value: 'pat',
+            value: 'personal_access_token',
           },
           {
             field: 'repo_type',


### PR DESCRIPTION
## Summary

This PR updates the RCF for GitHub native connector, to support GitHub App as a new authentication method


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
