### PR TITLE
Correct custom threshold order in the rule list

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/plugins/observability_solution/observability/public/rules/register_observability_rule_types.ts
@@ -116,6 +116,6 @@ export const registerObservabilityRuleTypes = async (
           '../components/custom_threshold/components/alert_details_app_section/alert_details_app_section'
         )
     ),
-    priority: 5,
+    priority: 110,
   });
 };


### PR DESCRIPTION
Since the custom threshold is now GA, I changed the order based on the original plan mentioned [here](https://github.com/elastic/kibana/issues/166136).

<img src="https://github.com/elastic/kibana/assets/12370520/3438ad65-08b2-41fb-9dbb-1c5cb43e7cd3" width=500 />
