### PR TITLE
[Ops] Adjust serverless release settings

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -23,7 +23,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
       default_branch: main
       repository: elastic/kibana
-      pipeline_file: .buildkite/pipelines/serverless_deployment/create_deployment_tag.yml
+      pipeline_file: .buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -6,7 +6,7 @@ metadata:
   description: Initiate kibana serverless releases
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/kibana-serverless-release-1
+      url: https://buildkite.com/elastic/kibana-serverless-release
 spec:
   type: buildkite-pipeline
   owner: 'group:kibana-operations'
@@ -22,6 +22,8 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
       default_branch: main
+      allow_rebuilds: false
+      skip_intermediate_builds: false
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
       provider_settings:
@@ -30,9 +32,13 @@ spec:
         publish_commit_status: false
         trigger_mode: none
         build_tags: false
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         kibana-release-operators:
           access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
       schedules:
         Weekly automated promotion to QA:
           cronline: 0 6 * * 1

--- a/.buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
+++ b/.buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
@@ -1,4 +1,6 @@
+## Lists potential commits for deployment
 ## Creates deploy@<timestamp> tag on Kibana
+## Then kicks of the deployment to QA
 
 agents:
   image: family/kibana-ubuntu-2004


### PR DESCRIPTION
## Summary
When we rolled out the pipeline settings resulting from the defaults of the backstage-way of defining resources, we encountered a few defaults we didn't know about. 

This PR adjusts these missing values (they're not relevant for this job, as this job is more a process starter than a branch-related build job) and renames a used pipeline implementation to something more accurate.