### PR TITLE
[Cases] Fix expanding size of cases app component in stack management

### DIFF
--- a/x-pack/plugins/cases/public/components/app/index.tsx
+++ b/x-pack/plugins/cases/public/components/app/index.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import type { ScopedFilesClient } from '@kbn/files-plugin/public';
-import { EuiFlexGroup } from '@elastic/eui';
 
 import type { ExternalReferenceAttachmentTypeRegistry } from '../../client/attachment_framework/external_reference_registry';
 import type { PersistableStateAttachmentTypeRegistry } from '../../client/attachment_framework/persistable_state_registry';
@@ -33,7 +32,7 @@ const CasesAppComponent: React.FC<CasesAppProps> = ({
   const userCapabilities = useApplicationCapabilities();
 
   return (
-    <EuiFlexGroup direction="column" data-test-subj="cases-app">
+    <div data-test-subj="cases-app">
       {getCasesLazy({
         externalReferenceAttachmentTypeRegistry,
         persistableStateAttachmentTypeRegistry,
@@ -44,7 +43,7 @@ const CasesAppComponent: React.FC<CasesAppProps> = ({
         basePath: '/',
         features: { alerts: { enabled: true, sync: false } },
       })}
-    </EuiFlexGroup>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

This PR fixes a style issue of Cases app expanding in `stack management > cases` when there are less than 10 cases visible in cases table:

<details><summary>Issue:</summary>

![Screenshot 2024-03-22 at 12 49 09](https://github.com/elastic/kibana/assets/117571355/18229956-72cb-4633-9fcb-92ea0ada15ee)
</details>

<details><summary>Fix:</summary>

![image](https://github.com/elastic/kibana/assets/117571355/7c619eff-c043-4d95-94ad-47085daed866)
</details>

<details><summary>Observability Cases page:</summary>

![image](https://github.com/elastic/kibana/assets/117571355/455c4a4d-d6de-49b5-ac96-20fab07ecf1f)
</details>

<details><summary>Security Cases page:</summary>

![image](https://github.com/elastic/kibana/assets/117571355/1d280a3b-d4aa-4b3f-af5b-cd7c9bbd6b41)
</details>