### PR TITLE
[Security Solution] Remove @ts-expect-error from v4.9.5 upgrade in Detection and Response areas

### DIFF
--- a/packages/kbn-securitysolution-io-ts-alerting-types/src/threat_mapping/index.test.ts
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/src/threat_mapping/index.test.ts
@@ -37,12 +37,11 @@ describe('threat_mapping', () => {
     });
 
     test('it should fail validation with an extra entry item', () => {
-      const payload: ThreatMappingEntries & Array<{ extra: string }> = [
+      const payload: Array<ThreatMappingEntries[0] & { extra: string }> = [
         {
           field: 'field.one',
           type: 'mapping',
           value: 'field.one',
-          // @ts-expect-error upgrade typescript v4.9.5
           extra: 'blah',
         },
       ];
@@ -112,7 +111,7 @@ describe('threat_mapping', () => {
   });
 
   test('it should fail validate with an extra key', () => {
-    const payload: ThreatMapping & Array<{ extra: string }> = [
+    const payload: Array<ThreatMapping[0] & { extra: string }> = [
       {
         entries: [
           {
@@ -121,7 +120,6 @@ describe('threat_mapping', () => {
             value: 'field.one',
           },
         ],
-        // @ts-expect-error upgrade typescript v4.9.5
         extra: 'invalid',
       },
     ];
@@ -135,14 +133,13 @@ describe('threat_mapping', () => {
   });
 
   test('it should fail validate with an extra inner entry', () => {
-    const payload: ThreatMapping & Array<{ entries: Array<{ extra: string }> }> = [
+    const payload: Array<ThreatMapping[0] & { entries: Array<{ extra: string }> }> = [
       {
         entries: [
           {
             field: 'field.one',
             type: 'mapping',
             value: 'field.one',
-            // @ts-expect-error upgrade typescript v4.9.5
             extra: 'blah',
           },
         ],

--- a/packages/kbn-securitysolution-utils/src/add_remove_id_to_item/index.ts
+++ b/packages/kbn-securitysolution-utils/src/add_remove_id_to_item/index.ts
@@ -19,8 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 type NotArray<T> = T extends unknown[] ? never : T;
 export const addIdToItem = <T>(item: NotArray<T>): T => {
-  // @ts-expect-error upgrade typescript v4.9.5
-  const maybeId: typeof item & { id?: string } = item;
+  const maybeId = item as typeof item & { id?: string };
   if (maybeId.id != null) {
     return item;
   } else {
@@ -42,8 +41,7 @@ export const removeIdFromItem = <T>(
       },
       Exclude<keyof T, 'id'>
     > => {
-  // @ts-expect-error upgrade typescript v4.9.5
-  const maybeId: typeof item & { id?: string } = item;
+  const maybeId = item as typeof item & { id?: string };
   if (maybeId.id != null) {
     const { id, ...noId } = maybeId;
     return noId;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.ts
@@ -12,6 +12,8 @@ import type {
   RouteValidationFunction,
   KibanaResponseFactory,
   CustomHttpResponseOptions,
+  HttpResponsePayload,
+  ResponseError,
 } from '@kbn/core/server';
 
 import { CustomHttpRequestError } from '../../../utils/custom_http_request_error';
@@ -160,13 +162,14 @@ const statusToErrorMessage = (statusCode: number) => {
 export class SiemResponseFactory {
   constructor(private response: KibanaResponseFactory) {}
 
-  // @ts-expect-error upgrade typescript v4.9.5
-  error<T>({ statusCode, body, headers }: CustomHttpResponseOptions<T>) {
-    // @ts-expect-error upgrade typescript v4.9.5
+  error<T extends HttpResponsePayload | ResponseError>({
+    statusCode,
+    body,
+    headers,
+  }: CustomHttpResponseOptions<T>) {
     const contentType: CustomHttpResponseOptions<T>['headers'] = {
       'content-type': 'application/json',
     };
-    // @ts-expect-error upgrade typescript v4.9.5
     const defaultedHeaders: CustomHttpResponseOptions<T>['headers'] = {
       ...contentType,
       ...(headers ?? {}),

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/utils.ts
@@ -13,10 +13,11 @@ import { BulkActionEditTypeEnum } from '../../../../../../common/api/detection_e
  * @param editAction {@link BulkActionEditType}
  * @returns {boolean}
  */
-export const isIndexPatternsBulkEditAction = (editAction: BulkActionEditType) =>
-  [
+export const isIndexPatternsBulkEditAction = (editAction: BulkActionEditType) => {
+  const indexPatternsActions: BulkActionEditType[] = [
     BulkActionEditTypeEnum.add_index_patterns,
     BulkActionEditTypeEnum.delete_index_patterns,
     BulkActionEditTypeEnum.set_index_patterns,
-    // @ts-expect-error upgrade typescript v4.9.5
-  ].includes(editAction);
+  ];
+  return indexPatternsActions.includes(editAction);
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/validations.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/validations.ts
@@ -10,7 +10,10 @@ import { invariant } from '../../../../../../common/utils/invariant';
 import { isMlRule } from '../../../../../../common/machine_learning/helpers';
 import { isEsqlRule } from '../../../../../../common/detection_engine/utils';
 import { BulkActionsDryRunErrCode } from '../../../../../../common/constants';
-import type { BulkActionEditPayload } from '../../../../../../common/api/detection_engine/rule_management';
+import type {
+  BulkActionEditPayload,
+  BulkActionEditType,
+} from '../../../../../../common/api/detection_engine/rule_management';
 import { BulkActionEditTypeEnum } from '../../../../../../common/api/detection_engine/rule_management';
 import type { RuleAlertType } from '../../../rule_schema';
 import { isIndexPatternsBulkEditAction } from './utils';
@@ -99,12 +102,11 @@ export const validateBulkEditRule = async ({
  * add_rule_actions, set_rule_actions can be applied to prebuilt/immutable rules
  */
 const istEditApplicableToImmutableRule = (edit: BulkActionEditPayload[]): boolean => {
-  return edit.every(({ type }) =>
-    [BulkActionEditTypeEnum.set_rule_actions, BulkActionEditTypeEnum.add_rule_actions].includes(
-      // @ts-expect-error upgrade typescript v4.9.5
-      type
-    )
-  );
+  const applicableActions: BulkActionEditType[] = [
+    BulkActionEditTypeEnum.set_rule_actions,
+    BulkActionEditTypeEnum.add_rule_actions,
+  ];
+  return edit.every(({ type }) => applicableActions.includes(type));
 };
 
 /**


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/176287**
**Resolves: https://github.com/elastic/kibana/issues/176126**

## Summary

In https://github.com/elastic/kibana/pull/175178 Kibana was upgraded to TypeScript v4.9.5. That PR introduced a few type errors which were skipped by adding `@ts-expect-error` comments. This PR attempts to fix those type errors and remove the comments.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->