### PR TITLE
[Security Solution] Align on custom CSS within Rule Management

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.styles.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.styles.ts
@@ -9,37 +9,29 @@ import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-export const useFiltersStyles = () => {
-  return useMemo(
-    () => ({
-      flexGroup: css`
-        max-width: 600px;
-      `,
-    }),
-    []
-  );
+export const filtersStyles = {
+  flexGroup: css`
+    max-width: 600px;
+  `,
 };
 
-export const useQueryStyles = () => {
-  return useMemo(
-    () => ({
-      content: css`
-        white-space: pre-wrap;
-      `,
-    }),
-    []
-  );
+export const queryStyles = {
+  content: css`
+    white-space: pre-wrap;
+  `,
 };
 
 export const useRequiredFieldsStyles = () => {
   const { euiTheme } = useEuiTheme();
+  const { font } = euiTheme;
+
   return useMemo(
     () => ({
-      fieldTypeText: css({
-        fontFamily: euiTheme.font.familyCode,
-        display: 'inline',
-      }),
+      fieldNameText: css`
+        font-family: ${font.familyCode ?? font.family};
+        display: inline;
+      `,
     }),
-    [euiTheme.font.familyCode]
+    [font.familyCode, font.family]
   );
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
@@ -55,8 +55,8 @@ import { DEFAULT_DESCRIPTION_LIST_COLUMN_WIDTHS } from './constants';
 import * as i18n from './translations';
 import { useAlertSuppression } from '../../logic/use_alert_suppression';
 import {
-  useFiltersStyles,
-  useQueryStyles,
+  filtersStyles,
+  queryStyles,
   useRequiredFieldsStyles,
 } from './rule_definition_section.styles';
 
@@ -86,7 +86,7 @@ const Filters = ({ filters, dataViewId, index, 'data-test-subj': dataTestSubj }:
     dataViewId,
   });
 
-  const styles = useFiltersStyles();
+  const styles = filtersStyles;
 
   return (
     <EuiFlexGroup
@@ -107,7 +107,7 @@ interface QueryProps {
 }
 
 const Query = ({ query, 'data-test-subj': dataTestSubj = 'query' }: QueryProps) => {
-  const styles = useQueryStyles();
+  const styles = queryStyles;
   return (
     <div data-test-subj={dataTestSubj} className={styles.content}>
       {query}
@@ -270,7 +270,7 @@ const RequiredFields = ({ requiredFields }: RequiredFieldsProps) => {
             <EuiFlexItem grow={false}>
               <EuiText
                 data-test-subj="requiredFieldsPropertyValueItem"
-                className={styles.fieldTypeText}
+                className={styles.fieldNameText}
                 grow={false}
                 size="xs"
               >


### PR DESCRIPTION
**Related to:** https://github.com/elastic/kibana/pull/177081

## Summary

This PR builds upon some custom CSS introduced in https://github.com/elastic/kibana/pull/177081 according to @maximpn's [suggestion](https://github.com/elastic/kibana/pull/177081#discussion_r1494357297).

It slightly adjusts the way the styles are defined based on our prior discussion at Tech Time, proposing a canonical way to write custom CSS within the @elastic/security-detection-rule-management team.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->