### PR TITLE
[chore] Fix kebab warnings in Kibana start and ML plugin build

### DIFF
--- a/x-pack/packages/ml/aiops_components/src/document_count_chart/document_count_chart.tsx
+++ b/x-pack/packages/ml/aiops_components/src/document_count_chart/document_count_chart.tsx
@@ -436,7 +436,7 @@ export const DocumentCountChart: FC<DocumentCountChartProps> = (props) => {
           </div>
           <div
             css={{
-              'margin-bottom': '-4px',
+              marginBottom: '-4px',
             }}
           >
             <DualBrush

--- a/x-pack/plugins/data_visualizer/public/application/data_drift/document_count_chart_single_brush/document_count_chart_singular.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/document_count_chart_single_brush/document_count_chart_singular.tsx
@@ -383,7 +383,7 @@ export const DocumentCountChartWithBrush: FC<DocumentCountChartProps> = (props) 
         <div className="dataDriftSingleBrush" data-test-subj={`dataDriftSingleBrush-${id}`}>
           <div
             css={{
-              'margin-bottom': '-4px',
+              marginBottom: '-4px',
             }}
           >
             <SingleBrush

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
@@ -148,7 +148,7 @@ export const DFAnalyticsJobIdLink = ({ jobId }: { jobId: string }) => {
   });
 
   return (
-    <EuiLink href={href} css={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }} title={jobId}>
+    <EuiLink href={href} css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={jobId}>
       {jobId}
     </EuiLink>
   );

--- a/x-pack/plugins/ml/public/application/explorer/anomaly_timeline.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/anomaly_timeline.tsx
@@ -413,7 +413,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
             {menuPanels[0].items!.length > 0 ? (
               <EuiFlexItem
                 grow={false}
-                css={{ 'margin-left': 'auto !important', 'align-self': 'baseline' }}
+                css={{ marginLeft: 'auto !important', alignSelf: 'baseline' }}
               >
                 <EuiPopover
                   button={
@@ -461,7 +461,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
               </>
             )}
 
-            <EuiFlexItem grow={true} css={{ 'max-width': '500px' }}>
+            <EuiFlexItem grow={true} css={{ maxWidth: '500px' }}>
               <SeverityControl
                 value={severityUpdate ?? 0}
                 onChange={useCallback((update) => {

--- a/x-pack/plugins/ml/public/application/explorer/components/explorer_query_bar/explorer_query_bar.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/components/explorer_query_bar/explorer_query_bar.tsx
@@ -158,7 +158,7 @@ export const ExplorerQueryBar: FC<ExplorerQueryBarProps> = ({
 
   return (
     <EuiInputPopover
-      css={{ 'max-width': '100%' }}
+      css={{ maxWidth: '100%' }}
       closePopover={setQueryErrorMessage.bind(null, undefined)}
       input={
         <QueryStringInput

--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -441,8 +441,8 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
           <EuiFlexItem
             css={{
               width: '100%',
-              'overflow-y': 'auto',
-              'overflow-x': 'hidden',
+              overflowY: 'auto',
+              overflowX: 'hidden',
             }}
             grow={false}
           >

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list/job_id_link.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list/job_id_link.tsx
@@ -68,7 +68,7 @@ export const AnomalyDetectionJobIdLink = (props: AnomalyDetectionJobIdLinkProps)
       <EuiLink
         key={props.id}
         href={href}
-        css={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }}
+        css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
         title={props.id}
       >
         {props.id}

--- a/x-pack/plugins/ml/public/application/model_management/model_link.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/model_link.tsx
@@ -22,7 +22,7 @@ export const TrainedModelLink: FC<TrainedModelLinkProps> = ({ id }) => {
   });
 
   return (
-    <EuiLink href={href} css={{ overflow: 'hidden', 'text-overflow': 'ellipsis' }} title={id}>
+    <EuiLink href={href} css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={id}>
       {id}
     </EuiLink>
   );


### PR DESCRIPTION
## Summary

I've always been annoyed with these warnings that appear in the console when starting Kibana:

<img width="1344" alt="Screenshot 2024-03-22 at 3 40 09 PM" src="https://github.com/elastic/kibana/assets/297604/9e722ea9-8ca4-47de-8f28-ca511d6e7194">

The trouble is, it's been nearly impossible to find these in the code.

While working with some changes to the `ml` plugin, I noticed something familiar:

<img width="925" alt="Screenshot 2024-03-22 at 3 39 56 PM" src="https://github.com/elastic/kibana/assets/297604/5d69c693-512b-4794-9bd7-f2d12c693d7d">

So with a smaller haystack, I was able to find and fix them.

<img width="671" alt="Screenshot 2024-03-22 at 4 51 43 PM" src="https://github.com/elastic/kibana/assets/297604/70db7016-eb04-4171-a4a8-18e4df7131ae">
