### PR TITLE
Discover flaky test

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/data_views/_data_view_create_delete.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/data_views/_data_view_create_delete.ts
@@ -24,7 +24,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // "index_not_found_exception: no such index [.kibana_ingest]",
       // so it was switched to `savedObjects.cleanStandardList()`
       await kibanaServer.savedObjects.cleanStandardList();
-      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern.json');
+      await kibanaServer.importExport.load(
+        'test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern.json'
+      );
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({});
       // TODO: Navigation to Data View Management is different in Serverless
@@ -33,7 +35,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async function () {
-      await kibanaServer.importExport.unload('test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern.json');
+      await kibanaServer.importExport.unload(
+        'test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern.json'
+      );
       await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 

--- a/x-pack/test_serverless/functional/test_suites/common/management/data_views/_data_view_create_delete.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/data_views/_data_view_create_delete.ts
@@ -19,18 +19,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['settings', 'common', 'header']);
 
   describe('creating and deleting default data view', function describeIndexTests() {
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/171479
-    this.tags(['failsOnMKI']);
     before(async function () {
       // TODO: emptyKibanaIndex fails in Serverless with
       // "index_not_found_exception: no such index [.kibana_ingest]",
       // so it was switched to `savedObjects.cleanStandardList()`
       await kibanaServer.savedObjects.cleanStandardList();
-      // TODO: Loading this from `es_archives` in `test_serverless`
-      // instead since minor modifications were required
-      await esArchiver.loadIfNeeded(
-        'x-pack/test_serverless/functional/es_archives/kibana_sample_data_flights_index_pattern'
-      );
+      await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern.json');
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.uiSettings.replace({});
       // TODO: Navigation to Data View Management is different in Serverless
@@ -39,12 +33,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async function () {
-      // TODO: Loading this from `es_archives` in `test_serverless`
-      // instead since minor modifications were required
-      await esArchiver.unload(
-        'x-pack/test_serverless/functional/es_archives/kibana_sample_data_flights_index_pattern'
-      );
-
+      await kibanaServer.importExport.unload('test/functional/fixtures/kbn_archiver/kibana_sample_data_flights_index_pattern.json');
       await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
     });
 


### PR DESCRIPTION
## Summary

trying to fix a fails on MKI test

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
