### PR TITLE
[SLO] Details page display sub headers as children 

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_overview_details.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_overview_details.tsx
@@ -30,7 +30,6 @@ import {
   SloDetails,
   SloTabId,
 } from '../../../pages/slo_details/components/slo_details';
-import { SLOGroupings } from '../../../pages/slos/components/common/slo_groupings';
 
 export function SloOverviewDetails({
   slo,
@@ -73,7 +72,6 @@ export function SloOverviewDetails({
             })}
           </h2>
         </EuiTitle>
-        <SLOGroupings slo={slo} />
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <HeaderTitle slo={slo} isLoading={false} />

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_overview_details.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_overview_details.tsx
@@ -76,7 +76,7 @@ export function SloOverviewDetails({
         <SLOGroupings slo={slo} />
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <HeaderTitle slo={slo} isLoading={false} showTitle={false} />
+        <HeaderTitle slo={slo} isLoading={false} />
         <EuiTabs>
           {tabs.map((tab, index) => (
             <EuiTab

--- a/x-pack/plugins/observability_solution/slo/public/pages/slo_details/components/header_title.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slo_details/components/header_title.tsx
@@ -26,7 +26,6 @@ export function HeaderTitle({ isLoading, slo }: Props) {
 
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">
-      <EuiFlexItem grow={false}>{slo.name}</EuiFlexItem>
       <SLOGroupings slo={slo} />
 
       <EuiFlexGroup

--- a/x-pack/plugins/observability_solution/slo/public/pages/slo_details/components/header_title.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slo_details/components/header_title.tsx
@@ -19,19 +19,15 @@ export interface Props {
   showTitle?: boolean;
 }
 
-export function HeaderTitle({ isLoading, slo, showTitle = true }: Props) {
+export function HeaderTitle({ isLoading, slo }: Props) {
   if (isLoading || !slo) {
     return <EuiSkeletonText lines={1} data-test-subj="loadingTitle" />;
   }
 
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">
-      {showTitle && (
-        <>
-          <EuiFlexItem grow={false}>{slo.name}</EuiFlexItem>
-          <SLOGroupings slo={slo} />
-        </>
-      )}
+      <EuiFlexItem grow={false}>{slo.name}</EuiFlexItem>
+      <SLOGroupings slo={slo} />
 
       <EuiFlexGroup
         direction="row"

--- a/x-pack/plugins/observability_solution/slo/public/pages/slo_details/slo_details.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slo_details/slo_details.tsx
@@ -8,7 +8,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { useIsMutating } from '@tanstack/react-query';
-import { EuiLoadingSpinner } from '@elastic/eui';
+import { EuiLoadingSpinner, EuiSkeletonText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { IBasePath } from '@kbn/core-http-browser';
 import type { ChromeBreadcrumb } from '@kbn/core-chrome-browser';
@@ -124,7 +124,8 @@ export function SloDetailsPage() {
   return (
     <ObservabilityPageTemplate
       pageHeader={{
-        pageTitle: <HeaderTitle isLoading={isPerformingAction} slo={slo} />,
+        pageTitle: slo?.name ?? <EuiSkeletonText lines={1} />,
+        children: <HeaderTitle isLoading={isPerformingAction} slo={slo} />,
         rightSideItems: [
           <HeaderControl isLoading={isPerformingAction} slo={slo} />,
           <AutoRefreshButton


### PR DESCRIPTION
## Summary

Display Header sub heading as children of page template !!

### After
<img width="1728" alt="image" src="https://github.com/elastic/kibana/assets/3505601/d6198df4-40b7-488f-a7df-0fcbc514a371">
