### PR TITLE
Fix serverless reporting API integration tests for MKI runs

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
@@ -13,14 +13,16 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 // the archived data holds a report created by test_user
 const TEST_USERNAME = 'test_user';
 const TEST_USER_PASSWORD = 'changeme';
-const REPORTING_USER_USERNAME = 'elastic_serverless';
-const REPORTING_USER_PASSWORD = 'changeme';
 const API_HEADER: [string, string] = ['kbn-xsrf', 'reporting'];
 const INTERNAL_HEADER: [string, string] = [X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'Kibana'];
 
 export default ({ getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertestWithoutAuth');
+  const config = getService('config');
+
+  const REPORTING_USER_USERNAME = config.get('servers.kibana.username');
+  const REPORTING_USER_PASSWORD = config.get('servers.kibana.password');
 
   describe('Reporting Management', function () {
     // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.reporting-2020.04.19], this action is granted by the index privileges [create_index,manage,all]

--- a/x-pack/test_serverless/functional/services/svl_reporting.ts
+++ b/x-pack/test_serverless/functional/services/svl_reporting.ts
@@ -18,8 +18,6 @@ const INTERNAL_HEADER: [string, string] = [X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'K
 // const REPORTING_ROLE = 'reporting_user_role';
 // const REPORTING_USER_PASSWORD = 'reporting_user-password';
 // const REPORTING_USER_USERNAME = 'reporting_user';
-const REPORTING_USER_USERNAME = 'elastic_serverless';
-const REPORTING_USER_PASSWORD = 'changeme';
 
 /**
  * Services to create roles and users for security testing
@@ -29,6 +27,9 @@ export function SvlReportingServiceProvider({ getService }: FtrProviderContext) 
   const supertest = getService('supertestWithoutAuth');
   const retry = getService('retry');
   const config = getService('config');
+
+  const REPORTING_USER_USERNAME = config.get('servers.kibana.username');
+  const REPORTING_USER_PASSWORD = config.get('servers.kibana.password');
 
   return {
     /**

--- a/x-pack/test_serverless/shared/services/svl_reporting.ts
+++ b/x-pack/test_serverless/shared/services/svl_reporting.ts
@@ -15,9 +15,6 @@ import { FtrProviderContext } from '../../functional/ftr_provider_context';
 const API_HEADER: [string, string] = ['kbn-xsrf', 'reporting'];
 const INTERNAL_HEADER: [string, string] = [X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'Kibana'];
 
-const REPORTING_USER_USERNAME = 'elastic_serverless';
-const REPORTING_USER_PASSWORD = 'changeme';
-
 /**
  * Services to create roles and users for security testing
  */
@@ -26,6 +23,9 @@ export function SvlReportingServiceProvider({ getService }: FtrProviderContext) 
   const supertest = getService('supertestWithoutAuth');
   const retry = getService('retry');
   const config = getService('config');
+
+  const REPORTING_USER_USERNAME = config.get('servers.kibana.username');
+  const REPORTING_USER_PASSWORD = config.get('servers.kibana.password');
 
   return {
     /**


### PR DESCRIPTION
## Summary

This PR fixes the serverless reporting API integration tests for MKI runs.

### The problem that we saw

After #178159 was merged, we saw the `Reporting Generate CSV` API integration tests fail with `401` responses when running against MKI projects. It turned out that the tests were using hard-coded credentials that are only working locally / in CI - real serverless projects run with a different set of username and password.

### How this PR fixes it

Remove hard-coded credentials from `x-pack/test_serverless/shared/services/svl_reporting.ts` and instead read them from the test config, which has the proper entries for local and MKI runs.

I've also preemptively adjusted `x-pack/test_serverless/functional/services/svl_reporting.ts` and `x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts` in the same way even though they not run in MKI projects today. This will hopefully avoid the same set of problems when the tests eventually get re-enabled for MKI runs.