### PR TITLE
[EnvironmentService] Prepend `unhandledRejection` listener

### DIFF
--- a/packages/core/environment/core-environment-server-internal/src/environment_service.ts
+++ b/packages/core/environment/core-environment-server-internal/src/environment_service.ts
@@ -64,7 +64,8 @@ export class EnvironmentService {
     ]);
 
     // Log unhandled rejections so that we can fix them in preparation for https://github.com/elastic/kibana/issues/77469
-    process.on('unhandledRejection', (reason) => {
+    // Using `prependListener` so that it runs before the setup_node_env/exit_on_warning one.
+    process.prependListener('unhandledRejection', (reason) => {
       const message = (reason as Error)?.stack ?? JSON.stringify(reason);
       this.log.warn(`Detected an unhandled Promise rejection: ${message}`);
     });


### PR DESCRIPTION
## Summary

[This listener](https://github.com/elastic/kibana/blob/c345fc65a40dfd817500da57d715d1e223aec608/src/setup_node_env/exit_on_warning.js#L78-L85) is running before the one registered by the Environment Service. It means, it calls `process.exit(1)` before this handler runs, so we're missing out on these extra logs.


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Many places handling this event in our codebase makes it harder to troubleshoot. | Low | Low | We could unify the logging strategy for this event. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
