### PR TITLE
Risk Engine - Changed alertSampleSizePerShard from 10,000 to 1,000

### DIFF
--- a/x-pack/plugins/security_solution/server/config.mock.ts
+++ b/x-pack/plugins/security_solution/server/config.mock.ts
@@ -36,7 +36,7 @@ export const createMockConfig = (): ConfigType => {
     enableUiSettingsValidations: false,
     entityAnalytics: {
       riskEngine: {
-        alertSampleSizePerShard: 10_000,
+        alertSampleSizePerShard: 1_000,
       },
     },
   };

--- a/x-pack/plugins/security_solution/server/config.ts
+++ b/x-pack/plugins/security_solution/server/config.ts
@@ -167,7 +167,7 @@ export const configSchema = schema.object({
   }),
   entityAnalytics: schema.object({
     riskEngine: schema.object({
-      alertSampleSizePerShard: schema.number({ defaultValue: 10_000 }),
+      alertSampleSizePerShard: schema.number({ defaultValue: 1_000 }),
     }),
   }),
 });

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_risk_scores.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_risk_scores.ts
@@ -207,13 +207,13 @@ const buildIdentifierTypeAggregation = ({
                 String category = doc['${EVENT_KIND}'].value;
                 double score = doc['${ALERT_RISK_SCORE}'].value;
                 double weighted_score = 0.0;
-          
+
                 fields.put('time', doc['@timestamp'].value);
                 fields.put('category', category);
                 fields.put('score', score);
                 ${buildWeightingOfScoreByCategory({ userWeights: weights, identifierType })}
                 fields.put('weighted_score', weighted_score);
-          
+
                 state.inputs.add(fields);
               `,
               combine_script: 'return state;',
@@ -291,7 +291,7 @@ export const calculateRiskScores = async ({
   range,
   runtimeMappings,
   weights,
-  alertSampleSizePerShard = 10_000,
+  alertSampleSizePerShard = 1_000,
 }: {
   assetCriticalityService: AssetCriticalityService;
   esClient: ElasticsearchClient;

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.test.ts
@@ -25,7 +25,7 @@ const ISO_8601_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
 
 const entityAnalyticsConfig = {
   riskEngine: {
-    alertSampleSizePerShard: 10_000,
+    alertSampleSizePerShard: 1_000,
   },
 };
 describe('Risk Scoring Task', () => {
@@ -201,7 +201,7 @@ describe('Risk Scoring Task', () => {
         interval: '1h',
         pageSize: 10_000,
         range: { start: 'now-30d', end: 'now' },
-        alertSampleSizePerShard: 10_000,
+        alertSampleSizePerShard: 1_000,
       });
       mockIsCancelled = jest.fn().mockReturnValue(false);
 
@@ -281,7 +281,7 @@ describe('Risk Scoring Task', () => {
           interval: '2h',
           pageSize: 11_111,
           range: { start: 'now-30d', end: 'now' },
-          alertSampleSizePerShard: 10_000,
+          alertSampleSizePerShard: 1_000,
         });
         await runTask({
           getRiskScoreService,
@@ -317,7 +317,7 @@ describe('Risk Scoring Task', () => {
             interval: '1h',
             pageSize: 10_000,
             range: { start: 'now-30d', end: 'now' },
-            alertSampleSizePerShard: 10_000,
+            alertSampleSizePerShard: 1_000,
           });
           // add additional mock responses for the additional identifier calls
           mockRiskScoreService.calculateAndPersistScores
@@ -389,7 +389,7 @@ describe('Risk Scoring Task', () => {
             interval: '2h',
             pageSize: 11_111,
             range: { start: 'now-30d', end: 'now' },
-            alertSampleSizePerShard: 10_000,
+            alertSampleSizePerShard: 1_000,
           });
           await runTask({
             getRiskScoreService,
@@ -500,7 +500,7 @@ describe('Risk Scoring Task', () => {
             interval: '1h',
             scoresWritten: 10,
             taskDurationInSeconds: 0,
-            alertSampleSizePerShard: 10000,
+            alertSampleSizePerShard: 1000,
           });
         });
 
@@ -578,7 +578,7 @@ describe('Risk Scoring Task', () => {
               interval: '1h',
               scoresWritten: 0,
               taskDurationInSeconds: 0,
-              alertSampleSizePerShard: 10000,
+              alertSampleSizePerShard: 1000,
             }
           );
         });


### PR DESCRIPTION
## Summary

In order to further improve risk engine performance, changed the `alertSampleSizePerShard` configuration from 10,000 to 1,000. 

## Testing

Ongoing...