### PR TITLE
[ES|QL] Reduce the scope of grammar sync job

### DIFF
--- a/.buildkite/scripts/steps/esql_grammar_sync.sh
+++ b/.buildkite/scripts/steps/esql_grammar_sync.sh
@@ -113,7 +113,7 @@ main () {
 
   git checkout -b "$BRANCH_NAME"
 
-  git add -A
+  git add esql/antlr/*
   git commit -m "Update ES|QL grammars"
 
   report_main_step "Changes committed. Creating pull request."


### PR DESCRIPTION
## Summary

Fix an issue with committing too much into the ES|QL grammar PR job.
Now it targets only grammar files without anything else.