### PR TITLE
[Fleet] Allow to request diagnostics with Agent:Read privileges

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/action_menu.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/action_menu.test.tsx
@@ -48,6 +48,7 @@ describe('AgentDetailsActionMenu', () => {
     } as any);
     mockedUseAuthz.mockReturnValue({
       fleet: {
+        readAgents: true,
         allAgents: true,
       },
     } as any);
@@ -127,10 +128,10 @@ describe('AgentDetailsActionMenu', () => {
       expect(res).not.toBeEnabled();
     });
 
-    it('should not render an active action button if agent version >= 8.7 and user do not have Agent:All authz', async () => {
+    it('should not render an active action button if agent version >= 8.7 and user do not have Agent:Read authz', async () => {
       mockedUseAuthz.mockReturnValue({
         fleet: {
-          allAgents: false,
+          readAgents: false,
         },
       } as any);
       const res = renderAndGetDiagnosticsButton({

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -33,7 +33,8 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
   assignFlyoutOpenByDefault?: boolean;
   onCancelReassign?: () => void;
 }> = memo(({ agent, assignFlyoutOpenByDefault = false, onCancelReassign, agentPolicy }) => {
-  const hasFleetAllPrivileges = useAuthz().fleet.allAgents;
+  const authz = useAuthz();
+  const hasFleetAllPrivileges = authz.fleet.allAgents;
   const refreshAgent = useAgentRefresh();
   const [isReassignFlyoutOpen, setIsReassignFlyoutOpen] = useState(assignFlyoutOpenByDefault);
   const [isUnenrollModalOpen, setIsUnenrollModalOpen] = useState(false);
@@ -151,11 +152,11 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
     </EuiContextMenuItem>
   );
 
-  if (hasFleetAllPrivileges && diagnosticFileUploadEnabled) {
+  if (authz.fleet.readAgents && diagnosticFileUploadEnabled) {
     menuItems.push(
       <EuiContextMenuItem
         icon="download"
-        disabled={!hasFleetAllPrivileges || !isAgentRequestDiagnosticsSupported(agent)}
+        disabled={!isAgentRequestDiagnosticsSupported(agent)}
         onClick={() => {
           setIsRequestDiagnosticsModalOpen(true);
         }}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_diagnostics/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_diagnostics/index.tsx
@@ -228,7 +228,7 @@ export const AgentDiagnosticsTab: React.FunctionComponent<AgentDiagnosticsProps>
       size="m"
       onClick={onSubmit}
       disabled={
-        isSubmitting || !isAgentRequestDiagnosticsSupported(agent) || !authz.fleet.allAgents
+        isSubmitting || !isAgentRequestDiagnosticsSupported(agent) || !authz.fleet.readAgents
       }
     >
       <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.test.tsx
@@ -58,6 +58,7 @@ describe('TableRowActions', () => {
     mockedUseAuthz.mockReturnValue({
       fleet: {
         all: true,
+        readAgents: true,
         allAgents: true,
       },
     } as any);
@@ -186,10 +187,10 @@ describe('TableRowActions', () => {
       expect(res).not.toBe(null);
       expect(res).toBeEnabled();
     });
-    it('should not render action if authz do not have Agents:All', async () => {
+    it('should not render action if authz do not have Agents:Read', async () => {
       mockedUseAuthz.mockReturnValue({
         fleet: {
-          allAgents: false,
+          readAgents: false,
         },
       } as any);
       const res = renderAndGetRestartUpgradeButton({

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
@@ -159,7 +159,7 @@ export const TableRowActions: React.FunctionComponent<{
     }
   }
 
-  if (authz.fleet.allAgents && diagnosticFileUploadEnabled) {
+  if (authz.fleet.readAgents && diagnosticFileUploadEnabled) {
     menuItems.push(
       <EuiContextMenuItem
         key="requestAgentDiagnosticsBtn"

--- a/x-pack/plugins/fleet/server/routes/agent/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/index.ts
@@ -276,7 +276,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .post({
       path: AGENT_API_ROUTES.REQUEST_DIAGNOSTICS_PATTERN,
       fleetAuthz: {
-        fleet: { allAgents: true },
+        fleet: { readAgents: true },
       },
     })
     .addVersion(
@@ -291,7 +291,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .post({
       path: AGENT_API_ROUTES.BULK_REQUEST_DIAGNOSTICS_PATTERN,
       fleetAuthz: {
-        fleet: { allAgents: true },
+        fleet: { readAgents: true },
       },
     })
     .addVersion(

--- a/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
@@ -10,11 +10,13 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { setupFleetAndAgents } from './services';
 import { skipIfNoDockerRegistry } from '../../helpers';
+import { testUsers } from '../test_users';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('fleet_request_diagnostics', () => {
     skipIfNoDockerRegistry(providerContext);
@@ -38,19 +40,29 @@ export default function (providerContext: FtrProviderContext) {
       expect(actionStatus.nbAgentsActionCreated).to.eql(agentCount);
     }
 
-    it('/agents/{agent_id}/request_diagnostics should work', async () => {
-      await supertest
+    it('should respond 403 if user lacks fleet read permissions', async () => {
+      await supertestWithoutAuth
         .post(`/api/fleet/agents/agent1/request_diagnostics`)
         .set('kbn-xsrf', 'xxx')
+        .auth(testUsers.fleet_no_access.username, testUsers.fleet_no_access.password)
+        .expect(403);
+    });
+
+    it('/agents/{agent_id}/request_diagnostics should work', async () => {
+      await supertestWithoutAuth
+        .post(`/api/fleet/agents/agent1/request_diagnostics`)
+        .set('kbn-xsrf', 'xxx')
+        .auth(testUsers.fleet_agents_read_only.username, testUsers.fleet_agents_read_only.password)
         .expect(200);
 
       await verifyActionResult(1);
     });
 
     it('/agents/bulk_request_diagnostics should work for multiple agents by id', async () => {
-      await supertest
+      await supertestWithoutAuth
         .post(`/api/fleet/agents/bulk_request_diagnostics`)
         .set('kbn-xsrf', 'xxx')
+        .auth(testUsers.fleet_agents_read_only.username, testUsers.fleet_agents_read_only.password)
         .send({
           agents: ['agent2', 'agent3'],
         });
@@ -59,9 +71,10 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     it('/agents/bulk_request_diagnostics should work for multiple agents by kuery', async () => {
-      await supertest
+      await supertestWithoutAuth
         .post(`/api/fleet/agents/bulk_request_diagnostics`)
         .set('kbn-xsrf', 'xxx')
+        .auth(testUsers.fleet_agents_read_only.username, testUsers.fleet_agents_read_only.password)
         .send({
           agents: '',
         })
@@ -71,8 +84,9 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     it('/agents/bulk_request_diagnostics should work for multiple agents by kuery in batches async', async () => {
-      const { body } = await supertest
+      const { body } = await supertestWithoutAuth
         .post(`/api/fleet/agents/bulk_request_diagnostics`)
+        .auth(testUsers.fleet_agents_read_only.username, testUsers.fleet_agents_read_only.password)
         .set('kbn-xsrf', 'xxx')
         .send({
           agents: '',


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/ingest-dev/issues/2903

Allow User with Agents:Read to request agent diagnostics

## UI Changes

<img width="1562" alt="Screenshot 2024-03-25 at 11 27 26 AM" src="https://github.com/elastic/kibana/assets/1336873/9a4bdf80-b8f2-4ede-9e40-062cb263cac8">
<img width="1409" alt="Screenshot 2024-03-25 at 11 27 22 AM" src="https://github.com/elastic/kibana/assets/1336873/c2850601-d22a-40dc-bf6c-14df897f11b3">


## Tests

The PR changes are covered with automated tests unit and API integration