### PR TITLE
[Ops] Enables serverless release failure notifications

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -19,8 +19,8 @@ spec:
       description: Initiate kibana serverless releases
     spec:
       env:
-        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-mission-control'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       default_branch: main
       allow_rebuilds: false
       skip_intermediate_builds: false


### PR DESCRIPTION
## Summary
This PR enables notifications about failures of the https://buildkite.com/elastic/kibana-serverless-release job.