### PR TITLE
[Search] Display Index Nav Items when child items are selected

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/add_domain_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/add_domain/add_domain_logic.ts
@@ -251,6 +251,7 @@ export const AddDomainLogic = kea<MakeLogicType<AddDomainLogicValues, AddDomainL
         generateEncodedPath(SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH, {
           domainId: domain.id,
           indexName,
+          tabId: 'domain_management',
         })
       );
       CrawlerLogic.actions.fetchCrawlerData();

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domains_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/domain_management/domains_table.tsx
@@ -51,6 +51,7 @@ export const DomainsTable: React.FC = () => {
             to={generateEncodedPath(SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH, {
               domainId: domain.id,
               indexName,
+              tabId: 'domain_management',
             })}
           >
             {domain.url}
@@ -95,6 +96,7 @@ export const DomainsTable: React.FC = () => {
               generateEncodedPath(SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH, {
                 domainId: domain.id,
                 indexName,
+                tabId: 'domain_management',
               })
             );
           },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/indices/indices_nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/indices/indices_nav.tsx
@@ -154,6 +154,7 @@ export const useIndicesNav = () => {
                   }
                 ),
                 ...generateNavLink({
+                  shouldShowActiveForSubroutes: true,
                   to: generateEncodedPath(SEARCH_INDEX_TAB_PATH, {
                     indexName,
                     tabId: SearchIndexTabId.DOMAIN_MANAGEMENT,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/routes.ts
@@ -29,7 +29,7 @@ export const NEW_INDEX_SELECT_CONNECTOR_CLIENTS_PATH = `${CONNECTORS_PATH}/selec
 export const SEARCH_INDEX_PATH = `${SEARCH_INDICES_PATH}/:indexName`;
 export const SEARCH_INDEX_TAB_PATH = `${SEARCH_INDEX_PATH}/:tabId`;
 export const SEARCH_INDEX_TAB_DETAIL_PATH = `${SEARCH_INDEX_TAB_PATH}/:detailId`;
-export const SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH = `${SEARCH_INDEX_PATH}/domain_management/:domainId`;
+export const SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH = `${SEARCH_INDEX_TAB_PATH}/:domainId`;
 export const OLD_SEARCH_INDEX_CRAWLER_DOMAIN_DETAIL_PATH = `${SEARCH_INDEX_PATH}/crawler/domains/:domainId`;
 
 export const ML_MANAGE_TRAINED_MODELS_PATH = '/app/ml/trained_models';


### PR DESCRIPTION
## Summary

Currently, if we visit a specific domain item for an index or navigating to specific `domain` in `domain management`, the left expended `index` nav menu does not show up (hides immediately if the index menu were expanded).

### Before
- The index nav is expanded initially
![Screenshot 2024-03-25 at 12 56 06 PM](https://github.com/elastic/kibana/assets/150824886/b71a4d5f-2167-4970-9381-a47f66ab014e)
- The index nav menu hides when specific domain selected
![Screenshot 2024-03-25 at 12 56 20 PM](https://github.com/elastic/kibana/assets/150824886/7bcd9818-68cb-442d-8f92-d2900fd7c9d6)

### After:
- the menu stays up:
![Screenshot 2024-03-25 at 12 56 37 PM](https://github.com/elastic/kibana/assets/150824886/c5a4273d-3363-47c5-bcf1-4bad0fb4f626)



### Checklist

Delete any items that are not applicable to this PR.

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [X] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [X] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [X] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [X] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [X] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->