### PR TITLE
[Metric threshold] Stop reporting no data alert for missing groups that are untracked

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.mock.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.mock.ts
@@ -35,6 +35,7 @@ const createPublicAlertsClientMock = () => {
     return {
       create: jest.fn(),
       report: jest.fn(),
+      isTrackedAlert: jest.fn(),
       getAlertLimitValue: jest.fn().mockReturnValue(1000),
       setAlertLimitReached: jest.fn(),
       getRecoveredAlerts: jest.fn().mockReturnValue([]),

--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
@@ -225,6 +225,7 @@ export const createMetricThresholdExecutor =
     const previousMissingGroups =
       alertOnGroupDisappear && filterQueryIsSame && groupByIsSame && state.missingGroups
         ? state.missingGroups.filter((missingGroup) =>
+            // We use isTrackedAlert to remove missing groups that are untracked by the user
             typeof missingGroup === 'string'
               ? alertsClient.isTrackedAlert(missingGroup)
               : alertsClient.isTrackedAlert(missingGroup.key)

--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.ts
@@ -224,7 +224,11 @@ export const createMetricThresholdExecutor =
     const groupByIsSame = isEqual(state.groupBy, params.groupBy);
     const previousMissingGroups =
       alertOnGroupDisappear && filterQueryIsSame && groupByIsSame && state.missingGroups
-        ? state.missingGroups
+        ? state.missingGroups.filter((missingGroup) =>
+            typeof missingGroup === 'string'
+              ? alertsClient.isTrackedAlert(missingGroup)
+              : alertsClient.isTrackedAlert(missingGroup.key)
+          )
         : [];
 
     const alertResults = await evaluateRule(


### PR DESCRIPTION
Fixes #161621

## Summary

This PR removes untracked alerts from the missing group array in the rule state and as a result, those no data alerts will not be reported again.

### 🧪 How to test
- Create some metric threshold alerts for different groups
- Stop sending data for `group-1` (You should see a no data alert for it)
- Untrack no data alert related to `group-1`, after the next rule execution, you should not see any no data alert for this group.
- Again send data for `group-1` to meet the threshold, you should see an alert for it as before.