### PR TITLE
[8.13] [Upgrade Assistant] Add missing cluster privilege check (#179033)

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecations_table/error_handling.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana_deprecations/deprecations_table/error_handling.test.ts
@@ -8,6 +8,7 @@
 import { act } from 'react-dom/test-utils';
 import { deprecationsServiceMock } from '@kbn/core/public/mocks';
 
+import { APP_LOGS_COUNT_CLUSTER_PRIVILEGES } from '../../../../common/constants';
 import { setupEnvironment } from '../../helpers';
 import { kibanaDeprecationsServiceHelpers } from '../service.mock';
 import { KibanaTestBed, setupKibanaPage } from '../kibana_deprecations.helpers';
@@ -64,6 +65,13 @@ describe('Kibana deprecations - Deprecations table - Error handling', () => {
             deprecations: deprecationService,
           },
         },
+        privileges: {
+          hasAllPrivileges: true,
+          missingPrivileges: {
+            cluster: [...APP_LOGS_COUNT_CLUSTER_PRIVILEGES],
+            index: [],
+          },
+        },
       });
     });
 
@@ -72,8 +80,13 @@ describe('Kibana deprecations - Deprecations table - Error handling', () => {
     component.update();
 
     expect(exists('kibanaDeprecationErrors')).toBe(true);
+    // Should contain error about failed deprecations
     expect(find('kibanaDeprecationErrors').text()).toContain(
       'Failed to get deprecation issues for these plugins: failed_plugin_id_1, failed_plugin_id_2.'
+    );
+    // Should contain error about missing privilege
+    expect(find('kibanaDeprecationErrors').text()).toContain(
+      'Certain issues might be missing due to missing cluster privilege for: manage_security'
     );
   });
 

--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/overview/logs_step/logs_step.test.tsx
@@ -6,7 +6,10 @@
  */
 
 import { act } from 'react-dom/test-utils';
-import { DEPRECATION_LOGS_INDEX } from '../../../../common/constants';
+import {
+  DEPRECATION_LOGS_INDEX,
+  APP_LOGS_COUNT_CLUSTER_PRIVILEGES,
+} from '../../../../common/constants';
 import { setupEnvironment } from '../../helpers';
 import { OverviewTestBed, setupOverviewPage } from '../overview.helpers';
 
@@ -134,27 +137,44 @@ describe('Overview - Logs Step', () => {
         isDeprecationLogIndexingEnabled: true,
         isDeprecationLoggingEnabled: true,
       });
+    });
 
+    test('warns the user of missing index privileges', async () => {
       await act(async () => {
         testBed = await setupOverviewPage(httpSetup, {
           privileges: {
             hasAllPrivileges: true,
             missingPrivileges: {
+              cluster: [],
               index: [DEPRECATION_LOGS_INDEX],
             },
           },
         });
       });
 
-      const { component } = testBed;
-
+      const { component, exists } = testBed;
       component.update();
+
+      expect(exists('missingIndexPrivilegesCallout')).toBe(true);
     });
 
-    test('warns the user of missing index privileges', () => {
-      const { exists } = testBed;
+    test('warns the user of missing cluster privileges', async () => {
+      await act(async () => {
+        testBed = await setupOverviewPage(httpSetup, {
+          privileges: {
+            hasAllPrivileges: true,
+            missingPrivileges: {
+              cluster: [...APP_LOGS_COUNT_CLUSTER_PRIVILEGES],
+              index: [],
+            },
+          },
+        });
+      });
 
-      expect(exists('missingPrivilegesCallout')).toBe(true);
+      const { component, exists } = testBed;
+      component.update();
+
+      expect(exists('missingClusterPrivilegesCallout')).toBe(true);
     });
   });
 });

--- a/x-pack/plugins/upgrade_assistant/common/constants.ts
+++ b/x-pack/plugins/upgrade_assistant/common/constants.ts
@@ -41,3 +41,6 @@ export const APPS_WITH_DEPRECATION_LOGS = [
 
 // The field that will indicate which elastic product generated the deprecation log
 export const DEPRECATION_LOGS_ORIGIN_FIELD = 'elasticsearch.elastic_product_origin';
+
+export const APP_LOGS_COUNT_INDEX_PRIVILEGES = ['read', 'view_index_metadata'];
+export const APP_LOGS_COUNT_CLUSTER_PRIVILEGES = ['manage_security'];

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
@@ -12,7 +12,11 @@ import { i18n } from '@kbn/i18n';
 import { FormattedDate, FormattedTime, FormattedMessage } from '@kbn/i18n-react';
 import type { EuiStepProps } from '@elastic/eui/src/components/steps/step';
 
-import { DEPRECATION_LOGS_INDEX } from '../../../../../common/constants';
+import {
+  DEPRECATION_LOGS_INDEX,
+  APP_LOGS_COUNT_CLUSTER_PRIVILEGES,
+  APP_LOGS_COUNT_INDEX_PRIVILEGES,
+} from '../../../../../common/constants';
 import { WithPrivileges, MissingPrivileges } from '../../../../shared_imports';
 import { useAppContext } from '../../../app_context';
 import { loadLogsCheckpoint } from '../../../lib/logs_checkpoint';
@@ -53,21 +57,39 @@ const i18nTexts = {
       }}
     />
   ),
-  missingPrivilegesTitle: i18n.translate(
+  missingIndexPrivilegesTitle: i18n.translate(
     'xpack.upgradeAssistant.overview.logsStep.missingPrivilegesTitle',
     {
       defaultMessage: 'You require index privileges to analyze the deprecation logs',
     }
   ),
-  missingPrivilegesDescription: (privilegesMissing: MissingPrivileges) => (
+  missingIndexPrivilegesDescription: (privilegesMissing: MissingPrivileges) => (
     <FormattedMessage
       id="xpack.upgradeAssistant.overview.logsStep.missingPrivilegesDescription"
-      defaultMessage="The deprecation logs will continue to be indexed, but you won't be able to analyze them until you have the read index {privilegesCount, plural, one {privilege} other {privileges}} for: {missingPrivileges}"
+      defaultMessage="The deprecation logs will continue to be indexed, but you won't be able to analyze them until you have the {requiredPrivileges} index privileges for: {missingPrivileges}"
       values={{
+        requiredPrivileges: <i>{APP_LOGS_COUNT_INDEX_PRIVILEGES.join(', ')}</i>,
         missingPrivileges: (
           <EuiCode transparentBackground={true}>{privilegesMissing?.index?.join(', ')}</EuiCode>
         ),
-        privilegesCount: privilegesMissing?.index?.length,
+      }}
+    />
+  ),
+  missingClusterPrivilegesTitle: i18n.translate(
+    'xpack.upgradeAssistant.overview.logsStep.missingClusterPrivilegesTitle',
+    {
+      defaultMessage: 'You require cluster privileges to analyze the deprecation logs',
+    }
+  ),
+  missingClusterPrivilegesDescription: (privilegesMissing: MissingPrivileges) => (
+    <FormattedMessage
+      id="xpack.upgradeAssistant.overview.logsStep.missingClusterPrivilegesDescription"
+      defaultMessage="The deprecation logs will continue to be indexed, but you won't be able to analyze them until you have the cluster {privilegesCount, plural, one {privilege} other {privileges}} for: {missingPrivileges}"
+      values={{
+        missingPrivileges: (
+          <EuiCode transparentBackground={true}>{privilegesMissing?.cluster?.join(', ')}</EuiCode>
+        ),
+        privilegesCount: privilegesMissing?.cluster?.length,
       }}
     />
   ),
@@ -132,14 +154,29 @@ const LogsStep = ({
 
         <EuiSpacer />
 
-        <EuiCallOut
-          iconType="help"
-          color="warning"
-          title={i18nTexts.missingPrivilegesTitle}
-          data-test-subj="missingPrivilegesCallout"
-        >
-          <p>{i18nTexts.missingPrivilegesDescription(privilegesMissing)}</p>
-        </EuiCallOut>
+        {privilegesMissing.cluster && (
+          <EuiCallOut
+            iconType="help"
+            color="warning"
+            title={i18nTexts.missingClusterPrivilegesTitle}
+            data-test-subj="missingClusterPrivilegesCallout"
+          >
+            <p>{i18nTexts.missingClusterPrivilegesDescription(privilegesMissing)}</p>
+          </EuiCallOut>
+        )}
+
+        {privilegesMissing.cluster && privilegesMissing.index && <EuiSpacer />}
+
+        {privilegesMissing.index && (
+          <EuiCallOut
+            iconType="help"
+            color="warning"
+            title={i18nTexts.missingIndexPrivilegesTitle}
+            data-test-subj="missingIndexPrivilegesCallout"
+          >
+            <p>{i18nTexts.missingIndexPrivilegesDescription(privilegesMissing)}</p>
+          </EuiCallOut>
+        )}
       </>
     );
   }
@@ -216,12 +253,17 @@ export const getLogsStep = ({
 }: OverviewStepProps & CustomProps): EuiStepProps => {
   const status = isComplete ? 'complete' : 'incomplete';
 
+  const requiredPrivileges = [
+    `index.${DEPRECATION_LOGS_INDEX}`,
+    ...APP_LOGS_COUNT_CLUSTER_PRIVILEGES.map((privilege) => `cluster.${privilege}`),
+  ];
+
   return {
     status,
     title: i18nTexts.logsStepTitle,
     'data-test-subj': `logsStep-${status}`,
     children: (
-      <WithPrivileges privileges={`index.${DEPRECATION_LOGS_INDEX}`}>
+      <WithPrivileges privileges={requiredPrivileges}>
         {({ hasPrivileges, isLoading, privilegesMissing }) => (
           <LogsStep
             setIsComplete={setIsComplete}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Upgrade Assistant] Add missing cluster privilege check (#179033)](https://github.com/elastic/kibana/pull/179033)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2024-03-25T17:06:22Z","message":"[Upgrade Assistant] Add missing cluster privilege check (#179033)","sha":"4961e52bdfc39f59ac9ce3f767204c3be537ba45","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","Feature:Upgrade Assistant","v8.14.0","v8.12.3","v8.13.1"],"number":179033,"url":"https://github.com/elastic/kibana/pull/179033","mergeCommit":{"message":"[Upgrade Assistant] Add missing cluster privilege check (#179033)","sha":"4961e52bdfc39f59ac9ce3f767204c3be537ba45"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179033","number":179033,"mergeCommit":{"message":"[Upgrade Assistant] Add missing cluster privilege check (#179033)","sha":"4961e52bdfc39f59ac9ce3f767204c3be537ba45"}},{"branch":"8.12","label":"v8.12.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/179371","number":179371,"state":"OPEN"},{"branch":"8.13","label":"v8.13.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->