### PR TITLE
[home] add caching for tutorial instructions

### DIFF
--- a/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/metricbeat_instructions.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { memoize } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { INSTRUCTION_VARIANT } from '../../../common/instruction_variant';
 import { createTrycloudOption1, createTrycloudOption2 } from './onprem_cloud_instructions';
@@ -13,324 +14,354 @@ import { getSpaceIdForBeatsTutorial } from './get_space_id_for_beats_tutorial';
 import { TutorialContext } from '../../services/tutorials/lib/tutorials_registry_types';
 import { cloudPasswordAndResetLink } from './cloud_instructions';
 
-export const createMetricbeatInstructions = (context: TutorialContext) => {
-  const SSL_DOC_URL = `https://www.elastic.co/guide/en/beats/metricbeat/${context.kibanaBranch}/configuration-ssl.html#ca-sha256`;
-
-  return {
-    INSTALL: {
-      OSX: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.osxTitle', {
-          defaultMessage: 'Download and install Metricbeat',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.install.osxTextPre', {
-          defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
-          values: {
-            link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
-          },
-        }),
-        commands: [
-          'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
-          'tar xzvf metricbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
-          'cd metricbeat-{config.kibana.version}-darwin-x86_64/',
-        ],
-      },
-      DEB: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.debTitle', {
-          defaultMessage: 'Download and install Metricbeat',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.install.debTextPre', {
-          defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
-          values: {
-            link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
-          },
-        }),
-        commands: [
-          'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-amd64.deb',
-          'sudo dpkg -i metricbeat-{config.kibana.version}-amd64.deb',
-        ],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.install.debTextPost',
-          {
-            defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({link}).',
-            values: { link: 'https://www.elastic.co/downloads/beats/metricbeat' },
-          }
-        ),
-      },
-      RPM: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.rpmTitle', {
-          defaultMessage: 'Download and install Metricbeat',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.install.rpmTextPre', {
-          defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
-          values: {
-            link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
-          },
-        }),
-        commands: [
-          'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-x86_64.rpm',
-          'sudo rpm -vi metricbeat-{config.kibana.version}-x86_64.rpm',
-        ],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.install.debTextPost',
-          {
-            defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({link}).',
-            values: { link: 'https://www.elastic.co/downloads/beats/metricbeat' },
-          }
-        ),
-      },
-      WINDOWS: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.windowsTitle', {
-          defaultMessage: 'Download and install Metricbeat',
-        }),
-        textPre: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.install.windowsTextPre',
-          {
-            defaultMessage:
-              'First time using Metricbeat? See the [Quick Start]({metricbeatLink}).\n\
+export const createMetricbeatInstructions = memoize(
+  (context: TutorialContext) => {
+    const SSL_DOC_URL = `https://www.elastic.co/guide/en/beats/metricbeat/${context.kibanaBranch}/configuration-ssl.html#ca-sha256`;
+    const spaceId = getSpaceIdForBeatsTutorial(context);
+    return {
+      INSTALL: {
+        OSX: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.osxTitle', {
+            defaultMessage: 'Download and install Metricbeat',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.osxTextPre',
+            {
+              defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
+              values: {
+                link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
+              },
+            }
+          ),
+          commands: [
+            'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
+            'tar xzvf metricbeat-{config.kibana.version}-darwin-x86_64.tar.gz',
+            'cd metricbeat-{config.kibana.version}-darwin-x86_64/',
+          ],
+        },
+        DEB: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.debTitle', {
+            defaultMessage: 'Download and install Metricbeat',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.debTextPre',
+            {
+              defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
+              values: {
+                link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
+              },
+            }
+          ),
+          commands: [
+            'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-amd64.deb',
+            'sudo dpkg -i metricbeat-{config.kibana.version}-amd64.deb',
+          ],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.debTextPost',
+            {
+              defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({link}).',
+              values: { link: 'https://www.elastic.co/downloads/beats/metricbeat' },
+            }
+          ),
+        },
+        RPM: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.install.rpmTitle', {
+            defaultMessage: 'Download and install Metricbeat',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.rpmTextPre',
+            {
+              defaultMessage: 'First time using Metricbeat? See the [Quick Start]({link}).',
+              values: {
+                link: '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
+              },
+            }
+          ),
+          commands: [
+            'curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-{config.kibana.version}-x86_64.rpm',
+            'sudo rpm -vi metricbeat-{config.kibana.version}-x86_64.rpm',
+          ],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.debTextPost',
+            {
+              defaultMessage: 'Looking for the 32-bit packages? See the [Download page]({link}).',
+              values: { link: 'https://www.elastic.co/downloads/beats/metricbeat' },
+            }
+          ),
+        },
+        WINDOWS: {
+          title: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.windowsTitle',
+            {
+              defaultMessage: 'Download and install Metricbeat',
+            }
+          ),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.windowsTextPre',
+            {
+              defaultMessage:
+                'First time using Metricbeat? See the [Quick Start]({metricbeatLink}).\n\
  1. Download the Metricbeat Windows zip file from the [Download]({elasticLink}) page.\n\
  2. Extract the contents of the zip file into {folderPath}.\n\
  3. Rename the {directoryName} directory to `Metricbeat`.\n\
  4. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select \
 **Run As Administrator**). If you are running Windows XP, you might need to download and install PowerShell.\n\
  5. From the PowerShell prompt, run the following commands to install Metricbeat as a Windows service.',
-            values: {
-              directoryName: '`metricbeat-{config.kibana.version}-windows`',
-              folderPath: '`C:\\Program Files`',
-              metricbeatLink:
-                '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
-              elasticLink: 'https://www.elastic.co/downloads/beats/metricbeat',
-            },
-          }
-        ),
-        commands: ['cd "C:\\Program Files\\Metricbeat"', '.\\install-service-metricbeat.ps1'],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.install.windowsTextPost',
-          {
-            defaultMessage:
-              'Modify the settings under `output.elasticsearch` in the {path} file to point to your Elasticsearch installation.',
-            values: { path: '`C:\\Program Files\\Metricbeat\\metricbeat.yml`' },
-          }
-        ),
+              values: {
+                directoryName: '`metricbeat-{config.kibana.version}-windows`',
+                folderPath: '`C:\\Program Files`',
+                metricbeatLink:
+                  '{config.docs.beats.metricbeat}/metricbeat-installation-configuration.html',
+                elasticLink: 'https://www.elastic.co/downloads/beats/metricbeat',
+              },
+            }
+          ),
+          commands: ['cd "C:\\Program Files\\Metricbeat"', '.\\install-service-metricbeat.ps1'],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.install.windowsTextPost',
+            {
+              defaultMessage:
+                'Modify the settings under `output.elasticsearch` in the {path} file to point to your Elasticsearch installation.',
+              values: { path: '`C:\\Program Files\\Metricbeat\\metricbeat.yml`' },
+            }
+          ),
+        },
       },
-    },
-    START: {
-      OSX: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.osxTitle', {
-          defaultMessage: 'Start Metricbeat',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.start.osxTextPre', {
-          defaultMessage:
-            'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
-        }),
-        commands: ['./metricbeat setup', './metricbeat -e'],
-      },
-      DEB: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.debTitle', {
-          defaultMessage: 'Start Metricbeat',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.start.debTextPre', {
-          defaultMessage:
-            'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
-        }),
-        commands: ['sudo metricbeat setup', 'sudo service metricbeat start'],
-      },
-      RPM: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.rpmTitle', {
-          defaultMessage: 'Start Metricbeat',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.start.rpmTextPre', {
-          defaultMessage:
-            'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
-        }),
-        commands: ['sudo metricbeat setup', 'sudo service metricbeat start'],
-      },
-      WINDOWS: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.windowsTitle', {
-          defaultMessage: 'Start Metricbeat',
-        }),
-        textPre: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.start.windowsTextPre',
-          {
+      START: {
+        OSX: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.osxTitle', {
+            defaultMessage: 'Start Metricbeat',
+          }),
+          textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.start.osxTextPre', {
             defaultMessage:
               'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
-          }
-        ),
-        commands: ['.\\metricbeat.exe setup', 'Start-Service metricbeat'],
-      },
-    },
-    CONFIG: {
-      OSX: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.osxTitle', {
-          defaultMessage: 'Edit the configuration',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.config.osxTextPre', {
-          defaultMessage: 'Modify {path} to set the connection information:',
-          values: {
-            path: '`metricbeat.yml`',
-          },
-        }),
-        commands: [
-          'output.elasticsearch:',
-          '  hosts: ["<es_url>"]',
-          '  username: "elastic"',
-          '  password: "<password>"',
-          "  # If using Elasticsearch's default certificate",
-          '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
-          'setup.kibana:',
-          '  host: "<kibana_url>"',
-          getSpaceIdForBeatsTutorial(context),
-        ],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.config.osxTextPostMarkdown',
-          {
+          }),
+          commands: ['./metricbeat setup', './metricbeat -e'],
+        },
+        DEB: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.debTitle', {
+            defaultMessage: 'Start Metricbeat',
+          }),
+          textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.start.debTextPre', {
             defaultMessage:
-              'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
+              'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
+          }),
+          commands: ['sudo metricbeat setup', 'sudo service metricbeat start'],
+        },
+        RPM: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.rpmTitle', {
+            defaultMessage: 'Start Metricbeat',
+          }),
+          textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.start.rpmTextPre', {
+            defaultMessage:
+              'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
+          }),
+          commands: ['sudo metricbeat setup', 'sudo service metricbeat start'],
+        },
+        WINDOWS: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.start.windowsTitle', {
+            defaultMessage: 'Start Metricbeat',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.start.windowsTextPre',
+            {
+              defaultMessage:
+                'The `setup` command loads the Kibana dashboards. If the dashboards are already set up, omit this command.',
+            }
+          ),
+          commands: ['.\\metricbeat.exe setup', 'Start-Service metricbeat'],
+        },
+      },
+      CONFIG: {
+        OSX: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.osxTitle', {
+            defaultMessage: 'Edit the configuration',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.osxTextPre',
+            {
+              defaultMessage: 'Modify {path} to set the connection information:',
+              values: {
+                path: '`metricbeat.yml`',
+              },
+            }
+          ),
+          commands: [
+            'output.elasticsearch:',
+            '  hosts: ["<es_url>"]',
+            '  username: "elastic"',
+            '  password: "<password>"',
+            "  # If using Elasticsearch's default certificate",
+            '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
+            'setup.kibana:',
+            '  host: "<kibana_url>"',
+            spaceId,
+          ],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.osxTextPostMarkdown',
+            {
+              defaultMessage:
+                'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
               Elasticsearch, and {kibanaUrlTemplate} is the URL of Kibana. To [configure SSL]({configureSslUrl}) with the \
               default certificate generated by Elasticsearch, add its fingerprint in {esCertFingerprintTemplate}.\n\n\
   > **_Important:_**  Do not use the built-in `elastic` user to secure clients in a production environment. Instead set up \
   authorized users or API keys, and do not expose passwords in configuration files. [Learn more]({linkUrl}).',
-            values: {
-              passwordTemplate: '`<password>`',
-              esUrlTemplate: '`<es_url>`',
-              kibanaUrlTemplate: '`<kibana_url>`',
-              configureSslUrl: SSL_DOC_URL,
-              esCertFingerprintTemplate: '`<es cert fingerprint>`',
-              linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
-            },
-          }
-        ),
-      },
-      DEB: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.debTitle', {
-          defaultMessage: 'Edit the configuration',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.config.debTextPre', {
-          defaultMessage: 'Modify {path} to set the connection information:',
-          values: {
-            path: '`/etc/metricbeat/metricbeat.yml`',
-          },
-        }),
-        commands: [
-          'output.elasticsearch:',
-          '  hosts: ["<es_url>"]',
-          '  username: "elastic"',
-          '  password: "<password>"',
-          "  # If using Elasticsearch's default certificate",
-          '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
-          'setup.kibana:',
-          '  host: "<kibana_url>"',
-          getSpaceIdForBeatsTutorial(context),
-        ],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.config.debTextPostMarkdown',
-          {
-            defaultMessage:
-              'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
+              values: {
+                passwordTemplate: '`<password>`',
+                esUrlTemplate: '`<es_url>`',
+                kibanaUrlTemplate: '`<kibana_url>`',
+                configureSslUrl: SSL_DOC_URL,
+                esCertFingerprintTemplate: '`<es cert fingerprint>`',
+                linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
+              },
+            }
+          ),
+        },
+        DEB: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.debTitle', {
+            defaultMessage: 'Edit the configuration',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.debTextPre',
+            {
+              defaultMessage: 'Modify {path} to set the connection information:',
+              values: {
+                path: '`/etc/metricbeat/metricbeat.yml`',
+              },
+            }
+          ),
+          commands: [
+            'output.elasticsearch:',
+            '  hosts: ["<es_url>"]',
+            '  username: "elastic"',
+            '  password: "<password>"',
+            "  # If using Elasticsearch's default certificate",
+            '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
+            'setup.kibana:',
+            '  host: "<kibana_url>"',
+            spaceId,
+          ],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.debTextPostMarkdown',
+            {
+              defaultMessage:
+                'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
               Elasticsearch, and {kibanaUrlTemplate} is the URL of Kibana. To [configure SSL]({configureSslUrl}) with the \
               default certificate generated by Elasticsearch, add its fingerprint in {esCertFingerprintTemplate}.\n\n\
   > **_Important:_**  Do not use the built-in `elastic` user to secure clients in a production environment. Instead set up \
   authorized users or API keys, and do not expose passwords in configuration files. [Learn more]({linkUrl}).',
-            values: {
-              passwordTemplate: '`<password>`',
-              esUrlTemplate: '`<es_url>`',
-              kibanaUrlTemplate: '`<kibana_url>`',
-              configureSslUrl: SSL_DOC_URL,
-              esCertFingerprintTemplate: '`<es cert fingerprint>`',
-              linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
-            },
-          }
-        ),
-      },
-      RPM: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.rpmTitle', {
-          defaultMessage: 'Edit the configuration',
-        }),
-        textPre: i18n.translate('home.tutorials.common.metricbeatInstructions.config.rpmTextPre', {
-          defaultMessage: 'Modify {path} to set the connection information:',
-          values: {
-            path: '`/etc/metricbeat/metricbeat.yml`',
-          },
-        }),
-        commands: [
-          'output.elasticsearch:',
-          '  hosts: ["<es_url>"]',
-          '  username: "elastic"',
-          '  password: "<password>"',
-          "  # If using Elasticsearch's default certificate",
-          '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
-          'setup.kibana:',
-          '  host: "<kibana_url>"',
-          getSpaceIdForBeatsTutorial(context),
-        ],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.config.rpmTextPostMarkdown',
-          {
-            defaultMessage:
-              'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
+              values: {
+                passwordTemplate: '`<password>`',
+                esUrlTemplate: '`<es_url>`',
+                kibanaUrlTemplate: '`<kibana_url>`',
+                configureSslUrl: SSL_DOC_URL,
+                esCertFingerprintTemplate: '`<es cert fingerprint>`',
+                linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
+              },
+            }
+          ),
+        },
+        RPM: {
+          title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.rpmTitle', {
+            defaultMessage: 'Edit the configuration',
+          }),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.rpmTextPre',
+            {
+              defaultMessage: 'Modify {path} to set the connection information:',
+              values: {
+                path: '`/etc/metricbeat/metricbeat.yml`',
+              },
+            }
+          ),
+          commands: [
+            'output.elasticsearch:',
+            '  hosts: ["<es_url>"]',
+            '  username: "elastic"',
+            '  password: "<password>"',
+            "  # If using Elasticsearch's default certificate",
+            '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
+            'setup.kibana:',
+            '  host: "<kibana_url>"',
+            spaceId,
+          ],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.rpmTextPostMarkdown',
+            {
+              defaultMessage:
+                'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
               Elasticsearch, and {kibanaUrlTemplate} is the URL of Kibana. To [configure SSL]({configureSslUrl}) with the \
               default certificate generated by Elasticsearch, add its fingerprint in {esCertFingerprintTemplate}.\n\n\
   > **_Important:_**  Do not use the built-in `elastic` user to secure clients in a production environment. Instead set up \
   authorized users or API keys, and do not expose passwords in configuration files. [Learn more]({linkUrl}).',
-            values: {
-              passwordTemplate: '`<password>`',
-              esUrlTemplate: '`<es_url>`',
-              kibanaUrlTemplate: '`<kibana_url>`',
-              configureSslUrl: SSL_DOC_URL,
-              esCertFingerprintTemplate: '`<es cert fingerprint>`',
-              linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
-            },
-          }
-        ),
-      },
-      WINDOWS: {
-        title: i18n.translate('home.tutorials.common.metricbeatInstructions.config.windowsTitle', {
-          defaultMessage: 'Edit the configuration',
-        }),
-        textPre: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.config.windowsTextPre',
-          {
-            defaultMessage: 'Modify {path} to set the connection information:',
-            values: {
-              path: '`C:\\Program Files\\Metricbeat\\metricbeat.yml`',
-            },
-          }
-        ),
-        commands: [
-          'output.elasticsearch:',
-          '  hosts: ["<es_url>"]',
-          '  username: "elastic"',
-          '  password: "<password>"',
-          "  # If using Elasticsearch's default certificate",
-          '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
-          'setup.kibana:',
-          '  host: "<kibana_url>"',
-          getSpaceIdForBeatsTutorial(context),
-        ],
-        textPost: i18n.translate(
-          'home.tutorials.common.metricbeatInstructions.config.windowsTextPostMarkdown',
-          {
-            defaultMessage:
-              'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
+              values: {
+                passwordTemplate: '`<password>`',
+                esUrlTemplate: '`<es_url>`',
+                kibanaUrlTemplate: '`<kibana_url>`',
+                configureSslUrl: SSL_DOC_URL,
+                esCertFingerprintTemplate: '`<es cert fingerprint>`',
+                linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
+              },
+            }
+          ),
+        },
+        WINDOWS: {
+          title: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.windowsTitle',
+            {
+              defaultMessage: 'Edit the configuration',
+            }
+          ),
+          textPre: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.windowsTextPre',
+            {
+              defaultMessage: 'Modify {path} to set the connection information:',
+              values: {
+                path: '`C:\\Program Files\\Metricbeat\\metricbeat.yml`',
+              },
+            }
+          ),
+          commands: [
+            'output.elasticsearch:',
+            '  hosts: ["<es_url>"]',
+            '  username: "elastic"',
+            '  password: "<password>"',
+            "  # If using Elasticsearch's default certificate",
+            '  ssl.ca_trusted_fingerprint: "<es cert fingerprint>"',
+            'setup.kibana:',
+            '  host: "<kibana_url>"',
+            spaceId,
+          ],
+          textPost: i18n.translate(
+            'home.tutorials.common.metricbeatInstructions.config.windowsTextPostMarkdown',
+            {
+              defaultMessage:
+                'Where {passwordTemplate} is the password of the `elastic` user, {esUrlTemplate} is the URL of \
               Elasticsearch, and {kibanaUrlTemplate} is the URL of Kibana. To [configure SSL]({configureSslUrl}) with the \
               default certificate generated by Elasticsearch, add its fingerprint in {esCertFingerprintTemplate}.\n\n\
   > **_Important:_**  Do not use the built-in `elastic` user to secure clients in a production environment. Instead set up \
   authorized users or API keys, and do not expose passwords in configuration files. [Learn more]({linkUrl}).',
-            values: {
-              passwordTemplate: '`<password>`',
-              esUrlTemplate: '`<es_url>`',
-              kibanaUrlTemplate: '`<kibana_url>`',
-              configureSslUrl: SSL_DOC_URL,
-              esCertFingerprintTemplate: '`<es cert fingerprint>`',
-              linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
-            },
-          }
-        ),
+              values: {
+                passwordTemplate: '`<password>`',
+                esUrlTemplate: '`<es_url>`',
+                kibanaUrlTemplate: '`<kibana_url>`',
+                configureSslUrl: SSL_DOC_URL,
+                esCertFingerprintTemplate: '`<es cert fingerprint>`',
+                linkUrl: '{config.docs.beats.metricbeat}/securing-metricbeat.html',
+              },
+            }
+          ),
+        },
       },
-    },
-  };
-};
+    };
+  },
+  // key resolver based on the context keys effectively used
+  (context: TutorialContext) => {
+    return `${context.kibanaBranch}|${context.spaceId ?? 'default'}`;
+  }
+);
 
-export const createMetricbeatCloudInstructions = () => ({
+export const createMetricbeatCloudInstructions = memoize(() => ({
   CONFIG: {
     OSX: {
       title: i18n.translate('home.tutorials.common.metricbeatCloudInstructions.config.osxTitle', {
@@ -400,7 +431,7 @@ export const createMetricbeatCloudInstructions = () => ({
       textPost: cloudPasswordAndResetLink,
     },
   },
-});
+}));
 
 export function metricbeatEnableInstructions(moduleName: string) {
   return {
@@ -498,6 +529,7 @@ export function metricbeatStatusCheck(moduleName: string) {
 
 export function onPremInstructions(moduleName: string, context: TutorialContext) {
   const METRICBEAT_INSTRUCTIONS = createMetricbeatInstructions(context);
+  const METRICBEAT_ENABLE_INSTRUCTIONS = metricbeatEnableInstructions(moduleName);
 
   return {
     instructionSets: [
@@ -514,7 +546,7 @@ export function onPremInstructions(moduleName: string, context: TutorialContext)
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.OSX,
               METRICBEAT_INSTRUCTIONS.CONFIG.OSX,
-              metricbeatEnableInstructions(moduleName).OSX,
+              METRICBEAT_ENABLE_INSTRUCTIONS.OSX,
               METRICBEAT_INSTRUCTIONS.START.OSX,
             ],
           },
@@ -523,7 +555,7 @@ export function onPremInstructions(moduleName: string, context: TutorialContext)
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.DEB,
               METRICBEAT_INSTRUCTIONS.CONFIG.DEB,
-              metricbeatEnableInstructions(moduleName).DEB,
+              METRICBEAT_ENABLE_INSTRUCTIONS.DEB,
               METRICBEAT_INSTRUCTIONS.START.DEB,
             ],
           },
@@ -532,7 +564,7 @@ export function onPremInstructions(moduleName: string, context: TutorialContext)
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.RPM,
               METRICBEAT_INSTRUCTIONS.CONFIG.RPM,
-              metricbeatEnableInstructions(moduleName).RPM,
+              METRICBEAT_ENABLE_INSTRUCTIONS.RPM,
               METRICBEAT_INSTRUCTIONS.START.RPM,
             ],
           },
@@ -541,7 +573,7 @@ export function onPremInstructions(moduleName: string, context: TutorialContext)
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.WINDOWS,
               METRICBEAT_INSTRUCTIONS.CONFIG.WINDOWS,
-              metricbeatEnableInstructions(moduleName).WINDOWS,
+              METRICBEAT_ENABLE_INSTRUCTIONS.WINDOWS,
               METRICBEAT_INSTRUCTIONS.START.WINDOWS,
             ],
           },
@@ -556,6 +588,7 @@ export function onPremCloudInstructions(moduleName: string, context: TutorialCon
   const TRYCLOUD_OPTION1 = createTrycloudOption1();
   const TRYCLOUD_OPTION2 = createTrycloudOption2();
   const METRICBEAT_INSTRUCTIONS = createMetricbeatInstructions(context);
+  const METRICBEAT_ENABLE_INSTRUCTIONS = metricbeatEnableInstructions(moduleName);
 
   return {
     instructionSets: [
@@ -574,7 +607,7 @@ export function onPremCloudInstructions(moduleName: string, context: TutorialCon
               TRYCLOUD_OPTION2,
               METRICBEAT_INSTRUCTIONS.INSTALL.OSX,
               METRICBEAT_INSTRUCTIONS.CONFIG.OSX,
-              metricbeatEnableInstructions(moduleName).OSX,
+              METRICBEAT_ENABLE_INSTRUCTIONS.OSX,
               METRICBEAT_INSTRUCTIONS.START.OSX,
             ],
           },
@@ -585,7 +618,7 @@ export function onPremCloudInstructions(moduleName: string, context: TutorialCon
               TRYCLOUD_OPTION2,
               METRICBEAT_INSTRUCTIONS.INSTALL.DEB,
               METRICBEAT_INSTRUCTIONS.CONFIG.DEB,
-              metricbeatEnableInstructions(moduleName).DEB,
+              METRICBEAT_ENABLE_INSTRUCTIONS.DEB,
               METRICBEAT_INSTRUCTIONS.START.DEB,
             ],
           },
@@ -596,7 +629,7 @@ export function onPremCloudInstructions(moduleName: string, context: TutorialCon
               TRYCLOUD_OPTION2,
               METRICBEAT_INSTRUCTIONS.INSTALL.RPM,
               METRICBEAT_INSTRUCTIONS.CONFIG.RPM,
-              metricbeatEnableInstructions(moduleName).RPM,
+              METRICBEAT_ENABLE_INSTRUCTIONS.RPM,
               METRICBEAT_INSTRUCTIONS.START.RPM,
             ],
           },
@@ -607,7 +640,7 @@ export function onPremCloudInstructions(moduleName: string, context: TutorialCon
               TRYCLOUD_OPTION2,
               METRICBEAT_INSTRUCTIONS.INSTALL.WINDOWS,
               METRICBEAT_INSTRUCTIONS.CONFIG.WINDOWS,
-              metricbeatEnableInstructions(moduleName).WINDOWS,
+              METRICBEAT_ENABLE_INSTRUCTIONS.WINDOWS,
               METRICBEAT_INSTRUCTIONS.START.WINDOWS,
             ],
           },
@@ -621,6 +654,7 @@ export function onPremCloudInstructions(moduleName: string, context: TutorialCon
 export function cloudInstructions(moduleName: string, context: TutorialContext) {
   const METRICBEAT_INSTRUCTIONS = createMetricbeatInstructions(context);
   const METRICBEAT_CLOUD_INSTRUCTIONS = createMetricbeatCloudInstructions();
+  const METRICBEAT_ENABLE_INSTRUCTIONS = metricbeatEnableInstructions(moduleName);
 
   return {
     instructionSets: [
@@ -637,7 +671,7 @@ export function cloudInstructions(moduleName: string, context: TutorialContext) 
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.OSX,
               METRICBEAT_CLOUD_INSTRUCTIONS.CONFIG.OSX,
-              metricbeatEnableInstructions(moduleName).OSX,
+              METRICBEAT_ENABLE_INSTRUCTIONS.OSX,
               METRICBEAT_INSTRUCTIONS.START.OSX,
             ],
           },
@@ -646,7 +680,7 @@ export function cloudInstructions(moduleName: string, context: TutorialContext) 
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.DEB,
               METRICBEAT_CLOUD_INSTRUCTIONS.CONFIG.DEB,
-              metricbeatEnableInstructions(moduleName).DEB,
+              METRICBEAT_ENABLE_INSTRUCTIONS.DEB,
               METRICBEAT_INSTRUCTIONS.START.DEB,
             ],
           },
@@ -655,7 +689,7 @@ export function cloudInstructions(moduleName: string, context: TutorialContext) 
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.RPM,
               METRICBEAT_CLOUD_INSTRUCTIONS.CONFIG.RPM,
-              metricbeatEnableInstructions(moduleName).RPM,
+              METRICBEAT_ENABLE_INSTRUCTIONS.RPM,
               METRICBEAT_INSTRUCTIONS.START.RPM,
             ],
           },
@@ -664,7 +698,7 @@ export function cloudInstructions(moduleName: string, context: TutorialContext) 
             instructions: [
               METRICBEAT_INSTRUCTIONS.INSTALL.WINDOWS,
               METRICBEAT_CLOUD_INSTRUCTIONS.CONFIG.WINDOWS,
-              metricbeatEnableInstructions(moduleName).WINDOWS,
+              METRICBEAT_ENABLE_INSTRUCTIONS.WINDOWS,
               METRICBEAT_INSTRUCTIONS.START.WINDOWS,
             ],
           },

--- a/src/plugins/home/server/tutorials/instructions/onprem_cloud_instructions.ts
+++ b/src/plugins/home/server/tutorials/instructions/onprem_cloud_instructions.ts
@@ -6,9 +6,10 @@
  * Side Public License, v 1.
  */
 
+import { memoize } from 'lodash';
 import { i18n } from '@kbn/i18n';
 
-export const createTrycloudOption1 = () => ({
+export const createTrycloudOption1 = memoize(() => ({
   title: i18n.translate('home.tutorials.common.premCloudInstructions.option1.title', {
     defaultMessage: 'Option 1: Try in Elastic Cloud',
   }),
@@ -27,9 +28,9 @@ To create a cluster, in Elastic Cloud console:\n\
       link: 'https://www.elastic.co/cloud/as-a-service/signup?blade=kib',
     },
   }),
-});
+}));
 
-export const createTrycloudOption2 = () => ({
+export const createTrycloudOption2 = memoize(() => ({
   title: i18n.translate('home.tutorials.common.premCloudInstructions.option2.title', {
     defaultMessage: 'Option 2: Connect local Kibana to a Cloud instance',
   }),
@@ -43,4 +44,4 @@ Save the **Elasticsearch** endpoint as {urlTemplate} and the cluster **Password*
       passwordTemplate: '`<password>`',
     },
   }),
-});
+}));


### PR DESCRIPTION
## Summary

We're spending ~200ms (on benchmark machine) in the `start` lifecycle of the `home` plugin.

After some investigations, this time is spent evaluating the tutorial providers, here:

https://github.com/elastic/kibana/blob/c713b91e661f18986429da59c750a144333c5d13/src/plugins/home/server/services/tutorials/tutorials_registry.ts#L140-L143

A significant amount of time and GC cycles are spent generating the various instructions for all those tutorials. 

I feel like the proper solution would be to have those instructions (`TutorialSchema.onPrem`, `TutorialSchema.elasticCloud` and `TutorialSchema.onPremElasticCloud`) living on the browser-side only (given the server don't really need to know about them), however doing it would imply some serious refactoring (especially to handle externally-registered tutorials..), so for now this PR just adds some cache, reducing those `200ms` to around `110ms`, so almost in half
