### PR TITLE
[Infra] Fix breakdown config to host view charts

### DIFF
--- a/x-pack/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/disk.ts
+++ b/x-pack/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/disk.ts
@@ -49,7 +49,7 @@ const diskThroughputReadWrite: LensConfigWithId = {
 };
 
 const diskUsageByMountPoint: LensConfigWithId = {
-  id: 'DiskUsageByMountPoint',
+  id: 'diskUsageByMountPoint',
   chartType: 'xy',
   title: i18n.translate('xpack.metricsData.assetDetails.metricsCharts.diskUsageByMountingPoint', {
     defaultMessage: 'Disk Usage by Mount Point',

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/components/kpis/host_kpi_charts.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/components/kpis/host_kpi_charts.tsx
@@ -9,10 +9,8 @@ import React from 'react';
 import { EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { Filter, Query, TimeRange } from '@kbn/es-query';
-import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
-import useAsync from 'react-use/lib/useAsync';
-import { i18n } from '@kbn/i18n';
 import { Kpi } from './kpi';
+import { useHostKpiCharts } from '../../hooks/use_metrics_charts';
 
 export interface HostKpiChartsProps {
   dataView?: DataView;
@@ -36,34 +34,13 @@ export const HostKpiCharts = ({
   loading = false,
 }: HostKpiChartsProps) => {
   const { euiTheme } = useEuiTheme();
-
-  const { value: charts = [] } = useAsync(async () => {
-    const model = findInventoryModel('host');
-    const { cpu, disk, memory } = await model.metrics.getCharts();
-
-    return [
-      cpu.metric.cpuUsage,
-      cpu.metric.normalizedLoad1m,
-      memory.metric.memoryUsage,
-      disk.metric.diskUsage,
-    ].map((chart) => ({
-      ...chart,
+  const charts = useHostKpiCharts({
+    dataViewId: dataView?.id,
+    options: {
+      subtitle: options?.subtitle,
       seriesColor: euiTheme.colors.lightestShade,
-      decimals: 1,
-      subtitle:
-        options?.subtitle ??
-        i18n.translate('xpack.infra.assetDetails.kpi.subtitle.average', {
-          defaultMessage: 'Average',
-        }),
-      ...(dataView?.id
-        ? {
-            dataset: {
-              index: dataView.id,
-            },
-          }
-        : {}),
-    }));
-  }, [dataView?.id, euiTheme.colors.lightestShade, options?.subtitle]);
+    },
+  });
 
   return (
     <>

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.test.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.test.ts
@@ -17,7 +17,7 @@ import {
 const metricsDataViewId = 'metricsDataViewId';
 const logsDataViewId = 'logsDataViewId';
 
-describe('useFlyoutMetricsCharts', () => {
+describe('useHostFlyoutViewMetricsCharts', () => {
   it('should return an array of charts with correct order', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useHostFlyoutViewMetricsCharts({ metricsDataViewId, logsDataViewId })
@@ -55,7 +55,7 @@ describe('useFlyoutMetricsCharts', () => {
   });
 });
 
-describe('useHostMetricsCharts', () => {
+describe('useHostPageViewMetricsCharts', () => {
   it('should return an array of charts with correct order', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useHostPageViewMetricsCharts({ metricsDataViewId, logsDataViewId })
@@ -96,7 +96,7 @@ describe('useHostMetricsCharts', () => {
   });
 });
 
-describe('useKubernetesMetricsCharts', () => {
+describe('useKubernetesSectionMetricsCharts', () => {
   it('should return an array of charts with correct order', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useKubernetesSectionMetricsCharts({ metricsDataViewId })

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.test.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import type { LensXYConfig } from '@kbn/lens-embeddable-utils/config_builder';
+import {
+  useFlyoutMetricsCharts,
+  useHostKpiCharts,
+  useHostMetricsCharts,
+  useKubernetesMetricsCharts,
+} from './use_metrics_charts';
+
+const metricsDataViewId = 'metricsDataViewId';
+const logsDataViewId = 'logsDataViewId';
+
+describe('useFlyoutMetricsCharts', () => {
+  it('should return an array of charts with correct order', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlyoutMetricsCharts({ metricsDataViewId, logsDataViewId })
+    );
+    await waitForNextUpdate();
+
+    const expectedOrder = [
+      'cpuUsage',
+      'memoryUsage',
+      'normalizedLoad1m',
+      'logRate',
+      'diskSpaceUsageAvailable',
+      'diskUsageByMountPoint',
+      'diskThroughputReadWrite',
+      'diskIOReadWrite',
+      'rxTx',
+    ];
+
+    expect(result.current).toHaveLength(expectedOrder.length);
+
+    result.current.forEach((chart, index) => {
+      expect(chart).toHaveProperty('id', expectedOrder[index]);
+    });
+  });
+
+  it('should return a chart with id "logRate" using the logsDataViewId', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlyoutMetricsCharts({ metricsDataViewId, logsDataViewId })
+    );
+    await waitForNextUpdate();
+
+    const logRateChart = result.current.find((chart) => chart.id === 'logRate') as LensXYConfig;
+    expect(logRateChart).toBeDefined();
+    expect(logRateChart.dataset).toHaveProperty('index', logsDataViewId);
+  });
+});
+
+describe('useHostMetricsCharts', () => {
+  it('should return an array of charts with correct order', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useHostMetricsCharts({ metricsDataViewId, logsDataViewId })
+    );
+    await waitForNextUpdate();
+
+    const expectedOrder = [
+      'cpuUsage',
+      'cpuUsageBreakdown',
+      'memoryUsage',
+      'memoryUsageBreakdown',
+      'normalizedLoad1m',
+      'loadBreakdown',
+      'logRate',
+      'diskSpaceUsageAvailable',
+      'diskUsageByMountPoint',
+      'diskThroughputReadWrite',
+      'diskIOReadWrite',
+      'rxTx',
+    ];
+
+    expect(result.current).toHaveLength(expectedOrder.length);
+
+    result.current.forEach((chart, index) => {
+      expect(chart).toHaveProperty('id', expectedOrder[index]);
+    });
+  });
+
+  it('should return a chart with id "logRate" using the logsDataViewId', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useHostMetricsCharts({ metricsDataViewId, logsDataViewId })
+    );
+    await waitForNextUpdate();
+
+    const logRateChart = result.current.find((chart) => chart.id === 'logRate') as LensXYConfig;
+    expect(logRateChart).toBeDefined();
+    expect(logRateChart.dataset).toHaveProperty('index', logsDataViewId);
+  });
+});
+
+describe('useKubernetesMetricsCharts', () => {
+  it('should return an array of charts with correct order', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useKubernetesMetricsCharts({ metricsDataViewId })
+    );
+    await waitForNextUpdate();
+
+    const expectedOrder = [
+      'nodeCpuCapacity',
+      'nodeMemoryCapacity',
+      'nodeDiskCapacity',
+      'nodePodCapacity',
+    ];
+
+    expect(result.current).toHaveLength(expectedOrder.length);
+
+    result.current.forEach((chart, index) => {
+      expect(chart).toHaveProperty('id', expectedOrder[index]);
+    });
+  });
+});
+
+describe('useHostKpiCharts', () => {
+  it('should return an array of charts with correct order', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useHostKpiCharts({ dataViewId: metricsDataViewId })
+    );
+    await waitForNextUpdate();
+
+    const expectedOrder = ['cpuUsage', 'normalizedLoad1m', 'memoryUsage', 'diskUsage'];
+
+    expect(result.current).toHaveLength(expectedOrder.length);
+
+    result.current.forEach((chart, index) => {
+      expect(chart).toHaveProperty('id', expectedOrder[index]);
+      expect(chart).toHaveProperty('subtitle', 'Average');
+      expect(chart).toHaveProperty('decimals', 1);
+    });
+  });
+
+  it('should return an array of charts with correct options', async () => {
+    const options = {
+      seriesColor: 'blue',
+      subtitle: 'Custom Subtitle',
+    };
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useHostKpiCharts({ dataViewId: metricsDataViewId, options })
+    );
+    await waitForNextUpdate();
+
+    expect(result.current).toHaveLength(4);
+
+    result.current.forEach((chart) => {
+      expect(chart).toHaveProperty('seriesColor', options.seriesColor);
+      expect(chart).toHaveProperty('subtitle', options.subtitle);
+    });
+  });
+});

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.test.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.test.ts
@@ -8,10 +8,10 @@
 import { renderHook } from '@testing-library/react-hooks';
 import type { LensXYConfig } from '@kbn/lens-embeddable-utils/config_builder';
 import {
-  useFlyoutMetricsCharts,
+  useHostFlyoutViewMetricsCharts,
   useHostKpiCharts,
-  useHostMetricsCharts,
-  useKubernetesMetricsCharts,
+  useHostPageViewMetricsCharts,
+  useKubernetesSectionMetricsCharts,
 } from './use_metrics_charts';
 
 const metricsDataViewId = 'metricsDataViewId';
@@ -20,7 +20,7 @@ const logsDataViewId = 'logsDataViewId';
 describe('useFlyoutMetricsCharts', () => {
   it('should return an array of charts with correct order', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFlyoutMetricsCharts({ metricsDataViewId, logsDataViewId })
+      useHostFlyoutViewMetricsCharts({ metricsDataViewId, logsDataViewId })
     );
     await waitForNextUpdate();
 
@@ -45,7 +45,7 @@ describe('useFlyoutMetricsCharts', () => {
 
   it('should return a chart with id "logRate" using the logsDataViewId', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFlyoutMetricsCharts({ metricsDataViewId, logsDataViewId })
+      useHostFlyoutViewMetricsCharts({ metricsDataViewId, logsDataViewId })
     );
     await waitForNextUpdate();
 
@@ -58,7 +58,7 @@ describe('useFlyoutMetricsCharts', () => {
 describe('useHostMetricsCharts', () => {
   it('should return an array of charts with correct order', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
-      useHostMetricsCharts({ metricsDataViewId, logsDataViewId })
+      useHostPageViewMetricsCharts({ metricsDataViewId, logsDataViewId })
     );
     await waitForNextUpdate();
 
@@ -86,7 +86,7 @@ describe('useHostMetricsCharts', () => {
 
   it('should return a chart with id "logRate" using the logsDataViewId', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
-      useHostMetricsCharts({ metricsDataViewId, logsDataViewId })
+      useHostPageViewMetricsCharts({ metricsDataViewId, logsDataViewId })
     );
     await waitForNextUpdate();
 
@@ -99,7 +99,7 @@ describe('useHostMetricsCharts', () => {
 describe('useKubernetesMetricsCharts', () => {
   it('should return an array of charts with correct order', async () => {
     const { result, waitForNextUpdate } = renderHook(() =>
-      useKubernetesMetricsCharts({ metricsDataViewId })
+      useKubernetesSectionMetricsCharts({ metricsDataViewId })
     );
     await waitForNextUpdate();
 

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
 import useAsync from 'react-use/lib/useAsync';
 
-export const useFlyoutMetricsCharts = ({
+export const useHostFlyoutViewMetricsCharts = ({
   metricsDataViewId,
   logsDataViewId,
 }: {
@@ -47,7 +47,7 @@ export const useFlyoutMetricsCharts = ({
   return charts;
 };
 
-export const useHostMetricsCharts = ({
+export const useHostPageViewMetricsCharts = ({
   metricsDataViewId,
   logsDataViewId,
 }: {
@@ -88,7 +88,7 @@ export const useHostMetricsCharts = ({
   return charts;
 };
 
-export const useKubernetesMetricsCharts = ({
+export const useKubernetesSectionMetricsCharts = ({
   metricsDataViewId,
 }: {
   metricsDataViewId?: string;

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_metrics_charts.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
+import useAsync from 'react-use/lib/useAsync';
+
+export const useFlyoutMetricsCharts = ({
+  metricsDataViewId,
+  logsDataViewId,
+}: {
+  metricsDataViewId?: string;
+  logsDataViewId?: string;
+}) => {
+  const model = findInventoryModel('host');
+
+  const { value: charts = [] } = useAsync(async () => {
+    const { cpu, disk, memory, network, logs } = await model.metrics.getCharts();
+
+    return [
+      cpu.xy.cpuUsage,
+      memory.xy.memoryUsage,
+      cpu.xy.normalizedLoad1m,
+      logs.xy.logRate,
+      disk.xy.diskSpaceUsageAvailable,
+      disk.xy.diskUsageByMountPoint,
+      disk.xy.diskThroughputReadWrite,
+      disk.xy.diskIOReadWrite,
+      network.xy.rxTx,
+    ].map((chart) => {
+      const dataViewId = chart.id === 'logRate' ? logsDataViewId : metricsDataViewId;
+      return {
+        ...chart,
+        ...(dataViewId && {
+          dataset: {
+            index: dataViewId,
+          },
+        }),
+      };
+    });
+  }, [metricsDataViewId, logsDataViewId]);
+
+  return charts;
+};
+
+export const useHostMetricsCharts = ({
+  metricsDataViewId,
+  logsDataViewId,
+}: {
+  metricsDataViewId?: string;
+  logsDataViewId?: string;
+}) => {
+  const model = findInventoryModel('host');
+
+  const { value: charts = [] } = useAsync(async () => {
+    const { cpu, disk, memory, network, logs } = await model.metrics.getCharts();
+
+    return [
+      cpu.xy.cpuUsage,
+      cpu.xy.cpuUsageBreakdown,
+      memory.xy.memoryUsage,
+      memory.xy.memoryUsageBreakdown,
+      cpu.xy.normalizedLoad1m,
+      cpu.xy.loadBreakdown,
+      logs.xy.logRate,
+      disk.xy.diskSpaceUsageAvailable,
+      disk.xy.diskUsageByMountPoint,
+      disk.xy.diskThroughputReadWrite,
+      disk.xy.diskIOReadWrite,
+      network.xy.rxTx,
+    ].map((chart) => {
+      const dataViewId = chart.id === 'logRate' ? logsDataViewId : metricsDataViewId;
+      return {
+        ...chart,
+        ...(dataViewId && {
+          dataset: {
+            index: dataViewId,
+          },
+        }),
+      };
+    });
+  }, [metricsDataViewId, logsDataViewId]);
+
+  return charts;
+};
+
+export const useKubernetesMetricsCharts = ({
+  metricsDataViewId,
+}: {
+  metricsDataViewId?: string;
+}) => {
+  const model = findInventoryModel('host');
+
+  const { value: charts = [] } = useAsync(async () => {
+    const { kibernetesNode } = await model.metrics.getCharts();
+
+    return [
+      kibernetesNode.xy.nodeCpuCapacity,
+      kibernetesNode.xy.nodeMemoryCapacity,
+      kibernetesNode.xy.nodeDiskCapacity,
+      kibernetesNode.xy.nodePodCapacity,
+    ].map((chart) => {
+      return {
+        ...chart,
+        ...(metricsDataViewId && {
+          dataset: {
+            index: metricsDataViewId,
+          },
+        }),
+      };
+    });
+  }, [metricsDataViewId]);
+
+  return charts;
+};
+
+export const useHostKpiCharts = ({
+  dataViewId,
+  options,
+}: {
+  dataViewId?: string;
+  options?: { seriesColor: string; subtitle?: string };
+}) => {
+  const { value: charts = [] } = useAsync(async () => {
+    const model = findInventoryModel('host');
+    const { cpu, disk, memory } = await model.metrics.getCharts();
+
+    return [
+      cpu.metric.cpuUsage,
+      cpu.metric.normalizedLoad1m,
+      memory.metric.memoryUsage,
+      disk.metric.diskUsage,
+    ].map((chart) => ({
+      ...chart,
+      seriesColor: options?.seriesColor,
+      decimals: 1,
+      subtitle:
+        options?.subtitle ??
+        i18n.translate('xpack.infra.assetDetails.kpi.subtitle.average', {
+          defaultMessage: 'Average',
+        }),
+      ...(dataViewId && {
+        dataset: {
+          index: dataViewId,
+        },
+      }),
+    }));
+  }, [dataViewId, options?.seriesColor, options?.subtitle]);
+
+  return charts;
+};

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/metrics/metrics_section.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/metrics/metrics_section.tsx
@@ -10,7 +10,6 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import type { TimeRange } from '@kbn/es-query';
 import { EuiFlexGroup } from '@elastic/eui';
 import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
-import useAsync from 'react-use/lib/useAsync';
 import {
   MetricsSectionTitle,
   KubernetesMetricsSectionTitle,
@@ -18,6 +17,11 @@ import {
 import { useMetadataStateContext } from '../../../hooks/use_metadata_state';
 import { MetricsGrid } from './metrics_grid';
 import { CollapsibleSection } from '../section/collapsible_section';
+import {
+  useFlyoutMetricsCharts,
+  useHostMetricsCharts,
+  useKubernetesMetricsCharts,
+} from '../../../hooks/use_metrics_charts';
 
 interface Props {
   assetName: string;
@@ -42,34 +46,10 @@ export const MetricsSectionCompact = ({
   dateRange,
 }: Props) => {
   const model = findInventoryModel('host');
-
-  const { value: charts = [] } = useAsync(async () => {
-    const { cpu, disk, memory, network, logs } = await model.metrics.getCharts();
-
-    return [
-      cpu.xy.cpuUsage,
-      memory.xy.memoryUsage,
-      cpu.xy.normalizedLoad1m,
-      logs.xy.logRate,
-      disk.xy.diskSpaceUsageAvailable,
-      disk.xy.diskUsageByMountPoint,
-      disk.xy.diskThroughputReadWrite,
-      disk.xy.diskIOReadWrite,
-      network.xy.rxTx,
-    ].map((chart) => {
-      const dataViewId = chart.id === 'logRate' ? logsDataView?.id : metricsDataView?.id;
-      return {
-        ...chart,
-        ...(dataViewId
-          ? {
-              dataset: {
-                index: dataViewId,
-              },
-            }
-          : {}),
-      };
-    });
-  }, [metricsDataView?.id, logsDataView?.id]);
+  const charts = useFlyoutMetricsCharts({
+    metricsDataViewId: metricsDataView?.id,
+    logsDataViewId: logsDataView?.id,
+  });
 
   return (
     <Section title={MetricsSectionTitle} collapsible>
@@ -86,37 +66,10 @@ export const MetricsSectionCompact = ({
 
 const HostMetricsSection = ({ assetName, metricsDataView, logsDataView, dateRange }: Props) => {
   const model = findInventoryModel('host');
-
-  const { value: charts = [] } = useAsync(async () => {
-    const { cpu, disk, memory, network, logs } = await model.metrics.getCharts();
-
-    return [
-      cpu.xy.cpuUsage,
-      cpu.xy.cpuUsageBreakdown,
-      memory.xy.memoryUsage,
-      memory.xy.memoryUsageBreakdown,
-      cpu.xy.normalizedLoad1m,
-      cpu.xy.loadBreakdown,
-      logs.xy.logRate,
-      disk.xy.diskSpaceUsageAvailable,
-      disk.xy.diskUsageByMountPoint,
-      disk.xy.diskThroughputReadWrite,
-      disk.xy.diskIOReadWrite,
-      network.xy.rxTx,
-    ].map((chart) => {
-      const dataViewId = chart.id === 'logRate' ? logsDataView?.id : metricsDataView?.id;
-      return {
-        ...chart,
-        ...(dataViewId
-          ? {
-              dataset: {
-                index: dataViewId,
-              },
-            }
-          : {}),
-      };
-    });
-  }, [metricsDataView?.id, logsDataView?.id]);
+  const charts = useHostMetricsCharts({
+    metricsDataViewId: metricsDataView?.id,
+    logsDataViewId: logsDataView?.id,
+  });
 
   return (
     <Section title={MetricsSectionTitle} collapsible>
@@ -137,28 +90,7 @@ const KubenetesMetricsSection = ({
   dateRange,
 }: Omit<Props, 'logsDataView'>) => {
   const model = findInventoryModel('host');
-
-  const { value: charts = [] } = useAsync(async () => {
-    const { kibernetesNode } = await model.metrics.getCharts();
-
-    return [
-      kibernetesNode.xy.nodeCpuCapacity,
-      kibernetesNode.xy.nodeMemoryCapacity,
-      kibernetesNode.xy.nodeDiskCapacity,
-      kibernetesNode.xy.nodePodCapacity,
-    ].map((chart) => {
-      return {
-        ...chart,
-        ...(metricsDataView?.id
-          ? {
-              dataset: {
-                index: metricsDataView.id,
-              },
-            }
-          : {}),
-      };
-    });
-  }, [metricsDataView?.id]);
+  const charts = useKubernetesMetricsCharts({ metricsDataViewId: metricsDataView?.id });
 
   return (
     <Section dependsOn={['kubernetes.node']} title={KubernetesMetricsSectionTitle} collapsible>

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/metrics/metrics_section.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/metrics/metrics_section.tsx
@@ -18,9 +18,9 @@ import { useMetadataStateContext } from '../../../hooks/use_metadata_state';
 import { MetricsGrid } from './metrics_grid';
 import { CollapsibleSection } from '../section/collapsible_section';
 import {
-  useFlyoutMetricsCharts,
-  useHostMetricsCharts,
-  useKubernetesMetricsCharts,
+  useHostFlyoutViewMetricsCharts,
+  useHostPageViewMetricsCharts,
+  useKubernetesSectionMetricsCharts,
 } from '../../../hooks/use_metrics_charts';
 
 interface Props {
@@ -46,7 +46,7 @@ export const MetricsSectionCompact = ({
   dateRange,
 }: Props) => {
   const model = findInventoryModel('host');
-  const charts = useFlyoutMetricsCharts({
+  const charts = useHostFlyoutViewMetricsCharts({
     metricsDataViewId: metricsDataView?.id,
     logsDataViewId: logsDataView?.id,
   });
@@ -66,7 +66,7 @@ export const MetricsSectionCompact = ({
 
 const HostMetricsSection = ({ assetName, metricsDataView, logsDataView, dateRange }: Props) => {
   const model = findInventoryModel('host');
-  const charts = useHostMetricsCharts({
+  const charts = useHostPageViewMetricsCharts({
     metricsDataViewId: metricsDataView?.id,
     logsDataViewId: logsDataView?.id,
   });
@@ -90,7 +90,7 @@ const KubenetesMetricsSection = ({
   dateRange,
 }: Omit<Props, 'logsDataView'>) => {
   const model = findInventoryModel('host');
-  const charts = useKubernetesMetricsCharts({ metricsDataViewId: metricsDataView?.id });
+  const charts = useKubernetesSectionMetricsCharts({ metricsDataViewId: metricsDataView?.id });
 
   return (
     <Section dependsOn={['kubernetes.node']} title={KubernetesMetricsSectionTitle} collapsible>

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -12,10 +12,8 @@ import { EuiEmptyPrompt } from '@elastic/eui';
 import { HostNodeRow, useHostsTableContext } from '../hooks/use_hosts_table';
 import { useHostsViewContext } from '../hooks/use_hosts_view';
 import { FlyoutWrapper } from './host_details_flyout/flyout_wrapper';
-import { DEFAULT_PAGE_SIZE } from '../constants';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '../constants';
 import { FilterAction } from './table/filter_action';
-
-const PAGE_SIZE_OPTIONS = [5, 10, 20];
 
 export const HostsTable = () => {
   const { loading } = useHostsViewContext();

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_grid.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_grid.tsx
@@ -7,57 +7,16 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGrid, EuiFlexItem, EuiText, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
-import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
-import useAsync from 'react-use/lib/useAsync';
-import type { LensBreakdownConfig } from '@kbn/lens-embeddable-utils/config_builder';
 import { HostMetricsExplanationContent } from '../../../../../../components/lens';
 import { Chart } from './chart';
 import { Popover } from '../../common/popover';
 import { useMetricsDataViewContext } from '../../../hooks/use_metrics_data_view';
+import { useMetricsCharts } from '../../../hooks/use_metrics_charts';
 
 export const MetricsGrid = () => {
-  const model = findInventoryModel('host');
   const { dataView } = useMetricsDataViewContext();
 
-  const { value: charts = [] } = useAsync(async () => {
-    const { cpu, disk, memory, network } = await model.metrics.getCharts();
-
-    return [
-      cpu.xy.cpuUsage,
-      cpu.xy.normalizedLoad1m,
-      memory.xy.memoryUsage,
-      memory.xy.memoryFree,
-      disk.xy.diskUsage,
-      disk.xy.diskSpaceAvailable,
-      disk.xy.diskIORead,
-      disk.xy.diskIOWrite,
-      disk.xy.diskReadThroughput,
-      disk.xy.diskWriteThroughput,
-      network.xy.rx,
-      network.xy.tx,
-    ].map((chart) => ({
-      ...chart,
-      layers: chart.layers.map((layer) =>
-        layer.type === 'series'
-          ? {
-              ...layer,
-              breakdown: {
-                type: 'topValues',
-                field: 'host.name',
-                size: 10,
-              } as LensBreakdownConfig,
-            }
-          : layer
-      ),
-      ...(dataView?.id
-        ? {
-            dataset: {
-              index: dataView.id,
-            },
-          }
-        : {}),
-    }));
-  }, [dataView?.id]);
+  const charts = useMetricsCharts({ dataViewId: dataView?.id });
 
   return (
     <>

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_grid.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_grid.tsx
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { EuiFlexGrid, EuiFlexItem, EuiText, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
 import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
 import useAsync from 'react-use/lib/useAsync';
+import type { LensBreakdownConfig } from '@kbn/lens-embeddable-utils/config_builder';
 import { HostMetricsExplanationContent } from '../../../../../../components/lens';
 import { Chart } from './chart';
 import { Popover } from '../../common/popover';
@@ -20,6 +21,7 @@ export const MetricsGrid = () => {
 
   const { value: charts = [] } = useAsync(async () => {
     const { cpu, disk, memory, network } = await model.metrics.getCharts();
+
     return [
       cpu.xy.cpuUsage,
       cpu.xy.normalizedLoad1m,
@@ -35,6 +37,18 @@ export const MetricsGrid = () => {
       network.xy.tx,
     ].map((chart) => ({
       ...chart,
+      layers: chart.layers.map((layer) =>
+        layer.type === 'series'
+          ? {
+              ...layer,
+              breakdown: {
+                type: 'topValues',
+                field: 'host.name',
+                size: 10,
+              } as LensBreakdownConfig,
+            }
+          : layer
+      ),
       ...(dataView?.id
         ? {
             dataset: {

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/constants.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/constants.ts
@@ -12,5 +12,7 @@ export const DEFAULT_PAGE_SIZE = 10;
 export const LOCAL_STORAGE_HOST_LIMIT_KEY = 'hostsView:hostLimitSelection';
 export const LOCAL_STORAGE_PAGE_SIZE_KEY = 'hostsView:pageSizeSelection';
 
+export const PAGE_SIZE_OPTIONS = [5, 10, 20];
+
 export const HOST_LIMIT_OPTIONS = [50, 100, 500] as const;
 export const HOST_METRICS_DOC_HREF = 'https://ela.st/docs-infra-host-metrics';

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.test.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.test.ts
@@ -7,6 +7,7 @@
 
 import type { LensSeriesLayer } from '@kbn/lens-embeddable-utils/config_builder';
 import { renderHook } from '@testing-library/react-hooks';
+import { PAGE_SIZE_OPTIONS } from '../constants';
 import { useMetricsCharts } from './use_metrics_charts';
 
 describe('useMetricsCharts', () => {
@@ -23,7 +24,7 @@ describe('useMetricsCharts', () => {
       expect(seriesLayer).toHaveProperty('breakdown');
       expect(seriesLayer.breakdown).toHaveProperty('type', 'topValues');
       expect(seriesLayer.breakdown).toHaveProperty('field', 'host.name');
-      expect(seriesLayer.breakdown).toHaveProperty('size', 10);
+      expect(seriesLayer.breakdown).toHaveProperty('size', PAGE_SIZE_OPTIONS.at(-1));
     });
   });
 

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.test.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensSeriesLayer } from '@kbn/lens-embeddable-utils/config_builder';
+import { renderHook } from '@testing-library/react-hooks';
+import { useMetricsCharts } from './use_metrics_charts';
+
+describe('useMetricsCharts', () => {
+  it('should return an array of charts with breakdown config', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMetricsCharts({ dataViewId: 'dataViewId' })
+    );
+    await waitForNextUpdate();
+
+    expect(result.current).toHaveLength(12);
+
+    result.current.forEach((chart) => {
+      const seriesLayer = chart.layers.find((layer) => layer.type === 'series') as LensSeriesLayer;
+      expect(seriesLayer).toHaveProperty('breakdown');
+      expect(seriesLayer.breakdown).toHaveProperty('type', 'topValues');
+      expect(seriesLayer.breakdown).toHaveProperty('field', 'host.name');
+      expect(seriesLayer.breakdown).toHaveProperty('size', 10);
+    });
+  });
+
+  it('should return an array of charts with correct order', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMetricsCharts({ dataViewId: 'dataViewId' })
+    );
+    await waitForNextUpdate();
+
+    const expectedOrder = [
+      'cpuUsage',
+      'normalizedLoad1m',
+      'memoryUsage',
+      'memoryFree',
+      'diskUsage',
+      'diskSpaceAvailable',
+      'diskIORead',
+      'diskIOWrite',
+      'diskReadThroughput',
+      'diskWriteThroughput',
+      'rx',
+      'tx',
+    ];
+
+    expect(result.current).toHaveLength(expectedOrder.length);
+
+    result.current.forEach((chart, index) => {
+      expect(chart).toHaveProperty('id', expectedOrder[index]);
+    });
+  });
+});

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import useAsync from 'react-use/lib/useAsync';
+import type { LensBreakdownConfig } from '@kbn/lens-embeddable-utils/config_builder';
+import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
+
+export const useMetricsCharts = ({ dataViewId }: { dataViewId?: string }) => {
+  const model = findInventoryModel('host');
+
+  const { value: charts = [] } = useAsync(async () => {
+    const { cpu, disk, memory, network } = await model.metrics.getCharts();
+
+    return [
+      cpu.xy.cpuUsage,
+      cpu.xy.normalizedLoad1m,
+      memory.xy.memoryUsage,
+      memory.xy.memoryFree,
+      disk.xy.diskUsage,
+      disk.xy.diskSpaceAvailable,
+      disk.xy.diskIORead,
+      disk.xy.diskIOWrite,
+      disk.xy.diskReadThroughput,
+      disk.xy.diskWriteThroughput,
+      network.xy.rx,
+      network.xy.tx,
+    ].map((chart) => ({
+      ...chart,
+      layers: chart.layers.map((layer) =>
+        layer.type === 'series'
+          ? {
+              ...layer,
+              breakdown: {
+                type: 'topValues',
+                field: 'host.name',
+                size: 10,
+              } as LensBreakdownConfig,
+            }
+          : layer
+      ),
+      ...(dataViewId && {
+        dataset: {
+          index: dataViewId,
+        },
+      }),
+    }));
+  }, [dataViewId]);
+
+  return charts;
+};

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_metrics_charts.ts
@@ -8,6 +8,7 @@
 import useAsync from 'react-use/lib/useAsync';
 import type { LensBreakdownConfig } from '@kbn/lens-embeddable-utils/config_builder';
 import { findInventoryModel } from '@kbn/metrics-data-access-plugin/common';
+import { PAGE_SIZE_OPTIONS } from '../constants';
 
 export const useMetricsCharts = ({ dataViewId }: { dataViewId?: string }) => {
   const model = findInventoryModel('host');
@@ -37,7 +38,7 @@ export const useMetricsCharts = ({ dataViewId }: { dataViewId?: string }) => {
               breakdown: {
                 type: 'topValues',
                 field: 'host.name',
-                size: 10,
+                size: PAGE_SIZE_OPTIONS.at(-1),
               } as LensBreakdownConfig,
             }
           : layer


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/179378

## Summary

This PR fixes a problem introduced by a refactoring in the charts config catalog, which removed the `breakdown` config from the charts in the Hosts View

<img width="691" alt="image" src="https://github.com/elastic/kibana/assets/2767137/0bfe6093-887b-4a46-8d53-2580fea9ee39">


### How to test
- Start a local Kibana instance
- Either point it to an oblt-cli cluster or run the `infra_hosts_with_apm_hosts.ts` synthtrace scenario (we need more than 1 host in the page)
- Navigate to `Infrastructure > Hosts` and also validate the asset details page
