### PR TITLE
[Lens] Update time_range() function with an additional example

### DIFF
--- a/packages/kbn-lens-formula-docs/src/operations/time_range.ts
+++ b/packages/kbn-lens-formula-docs/src/operations/time_range.ts
@@ -21,8 +21,11 @@ export const timeRange = buildContextVariableDocumentationDefinition({
     defaultMessage: `
 The specified time range, in milliseconds (ms).
 
-Example: How long is the current time range?
+Example: How long is the current time range in (ms)?
 \`time_range()\`
+
+Example: A static average per minute computed with the current time range:
+\`(sum(bytes) / time_range()) * 1000 * 60\`
 `,
   }),
 });


### PR DESCRIPTION
## Summary

Closes #164952 

Apparently part of the task was already done via #173770 but the issue hasn't been updated.
I've now added one more example just to show a practical usage of `time_range()` but the other 2 constant functions have already meaningful examples in place.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials