### PR TITLE
[Fleet] fix install packages script + add notification

### DIFF
--- a/.buildkite/pipelines/fleet/packages_daily.yml
+++ b/.buildkite/pipelines/fleet/packages_daily.yml
@@ -25,7 +25,3 @@ steps:
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
       queue: kibana-default
-
-notify:
-  - slack: "#fleet-notifications"
-    if: build.branch == "main" && build.state == "failed"

--- a/.buildkite/pipelines/fleet/packages_daily.yml
+++ b/.buildkite/pipelines/fleet/packages_daily.yml
@@ -25,3 +25,7 @@ steps:
     command: .buildkite/scripts/lifecycle/post_build.sh
     agents:
       queue: kibana-default
+
+notify:
+  - slack: "#fleet-notifications"
+    if: build.branch == "main" && build.state == "failed"

--- a/x-pack/test/fleet_packages/tests/install_all.ts
+++ b/x-pack/test/fleet_packages/tests/install_all.ts
@@ -18,6 +18,8 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const logger = getService('log');
+  const API_VERSION = '2023-10-31';
+  const API_VERSION_HEADER_NAME = 'elastic-api-version';
 
   function installPackage(
     name: string,
@@ -27,6 +29,7 @@ export default function (providerContext: FtrProviderContext) {
     return supertest
       .post(`/api/fleet/epm/packages/${name}/${version}`)
       .set('kbn-xsrf', 'xxx')
+      .set(API_VERSION_HEADER_NAME, API_VERSION)
       .send({ force: true })
       .expect(200)
       .then(() => {
@@ -45,6 +48,7 @@ export default function (providerContext: FtrProviderContext) {
     return supertest
       .delete(`/api/fleet/epm/packages/${name}/${version}`)
       .set('kbn-xsrf', 'xxx')
+      .set(API_VERSION_HEADER_NAME, API_VERSION)
       .expect(200)
       .then(() => {
         return { name, success: true };
@@ -59,7 +63,10 @@ export default function (providerContext: FtrProviderContext) {
     it('should work and install all packages', async () => {
       const {
         body: { items: packages },
-      } = await supertest.get('/api/fleet/epm/packages?prerelease=true').expect(200);
+      } = await supertest
+        .get('/api/fleet/epm/packages?prerelease=true')
+        .set(API_VERSION_HEADER_NAME, API_VERSION)
+        .expect(200);
       const allResults = [];
       for (const pkg of packages) {
         // skip deprecated failing package https://github.com/elastic/integrations/issues/4947


### PR DESCRIPTION
## Summary

Fixed install package script, it was missing version header. It turned out the job was failing since last summer: https://buildkite.com/elastic/kibana-fleet-packages

Added a notification section to send notification to #fleet-notifications slack channel on failed builds.

Ran locally:
```
       │ info ✅ juniper@1.2.0 took 31.24s
       │ info ✅ dga@2.0.1 took 12.603s
       │ info ✅ security_detection_engine@8.13.2 took 5.152s
       │ info ✅ aws@2.13.1 took 5.115s
       │ info ✅ jumpcloud@1.10.0 took 4.199s
       │ info ✅ ti_threatconnect@0.3.0 took 4.126s
       │ info ✅ cloudflare_logpush@1.18.0 took 4.101s
       │ info ✅ beaconing@1.2.0 took 4.068s
       │ info ✅ arista_ngfw@1.1.0 took 4.066s
       │ info ✅ google_workspace@2.20.0 took 4.064s
       │ info ✅ linux@0.6.9 took 3.443s
       │ info ✅ influxdb@0.7.0 took 3.167s
       │ info ✅ snort@1.15.0 took 3.157s
       │ info ✅ ti_misp@1.32.0 took 3.139s
       │ info ✅ endpoint@8.14.0-prerelease.0 took 3.127s
       │ info ✅ ti_crowdstrike@0.5.3 took 3.124s
       │ info ✅ lmd@2.1.2 took 3.118s
       │ info ✅ ti_anomali@1.20.0 took 3.109s
       │ info ✅ vectra_detect@1.7.2 took 3.097s
       │ info ✅ hadoop@1.5.2 took 3.095s
       │ info ✅ proofpoint@0.9.1 took 3.092s
       │ info ✅ redis@1.14.0 took 3.092s
       │ info ✅ citrix_waf@1.14.0 took 3.091s
       │ info ✅ nagios_xi@1.2.1 took 3.09s
       │ info ✅ microsoft_defender_cloud@1.1.1 took 3.089s
       │ info ✅ sysmon_linux@1.6.2 took 3.088s
       │ info ✅ thycotic_ss@1.7.0 took 3.085s
       │ info ✅ cyberark_pta@1.9.0 took 3.082s
       │ info ✅ salesforce@0.14.0 took 3.081s
       │ info ✅ trendmicro@2.2.0 took 3.079s
       │ info ✅ netscout@0.20.0 took 3.078s
       │ info ✅ proofpoint_tap@1.17.0 took 3.078s
       │ info ✅ ti_rapid7_threat_command@1.15.0 took 3.076s
       │ info ✅ cloud_security_posture@1.9.0-preview01 took 3.075s
       │ info ✅ nats@1.5.1 took 3.075s
       │ info ✅ sonicwall@0.8.2 took 3.075s
       │ info ✅ websphere_application_server@1.3.0 took 3.074s
       │ info ✅ netskope@1.17.0 took 3.072s
       │ info ✅ ti_mandiant_advantage@1.1.1 took 3.072s
       │ info ✅ m365_defender@2.8.0 took 3.071s
       │ info ✅ zscaler_zpa@1.17.0 took 3.071s
       │ info ✅ modsecurity@1.18.0 took 3.068s
       │ info ✅ redisenterprise@0.9.0 took 3.068s
       │ info ✅ sentinel_one_cloud_funnel@0.13.0 took 3.066s
       │ info ✅ apache_tomcat@1.4.0 took 3.065s
       │ info ✅ apm@8.13.1-preview-1708411360 took 3.065s
       │ info ✅ azure_metrics@1.4.2 took 3.065s
       │ info ✅ cisco_meraki@1.21.2 took 3.064s
       │ info ✅ azure@1.10.0 took 3.063s
       │ info ✅ checkpoint@1.31.0 took 3.063s
       │ info ✅ zeek@2.24.0 took 3.063s
       │ info ✅ iptables@1.16.0 took 3.062s
       │ info ✅ qualys_vmdr@2.1.0 took 3.061s
       │ info ✅ microsoft_sqlserver@2.5.0 took 3.059s
       │ info ✅ box_events@2.7.0 took 3.058s
       │ info ✅ google_scc@1.1.1 took 3.058s
       │ info ✅ hid_bravura_monitor@1.17.2 took 3.057s
       │ info ✅ ibmmq@1.2.4 took 3.056s
       │ info ✅ awsfirehose@0.5.0 took 3.055s
       │ info ✅ memcached@1.3.0 took 3.054s
       │ info ✅ microsoft_exchange_server@0.1.2 took 3.054s
       │ info ✅ prisma_cloud@1.1.1 took 3.054s
       │ info ✅ oracle_weblogic@1.5.0 took 3.053s
       │ info ✅ pps@0.0.1 took 3.053s
       │ info ✅ gcp@2.33.1 took 3.052s
       │ info ✅ jamf_compliance_reporter@1.12.0 took 3.052s
       │ info ✅ amazon_security_lake@1.1.0 took 3.051s
       │ info ✅ bluecoat@0.17.2 took 3.051s
       │ info ✅ activemq@1.2.0 took 3.05s
       │ info ✅ barracuda@1.12.0 took 3.05s
       │ info ✅ tanium@1.8.0 took 3.049s
       │ info ✅ trellix_epo_cloud@1.10.0 took 3.049s
       │ info ✅ imperva_cloud_waf@0.3.0 took 3.048s
       │ info ✅ lyve_cloud@1.13.0 took 3.048s
       │ info ✅ juniper_junos@0.10.1 took 3.047s
       │ info ✅ ceph@1.4.0 took 3.046s
       │ info ✅ nginx_ingress_controller@1.8.2 took 3.046s
       │ info ✅ cassandra@1.12.0 took 3.045s
       │ info ✅ cribl@0.3.0 took 3.045s
       │ info ✅ istio@0.5.0 took 3.045s
       │ info ✅ hashicorp_vault@1.24.0 took 3.044s
       │ info ✅ kafka@1.13.0 took 3.043s
       │ info ✅ azure_functions@0.4.0 took 3.042s
       │ info ✅ auth0@1.15.0 took 3.04s
       │ info ✅ imperva@1.1.0 took 3.039s
       │ info ✅ infoblox_bloxone_ddi@1.16.0 took 3.038s
       │ info ✅ bitdefender@1.12.0 took 3.037s
       │ info ✅ cisco_secure_email_gateway@1.23.0 took 3.037s
       │ info ✅ problemchild@2.1.2 took 3.036s
       │ info ✅ juniper_netscreen@0.10.1 took 3.032s
       │ info ✅ infoblox@0.8.1 took 3.023s
       │ info ✅ 1password@1.27.0 took 2.728s
       │ info ✅ kafka_log@1.6.0 took 2.118s
       │ info ✅ keycloak@1.21.0 took 2.117s
       │ info ✅ fortinet_fortiedr@1.15.0 took 2.108s
       │ info ✅ network_traffic@1.30.0 took 2.098s
       │ info ✅ prometheus_input@0.4.0 took 2.091s
       │ info ✅ rabbitmq@1.13.0 took 2.091s
       │ info ✅ ping_one@1.14.0 took 2.089s
       │ info ✅ vsphere@1.11.1 took 2.087s
       │ info ✅ snyk@1.20.1 took 2.086s
       │ info ✅ okta@2.8.0 took 2.085s
       │ info ✅ kibana@2.5.2 took 2.084s
       │ info ✅ log@2.3.1 took 2.082s
       │ info ✅ mongodb@1.13.2 took 2.082s
       │ info ✅ microsoft_exchange_online_message_trace@1.19.0 took 2.08s
       │ info ✅ panw@3.24.0 took 2.08s
       │ info ✅ ti_abusech@1.25.0 took 2.078s
       │ info ✅ php_fpm@1.2.1 took 2.077s
       │ info ✅ qnap_nas@1.20.0 took 2.077s
       │ info ✅ microsoft_dhcp@1.24.2 took 2.076s
       │ info ✅ oracle@1.24.3 took 2.076s
       │ info ✅ osquery@1.19.0 took 2.076s
       │ info ✅ statsd_input@0.2.3 took 2.075s
       │ info ✅ system_audit@1.10.1 took 2.075s
       │ info ✅ zscaler_zia@2.19.0 took 2.075s
       │ info ✅ logstash@2.4.3 took 2.074s
       │ info ✅ lumos@0.1.0 took 2.074s
       │ info ✅ udp@1.19.0 took 2.074s
       │ info ✅ windows@1.44.4 took 2.074s
       │ info ✅ kubernetes@1.58.0 took 2.073s
       │ info ✅ netflow@2.18.0 took 2.073s
       │ info ✅ zerofox@1.23.0 took 2.072s
       │ info ✅ zookeeper@1.10.0 took 2.072s
       │ info ✅ lastpass@1.15.0 took 2.07s
       │ info ✅ ti_cif3@1.11.0 took 2.07s
       │ info ✅ wiz@1.1.1 took 2.07s
       │ info ✅ azure_billing@1.5.0 took 2.069s
       │ info ✅ platform_observability@0.0.2 took 2.069s
       │ info ✅ sql@0.4.0 took 2.068s
       │ info ✅ tines@1.11.0 took 2.068s
       │ info ✅ mysql@1.19.0 took 2.067s
       │ info ✅ elastic_agent@1.18.0 took 2.066s
       │ info ✅ panw_cortex_xdr@1.25.0 took 2.066s
       │ info ✅ ti_util@1.5.0 took 2.066s
       │ info ✅ tomcat@1.10.0 took 2.066s
       │ info ✅ winlog@2.1.1 took 2.066s
       │ info ✅ system@1.54.0 took 2.065s
       │ info ✅ apache@1.17.0 took 2.064s
       │ info ✅ darktrace@1.16.0 took 2.064s
       │ info ✅ mysql_enterprise@1.14.2 took 2.064s
       │ info ✅ pfsense@1.19.0 took 2.063s
       │ info ✅ profiler_agent@8.12.0 took 2.063s
       │ info ✅ ti_recordedfuture@1.22.0 took 2.062s
       │ info ✅ squid@0.19.3 took 2.061s
       │ info ✅ couchbase@1.5.0 took 2.06s
       │ info ✅ cyberarkpas@2.20.0 took 2.06s
       │ info ✅ ded@2.1.1 took 2.06s
       │ info ✅ synthetics_dashboards@1.0.1 took 2.06s
       │ info ✅ coredns@0.6.1 took 2.059s
       │ info ✅ mimecast@1.23.0 took 2.059s
       │ info ✅ nginx@1.20.0 took 2.059s
       │ info ✅ ti_otx@1.24.1 took 2.059s
       │ info ✅ cockroachdb@1.9.0 took 2.058s
       │ info ✅ sophos@3.9.0 took 2.058s
       │ info ✅ google_cloud_storage@1.1.0 took 2.056s
       │ info ✅ journald@1.1.0 took 2.056s
       │ info ✅ sophos_central@1.14.0 took 2.056s
       │ info ✅ synthetics@1.2.1 took 2.056s
       │ info ✅ microsoft_defender_endpoint@2.24.1 took 2.055s
       │ info ✅ osquery_manager@1.11.0 took 2.055s
       │ info ✅ symantec_edr_cloud@1.1.0 took 2.055s
       │ info ✅ azure_frontdoor@1.7.0 took 2.054s
       │ info ✅ forcepoint_web@1.8.0 took 2.054s
       │ info ✅ stan@1.5.0 took 2.054s
       │ info ✅ traefik@1.11.1 took 2.054s
       │ info ✅ trend_micro_vision_one@1.16.0 took 2.054s
       │ info ✅ cisa_kevs@0.1.0 took 2.053s
       │ info ✅ fireeye@1.22.0 took 2.053s
       │ info ✅ infoblox_nios@1.21.0 took 2.053s
       │ info ✅ o365@2.3.0 took 2.053s
       │ info ✅ suricata@2.21.0 took 2.053s
       │ info ✅ tenable_io@2.9.0 took 2.053s
       │ info ✅ ti_cybersixgill@1.27.0 took 2.053s
       │ info ✅ containerd@0.3.0 took 2.052s
       │ info ✅ jolokia@0.3.0 took 2.052s
       │ info ✅ sonicwall_firewall@1.16.0 took 2.052s
       │ info ✅ spring_boot@1.4.0 took 2.052s
       │ info ✅ tcp@1.19.0 took 2.052s
       │ info ✅ ti_maltiverse@1.1.0 took 2.052s
       │ info ✅ cisco_ise@1.22.0 took 2.051s
       │ info ✅ fortinet_fortigate@1.25.1 took 2.051s
       │ info ✅ sentinel_one@1.20.0 took 2.051s
       │ info ✅ tenable_sc@1.21.0 took 2.051s
       │ info ✅ fleet_server@1.5.0 took 2.05s
       │ info ✅ azure_application_insights@1.4.0 took 2.049s
       │ info ✅ cef@2.17.0 took 2.049s
       │ info ✅ juniper_srx@1.21.0 took 2.049s
       │ info ✅ zoom@1.19.0 took 2.049s
       │ info ✅ awsfargate@1.0.0 took 2.048s
       │ info ✅ crowdstrike@1.32.1 took 2.048s
       │ info ✅ zeronetworks@1.12.0 took 2.048s
       │ info ✅ akamai@2.23.0 took 2.047s
       │ info ✅ barracuda_cloudgen_firewall@1.11.0 took 2.047s
       │ info ✅ eset_protect@0.3.0 took 2.047s
       │ info ✅ cisco_umbrella@1.22.0 took 2.046s
       │ info ✅ httpjson@1.20.0 took 2.046s
       │ info ✅ iis@1.17.4 took 2.046s
       │ info ✅ bitwarden@1.11.0 took 2.045s
       │ info ✅ cisco_duo@1.22.0 took 2.045s
       │ info ✅ cisco_secure_endpoint@2.25.0 took 2.045s
       │ info ✅ couchdb@1.1.0 took 2.045s
       │ info ✅ golang@1.4.0 took 2.045s
       │ info ✅ haproxy@1.11.1 took 2.045s
       │ info ✅ slack@1.19.0 took 2.045s
       │ info ✅ auditd@3.19.1 took 2.044s
       │ info ✅ entityanalytics_okta@1.1.0 took 2.044s
       │ info ✅ f5@0.17.2 took 2.044s
       │ info ✅ gcp_metrics@0.1.0 took 2.044s
       │ info ✅ postgresql@1.19.0 took 2.044s
       │ info ✅ entityanalytics_entra_id@1.1.0 took 2.043s
       │ info ✅ f5_bigip@1.14.0 took 2.043s
       │ info ✅ fim@1.14.1 took 2.043s
       │ info ✅ beat@1.0.0-beta1 took 2.042s
       │ info ✅ cel@1.9.0 took 2.042s
       │ info ✅ cylance@0.19.2 took 2.042s
       │ info ✅ fortinet_fortimail@2.13.0 took 2.042s
       │ info ✅ github@1.28.0 took 2.042s
       │ info ✅ pulse_connect_secure@1.19.0 took 2.042s
       │ info ✅ rapid7_insightvm@1.9.0 took 2.042s
       │ info ✅ ti_threatq@1.25.0 took 2.042s
       │ info ✅ auditd_manager@1.16.2 took 2.041s
       │ info ✅ carbonblack_edr@1.17.0 took 2.041s
       │ info ✅ cisco_ios@1.26.2 took 2.041s
       │ info ✅ cloud_defend@1.2.4 took 2.041s
       │ info ✅ gcp_pubsub@1.13.0 took 2.041s
       │ info ✅ ti_opencti@2.1.0 took 2.041s
       │ info ✅ airflow@0.6.0 took 2.039s
       │ info ✅ atlassian_bitbucket@1.23.0 took 2.039s
       │ info ✅ cisco_ftd@3.2.0 took 2.039s
       │ info ✅ cloudflare@2.24.0 took 2.039s
       │ info ✅ enterprisesearch@1.0.1 took 2.039s
       │ info ✅ fortinet_forticlient@1.10.2 took 2.039s
       │ info ✅ aws_logs@1.1.0 took 2.038s
       │ info ✅ fortinet_fortimanager@2.11.0 took 2.038s
       │ info ✅ atlassian_confluence@1.24.0 took 2.037s
       │ info ✅ azure_app_service@0.3.0 took 2.037s
       │ info ✅ etcd@1.0.0 took 2.037s
       │ info ✅ fortinet@1.9.0 took 2.037s
       │ info ✅ http_endpoint@1.15.0 took 2.037s
       │ info ✅ trellix_edr_cloud@1.1.0 took 2.037s
       │ info ✅ apache_spark@1.0.3 took 2.036s
       │ info ✅ elastic_package_registry@0.2.0 took 2.036s
       │ info ✅ prometheus@1.15.0 took 2.036s
       │ info ✅ santa@3.17.0 took 2.036s
       │ info ✅ cisco_aironet@1.13.0 took 2.035s
       │ info ✅ docker@2.9.0 took 2.035s
       │ info ✅ elasticsearch@1.14.0 took 2.035s
       │ info ✅ carbon_black_cloud@1.21.3 took 2.034s
       │ info ✅ cisco_asa@2.32.0 took 2.034s
       │ info ✅ symantec_endpoint@2.15.0 took 2.033s
       │ info ✅ ti_eclecticiq@0.3.0 took 2.033s
       │ info ✅ cisco_nexus@1.1.0 took 2.032s
       │ info ✅ citrix_adc@1.4.0 took 2.032s
       │ info ✅ forgerock@1.15.0 took 2.031s
       │ info ✅ atlassian_jira@1.24.0 took 2.03s
       │ info ✅ radware@0.19.0 took 2.03s
       │ info ✅ mattermost@1.18.0 took 2.028s
       │ info ✅ azure_blob_storage@1.1.0 took 2.026s
       └- ✓ pass  (20.0m)
     └-> "after all" hook: afterTestSuite.trigger for "should work and install all packages"
   └-> "after all" hook: afterTestSuite.trigger in "Fleet packages test"

1 passing (20.0m)
```