### PR TITLE
[Dataset quality] Awaiting table to be loaded before checking rows

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
@@ -20,8 +20,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   const testSubjects = getService('testSubjects');
   const to = '2024-01-01T12:00:00.000Z';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/179092
-  describe.skip('Dataset quality table filters', () => {
+  describe('Dataset quality table filters', () => {
     before(async () => {
       await synthtrace.index(getInitialTestLogs({ to, count: 4 }));
       await PageObjects.datasetQuality.navigateTo();

--- a/x-pack/test/functional/page_objects/dataset_quality.ts
+++ b/x-pack/test/functional/page_objects/dataset_quality.ts
@@ -104,6 +104,10 @@ export function DatasetQualityPageObject({ getPageObjects, getService }: FtrProv
       );
     },
 
+    async waitUntilTableLoaded() {
+      await testSubjects.missingOrFail('.euiBasicTable-loading');
+    },
+
     async waitUntilSummaryPanelLoaded() {
       await testSubjects.missingOrFail(`datasetQuality-${texts.activeDatasets}-loading`);
       await testSubjects.missingOrFail(`datasetQuality-${texts.estimatedData}-loading`);
@@ -151,6 +155,7 @@ export function DatasetQualityPageObject({ getPageObjects, getService }: FtrProv
     },
 
     async getDatasetTableRows(): Promise<WebElementWrapper[]> {
+      await this.waitUntilTableLoaded();
       const table = await testSubjects.find(testSubjectSelectors.datasetQualityTable);
       const tBody = await table.findByTagName('tbody');
       return tBody.findAllByTagName('tr');

--- a/x-pack/test/functional/page_objects/dataset_quality.ts
+++ b/x-pack/test/functional/page_objects/dataset_quality.ts
@@ -105,7 +105,7 @@ export function DatasetQualityPageObject({ getPageObjects, getService }: FtrProv
     },
 
     async waitUntilTableLoaded() {
-      await testSubjects.missingOrFail('.euiBasicTable-loading');
+      await find.waitForDeletedByCssSelector('.euiBasicTable-loading');
     },
 
     async waitUntilSummaryPanelLoaded() {

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_table_filters.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_table_filters.ts
@@ -21,8 +21,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const to = '2024-01-01T12:00:00.000Z';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/178652
-  describe.skip('Dataset quality table filters', () => {
+  describe('Dataset quality table filters', () => {
     before(async () => {
       await synthtrace.index(getInitialTestLogs({ to, count: 4 }));
       await PageObjects.svlCommonPage.loginWithRole('admin');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/179092 and https://github.com/elastic/kibana/issues/178652.

Not awaiting for the loading state to be false produce some flakiness because the request could be slower some times, this PR adds the awaiting when getting table rows.

[Flaky test runner (50 times)](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5563)