### PR TITLE
[8.13][Fleet] Workaround: avoid using bad artifact ids

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_services.ts
@@ -91,10 +91,10 @@ const randomAgentPolicyName = (() => {
 })();
 
 /**
- * Used for filtering out any versions in the format "8.13.0+build202403222138"
+ * Check if the given version string is a valid artifact version
  * @param version Version string
  */
-const hasNoBuildLabel = (version: string) => !version.includes('+build');
+const isValidArtifactVersion = (version: string) => !!version.match(/^\d+\.\d+\.\d+(-SNAPSHOT)?$/);
 
 export const checkInFleetAgent = async (
   esClient: Client,
@@ -404,7 +404,7 @@ export const getAgentVersionMatchingCurrentStack = async (
     .get('https://artifacts-api.elastic.co/v1/versions')
     .then((response) =>
       map(
-        response.data.versions.filter(hasNoBuildLabel),
+        response.data.versions.filter(isValidArtifactVersion),
         (version) => version.split('-SNAPSHOT')[0]
       )
     );
@@ -531,7 +531,7 @@ export const getLatestAgentDownloadVersion = async (
   );
 
   const stackVersionToArtifactVersion: Record<string, string> = artifactVersionsResponse.versions
-    .filter(hasNoBuildLabel)
+    .filter(isValidArtifactVersion)
     .reduce((acc, artifactVersion) => {
       const stackVersion = artifactVersion.split('-SNAPSHOT')[0];
       acc[stackVersion] = artifactVersion;


### PR DESCRIPTION
## Summary
This PR adds a filter, to exclude listed artifact versions that are in the format `8.13+build202403222138` (or any format differing form `^\d+\.\d+\.\d+(?:-SNAPSHOT)?$`).

This workaround is to fix issues arising from the https://artifacts-api.elastic.co/v1/versions api returning versions that are not expected in that context.