### PR TITLE
[SecuritySolution][Serverless] Fix video missing from the onboarding page

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/card_step/content/video.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/card_step/content/video.tsx
@@ -14,6 +14,8 @@ import { WATCH_VIDEO_BUTTON_TITLE } from '../../translations';
 import { OverviewSteps, QuickStartSectionCardsId, SectionId } from '../../types';
 import { ContentWrapper } from './content_wrapper';
 
+const VIDEO_CONTENT_HEIGHT = 320;
+
 const VideoComponent: React.FC = () => {
   const { toggleTaskCompleteStatus, finishedSteps } = useStepContext();
   const ref = React.useRef<HTMLIFrameElement>(null);
@@ -37,7 +39,11 @@ const VideoComponent: React.FC = () => {
 
   return (
     <ContentWrapper>
-      <>
+      <div
+        css={css`
+          height: ${VIDEO_CONTENT_HEIGHT}px;
+        `}
+      >
         {!isVideoPlaying && !isFinishedStep && (
           <EuiFlexGroup
             css={css`
@@ -74,7 +80,7 @@ const VideoComponent: React.FC = () => {
             title={WATCH_VIDEO_BUTTON_TITLE}
           />
         )}
-      </>
+      </div>
     </ContentWrapper>
   );
 };


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/178187


Before: ![image](https://github.com/elastic/kibana/assets/60252716/d332e87a-1da2-4110-85d1-fe3039b2dfc4)

After:


https://github.com/elastic/kibana/assets/6295984/99a68776-ced5-4584-90aa-94d4c16cddd2



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->