### PR TITLE
[Serverless] Skip "nanosecond formatting" suite on MKI

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -478,6 +478,8 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('nanosecond formatting', () => {
+      // failsOnMKI, see https://github.com/elastic/kibana/issues/179456
+      this.tags(['failsOnMKI']);
       before(async () => {
         await esArchiver.load(archives.nanos.data);
         await kibanaServer.importExport.load(archives.nanos.savedObjects);

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -68,6 +68,8 @@ export default ({ getService }: FtrProviderContext) => {
    * Tests
    */
   describe('Generate CSV from SearchSource', () => {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/179456
+    this.tags(['failsOnMKI']);
     beforeEach(async () => {
       await kibanaServer.uiSettings.update({
         'csv:quoteValues': true,
@@ -478,8 +480,6 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('nanosecond formatting', () => {
-      // failsOnMKI, see https://github.com/elastic/kibana/issues/179456
-      this.tags(['failsOnMKI']);
       before(async () => {
         await esArchiver.load(archives.nanos.data);
         await kibanaServer.importExport.load(archives.nanos.savedObjects);


### PR DESCRIPTION
Skip "Serverless Common UI - Reporting Generate CSV from SearchSource" suite for MKI runs.

Details about the failure in https://github.com/elastic/kibana/issues/179456


