### PR TITLE
[Security Solution] removing all constant imports from the app within Cypress

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel.ts
@@ -5,19 +5,17 @@
  * 2.0.
  */
 
-import {
-  INSIGHTS_TAB_TEST_ID,
-  INVESTIGATION_TAB_TEST_ID,
-  RESPONSE_TAB_TEST_ID,
-  VISUALIZE_TAB_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/left/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
-export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB =
-  getDataTestSubjectSelector(INSIGHTS_TAB_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB =
-  getDataTestSubjectSelector(VISUALIZE_TAB_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB =
-  getDataTestSubjectSelector(INVESTIGATION_TAB_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB =
-  getDataTestSubjectSelector(RESPONSE_TAB_TEST_ID);
+export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutInsightsTab'
+);
+export const DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutVisualizeTab'
+);
+export const DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutInvestigationTab'
+);
+export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutResponseTab'
+);

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.ts
@@ -5,11 +5,9 @@
  * 2.0.
  */
 
-import { VISUALIZE_TAB_GRAPH_ANALYZER_BUTTON_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
-import { ANALYZER_GRAPH_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_BUTTON =
-  getDataTestSubjectSelector(VISUALIZE_TAB_GRAPH_ANALYZER_BUTTON_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutVisualizeTabGraphAnalyzerButton');
 export const DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_GRAPH_ANALYZER_CONTENT =
-  getDataTestSubjectSelector(ANALYZER_GRAPH_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutAnalyzerGraph');

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_correlations_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_correlations_tab.ts
@@ -5,73 +5,64 @@
  * 2.0.
  */
 
-import { INSIGHTS_TAB_CORRELATIONS_BUTTON_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
-import {
-  CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TEST_ID,
-  CORRELATIONS_DETAILS_BY_SESSION_SECTION_TEST_ID,
-  CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TEST_ID,
-  CORRELATIONS_DETAILS_CASES_SECTION_TEST_ID,
-  CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/left/components/test_ids';
-import { EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/shared/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON = getDataTestSubjectSelector(
-  INSIGHTS_TAB_CORRELATIONS_BUTTON_TEST_ID
+  'securitySolutionFlyoutInsightsTabCorrelationsButton'
 );
 
 export const CORRELATIONS_ANCESTRY_SECTION_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TEST_ID)
+  'securitySolutionFlyoutCorrelationsDetailsAlertsByAncestrySectionTitleText'
 );
 
 export const CORRELATIONS_ANCESTRY_SECTION_TABLE = getDataTestSubjectSelector(
-  `${CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TEST_ID}Table`
+  'securitySolutionFlyoutCorrelationsDetailsAlertsByAncestrySectionTable'
 );
 
 export const CORRELATIONS_ANCESTRY_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON =
   getDataTestSubjectSelector(
-    `${CORRELATIONS_DETAILS_BY_ANCESTRY_SECTION_TEST_ID}InvestigateInTimeline`
+    'securitySolutionFlyoutCorrelationsDetailsAlertsByAncestrySectionInvestigateInTimeline'
   );
 
 export const CORRELATIONS_SOURCE_SECTION_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TEST_ID)
+  'securitySolutionFlyoutCorrelationsDetailsAlertsBySourceSectionTitleText'
 );
 
 export const CORRELATIONS_SOURCE_SECTION_TABLE = getDataTestSubjectSelector(
-  `${CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TEST_ID}Table`
+  'securitySolutionFlyoutCorrelationsDetailsAlertsBySourceSectionTable'
 );
 
 export const CORRELATIONS_SOURCE_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON =
   getDataTestSubjectSelector(
-    `${CORRELATIONS_DETAILS_BY_SOURCE_SECTION_TEST_ID}InvestigateInTimeline`
+    'securitySolutionFlyoutCorrelationsDetailsAlertsBySourceSectionInvestigateInTimeline'
   );
 
 export const CORRELATIONS_SESSION_SECTION_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(CORRELATIONS_DETAILS_BY_SESSION_SECTION_TEST_ID)
+  'securitySolutionFlyoutCorrelationsDetailsAlertsBySessionSectionTitleText'
 );
 
 export const CORRELATIONS_SESSION_SECTION_TABLE = getDataTestSubjectSelector(
-  `${CORRELATIONS_DETAILS_BY_SESSION_SECTION_TEST_ID}Table`
+  'securitySolutionFlyoutCorrelationsDetailsAlertsBySessionSectionTable'
 );
 
 export const CORRELATIONS_SESSION_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON =
   getDataTestSubjectSelector(
-    `${CORRELATIONS_DETAILS_BY_SESSION_SECTION_TEST_ID}InvestigateInTimeline`
+    'securitySolutionFlyoutCorrelationsDetailsAlertsBySessionSectionInvestigateInTimeline'
   );
 
 export const CORRELATIONS_CASES_SECTION_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(CORRELATIONS_DETAILS_CASES_SECTION_TEST_ID)
+  'securitySolutionFlyoutCorrelationsDetailsCasesSectionTitleText'
 );
 
 export const CORRELATIONS_CASES_SECTION_TABLE = getDataTestSubjectSelector(
-  `${CORRELATIONS_DETAILS_CASES_SECTION_TEST_ID}Table`
+  'securitySolutionFlyoutCorrelationsDetailsCasesSectionTable'
 );
 
 export const CORRELATIONS_SUPPRESSED_ALERTS_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID)
+  'securitySolutionFlyoutCorrelationsDetailsSuppressedAlertsSectionTitleText'
 );
 
 export const CORRELATIONS_SUPPRESSED_ALERTS_INVESTIGATE_IN_TIMELINE_BUTTON =
   getDataTestSubjectSelector(
-    `${CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID}InvestigateInTimeline`
+    'securitySolutionFlyoutCorrelationsDetailsSuppressedAlertsSectionInvestigateInTimeline'
   );

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_entities_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_entities_tab.ts
@@ -5,34 +5,24 @@
  * 2.0.
  */
 
-import {
-  HOST_DETAILS_TEST_ID,
-  USER_DETAILS_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/left/components/test_ids';
-import { INSIGHTS_TAB_ENTITIES_BUTTON_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
-import {
-  EXPANDABLE_PANEL_CONTENT_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/shared/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_BUTTON = getDataTestSubjectSelector(
-  INSIGHTS_TAB_ENTITIES_BUTTON_TEST_ID
+  'securitySolutionFlyoutInsightsTabEntitiesButton'
 );
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(USER_DETAILS_TEST_ID)
+  'securitySolutionFlyoutUsersDetailsTitleText'
 );
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS_RIGHT_SECTION =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID(USER_DETAILS_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutUsersDetailsRightSection');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_USER_DETAILS = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_CONTENT_TEST_ID(USER_DETAILS_TEST_ID)
+  'securitySolutionFlyoutUsersDetailsContent'
 );
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS_TITLE = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(HOST_DETAILS_TEST_ID)
+  'securitySolutionFlyoutHostsDetailsTitleText'
 );
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS_RIGHT_SECTION =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_HEADER_RIGHT_SECTION_TEST_ID(HOST_DETAILS_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutHostsDetailsRightSection');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_HOST_DETAILS = getDataTestSubjectSelector(
-  EXPANDABLE_PANEL_CONTENT_TEST_ID(HOST_DETAILS_TEST_ID)
+  'securitySolutionFlyoutHostsDetailsContent'
 );

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_investigation_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_investigation_tab.ts
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { INVESTIGATION_TAB_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/test_ids';
-import { INVESTIGATION_TAB_CONTENT_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
-export const DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB =
-  getDataTestSubjectSelector(INVESTIGATION_TAB_TEST_ID);
+export const DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutInvestigationTab'
+);
 export const DOCUMENT_DETAILS_FLYOUT_INVESTIGATION_TAB_CONTENT = getDataTestSubjectSelector(
-  INVESTIGATION_TAB_CONTENT_TEST_ID
+  'securitySolutionFlyoutInvestigationsTabContent'
 );

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_prevalence_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_prevalence_tab.ts
@@ -5,32 +5,22 @@
  * 2.0.
  */
 
-import {
-  PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID,
-  PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID,
-  PREVALENCE_DETAILS_DATE_PICKER_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/left/components/test_ids';
-import { INSIGHTS_TAB_PREVALENCE_BUTTON_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_BUTTON = getDataTestSubjectSelector(
-  INSIGHTS_TAB_PREVALENCE_BUTTON_TEST_ID
+  'securitySolutionFlyoutInsightsTabPrevalenceButton'
 );
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_DATE_PICKER =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_DATE_PICKER_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsDatePicker');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_TYPE_CELL =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_TABLE_FIELD_CELL_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsTableFieldCell');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_NAME_CELL =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsTableValueCell');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_ALERT_COUNT_CELL =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsTableAlertCountCell');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_DOC_COUNT_CELL =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsTableDocCountCell');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_HOST_PREVALENCE_CELL =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_TABLE_HOST_PREVALENCE_CELL_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsTableHostPrevalenceCell');
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_USER_PREVALENCE_CELL =
-  getDataTestSubjectSelector(PREVALENCE_DETAILS_TABLE_USER_PREVALENCE_CELL_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutPrevalenceDetailsTableUserPrevalenceCell');

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_response_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_response_tab.ts
@@ -5,16 +5,14 @@
  * 2.0.
  */
 
-import { RESPONSE_TAB_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/test_ids';
-import {
-  RESPONSE_DETAILS_TEST_ID,
-  RESPONSE_NO_DATA_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/left/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
-export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB =
-  getDataTestSubjectSelector(RESPONSE_TAB_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_DETAILS =
-  getDataTestSubjectSelector(RESPONSE_DETAILS_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_EMPTY =
-  getDataTestSubjectSelector(RESPONSE_NO_DATA_TEST_ID);
+export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutResponseTab'
+);
+export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_DETAILS = getDataTestSubjectSelector(
+  'securitySolutionFlyoutResponseDetails'
+);
+export const DOCUMENT_DETAILS_FLYOUT_RESPONSE_EMPTY = getDataTestSubjectSelector(
+  'securitySolutionFlyoutResponseNoData'
+);

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_session_view_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_session_view_tab.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { VISUALIZE_TAB_SESSION_VIEW_BUTTON_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_BUTTON = getDataTestSubjectSelector(
-  VISUALIZE_TAB_SESSION_VIEW_BUTTON_TEST_ID
+  'securitySolutionFlyoutVisualizeTabSessionViewButton'
 );

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import { INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/left/tabs/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON =
-  getDataTestSubjectSelector(INSIGHTS_TAB_THREAT_INTELLIGENCE_BUTTON_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsTabThreatIntelligenceButton');

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_preview_panel_alert_reason_preview.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_preview_panel_alert_reason_preview.ts
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { ALERT_REASON_PREVIEW_BODY_TEST_ID } from '@kbn/security-solution-plugin/public/flyout/document_details/preview/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_ALERT_REASON_PREVIEW_CONTAINER = getDataTestSubjectSelector(
-  ALERT_REASON_PREVIEW_BODY_TEST_ID
+  'securitySolutionFlyoutAlertReasonPreviewBody'
 );

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_preview_panel_rule_preview.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_preview_panel_rule_preview.ts
@@ -5,46 +5,32 @@
  * 2.0.
  */
 
-import {
-  RULE_PREVIEW_TITLE_TEST_ID,
-  RULE_PREVIEW_RULE_CREATED_BY_TEST_ID,
-  RULE_PREVIEW_RULE_UPDATED_BY_TEST_ID,
-  RULE_PREVIEW_ABOUT_HEADER_TEST_ID,
-  RULE_PREVIEW_ABOUT_CONTENT_TEST_ID,
-  RULE_PREVIEW_DEFINITION_HEADER_TEST_ID,
-  RULE_PREVIEW_DEFINITION_CONTENT_TEST_ID,
-  RULE_PREVIEW_SCHEDULE_HEADER_TEST_ID,
-  RULE_PREVIEW_SCHEDULE_CONTENT_TEST_ID,
-  RULE_PREVIEW_FOOTER_TEST_ID,
-  RULE_PREVIEW_NAVIGATE_TO_RULE_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/preview/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_TITLE = getDataTestSubjectSelector(
-  RULE_PREVIEW_TITLE_TEST_ID
+  'securitySolutionFlyoutRulePreviewRulePreviewTitle'
 );
 export const DOCUMENT_DETAILS_FLYOUT_CREATED_BY = getDataTestSubjectSelector(
-  RULE_PREVIEW_RULE_CREATED_BY_TEST_ID
+  'securitySolutionFlyoutRulePreviewCreatedByText'
 );
 export const DOCUMENT_DETAILS_FLYOUT_UPDATED_BY = getDataTestSubjectSelector(
-  RULE_PREVIEW_RULE_UPDATED_BY_TEST_ID
+  'securitySolutionFlyoutRulePreviewUpdatedByText'
 );
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_ABOUT_SECTION_HEADER = getDataTestSubjectSelector(
-  RULE_PREVIEW_ABOUT_HEADER_TEST_ID
+  'securitySolutionFlyoutRulePreviewAboutSectionHeader'
 );
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_ABOUT_SECTION_CONTENT =
-  getDataTestSubjectSelector(RULE_PREVIEW_ABOUT_CONTENT_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutRulePreviewAboutSectionContent');
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_DEFINITION_SECTION_HEADER =
-  getDataTestSubjectSelector(RULE_PREVIEW_DEFINITION_HEADER_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutRulePreviewDefinitionSectionHeader');
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_DEFINITION_SECTION_CONTENT =
-  getDataTestSubjectSelector(RULE_PREVIEW_DEFINITION_CONTENT_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutRulePreviewDefinitionSectionContent');
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SCHEDULE_SECTION_HEADER =
-  getDataTestSubjectSelector(RULE_PREVIEW_SCHEDULE_HEADER_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutRulePreviewScheduleSectionHeader');
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_SCHEDULE_SECTION_CONTENT =
-  getDataTestSubjectSelector(RULE_PREVIEW_SCHEDULE_CONTENT_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutRulePreviewScheduleSectionContent');
 export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER = getDataTestSubjectSelector(
-  RULE_PREVIEW_FOOTER_TEST_ID
+  'securitySolutionFlyoutRulePreviewFooter'
 );
-export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER_LINK = getDataTestSubjectSelector(
-  RULE_PREVIEW_NAVIGATE_TO_RULE_TEST_ID
-);
+export const DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_FOOTER_LINK =
+  getDataTestSubjectSelector('goToRuleDetails');

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel.ts
@@ -5,63 +5,52 @@
  * 2.0.
  */
 
-import {
-  FLYOUT_BODY_TEST_ID,
-  JSON_TAB_TEST_ID,
-  OVERVIEW_TAB_TEST_ID,
-  TABLE_TAB_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/right/test_ids';
-import {
-  RISK_SCORE_TITLE_TEST_ID,
-  RISK_SCORE_VALUE_TEST_ID,
-  SEVERITY_VALUE_TEST_ID,
-  STATUS_BUTTON_TEST_ID,
-  FLYOUT_ALERT_HEADER_TITLE_TEST_ID,
-  ASSIGNEES_HEADER_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/right/components/test_ids';
-import {
-  COLLAPSE_DETAILS_BUTTON_TEST_ID,
-  EXPAND_DETAILS_BUTTON_TEST_ID,
-  TITLE_HEADER_TEXT_TEST_ID,
-  TITLE_LINK_ICON_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/shared/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
-export const DOCUMENT_DETAILS_FLYOUT_BODY = getDataTestSubjectSelector(FLYOUT_BODY_TEST_ID);
+export const DOCUMENT_DETAILS_FLYOUT_BODY = getDataTestSubjectSelector(
+  'securitySolutionFlyoutBody'
+);
 
 /* Header */
 
 export const DOCUMENT_DETAILS_FLYOUT_HEADER_ICON = getDataTestSubjectSelector(
-  TITLE_LINK_ICON_TEST_ID(FLYOUT_ALERT_HEADER_TITLE_TEST_ID)
+  'securitySolutionFlyoutAlertTitleIcon'
 );
 export const DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE = getDataTestSubjectSelector(
-  TITLE_HEADER_TEXT_TEST_ID(FLYOUT_ALERT_HEADER_TITLE_TEST_ID)
+  'securitySolutionFlyoutAlertTitleText'
 );
 export const DOCUMENT_DETAILS_FLYOUT_HEADER_LINK_ICON = getDataTestSubjectSelector(
-  TITLE_LINK_ICON_TEST_ID(FLYOUT_ALERT_HEADER_TITLE_TEST_ID)
+  'securitySolutionFlyoutAlertTitleLinkIcon'
 );
 export const DOCUMENT_DETAILS_FLYOUT_CLOSE_BUTTON =
   getDataTestSubjectSelector('euiFlyoutCloseButton');
 export const DOCUMENT_DETAILS_FLYOUT_EXPAND_DETAILS_BUTTON = getDataTestSubjectSelector(
-  EXPAND_DETAILS_BUTTON_TEST_ID
+  'securitySolutionFlyoutNavigationExpandDetailButton'
 );
 export const DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON = getDataTestSubjectSelector(
-  COLLAPSE_DETAILS_BUTTON_TEST_ID
+  'securitySolutionFlyoutNavigationCollapseDetailButton'
 );
-export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB =
-  getDataTestSubjectSelector(OVERVIEW_TAB_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_TABLE_TAB = getDataTestSubjectSelector(TABLE_TAB_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_JSON_TAB = getDataTestSubjectSelector(JSON_TAB_TEST_ID);
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutOverviewTab'
+);
+export const DOCUMENT_DETAILS_FLYOUT_TABLE_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutTableTab'
+);
+export const DOCUMENT_DETAILS_FLYOUT_JSON_TAB = getDataTestSubjectSelector(
+  'securitySolutionFlyoutJsonTab'
+);
 export const DOCUMENT_DETAILS_FLYOUT_HEADER_STATUS =
-  getDataTestSubjectSelector(STATUS_BUTTON_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE =
-  getDataTestSubjectSelector(RISK_SCORE_TITLE_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE_VALUE =
-  getDataTestSubjectSelector(RISK_SCORE_VALUE_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_HEADER_SEVERITY_VALUE =
-  getDataTestSubjectSelector(SEVERITY_VALUE_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_HEADER_ASSIGNEES =
-  getDataTestSubjectSelector(ASSIGNEES_HEADER_TEST_ID);
+  getDataTestSubjectSelector('rule-status-badge');
+export const DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE = getDataTestSubjectSelector(
+  'securitySolutionFlyoutHeaderRiskScoreTitle'
+);
+export const DOCUMENT_DETAILS_FLYOUT_HEADER_RISK_SCORE_VALUE = getDataTestSubjectSelector(
+  'securitySolutionFlyoutHeaderRiskScoreValue'
+);
+export const DOCUMENT_DETAILS_FLYOUT_HEADER_SEVERITY_VALUE = getDataTestSubjectSelector('severity');
+export const DOCUMENT_DETAILS_FLYOUT_HEADER_ASSIGNEES = getDataTestSubjectSelector(
+  'securitySolutionFlyoutHeaderAssigneesHeader'
+);
 
 /* Footer */
 

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel_json_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel_json_tab.ts
@@ -5,14 +5,9 @@
  * 2.0.
  */
 
-import {
-  JSON_TAB_CONTENT_TEST_ID,
-  JSON_TAB_COPY_TO_CLIPBOARD_BUTTON_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/right/tabs/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 export const DOCUMENT_DETAILS_FLYOUT_JSON_TAB_COPY_TO_CLIPBOARD_BUTTON = getDataTestSubjectSelector(
-  JSON_TAB_COPY_TO_CLIPBOARD_BUTTON_TEST_ID
+  'securitySolutionFlyoutJsonTabCopyToClipboard'
 );
-export const DOCUMENT_DETAILS_FLYOUT_JSON_TAB_CONTENT =
-  getDataTestSubjectSelector(JSON_TAB_CONTENT_TEST_ID);
+export const DOCUMENT_DETAILS_FLYOUT_JSON_TAB_CONTENT = getDataTestSubjectSelector('jsonView');

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel_overview_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel_overview_tab.ts
@@ -5,145 +5,106 @@
  * 2.0.
  */
 
-import {
-  EXPANDABLE_PANEL_CONTENT_TEST_ID,
-  EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/shared/components/test_ids';
-import {
-  ABOUT_SECTION_HEADER_TEST_ID,
-  ALERT_DESCRIPTION_DETAILS_TEST_ID,
-  ALERT_DESCRIPTION_TITLE_TEST_ID,
-  RULE_SUMMARY_BUTTON_TEST_ID,
-  HIGHLIGHTED_FIELDS_DETAILS_TEST_ID,
-  HIGHLIGHTED_FIELDS_TITLE_TEST_ID,
-  INSIGHTS_HEADER_TEST_ID,
-  INVESTIGATION_GUIDE_BUTTON_TEST_ID,
-  INVESTIGATION_SECTION_HEADER_TEST_ID,
-  MITRE_ATTACK_DETAILS_TEST_ID,
-  MITRE_ATTACK_TITLE_TEST_ID,
-  REASON_DETAILS_TEST_ID,
-  REASON_TITLE_TEST_ID,
-  VISUALIZATIONS_SECTION_HEADER_TEST_ID,
-  HIGHLIGHTED_FIELDS_CELL_TEST_ID,
-  RESPONSE_SECTION_HEADER_TEST_ID,
-  INSIGHTS_THREAT_INTELLIGENCE_TEST_ID,
-  CORRELATIONS_TEST_ID,
-  PREVALENCE_TEST_ID,
-  SUMMARY_ROW_VALUE_TEST_ID,
-  CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID,
-  CORRELATIONS_RELATED_ALERTS_BY_SAME_SOURCE_EVENT_TEST_ID,
-  CORRELATIONS_RELATED_ALERTS_BY_SESSION_TEST_ID,
-  CORRELATIONS_RELATED_CASES_TEST_ID,
-  CORRELATIONS_SUPPRESSED_ALERTS_TEST_ID,
-  INSIGHTS_ENTITIES_TEST_ID,
-  REASON_DETAILS_PREVIEW_BUTTON_TEST_ID,
-  ANALYZER_PREVIEW_TEST_ID,
-  SESSION_PREVIEW_TEST_ID,
-  RESPONSE_BUTTON_TEST_ID,
-} from '@kbn/security-solution-plugin/public/flyout/document_details/right/components/test_ids';
 import { getDataTestSubjectSelector } from '../../helpers/common';
 
 /* About section */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_HEADER = getDataTestSubjectSelector(
-  ABOUT_SECTION_HEADER_TEST_ID
+  'securitySolutionFlyoutAboutSectionHeader'
 );
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_TITLE = getDataTestSubjectSelector(
-  ALERT_DESCRIPTION_TITLE_TEST_ID
+  'securitySolutionFlyoutAlertDescriptionTitle'
 );
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_DETAILS = getDataTestSubjectSelector(
-  ALERT_DESCRIPTION_DETAILS_TEST_ID
+  'securitySolutionFlyoutAlertDescriptionDetails'
 );
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_OPEN_RULE_PREVIEW_BUTTON =
-  getDataTestSubjectSelector(RULE_SUMMARY_BUTTON_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_TITLE =
-  getDataTestSubjectSelector(REASON_TITLE_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_DETAILS =
-  getDataTestSubjectSelector(REASON_DETAILS_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutRuleSummaryButton');
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_TITLE = getDataTestSubjectSelector(
+  'securitySolutionFlyoutReasonTitle'
+);
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_REASON_DETAILS = getDataTestSubjectSelector(
+  'securitySolutionFlyoutReasonDetails'
+);
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_OPEN_ALERT_REASON_PREVIEW_BUTTON =
-  getDataTestSubjectSelector(REASON_DETAILS_PREVIEW_BUTTON_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutReasonPreviewButton');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_TITLE = getDataTestSubjectSelector(
-  MITRE_ATTACK_TITLE_TEST_ID
+  'securitySolutionFlyoutMitreAttackTitle'
 );
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_DETAILS = getDataTestSubjectSelector(
-  MITRE_ATTACK_DETAILS_TEST_ID
+  'securitySolutionFlyoutMitreAttackDetails'
 );
 
 /* Investigation section */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_HEADER =
-  getDataTestSubjectSelector(INVESTIGATION_SECTION_HEADER_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutInvestigationSectionHeader');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_HEADER_TITLE =
-  getDataTestSubjectSelector(HIGHLIGHTED_FIELDS_TITLE_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutHighlightedFieldsTitle');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_DETAILS =
-  getDataTestSubjectSelector(HIGHLIGHTED_FIELDS_DETAILS_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutHighlightedFieldsDetails');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_FIELD_CELL =
   getDataTestSubjectSelector('fieldCell');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_VALUE_CELL = (
   value: string
-) => getDataTestSubjectSelector(`${value}-${HIGHLIGHTED_FIELDS_CELL_TEST_ID}`);
+) => getDataTestSubjectSelector(`${value}-securitySolutionFlyoutHighlightedFieldsCell`);
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_GUIDE_BUTTON =
-  getDataTestSubjectSelector(INVESTIGATION_GUIDE_BUTTON_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutInvestigationGuideButton');
 
 /* Insights section */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_SECTION_HEADER =
-  getDataTestSubjectSelector(INSIGHTS_HEADER_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsHeader');
 
 /* Insights Entities */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_ENTITIES_HEADER =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(INSIGHTS_ENTITIES_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsEntitiesTitleLink');
 
 /* Insights Threat Intelligence */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_HEADER =
-  getDataTestSubjectSelector(
-    EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(INSIGHTS_THREAT_INTELLIGENCE_TEST_ID)
-  );
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsThreatIntelligenceTitleLink');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_THREAT_INTELLIGENCE_VALUES =
-  getDataTestSubjectSelector(SUMMARY_ROW_VALUE_TEST_ID(INSIGHTS_THREAT_INTELLIGENCE_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsThreatIntelligenceValue');
 
 /* Insights Correlations */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_HEADER =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(CORRELATIONS_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutCorrelationsTitleLink');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES_SUPPRESSED_ALERTS =
-  getDataTestSubjectSelector(SUMMARY_ROW_VALUE_TEST_ID(CORRELATIONS_SUPPRESSED_ALERTS_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutCorrelationsSuppressedAlertsValue');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES_RELATED_ALERTS_BY_ANCESTRY =
-  getDataTestSubjectSelector(
-    SUMMARY_ROW_VALUE_TEST_ID(CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID)
-  );
+  getDataTestSubjectSelector('securitySolutionFlyoutCorrelationsRelatedAlertsByAncestryValue');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES_RELATED_ALERTS_BY_SAME_SOURCE_EVENT =
   getDataTestSubjectSelector(
-    SUMMARY_ROW_VALUE_TEST_ID(CORRELATIONS_RELATED_ALERTS_BY_SAME_SOURCE_EVENT_TEST_ID)
+    'securitySolutionFlyoutCorrelationsRelatedAlertsBySameSourceEventValue'
   );
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES_RELATED_ALERTS_BY_SESSION =
-  getDataTestSubjectSelector(
-    SUMMARY_ROW_VALUE_TEST_ID(CORRELATIONS_RELATED_ALERTS_BY_SESSION_TEST_ID)
-  );
+  getDataTestSubjectSelector('securitySolutionFlyoutCorrelationsRelatedAlertsBySessionValue');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES_RELATED_CASES =
-  getDataTestSubjectSelector(SUMMARY_ROW_VALUE_TEST_ID(CORRELATIONS_RELATED_CASES_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutCorrelationsRelatedCasesValue');
 
 /* Insights Prevalence */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_HEADER =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(PREVALENCE_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsPrevalenceTitleLink');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_CONTENT =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_CONTENT_TEST_ID(PREVALENCE_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsPrevalenceContent');
 
 /* Visualization section */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_VISUALIZATIONS_SECTION_HEADER =
-  getDataTestSubjectSelector(VISUALIZATIONS_SECTION_HEADER_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutVisualizationsHeader');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_PREVIEW_CONTAINER =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_CONTENT_TEST_ID(ANALYZER_PREVIEW_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutAnalyzerPreviewContent');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW_CONTAINER =
-  getDataTestSubjectSelector(EXPANDABLE_PANEL_CONTENT_TEST_ID(SESSION_PREVIEW_TEST_ID));
+  getDataTestSubjectSelector('securitySolutionFlyoutSessionPreviewContent');
 
 /* Response section */
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_SECTION_HEADER =
-  getDataTestSubjectSelector(RESPONSE_SECTION_HEADER_TEST_ID);
-export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_BUTTON =
-  getDataTestSubjectSelector(RESPONSE_BUTTON_TEST_ID);
+  getDataTestSubjectSelector('securitySolutionFlyoutResponseSectionHeader');
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_BUTTON = getDataTestSubjectSelector(
+  'securitySolutionFlyoutResponseButton'
+);


### PR DESCRIPTION
## Summary

This PR fixes a really weird bug happening in Cypress. I noticed that making some changes to one of the Security Solution app files, some of the Cypress tests were completely broken. Here's the error that Webpack throws when trying to run these tests
![Screenshot 2024-03-26 at 6 05 58 PM](https://github.com/elastic/kibana/assets/17276605/3c97ff16-397d-4799-a1b0-83154d596483)

After a log of debugging, the issue comes from the fact that we're importing Security Solution app constants within Cypress and Webpack isn't able to handle it correctly.

This is the same test file running after the changes made in this PR
![Screenshot 2024-03-26 at 6 07 02 PM](https://github.com/elastic/kibana/assets/17276605/1233c1ee-77da-4d8d-8e33-b234cf3a32bb) 

### How to reproduce

1. checkout the `main` branch
2. go to the expandable_section.tsx [file](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.tsx) and add a usage of `useKibana`. For example `const { storage } = useKibana().services;` imported from `import { useKibana } from '../../../../common/lib/kibana';`
3. try to run some of the Cypress test files (I know [this one](https://github.com/elastic/kibana/blob/main/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts) fails but plenty others do as well)

Do the same on this branch and the tests will run fine.