### PR TITLE
[Security Solution] persists the alert details flyout right panel selected tab in localStorage

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -8,4 +8,5 @@
 export const FLYOUT_STORAGE_KEYS = {
   OVERVIEW_TAB_EXPANDED_SECTIONS:
     'securitySolution.documentDetailsFlyout.overviewSectionExpanded.v8.14',
+  RIGHT_PANEL_SELECTED_TABS: 'securitySolution.documentDetailsFlyout.rightPanel.selectedTabs.v8.14',
 };

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
@@ -12,7 +12,7 @@ import {
 import { DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB } from '../../../../screens/expandable_flyout/alert_details_left_panel';
 import { openGraphAnalyzerTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_analyzer_graph_tab';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { ANALYZER_NODE } from '../../../../screens/alerts';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
@@ -33,7 +33,7 @@ describe.skip(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
       openGraphAnalyzerTab();
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
@@ -26,7 +26,7 @@ import { openInsightsTab } from '../../../../tasks/expandable_flyout/alert_detai
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import {
   createNewCaseFromExpandableFlyout,
-  expandFirstAlertExpandableFlyout,
+  expandAlertAtIndexExpandableFlyout,
 } from '../../../../tasks/expandable_flyout/common';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
@@ -41,7 +41,7 @@ describe('Expandable flyout left panel correlations', { tags: ['@ess', '@serverl
     createRule(getNewRule());
     visit(ALERTS_URL);
     waitForAlertsToPopulate();
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
     expandDocumentDetailsExpandableFlyoutLeftSection();
     createNewCaseFromExpandableFlyout();
     openInsightsTab();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
@@ -18,7 +18,7 @@ import { DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB } from '../../../../screens/expand
 import { openEntitiesTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_entities_tab';
 import { openInsightsTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -37,7 +37,7 @@ describe(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
       openInsightsTab();
       openEntitiesTab();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../screens/expandable_flyout/alert_details_left_panel_investigation_tab';
 import { openInvestigationTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_investigation_tab';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -30,7 +30,7 @@ describe(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
       openInvestigationTab();
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
@@ -8,7 +8,7 @@
 import { openPrevalenceTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_prevalence_tab';
 import { openInsightsTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB } from '../../../../screens/expandable_flyout/alert_details_left_panel';
 import {
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_ALERT_COUNT_CELL,
@@ -38,7 +38,7 @@ describe(
       createRule({ ...getNewRule(), investigation_fields: { field_names: ['host.os.name'] } });
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
       openInsightsTab();
       openPrevalenceTab();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../screens/expandable_flyout/alert_details_left_panel_response_tab';
 import { openResponseTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_response_tab';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -31,7 +31,7 @@ describe(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
       openResponseTab();
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
@@ -8,7 +8,7 @@
 import { DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_BUTTON } from '../../../../screens/expandable_flyout/alert_details_left_panel_session_view_tab';
 import { DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB } from '../../../../screens/expandable_flyout/alert_details_left_panel';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
@@ -28,7 +28,7 @@ describe.skip(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
@@ -8,7 +8,7 @@
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { getNewRule } from '../../../../objects/rule';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { INDICATOR_MATCH_ENRICHMENT_SECTION } from '../../../../screens/alerts_details';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
@@ -30,7 +30,7 @@ describe(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       expandDocumentDetailsExpandableFlyoutLeftSection();
       openInsightsTab();
       openThreatIntelligenceTab();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_alert_reason_preview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_alert_reason_preview.cy.ts
@@ -6,7 +6,7 @@
  */
 
 import { DOCUMENT_DETAILS_FLYOUT_ALERT_REASON_PREVIEW_CONTAINER } from '../../../../screens/expandable_flyout/alert_details_preview_panel_alert_reason_preview';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { clickAlertReasonButton } from '../../../../tasks/expandable_flyout/alert_details_right_panel_overview_tab';
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
@@ -28,7 +28,7 @@ describe(
       createRule(rule);
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       clickAlertReasonButton();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import {
   DOCUMENT_DETAILS_FLYOUT_RULE_PREVIEW_TITLE,
   DOCUMENT_DETAILS_FLYOUT_CREATED_BY,
@@ -45,7 +45,7 @@ describe(
       createRule(rule);
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       clickRuleSummaryButton();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
@@ -11,7 +11,7 @@ import {
   EXISTING_CASE_SELECT_BUTTON,
   VIEW_CASE_TOASTER_LINK,
 } from '../../../../screens/expandable_flyout/common';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { ALERT_CHECKBOX, EMPTY_ALERT_TABLE } from '../../../../screens/alerts';
 import {
   DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON,
@@ -43,6 +43,7 @@ import {
   DOCUMENT_DETAILS_FLYOUT_TABLE_TAB,
 } from '../../../../screens/expandable_flyout/alert_details_right_panel';
 import {
+  closeFlyout,
   collapseDocumentDetailsExpandableFlyoutLeftSection,
   expandDocumentDetailsExpandableFlyoutLeftSection,
   fillOutFormToCreateNewCase,
@@ -73,7 +74,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
   });
 
   it('should display header and footer basics', () => {
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
 
     cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_ICON).should('exist');
     cy.get(DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE).should('have.text', rule.name);
@@ -131,7 +132,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
   // TODO this will change when add to existing case is improved
   //  https://github.com/elastic/security-team/issues/6298
   it('should add to existing case', () => {
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
     openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE);
     fillOutFormToCreateNewCase();
     openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_EXISTING_CASE);
@@ -144,7 +145,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
   // TODO this will change when add to new case is improved
   //  https://github.com/elastic/security-team/issues/6298
   it('should add to new case', () => {
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
     openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE);
     fillOutFormToCreateNewCase();
 
@@ -154,7 +155,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
   it('should mark as acknowledged', () => {
     cy.get(ALERT_CHECKBOX).should('have.length', 1);
 
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
     openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_MARK_AS_ACKNOWLEDGED);
 
     cy.get(TOASTER).should('have.text', 'Successfully marked 1 alert as acknowledged.');
@@ -164,7 +165,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
   it('should mark as closed', () => {
     cy.get(ALERT_CHECKBOX).should('have.length', 1);
 
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
     openTakeActionButtonAndSelectItem(DOCUMENT_DETAILS_FLYOUT_FOOTER_MARK_AS_CLOSED);
 
     cy.get(TOASTER).should('have.text', 'Successfully closed 1 alert.');
@@ -173,7 +174,7 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
 
   // these actions are now grouped together as we're not really testing their functionality but just the existence of the option in the dropdown
   it('should test other action within take action dropdown', () => {
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
 
     cy.log('should add endpoint exception');
 
@@ -214,5 +215,49 @@ describe('Alert details expandable flyout right panel', { tags: ['@ess', '@serve
       .within(() =>
         cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_INVESTIGATE_IN_TIMELINE_ENTRY).should('exist')
       );
+  });
+
+  describe('Local storage persistence', () => {
+    before(() => {
+      cy.task('esArchiverLoad', { archiveName: 'auditbeat_multiple' });
+    });
+
+    after(() => {
+      cy.task('esArchiverUnload', { archiveName: 'auditbeat_multiple' });
+    });
+
+    it('should remember which tab was selected when opening another alert or after page refresh', () => {
+      expandAlertAtIndexExpandableFlyout();
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).should('have.class', 'euiTab-isSelected');
+
+      openTableTab();
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('have.class', 'euiTab-isSelected');
+
+      cy.log('should persist selected tab when opening a different alert');
+
+      expandAlertAtIndexExpandableFlyout(1);
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).should('not.have.class', 'euiTab-isSelected');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('have.class', 'euiTab-isSelected');
+
+      cy.log('should persist selected tab after closing flyout');
+
+      closeFlyout();
+      expandAlertAtIndexExpandableFlyout();
+
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).should('not.have.class', 'euiTab-isSelected');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('have.class', 'euiTab-isSelected');
+
+      cy.log('should persist selected tab after page refresh');
+
+      closeFlyout();
+      cy.reload();
+
+      expandAlertAtIndexExpandableFlyout();
+      cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).should('not.have.class', 'euiTab-isSelected');
+      cy.get(DOCUMENT_DETAILS_FLYOUT_TABLE_TAB).should('have.class', 'euiTab-isSelected');
+    });
   });
 });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
@@ -6,7 +6,7 @@
  */
 
 import { openJsonTab } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import {
   DOCUMENT_DETAILS_FLYOUT_JSON_TAB_CONTENT,
   DOCUMENT_DETAILS_FLYOUT_JSON_TAB_COPY_TO_CLIPBOARD_BUTTON,
@@ -29,7 +29,7 @@ describe(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       openJsonTab();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -6,10 +6,13 @@
  */
 
 import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
-import { collapseDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
+import {
+  closeFlyout,
+  collapseDocumentDetailsExpandableFlyoutLeftSection,
+} from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import {
   createNewCaseFromExpandableFlyout,
-  expandFirstAlertExpandableFlyout,
+  expandAlertAtIndexExpandableFlyout,
 } from '../../../../tasks/expandable_flyout/common';
 import {
   DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_HEADER,
@@ -39,6 +42,7 @@ import {
   DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_TABLE_VALUE_CELL,
   DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_CORRELATIONS_VALUES_RELATED_ALERTS_BY_SAME_SOURCE_EVENT,
+  DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT,
 } from '../../../../screens/expandable_flyout/alert_details_right_panel_overview_tab';
 import {
   navigateToCorrelationsDetails,
@@ -85,7 +89,7 @@ describe(
       createRule(rule);
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
     });
 
     describe('about section', () => {
@@ -377,6 +381,43 @@ describe(
         cy.get(DOCUMENT_DETAILS_FLYOUT_RESPONSE_TAB)
           .should('have.text', 'Response')
           .and('have.class', 'euiTab-isSelected');
+      });
+    });
+
+    describe('local storage persistence', () => {
+      before(() => {
+        cy.task('esArchiverLoad', { archiveName: 'auditbeat_multiple' });
+      });
+
+      after(() => {
+        cy.task('esArchiverUnload', { archiveName: 'auditbeat_multiple' });
+      });
+
+      it('should persist which section are collapsed/expanded', () => {
+        cy.log('should show the correct expanded and collapsed section by default');
+
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT).should('be.visible');
+
+        cy.log('should persist the expanded and collapsed sections when opening another alert');
+
+        toggleOverviewTabAboutSection();
+
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT).should('not.be.visible');
+
+        cy.log('should persist the expanded and collapsed sections after closing the flyout');
+
+        closeFlyout();
+        expandAlertAtIndexExpandableFlyout();
+
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT).should('not.be.visible');
+
+        cy.log('should persist the expanded and collapsed sections after page reload');
+
+        closeFlyout();
+        cy.reload();
+        expandAlertAtIndexExpandableFlyout();
+
+        cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT).should('not.be.visible');
       });
     });
   }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
@@ -6,7 +6,7 @@
  */
 
 import { openTableTab } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { closeTimeline, openActiveTimeline } from '../../../../tasks/timeline';
 import { PROVIDER_BADGE } from '../../../../screens/timeline';
 import { removeKqlFilter } from '../../../../tasks/search_bar';
@@ -43,7 +43,7 @@ describe(
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
+      expandAlertAtIndexExpandableFlyout();
       openTableTab();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_url_sync.cy.ts
@@ -12,7 +12,7 @@ import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { closeFlyout } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
-import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { expandAlertAtIndexExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { DOCUMENT_DETAILS_FLYOUT_HEADER_TITLE } from '../../../../screens/expandable_flyout/alert_details_right_panel';
 
 describe('Expandable flyout state sync', { tags: ['@ess', '@serverless'] }, () => {
@@ -28,7 +28,7 @@ describe('Expandable flyout state sync', { tags: ['@ess', '@serverless'] }, () =
   it('should test flyout url sync', () => {
     cy.url().should('not.include', 'right');
 
-    expandFirstAlertExpandableFlyout();
+    expandAlertAtIndexExpandableFlyout();
 
     cy.log('should serialize its state to url');
 

--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel_overview_tab.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/alert_details_right_panel_overview_tab.ts
@@ -12,6 +12,8 @@ import { getDataTestSubjectSelector } from '../../helpers/common';
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_HEADER = getDataTestSubjectSelector(
   'securitySolutionFlyoutAboutSectionHeader'
 );
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ABOUT_SECTION_CONTENT =
+  getDataTestSubjectSelector('securitySolutionFlyoutAboutSectionContent');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_DESCRIPTION_TITLE = getDataTestSubjectSelector(
   'securitySolutionFlyoutAlertDescriptionTitle'
 );
@@ -39,6 +41,8 @@ export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_MITRE_ATTACK_DETAILS = getData
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_HEADER =
   getDataTestSubjectSelector('securitySolutionFlyoutInvestigationSectionHeader');
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_SECTION_CONTENT =
+  getDataTestSubjectSelector('securitySolutionFlyoutInvestigationSectionContent');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_HEADER_TITLE =
   getDataTestSubjectSelector('securitySolutionFlyoutHighlightedFieldsTitle');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_HIGHLIGHTED_FIELDS_DETAILS =
@@ -55,6 +59,8 @@ export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INVESTIGATION_GUIDE_BUTTON =
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_SECTION_HEADER =
   getDataTestSubjectSelector('securitySolutionFlyoutInsightsHeader');
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_SECTION_CONTENT =
+  getDataTestSubjectSelector('securitySolutionFlyoutInsightsContent');
 
 /* Insights Entities */
 
@@ -96,6 +102,8 @@ export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_INSIGHTS_PREVALENCE_CONTENT =
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_VISUALIZATIONS_SECTION_HEADER =
   getDataTestSubjectSelector('securitySolutionFlyoutVisualizationsHeader');
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_VISUALIZATIONS_SECTION_CONTENT =
+  getDataTestSubjectSelector('securitySolutionFlyoutVisualizationsContent');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_ANALYZER_PREVIEW_CONTAINER =
   getDataTestSubjectSelector('securitySolutionFlyoutAnalyzerPreviewContent');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW_CONTAINER =
@@ -105,6 +113,8 @@ export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_SESSION_PREVIEW_CONTAINER =
 
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_SECTION_HEADER =
   getDataTestSubjectSelector('securitySolutionFlyoutResponseSectionHeader');
+export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_SECTION_CONTENT =
+  getDataTestSubjectSelector('securitySolutionFlyoutResponseSectionContent');
 export const DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_BUTTON = getDataTestSubjectSelector(
   'securitySolutionFlyoutResponseButton'
 );

--- a/x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout/common.ts
@@ -17,10 +17,10 @@ import {
 import { openTakeActionButtonAndSelectItem } from './alert_details_right_panel';
 
 /**
- * Find the first alert row in the alerts table then click on the expand icon button to open the flyout
+ * Find the alert row at index in the alerts table then click on the expand icon button to open the flyout
  */
-export const expandFirstAlertExpandableFlyout = () => {
-  cy.get(EXPAND_ALERT_BTN).first().click();
+export const expandAlertAtIndexExpandableFlyout = (index = 0) => {
+  cy.get(EXPAND_ALERT_BTN).eq(index).click();
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR adds another persistence for the document details expandable flyout. We're now storing in localStorage which tab (`Overview`, `Table` or `Json`) is selected.
We want to reopen that tab:
- when the user selects a different alert
- when the user closes and reopens the flyout
- when the user refreshes the page

https://github.com/elastic/kibana/assets/17276605/eb2c9ee0-9b05-4574-bd5a-966e98128874

https://github.com/elastic/security-team/issues/7670

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed