### PR TITLE
[Ops] Add debug to manifest downloads @ trigger.sh

### DIFF
--- a/.buildkite/scripts/steps/artifacts/trigger.sh
+++ b/.buildkite/scripts/steps/artifacts/trigger.sh
@@ -4,9 +4,24 @@ set -euo pipefail
 
 source .buildkite/scripts/steps/artifacts/env.sh
 
-BEATS_MANIFEST_LATEST_URL=$(curl  "$BEATS_MANIFEST_LATEST" | jq -r '.manifest_url')
-KIBANA_MANIFEST_URL=$(curl  "$KIBANA_MANIFEST_LATEST" | jq -r '.manifest_url')
-KIBANA_BEATS_MANIFEST_URL=$(curl $KIBANA_MANIFEST_URL | jq -r '.projects.kibana.dependencies[] | select(.prefix == "beats") | .build_uri')
+function get_prop_safe() {
+  local json_url=$1
+  local prop=$2
+
+  local json_content=$(curl "$json_url")
+
+  if jq -e . >/dev/null 2>&1 <<<"$json_content"; then
+    echo "$json_content" | jq -r "$prop"
+  else
+    echo "Error: $json_url is not valid json" >&2
+    echo "$json_content" >&2
+    jq -e . >/dev/null <<< "$json_content"
+  fi
+}
+
+BEATS_MANIFEST_LATEST_URL=$(get_prop_safe  "$BEATS_MANIFEST_LATEST" '.json_url')
+KIBANA_MANIFEST_URL=$(get_prop_safe  "$KIBANA_MANIFEST_LATEST" '.json_url')
+KIBANA_BEATS_MANIFEST_URL=$(get_prop_safe $KIBANA_MANIFEST_URL '.projects.kibana.dependencies[] | select(.prefix == "beats") | .build_uri')
 
 echo "--- Trigger artifact builds"
 if [ "$BEATS_MANIFEST_LATEST_URL" = "$KIBANA_BEATS_MANIFEST_URL" ]; then


### PR DESCRIPTION
## Summary
There's a step in `.buildkite/scripts/steps/artifacts/trigger.sh` that fails with no traces or any hints what's wrong.

This PR adds a mechanism to print some info about the failure for the happiness of the developer.

See: https://buildkite.com/elastic/kibana-artifacts-trigger/builds/9400
Instead of the above failure, it will fail like this:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   291  100   291    0     0   1443      0 --:--:-- --:--:-- --:--:--  1440
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   127  100   127    0     0    790      0 --:--:-- --:--:-- --:--:--   793
Error: https://artifacts-snapshot.elastic.co/kibana/latest/8.13.1-SNAPSHOT.json is not valid json
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>
jq: parse error: Invalid numeric literal at line 1, column 6
```