### PR TITLE
[HTTP] Update plugin static asset registration to preserve legacy behaviour

### DIFF
--- a/packages/core/apps/core-apps-server-internal/src/core_app.test.ts
+++ b/packages/core/apps/core-apps-server-internal/src/core_app.test.ts
@@ -348,6 +348,12 @@ describe('CoreApp', () => {
       requiredBundles: [],
       version: '1.0.0',
     });
+    uiPlugins.internal.set('some-plugin-3-internal', {
+      publicAssetsDir: '/foo-internal',
+      publicTargetDir: '/bar-internal',
+      requiredBundles: [],
+      version: '1.0.0',
+    });
 
     internalCoreSetup.http.staticAssets.prependServerPath.mockReturnValue('/static-assets-path');
     internalCoreSetup.http.staticAssets.getPluginServerPath.mockImplementation(
@@ -356,8 +362,8 @@ describe('CoreApp', () => {
     await coreApp.setup(internalCoreSetup, uiPlugins);
 
     expect(internalCoreSetup.http.registerStaticDir).toHaveBeenCalledTimes(
-      // Twice for all UI plugins + core's UI asset routes
-      uiPlugins.public.size * 2 + 2
+      // Twice for all _internal_ UI plugins + core's UI asset routes
+      uiPlugins.internal.size * 2 + 2
     );
     expect(internalCoreSetup.http.registerStaticDir).toHaveBeenCalledWith(
       '/static-assets-path',
@@ -381,6 +387,15 @@ describe('CoreApp', () => {
     );
     expect(internalCoreSetup.http.registerStaticDir).toHaveBeenCalledWith(
       '/plugins/some-plugin-2/assets/{path*}', // legacy
+      expect.any(String)
+    );
+
+    expect(internalCoreSetup.http.registerStaticDir).toHaveBeenCalledWith(
+      '/static-assets-path/some-plugin-3-internal/{path*}',
+      expect.any(String)
+    );
+    expect(internalCoreSetup.http.registerStaticDir).toHaveBeenCalledWith(
+      '/plugins/some-plugin-3-internal/assets/{path*}', // legacy
       expect.any(String)
     );
   });

--- a/packages/core/apps/core-apps-server-internal/src/core_app.test.ts
+++ b/packages/core/apps/core-apps-server-internal/src/core_app.test.ts
@@ -316,7 +316,7 @@ describe('CoreApp', () => {
     });
   });
 
-  it('registers expected static dirs if there are public plugins', async () => {
+  it('registers expected static dirs for all plugins with static dirs', async () => {
     const uiPlugins = emptyPlugins();
     uiPlugins.public.set('some-plugin', {
       type: PluginType.preboot,

--- a/packages/core/apps/core-apps-server-internal/src/core_app.ts
+++ b/packages/core/apps/core-apps-server-internal/src/core_app.ts
@@ -283,9 +283,8 @@ export class CoreAppsService {
       );
     });
 
-    for (const [pluginName] of uiPlugins.public) {
-      const pluginInfo = uiPlugins.internal.get(pluginName);
-      if (!pluginInfo) continue; // assuming we will never hit this case; a public entry should have internal info registered
+    for (const [pluginName, pluginInfo] of uiPlugins.internal) {
+      if (!pluginInfo.publicAssetsDir) continue;
       /**
        * Serve UI from sha-scoped and not-sha-scoped paths to allow time for plugin code to migrate
        * Eventually we only want to serve from the sha scoped path


### PR DESCRIPTION
## Summary

Change the algorithm for registering plugin static assets to register all plugin static assets.

## How to test

1. Start Kibana with `enterpriseSearch.enabled: false` (with `--no-base-path`
2. Should still get an asset served at `http://localhost:5601/XXXXXXXXXXXX/plugins/enterpriseSearch/assets/images/cut.svg` and `http://localhost:5601/plugins/enterpriseSearch/assets/images/cut.svg`