### PR TITLE
[Logs Explorer] Update wrong base pattern for logs data view setting

### DIFF
--- a/x-pack/plugins/observability_solution/logs_explorer/common/constants.ts
+++ b/x-pack/plugins/observability_solution/logs_explorer/common/constants.ts
@@ -92,5 +92,5 @@ export const FILTER_OUT_FIELDS_PREFIXES_FOR_CONTENT = [
   'service.',
 ];
 
-export const DEFAULT_ALLOWED_DATA_VIEWS = ['logs', 'auditbeat', 'filebeat', 'winbeat'];
-export const DEFAULT_ALLOWED_LOGS_DATA_VIEWS = ['logs', 'auditbeat', 'filebeat', 'winbeat'];
+export const DEFAULT_ALLOWED_DATA_VIEWS = ['logs', 'auditbeat', 'filebeat', 'winlogbeat'];
+export const DEFAULT_ALLOWED_LOGS_DATA_VIEWS = ['logs', 'auditbeat', 'filebeat', 'winlogbeat'];


### PR DESCRIPTION
## 📓 Summary

Fix a typo on the default base patterns used in the settings for the logs-backed data views, renaming `winbeat` to `winlogbeat`.