### PR TITLE
[8.13] [Security Solution] Remove @ts-expect-error from v4.9.5 upgrade in Detection and Response areas (#179273)

### DIFF
--- a/packages/kbn-securitysolution-io-ts-alerting-types/src/threat_mapping/index.test.ts
+++ b/packages/kbn-securitysolution-io-ts-alerting-types/src/threat_mapping/index.test.ts
@@ -37,7 +37,7 @@ describe('threat_mapping', () => {
     });
 
     test('it should fail validation with an extra entry item', () => {
-      const payload: ThreatMappingEntries & Array<{ extra: string }> = [
+      const payload: Array<ThreatMappingEntries[0] & { extra: string }> = [
         {
           field: 'field.one',
           type: 'mapping',
@@ -111,7 +111,7 @@ describe('threat_mapping', () => {
   });
 
   test('it should fail validate with an extra key', () => {
-    const payload: ThreatMapping & Array<{ extra: string }> = [
+    const payload: Array<ThreatMapping[0] & { extra: string }> = [
       {
         entries: [
           {
@@ -133,7 +133,7 @@ describe('threat_mapping', () => {
   });
 
   test('it should fail validate with an extra inner entry', () => {
-    const payload: ThreatMapping & Array<{ entries: Array<{ extra: string }> }> = [
+    const payload: Array<ThreatMapping[0] & { entries: Array<{ extra: string }> }> = [
       {
         entries: [
           {

--- a/packages/kbn-securitysolution-utils/src/add_remove_id_to_item/index.ts
+++ b/packages/kbn-securitysolution-utils/src/add_remove_id_to_item/index.ts
@@ -19,7 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 type NotArray<T> = T extends unknown[] ? never : T;
 export const addIdToItem = <T>(item: NotArray<T>): T => {
-  const maybeId: typeof item & { id?: string } = item;
+  const maybeId = item as typeof item & { id?: string };
   if (maybeId.id != null) {
     return item;
   } else {
@@ -41,7 +41,7 @@ export const removeIdFromItem = <T>(
       },
       Exclude<keyof T, 'id'>
     > => {
-  const maybeId: typeof item & { id?: string } = item;
+  const maybeId = item as typeof item & { id?: string };
   if (maybeId.id != null) {
     const { id, ...noId } = maybeId;
     return noId;

--- a/x-pack/plugins/lists/server/routes/utils/build_siem_response.ts
+++ b/x-pack/plugins/lists/server/routes/utils/build_siem_response.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { CustomHttpResponseOptions, KibanaResponseFactory } from '@kbn/core/server';
+import {
+  CustomHttpResponseOptions,
+  HttpResponsePayload,
+  KibanaResponseFactory,
+  ResponseError,
+} from '@kbn/core/server';
 
 /**
  * Copied from x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.ts
@@ -49,7 +54,12 @@ export class SiemResponseFactory {
   constructor(private response: KibanaResponseFactory) {}
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  error<T>({ statusCode, body, headers, bypassErrorFormat }: CustomHttpResponseOptions<T>) {
+  error<T extends HttpResponsePayload | ResponseError>({
+    statusCode,
+    body,
+    headers,
+    bypassErrorFormat,
+  }: CustomHttpResponseOptions<T>) {
     // KibanaResponse is not exported so we cannot use a return type here and that is why the linter is turned off above
     const contentType: CustomHttpResponseOptions<T>['headers'] = {
       'content-type': 'application/json',
@@ -60,7 +70,7 @@ export class SiemResponseFactory {
     };
 
     const formattedBody = bypassErrorFormat
-      ? body
+      ? Object.assign<{}, unknown>({}, body) // eslint-disable-line prefer-object-spread
       : { message: body ?? statusToErrorMessage(statusCode) };
 
     return this.response.custom({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/utils.ts
@@ -12,6 +12,8 @@ import type {
   RouteValidationFunction,
   KibanaResponseFactory,
   CustomHttpResponseOptions,
+  HttpResponsePayload,
+  ResponseError,
 } from '@kbn/core/server';
 
 import { CustomHttpRequestError } from '../../../utils/custom_http_request_error';
@@ -160,7 +162,11 @@ const statusToErrorMessage = (statusCode: number) => {
 export class SiemResponseFactory {
   constructor(private response: KibanaResponseFactory) {}
 
-  error<T>({ statusCode, body, headers }: CustomHttpResponseOptions<T>) {
+  error<T extends HttpResponsePayload | ResponseError>({
+    statusCode,
+    body,
+    headers,
+  }: CustomHttpResponseOptions<T>) {
     const contentType: CustomHttpResponseOptions<T>['headers'] = {
       'content-type': 'application/json',
     };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/utils.ts
@@ -13,9 +13,11 @@ import { BulkActionEditTypeEnum } from '../../../../../../common/api/detection_e
  * @param editAction {@link BulkActionEditType}
  * @returns {boolean}
  */
-export const isIndexPatternsBulkEditAction = (editAction: BulkActionEditType) =>
-  [
+export const isIndexPatternsBulkEditAction = (editAction: BulkActionEditType) => {
+  const indexPatternsActions: BulkActionEditType[] = [
     BulkActionEditTypeEnum.add_index_patterns,
     BulkActionEditTypeEnum.delete_index_patterns,
     BulkActionEditTypeEnum.set_index_patterns,
-  ].includes(editAction);
+  ];
+  return indexPatternsActions.includes(editAction);
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/validations.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/validations.ts
@@ -10,7 +10,10 @@ import { invariant } from '../../../../../../common/utils/invariant';
 import { isMlRule } from '../../../../../../common/machine_learning/helpers';
 import { isEsqlRule } from '../../../../../../common/detection_engine/utils';
 import { BulkActionsDryRunErrCode } from '../../../../../../common/constants';
-import type { BulkActionEditPayload } from '../../../../../../common/api/detection_engine/rule_management';
+import type {
+  BulkActionEditPayload,
+  BulkActionEditType,
+} from '../../../../../../common/api/detection_engine/rule_management';
 import { BulkActionEditTypeEnum } from '../../../../../../common/api/detection_engine/rule_management';
 import type { RuleAlertType } from '../../../rule_schema';
 import { isIndexPatternsBulkEditAction } from './utils';
@@ -99,11 +102,11 @@ export const validateBulkEditRule = async ({
  * add_rule_actions, set_rule_actions can be applied to prebuilt/immutable rules
  */
 const istEditApplicableToImmutableRule = (edit: BulkActionEditPayload[]): boolean => {
-  return edit.every(({ type }) =>
-    [BulkActionEditTypeEnum.set_rule_actions, BulkActionEditTypeEnum.add_rule_actions].includes(
-      type
-    )
-  );
+  const applicableActions: BulkActionEditType[] = [
+    BulkActionEditTypeEnum.set_rule_actions,
+    BulkActionEditTypeEnum.add_rule_actions,
+  ];
+  return edit.every(({ type }) => applicableActions.includes(type));
 };
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Security Solution] Remove @ts-expect-error from v4.9.5 upgrade in Detection and Response areas (#179273)](https://github.com/elastic/kibana/pull/179273)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Georgii Gorbachev","email":"georgii.gorbachev@elastic.co"},"sourceCommit":{"committedDate":"2024-03-27T12:01:53Z","message":"[Security Solution] Remove @ts-expect-error from v4.9.5 upgrade in Detection and Response areas (#179273)\n\n**Resolves: https://github.com/elastic/kibana/issues/176287**\r\n**Resolves: https://github.com/elastic/kibana/issues/176126**\r\n\r\n## Summary\r\n\r\nIn https://github.com/elastic/kibana/pull/175178 Kibana was upgraded to\r\nTypeScript v4.9.5. That PR introduced a few type errors which were\r\nskipped by adding `@ts-expect-error` comments. This PR attempts to fix\r\nthose type errors and remove the comments.","sha":"f96818a0cb4cf20eeddf90f36aea4e0e67abefbd","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","technical debt","release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Team:Detection Engine","v8.14.0","v8.13.1"],"number":179273,"url":"https://github.com/elastic/kibana/pull/179273","mergeCommit":{"message":"[Security Solution] Remove @ts-expect-error from v4.9.5 upgrade in Detection and Response areas (#179273)\n\n**Resolves: https://github.com/elastic/kibana/issues/176287**\r\n**Resolves: https://github.com/elastic/kibana/issues/176126**\r\n\r\n## Summary\r\n\r\nIn https://github.com/elastic/kibana/pull/175178 Kibana was upgraded to\r\nTypeScript v4.9.5. That PR introduced a few type errors which were\r\nskipped by adding `@ts-expect-error` comments. This PR attempts to fix\r\nthose type errors and remove the comments.","sha":"f96818a0cb4cf20eeddf90f36aea4e0e67abefbd"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179273","number":179273,"mergeCommit":{"message":"[Security Solution] Remove @ts-expect-error from v4.9.5 upgrade in Detection and Response areas (#179273)\n\n**Resolves: https://github.com/elastic/kibana/issues/176287**\r\n**Resolves: https://github.com/elastic/kibana/issues/176126**\r\n\r\n## Summary\r\n\r\nIn https://github.com/elastic/kibana/pull/175178 Kibana was upgraded to\r\nTypeScript v4.9.5. That PR introduced a few type errors which were\r\nskipped by adding `@ts-expect-error` comments. This PR attempts to fix\r\nthose type errors and remove the comments.","sha":"f96818a0cb4cf20eeddf90f36aea4e0e67abefbd"}},{"branch":"8.13","label":"v8.13.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->