### PR TITLE
[Security] Reducing the metadata name  of the pipelines to less than 63 chars

### DIFF
--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-serverless-security-solution-quality-gate-detection-engine
+  name: kb-serverless-security-solution-quality-gate-detection-engine
   description: "[MKI] Executes Cypress tests for the Detection Engine team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: kb-serverless-security-solution-quality-gate-detection-engine
+  name: bk-kibana-serverless-secsol-qg-detection-engine
   description: "[MKI] Executes Cypress tests for the Detection Engine team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-serverless-security-solution-quality-gate-entity-analytics
+  name: kb-serverless-security-solution-quality-gate-entity-analytics
   description: "[MKI] Executes Cypress tests for the Entity Analytics team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: kb-serverless-security-solution-quality-gate-entity-analytics
+  name: bk-kibana-serverless-secsol-qg-entity-analytics
   description: "[MKI] Executes Cypress tests for the Entity Analytics team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-serverless-security-solution-quality-gate-explore
+  name: kb-serverless-security-solution-quality-gate-explore
   description: "[MKI] Executes Cypress tests for the Explore team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: kb-serverless-security-solution-quality-gate-explore
+  name: bk-kibana-serverless-secsol-qg-explore
   description: "[MKI] Executes Cypress tests for the Explore team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-serverless-security-solution-quality-gate-gen-ai
+  name: kb-serverless-security-solution-quality-gate-gen-ai
   description: "[MKI] Executes Cypress tests for the Gen AI team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: kb-serverless-security-solution-quality-gate-gen-ai
+  name: bk-kibana-serverless-secsol-qg-detection-gen-ai
   description: "[MKI] Executes Cypress tests for the Gen AI team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: kb-serverless-security-solution-quality-gate-investigations
+  name: bk-kibana-serverless-secsol-qg-detection-investigations
   description: "[MKI] Executes Cypress tests for the Investigations team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-serverless-security-solution-quality-gate-investigations
+  name: kb-serverless-security-solution-quality-gate-investigations
   description: "[MKI] Executes Cypress tests for the Investigations team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: kb-serverless-security-solution-quality-gate-rule-management
+  name: bk-kibana-serverless-secsol-qg-detection-rule-management
   description: "[MKI] Executes Cypress tests for the Rule Management team"
 spec:
   type: buildkite-pipeline

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
@@ -2,7 +2,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-kibana-serverless-security-solution-quality-gate-rule-management
+  name: kb-serverless-security-solution-quality-gate-rule-management
   description: "[MKI] Executes Cypress tests for the Rule Management team"
 spec:
   type: buildkite-pipeline


### PR DESCRIPTION
Backstage has a limitation of 63 chars in order to allow the resource entities to be created. Otherwise they are silently skipped. 

The RREs created can be validated against: https://backstage.elastic.dev/entity-validation

This PR addresses the required name change for the pipelines to be created.