### PR TITLE
[Search] [Security] Disable observability assistant

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -9,6 +9,7 @@ xpack.observabilityLogsExplorer.enabled: false
 xpack.observability.enabled: false
 xpack.securitySolution.enabled: false
 xpack.serverless.observability.enabled: false
+xpack.observabilityAIAssistant.enabled: false
 enterpriseSearch.enabled: false
 xpack.fleet.enabled: false
 

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -6,6 +6,7 @@ xpack.apm.enabled: false
 xpack.infra.enabled: false
 xpack.observabilityLogsExplorer.enabled: false
 xpack.observability.enabled: false
+xpack.observabilityAIAssistant.enabled: false
 
 ## Cloud settings
 xpack.cloud.serverless.project_type: security


### PR DESCRIPTION
## Summary

This disables the observability AI assistant in Search and Security projects, where it was showing up in the top level search bar.

