### PR TITLE
[Lens] Extract and unify beta badge

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/layer_settings.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/layer_settings.tsx
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiBetaBadge, EuiLink, EuiSpacer, EuiToolTip } from '@elastic/eui';
+import { EuiFormRow, EuiLink, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { RandomSamplingSlider } from '@kbn/random-sampling';

--- a/x-pack/plugins/lens/public/datasources/form_based/layer_settings.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/layer_settings.tsx
@@ -16,6 +16,7 @@ import type { FormBasedPrivateState } from './types';
 import { isSamplingValueEnabled } from './utils';
 import { IgnoreGlobalFilterRowControl } from '../../shared_components/ignore_global_filter';
 import { trackUiCounterEvents } from '../../lens_ui_telemetry';
+import { ExperimentalBadge } from '../../shared_components';
 
 const samplingValues = [0.00001, 0.0001, 0.001, 0.01, 0.1, 1];
 
@@ -65,22 +66,7 @@ export function LayerSettingsPanel({
             {i18n.translate('xpack.lens.indexPattern.randomSampling.label', {
               defaultMessage: 'Sampling',
             })}{' '}
-            <EuiToolTip
-              content={i18n.translate('xpack.lens.indexPattern.randomSampling.experimentalLabel', {
-                defaultMessage: 'Technical preview',
-              })}
-            >
-              <EuiBetaBadge
-                css={css`
-                  vertical-align: middle;
-                `}
-                iconType="beaker"
-                label={i18n.translate('xpack.lens.indexPattern.randomSampling.experimentalLabel', {
-                  defaultMessage: 'Technical preview',
-                })}
-                size="s"
-              />
-            </EuiToolTip>
+            <ExperimentalBadge />
           </>
         }
       >

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/chart_switch/chart_option_append.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/chart_switch/chart_option_append.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { EuiFlexItem, EuiIconTip, EuiBetaBadge, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
+import { ExperimentalBadge } from '../../../../shared_components';
 
 export const getDataLossWarning = (dataLoss: 'nothing' | 'layers' | 'everything' | 'columns') => {
   if (dataLoss === 'nothing') {
@@ -50,29 +51,6 @@ const DataLossWarning = ({ content, id }: { content?: string; id: string }) => {
   );
 };
 
-export const ExperimentalBadge = () => {
-  return (
-    <EuiFlexItem grow={false}>
-      <EuiToolTip
-        content={i18n.translate('xpack.lens.chartSwitch.experimentalLabel', {
-          defaultMessage: 'Technical preview',
-        })}
-      >
-        <EuiBetaBadge
-          css={css`
-            vertical-align: middle;
-          `}
-          iconType="beaker"
-          label={i18n.translate('xpack.lens.chartSwitch.experimentalLabel', {
-            defaultMessage: 'Technical preview',
-          })}
-          size="s"
-        />
-      </EuiToolTip>
-    </EuiFlexItem>
-  );
-};
-
 export const ChartOptionAppend = ({
   dataLoss,
   showExperimentalBadge,
@@ -88,7 +66,11 @@ export const ChartOptionAppend = ({
     alignItems="center"
     className="lnsChartSwitch__append"
   >
-    {showExperimentalBadge ? <ExperimentalBadge /> : null}
+    {showExperimentalBadge ? (
+      <EuiFlexItem grow={false}>
+        <ExperimentalBadge />
+      </EuiFlexItem>
+    ) : null}
     <DataLossWarning content={getDataLossWarning(dataLoss)} id={id} />
   </EuiFlexGroup>
 );

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/chart_switch/chart_option_append.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/chart_switch/chart_option_append.tsx
@@ -7,9 +7,8 @@
 
 import './chart_switch.scss';
 import React from 'react';
-import { EuiFlexItem, EuiIconTip, EuiBetaBadge, EuiFlexGroup, EuiToolTip } from '@elastic/eui';
+import { EuiFlexItem, EuiIconTip, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import { ExperimentalBadge } from '../../../../shared_components';
 
 export const getDataLossWarning = (dataLoss: 'nothing' | 'layers' | 'everything' | 'columns') => {

--- a/x-pack/plugins/lens/public/shared_components/experimental_badge.tsx
+++ b/x-pack/plugins/lens/public/shared_components/experimental_badge.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiBetaBadge, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
+
+const defaultLabel = i18n.translate('xpack.lens.experimentalLabel', {
+  defaultMessage: 'Technical preview',
+});
+
+export const ExperimentalBadge = ({
+  label = defaultLabel,
+  color,
+}: {
+  label?: string;
+  color?: 'subdued' | undefined;
+}) => {
+  return (
+    <EuiToolTip content={label}>
+      <EuiBetaBadge
+        css={css`
+          vertical-align: middle;
+        `}
+        iconType="beaker"
+        label={label}
+        size="s"
+        color={color}
+      />
+    </EuiToolTip>
+  );
+};

--- a/x-pack/plugins/lens/public/shared_components/index.ts
+++ b/x-pack/plugins/lens/public/shared_components/index.ts
@@ -26,3 +26,4 @@ export { AxisTitleSettings } from './axis/title/axis_title_settings';
 export { AxisTicksSettings } from './axis/ticks/axis_ticks_settings';
 export * from './static_header';
 export * from './vis_label';
+export { ExperimentalBadge } from './experimental_badge';

--- a/x-pack/plugins/lens/public/visualizations/xy/add_layer.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/add_layer.tsx
@@ -11,7 +11,6 @@ import {
   EuiPopover,
   EuiIcon,
   EuiContextMenu,
-  EuiBadge,
   EuiFlexItem,
   EuiFlexGroup,
 } from '@elastic/eui';

--- a/x-pack/plugins/lens/public/visualizations/xy/add_layer.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/add_layer.tsx
@@ -21,6 +21,7 @@ import { EventAnnotationServiceType } from '@kbn/event-annotation-plugin/public'
 import { AddLayerFunction, VisualizationLayerDescription } from '../../types';
 import { LoadAnnotationLibraryFlyout } from './load_annotation_library_flyout';
 import type { ExtraAppendLayerArg } from './visualization';
+import { ExperimentalBadge } from '../../shared_components';
 
 interface AddLayerButtonProps {
   supportedLayers: VisualizationLayerDescription[];
@@ -51,17 +52,12 @@ export function AddLayerButton({
       toolTipContent,
       disabled,
       name: (
-        <EuiFlexGroup gutterSize="m" responsive={false}>
-          <EuiFlexItem>
+        <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+          <EuiFlexItem grow={false}>
             <span className="lnsLayerAddButton__label">{label}</span>
           </EuiFlexItem>
-
           <EuiFlexItem grow={false}>
-            <EuiBadge className="lnsLayerAddButton__techBadge" color="hollow" isDisabled={disabled}>
-              {i18n.translate('xpack.lens.configPanel.experimentalLabel', {
-                defaultMessage: 'Technical preview',
-              })}
-            </EuiBadge>
+            <ExperimentalBadge color={disabled ? 'subdued' : undefined} />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),


### PR DESCRIPTION
## Summary

Just a small refactoring to avoid code repetition. Extract <ExperimentalBadge/> component to use it for Add layer button (the styles changed there), Chart Switch and sampling.

<img width="430" alt="Screenshot 2024-03-28 at 14 05 37" src="https://github.com/elastic/kibana/assets/4283304/422454b2-bfa9-431d-98a5-b9171cfb7fda">

<img width="367" alt="Screenshot 2024-03-28 at 14 05 31" src="https://github.com/elastic/kibana/assets/4283304/6cc17694-5d22-43f2-a744-2d689767bff1">

THe only visual changes happen for add layer button:

<img width="356" alt="Screenshot 2024-03-28 at 14 08 27" src="https://github.com/elastic/kibana/assets/4283304/f431d2d1-04a6-4550-af6d-5e8b8d3fa90f">

<img width="359" alt="Screenshot 2024-03-28 at 14 05 23" src="https://github.com/elastic/kibana/assets/4283304/f26c69da-f665-42e1-b683-a0a50148a5a3">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
