### PR TITLE
[Search] Move setting pipeline settings to component render

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -30,7 +30,12 @@ import { CANCEL_BUTTON_LABEL } from '../../../../shared/constants';
 import { DataPanel } from '../../../../shared/data_panel/data_panel';
 import { docLinks } from '../../../../shared/doc_links';
 import { RevertConnectorPipelineApilogic } from '../../../api/pipelines/revert_connector_pipeline_api_logic';
-import { getContentExtractionDisabled, isApiIndex } from '../../../utils/indices';
+import {
+  getContentExtractionDisabled,
+  isApiIndex,
+  isConnectorIndex,
+  isCrawlerIndex,
+} from '../../../utils/indices';
 
 import { IndexNameLogic } from '../index_name_logic';
 
@@ -52,14 +57,34 @@ export const SearchIndexPipelines: React.FC = () => {
     index,
     isDeleteModalOpen,
     pipelineName,
+    defaultPipelineValues,
   } = useValues(PipelinesLogic);
-  const { closeAddMlInferencePipelineModal, closeDeleteModal } = useActions(PipelinesLogic);
+  const {
+    closeAddMlInferencePipelineModal,
+    closeDeleteModal,
+    fetchDefaultPipeline,
+    setPipelineState,
+  } = useActions(PipelinesLogic);
   const { indexName } = useValues(IndexNameLogic);
   const { status: revertStatus } = useValues(RevertConnectorPipelineApilogic);
   const { makeRequest: revertPipeline } = useActions(RevertConnectorPipelineApilogic);
   const apiIndex = isApiIndex(index);
   const extractionDisabled = getContentExtractionDisabled(index);
 
+  useEffect(() => {
+    if (index) {
+      fetchDefaultPipeline(undefined);
+      setPipelineState(
+        isConnectorIndex(index) || isCrawlerIndex(index)
+          ? index.connector?.pipeline ?? defaultPipelineValues
+          : defaultPipelineValues
+      );
+    }
+  }, [index]);
+
+  if (!index) {
+    return <></>;
+  }
   const pipelinesTabs: EuiTabbedContentTab[] = [
     {
       content: <InferenceHistory />,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.ts
@@ -227,16 +227,6 @@ export const PipelinesLogic = kea<MakeLogicType<PipelinesValues, PipelinesAction
       ['data as mlInferencePipelineProcessors'],
     ],
   },
-  events: ({ actions, values }) => ({
-    afterMount: () => {
-      actions.fetchDefaultPipeline(undefined);
-      actions.setPipelineState(
-        isConnectorIndex(values.index) || isCrawlerIndex(values.index)
-          ? values.index.connector?.pipeline ?? values.defaultPipelineValues
-          : values.defaultPipelineValues
-      );
-    },
-  }),
   listeners: ({ actions, values }) => ({
     apiSuccess: ({ pipeline }) => {
       if (isConnectorIndex(values.index) || isCrawlerIndex(values.index)) {


### PR DESCRIPTION
## Summary

Setting pipeline settings data was in PipelineSettings logic. This is fine if the component is rendered where index is not undefined. But in Connector Detail view there is a brief period of `index` is null. That caused some unwanted "not found" errors to be seen on UI.

Therefore with this fix, views are hidden if index is null to prevent deeper components to try using same logic. And when index is defined, same logic from afterMount is used in useEffect hook.

Example: 
<img width="1429" alt="Screenshot 2024-03-28 at 16 19 20" src="https://github.com/elastic/kibana/assets/1410658/7147bb79-2506-46d1-83d3-fa7fa75fb945">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->