### PR TITLE
[embeddable refactor] rename library transform API methods

### DIFF
--- a/packages/presentation/presentation_publishing/interfaces/has_library_transforms.ts
+++ b/packages/presentation/presentation_publishing/interfaces/has_library_transforms.ts
@@ -60,8 +60,7 @@ export const apiHasLibraryTransforms = <StateT extends object = object>(
       typeof (unknownApi as HasLibraryTransforms<StateT>).canUnlinkFromLibrary === 'function' &&
       typeof (unknownApi as HasLibraryTransforms<StateT>).saveToLibrary === 'function' &&
       typeof (unknownApi as HasLibraryTransforms<StateT>).getByReferenceState === 'function' &&
-      typeof (unknownApi as HasLibraryTransforms<StateT>).getByValueState ===
-        'function' &&
+      typeof (unknownApi as HasLibraryTransforms<StateT>).getByValueState === 'function' &&
       typeof (unknownApi as HasLibraryTransforms<StateT>).checkForDuplicateTitle === 'function'
   );
 };

--- a/packages/presentation/presentation_publishing/interfaces/has_library_transforms.ts
+++ b/packages/presentation/presentation_publishing/interfaces/has_library_transforms.ts
@@ -17,13 +17,17 @@ export interface HasLibraryTransforms<StateT extends object = object> {
    */
   canLinkToLibrary: () => Promise<boolean>;
   /**
-   * Saves embeddable to library
+   * Save embeddable to library
    *
-   * @returns {Promise<{ state: StateT; savedObjectId: string }>}
-   *   state: by-reference embeddable state replacing by-value embeddable state
-   *   savedObjectId: Saved object id for new saved object added to library
+   * @returns {Promise<string>} id of persisted library item
    */
-  saveStateToSavedObject: (title: string) => Promise<{ state: StateT; savedObjectId: string }>;
+  saveToLibrary: (title: string) => Promise<string>;
+  /**
+   *
+   * @returns {StateT}
+   *   by-reference embeddable state replacing by-value embeddable state
+   */
+  getByReferenceState: (libraryId: string) => StateT;
   checkForDuplicateTitle: (
     newTitle: string,
     isTitleDuplicateConfirmed: boolean,
@@ -44,7 +48,7 @@ export interface HasLibraryTransforms<StateT extends object = object> {
    * @returns {StateT}
    *   by-value embeddable state replacing by-reference embeddable state
    */
-  savedObjectAttributesToState: () => StateT;
+  getByValueState: () => StateT;
 }
 
 export const apiHasLibraryTransforms = <StateT extends object = object>(
@@ -54,8 +58,9 @@ export const apiHasLibraryTransforms = <StateT extends object = object>(
     unknownApi &&
       typeof (unknownApi as HasLibraryTransforms<StateT>).canLinkToLibrary === 'function' &&
       typeof (unknownApi as HasLibraryTransforms<StateT>).canUnlinkFromLibrary === 'function' &&
-      typeof (unknownApi as HasLibraryTransforms<StateT>).saveStateToSavedObject === 'function' &&
-      typeof (unknownApi as HasLibraryTransforms<StateT>).savedObjectAttributesToState ===
+      typeof (unknownApi as HasLibraryTransforms<StateT>).saveToLibrary === 'function' &&
+      typeof (unknownApi as HasLibraryTransforms<StateT>).getByReferenceState === 'function' &&
+      typeof (unknownApi as HasLibraryTransforms<StateT>).getByValueState ===
         'function' &&
       typeof (unknownApi as HasLibraryTransforms<StateT>).checkForDuplicateTitle === 'function'
   );

--- a/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
@@ -95,7 +95,7 @@ export class AddToLibraryAction implements Action<EmbeddableApiContext> {
             props.onTitleDuplicate
           );
           try {
-            const libraryId =  await embeddable.saveToLibrary(props.newTitle);
+            const libraryId = await embeddable.saveToLibrary(props.newTitle);
             resolve({ ...embeddable.getByReferenceState(libraryId), title: props.newTitle });
             return { id: libraryId };
           } catch (error) {

--- a/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
@@ -95,11 +95,9 @@ export class AddToLibraryAction implements Action<EmbeddableApiContext> {
             props.onTitleDuplicate
           );
           try {
-            const { state, savedObjectId } = await embeddable.saveStateToSavedObject(
-              props.newTitle
-            );
-            resolve({ ...state, title: props.newTitle });
-            return { id: savedObjectId };
+            const libraryId =  await embeddable.saveToLibrary(props.newTitle);
+            resolve({ ...embeddable.getByReferenceState(libraryId), title: props.newTitle });
+            return { id: libraryId };
           } catch (error) {
             reject(error);
             return { error };

--- a/src/plugins/dashboard/public/dashboard_actions/unlink_from_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/unlink_from_library_action.tsx
@@ -81,7 +81,7 @@ export class UnlinkFromLibraryAction implements Action<EmbeddableApiContext> {
     try {
       await embeddable.parentApi.replacePanel(embeddable.uuid, {
         panelType: embeddable.type,
-        initialState: { ...embeddable.savedObjectAttributesToState(), title },
+        initialState: { ...embeddable.getByValueState(), title },
       });
       this.toastsService.addSuccess({
         title: dashboardUnlinkFromLibraryActionStrings.getSuccessMessage(title ? `'${title}'` : ''),

--- a/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
+++ b/x-pack/plugins/maps/public/embeddable/map_embeddable.tsx
@@ -673,7 +673,26 @@ export class MapEmbeddable
   linkToLibrary = undefined;
   unlinkFromLibrary = undefined;
   // add implemenation for library transform methods
-  saveStateToSavedObject = async (title: string) => {
+  checkForDuplicateTitle = async (
+    newTitle: string,
+    isTitleDuplicateConfirmed: boolean,
+    onTitleDuplicate: () => void
+  ) => {
+    await checkForDuplicateTitle(
+      {
+        title: newTitle,
+        copyOnSave: false,
+        lastSavedTitle: '',
+        isTitleDuplicateConfirmed,
+        getDisplayName: () => MAP_EMBEDDABLE_NAME,
+        onTitleDuplicate,
+      },
+      {
+        overlays: getCoreOverlays(),
+      }
+    );
+  };
+  saveToLibrary = async (title: string) => {
     const { attributes, references } = extractReferences({
       attributes: this._savedMap.getAttributes(),
     });
@@ -687,38 +706,19 @@ export class MapEmbeddable
       },
       options: { references },
     });
+    return savedObjectId;
+  };
+  getByReferenceState = (libraryId: string) => {
     return {
-      state: {
-        ..._.omit(this.getExplicitInput(), 'attributes'),
-        savedObjectId,
-      },
-      savedObjectId,
+      ..._.omit(this.getExplicitInput(), 'attributes'),
+      savedObjectId: libraryId,
     };
   };
-  savedObjectAttributesToState = () => {
+  getByValueState = () => {
     return {
       ..._.omit(this.getExplicitInput(), 'savedObjectId'),
       attributes: this._savedMap.getAttributes(),
     };
-  };
-  checkForDuplicateTitle = async (
-    newTitle: string,
-    isTitleDuplicateConfirmed: boolean,
-    onTitleDuplicate: () => void
-  ) => {
-    return checkForDuplicateTitle(
-      {
-        title: newTitle,
-        copyOnSave: false,
-        lastSavedTitle: '',
-        isTitleDuplicateConfirmed,
-        getDisplayName: () => MAP_EMBEDDABLE_NAME,
-        onTitleDuplicate,
-      },
-      {
-        overlays: getCoreOverlays(),
-      }
-    );
   };
 
   // Timing bug for dashboard with multiple maps with synchronized movement and filter by map extent enabled


### PR DESCRIPTION
While working on implementing `HasLibraryTransforms` in Map react embeddable and chatting with @ThomThomson, it became clear that current `HasLibraryTransforms` interface method names are obtuse. This PR does the following
1. Breaks `saveStateToSavedObject` into two separate methods, `saveToLibrary` and `getByReferenceState`.
2. Renames `savedObjectAttributesToState` to `getByValueState`.