### PR TITLE
Set ruleType thrown errors as Framework error

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/rule_type_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/rule_type_runner.ts
@@ -249,7 +249,7 @@ export class RuleTypeRunner<
             return {
               error: createTaskRunError(
                 new ErrorWithReason(RuleExecutionStatusErrorReasons.Execute, err),
-                TaskErrorSource.USER
+                TaskErrorSource.FRAMEWORK
               ),
               stackTrace: { message: err, stackTrace: err.stack },
             };

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
@@ -1942,7 +1942,7 @@ describe('Task Runner', () => {
     expect(loggerMeta?.tags).toEqual(['test', '1', 'rule-run-failed']);
     expect(loggerMeta?.error?.stack_trace).toBeDefined();
     expect(logger.error).toBeCalledTimes(1);
-    expect(getErrorSource(runnerResult.taskRunError as Error)).toBe(TaskErrorSource.USER);
+    expect(getErrorSource(runnerResult.taskRunError as Error)).toBe(TaskErrorSource.FRAMEWORK);
   });
 
   test('recovers gracefully when the Rule Task Runner throws an exception when loading rule to prepare for run', async () => {


### PR DESCRIPTION
This is a follow-on PR of https://github.com/elastic/kibana/issues/174035.

As we decided to set the errors reported by addLastRunError as Framework Error, this PR aligns the other errors thrown by the ruleTypes by switching from USER to FRAMEWORK.

## To verify

Throw an error in any of the ruleType executor, and expect to see framework error metrics in :
`/api/task_manager/metrics?reset=false`