### PR TITLE
Remove 8.12 from versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -14,12 +14,6 @@
       "previousMinor": true
     },
     {
-      "version": "8.12.3",
-      "branch": "8.12",
-      "currentMajor": true,
-      "previousMinor": true
-    },
-    {
       "version": "7.17.20",
       "branch": "7.17",
       "previousMajor": true


### PR DESCRIPTION
With the release of 8.13.0, 8.12 is no longer under active development.