### PR TITLE
[8.13] [Obs AI Assistant] Fall back to top 5 docs on scoring error (#179615)

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/server/functions/context.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/context.ts
@@ -122,23 +122,33 @@ export function registerContextFunction({
           };
         }
 
-        const { relevantDocuments, scores } = await scoreSuggestions({
-          suggestions,
-          queries: queriesOrUserPrompt,
-          messages,
-          client,
-          connectorId,
-          signal,
-          logger: resources.logger,
-        });
-
-        return {
-          content: { ...content, learnings: relevantDocuments as unknown as Serializable },
-          data: {
-            scores,
+        try {
+          const { relevantDocuments, scores } = await scoreSuggestions({
             suggestions,
-          },
-        };
+            queries: queriesOrUserPrompt,
+            messages,
+            client,
+            connectorId,
+            signal,
+            logger: resources.logger,
+          });
+
+          return {
+            content: { ...content, learnings: relevantDocuments as unknown as Serializable },
+            data: {
+              scores,
+              suggestions,
+            },
+          };
+        } catch (error) {
+          return {
+            content: { ...content, learnings: suggestions.slice(0, 5) },
+            data: {
+              error,
+              suggestions,
+            },
+          };
+        }
       }
 
       return new Observable<MessageAddEvent>((subscriber) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Obs AI Assistant] Fall back to top 5 docs on scoring error (#179615)](https://github.com/elastic/kibana/pull/179615)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dario Gieselaar","email":"dario.gieselaar@elastic.co"},"sourceCommit":{"committedDate":"2024-03-28T17:39:03Z","message":"[Obs AI Assistant] Fall back to top 5 docs on scoring error (#179615)\n\nIf there is an error scoring documents, we should fall back to the top 5\r\ndocuments that are returned from ELSER.","sha":"79a1b26d84c5e5a1566a28ba6d49073744570c90","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-knowledge","v8.14.0","v8.13.1"],"number":179615,"url":"https://github.com/elastic/kibana/pull/179615","mergeCommit":{"message":"[Obs AI Assistant] Fall back to top 5 docs on scoring error (#179615)\n\nIf there is an error scoring documents, we should fall back to the top 5\r\ndocuments that are returned from ELSER.","sha":"79a1b26d84c5e5a1566a28ba6d49073744570c90"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179615","number":179615,"mergeCommit":{"message":"[Obs AI Assistant] Fall back to top 5 docs on scoring error (#179615)\n\nIf there is an error scoring documents, we should fall back to the top 5\r\ndocuments that are returned from ELSER.","sha":"79a1b26d84c5e5a1566a28ba6d49073744570c90"}},{"branch":"8.13","label":"v8.13.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->