### PR TITLE
[Core] Add script to build Kibana plugin/packages plugin

### DIFF
--- a/scripts/build_dependency_graph.js
+++ b/scripts/build_dependency_graph.js
@@ -122,7 +122,7 @@ function registerDepsInES(dictionary) {
 }
 
 var dependenciesMap = {};
-walk('.', dependenciesMap).then(function (dictionary) {
+walk(info.REPO_ROOT, dependenciesMap).then(function (dictionary) {
   console.log('Dependency map created');
   return registerDepsInES(dictionary);
 });

--- a/scripts/build_dependency_graph.js
+++ b/scripts/build_dependency_graph.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+var Fs = require('fs');
+var Path = require('path');
+var JSON5 = require('json5');
+
+var info = require('@kbn/repo-info');
+var ES = require('@elastic/elasticsearch');
+var EsClient = ES.Client;
+var HttpConnection = ES.HttpConnection;
+
+var SKIP_FOLDERS = ['bazel-kibana', 'node_modules', '.es'];
+
+async function walk(dir, dictionary) {
+  var files = Fs.readdirSync(dir);
+  var jsoncFile = files.find(function (f) {
+    return f === 'kibana.jsonc';
+  });
+  var tsConfigFile = files.find(function (f) {
+    return f === 'tsconfig.json';
+  });
+  if (jsoncFile && tsConfigFile) {
+    var jsoncString = Fs.readFileSync(Path.resolve(dir, jsoncFile), { encoding: 'utf-8' });
+    var tsConfigString = Fs.readFileSync(Path.resolve(dir, tsConfigFile), { encoding: 'utf-8' });
+    var jsonc = JSON5.parse(jsoncString);
+    var tsConfig = JSON5.parse(tsConfigString);
+    dictionary[jsonc.id] = {
+      deps: tsConfig.kbn_references,
+      pluginId: jsonc.plugin ? jsonc.plugin.id : undefined,
+      path: dir,
+    };
+  }
+  files.map(function (file) {
+    var filePath = Path.join(dir, file);
+    var stats = Fs.statSync(filePath);
+    if (stats.isDirectory() && !jsoncFile && !SKIP_FOLDERS.includes(file)) {
+      return walk(filePath, dictionary);
+    }
+  });
+
+  return dictionary;
+}
+
+function prepareDocs(dictionary) {
+  var docs = [];
+  for (var record of Object.entries(dictionary)) {
+    if (Array.isArray(record[1].deps)) {
+      for (var dep of record[1].deps) {
+        docs.push({
+          package: record[0],
+          dependency: dep,
+          pluginId: record[1].pluginId,
+          path: record[1].path,
+        });
+      }
+    }
+  }
+  return docs;
+}
+
+var es = new EsClient({
+  Connection: HttpConnection,
+  tls: {
+    ca: Fs.readFileSync(Path.resolve(info.REPO_ROOT, 'packages/kbn-dev-utils/certs/', 'ca.crt')),
+  },
+  requestTimeout: 30000,
+  nodes: ['http://elastic:changeme@localhost:9200'],
+});
+
+function createIndex(indexName) {
+  return es.indices.create({
+    index: indexName,
+    body: {
+      mappings: {
+        properties: {
+          package: {
+            type: 'keyword',
+          },
+          dependency: {
+            type: 'keyword',
+          },
+        },
+      },
+    },
+  });
+}
+
+function addDocs(indexName, docs) {
+  es.bulk({
+    index: indexName,
+    body: docs.map(function (d) {
+      return `{"index": {}}\n${JSON.stringify(d)}\n`;
+    }),
+  });
+}
+
+function registerDepsInES(dictionary) {
+  var indexName = 'kibana_packages_dependencies';
+  return createIndex(indexName)
+    .then(
+      function () {
+        return addDocs(indexName, prepareDocs(dictionary));
+      },
+      function (err) {
+        console.error('Error while creating the ES index');
+        console.error(err.message);
+      }
+    )
+    .catch(function (err) {
+      console.error('Error while adding docs to ES');
+      console.error(err.message);
+      throw Error('');
+    })
+    .then(function () {
+      console.log('All done');
+    });
+}
+
+var dependenciesMap = {};
+walk('.', dependenciesMap).then(function (dictionary) {
+  console.log('Dependency map created');
+  return registerDepsInES(dictionary);
+});


### PR DESCRIPTION
## Summary

This is a basic scaffolding script I use to investigate plugin/packages dependencies in Kibana without digging too much into webpack stats stuff.
I had this around for a while and after a chat with @afharo I thought to publish it.

What can you do with this?
Asking things like:

* what's the dependency graph of Graph plugin?

<img width="910" alt="Screenshot 2024-03-29 at 17 14 24" src="https://github.com/elastic/kibana/assets/924948/aca4b454-545d-4f47-b4d9-4306d4163eea">

* Who is using `@kbn/monaco`?
<img width="851" alt="Screenshot 2024-03-29 at 17 58 55" src="https://github.com/elastic/kibana/assets/924948/b4d78179-2676-43c5-8a95-bf5d816e370f">

* Who is using `@kbn/esql-ast`?

<img width="631" alt="Screenshot 2024-03-29 at 17 59 25" src="https://github.com/elastic/kibana/assets/924948/702b203c-5083-4ea3-b030-51fbade63fcb">

**Strong assumptions**
* index name generated: `kibana_packages_dependencies`
* it relies on `kibana.jsonc` and `tsconfig.json` configurations
* local elasticsearch instance with port 9200 with default login credentials

**Known limitations of the tool**
* While the tool builds a directed graph, the actual Graph app doesn't have directed edges, so it's easy after few clicks to land into the hairball.
  * like in the case of `Which plugin depends on @kbn/core`? Everybody!
  
  <img width="1382" alt="Screenshot 2024-03-29 at 17 53 36" src="https://github.com/elastic/kibana/assets/924948/a6f31f06-f9e6-4f8a-ba31-41c85b60813d">

* To view a meaningful graph in the app disable the `Significant terms` toggle and set `Certainty` to 1 under `Settings`

<img width="373" alt="Screenshot 2024-03-29 at 18 01 20" src="https://github.com/elastic/kibana/assets/924948/58ffe154-c5c1-49b9-aa02-aaf943f62d75">

* When initial graphing the data, Graph will make sampling of the neighborhood of a node.
  * For instance if you're focusing on `Lens` it will probably get 5/6 nodes around it + extra notes 2/3 hops away. In this case click `Lens` again and hit the `+` button on the floating menu on the right more times until no more nodes come up.

### How to use

```sh
node scripts/build_dependency_graph.js
```

If all goes well then you have:
```
Dependency map created
All done
```

If something bad happens then the error is reported:
```
Dependency map created
Error while creating the ES index
resource_already_exists_exception
	Root causes:
		resource_already_exists_exception: index [kibana_packages_dependencies/FmJyMi7mQ-GWlNPzsZAZ5A] already exists
All done
```

So probably this is not the final shape of the script (also, I had to rewrite to not use any ES5+ stuff due to eslint rules within `scripts` folder), but just wanted to put it somewhere for now.