### PR TITLE
[Fleet] Fix agent upgrade modal in serverless

### DIFF
--- a/x-pack/plugins/fleet/common/services/check_fleet_server_versions.test.ts
+++ b/x-pack/plugins/fleet/common/services/check_fleet_server_versions.test.ts
@@ -36,4 +36,9 @@ describe('checkFleetServerVersion', () => {
       'Cannot force upgrade to version 8.5.1 because it does not satisfy the major and minor of the latest fleet server version 8.4.0.'
     );
   });
+
+  it('should not throw in serverless if there is not in fleetServers', () => {
+    const fleetServers = [] as any;
+    expect(() => checkFleetServerVersion('8.5.1', fleetServers, true)).not.toThrow();
+  });
 });

--- a/x-pack/plugins/fleet/common/services/check_fleet_server_versions.test.ts
+++ b/x-pack/plugins/fleet/common/services/check_fleet_server_versions.test.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { checkFleetServerVersion } from './check_fleet_server_versions';
+import {
+  checkFleetServerVersion,
+  isAgentVersionLessThanFleetServer,
+} from './check_fleet_server_versions';
 
 describe('checkFleetServerVersion', () => {
   it('should not throw if no force is specified and patch is newer', () => {
@@ -40,5 +43,27 @@ describe('checkFleetServerVersion', () => {
   it('should not throw in serverless if there is not in fleetServers', () => {
     const fleetServers = [] as any;
     expect(() => checkFleetServerVersion('8.5.1', fleetServers, true)).not.toThrow();
+  });
+});
+
+describe('isAgentVersionLessThanFleetServer', () => {
+  it('should return true if there is no fleet server (serverless)', () => {
+    expect(isAgentVersionLessThanFleetServer('8.12.0', [])).toBe(true);
+  });
+
+  it('should return true if version is less than fleet server ', () => {
+    const fleetServers = [
+      { local_metadata: { elastic: { agent: { version: '8.3.0' } } } },
+      { local_metadata: { elastic: { agent: { version: '8.4.0' } } } },
+    ] as any;
+    expect(isAgentVersionLessThanFleetServer('8.3.0', fleetServers)).toBe(true);
+  });
+
+  it('should return false if version is more than fleet server ', () => {
+    const fleetServers = [
+      { local_metadata: { elastic: { agent: { version: '8.3.0' } } } },
+      { local_metadata: { elastic: { agent: { version: '8.4.0' } } } },
+    ] as any;
+    expect(isAgentVersionLessThanFleetServer('8.5.0', fleetServers)).toBe(false);
   });
 });

--- a/x-pack/plugins/fleet/common/services/check_fleet_server_versions.ts
+++ b/x-pack/plugins/fleet/common/services/check_fleet_server_versions.ts
@@ -67,6 +67,10 @@ export const isAgentVersionLessThanFleetServer = (
   fleetServerAgents: Agent[],
   force = false
 ) => {
+  // For serverless it should not have any fleet server agents
+  if (fleetServerAgents.length === 0) {
+    return true;
+  }
   const fleetServerVersions = fleetServerAgents.map(
     (agent) => agent.local_metadata.elastic.agent.version
   ) as string[];


### PR DESCRIPTION
## Summary

Resolve #179730

Fix agent upgrade for serverless

Before 
<img width="600" alt="Screenshot 2024-04-01 at 10 02 20 AM" src="https://github.com/elastic/kibana/assets/1336873/0350aff3-4a40-48fe-ae20-e20f2c928d2d">


After
<img width="600" alt="Screenshot 2024-04-01 at 10 14 21 AM" src="https://github.com/elastic/kibana/assets/1336873/d2cb7135-2816-48db-91d2-1c323eeb1227">


## Test

I added some unit test to the `isAgentVersionLessThanFleetServer` for serverless.

Run fleet server standalone
```
xpack.fleet.internal.fleetServerStandalone: true
```

And check you can upgrade an agent 
