### PR TITLE
[Part of #176153] Saved objects

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/bulk_update.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/bulk_update.ts
@@ -262,9 +262,8 @@ export const performBulkUpdate = async <T>(
 
       const typeDefinition = registry.getType(type)!;
       const updatedAttributes = mergeForUpdate({
-        // @ts-expect-error upgrade typescript v4.9.5
         targetAttributes: {
-          ...migrated!.attributes,
+          ...(migrated!.attributes as Record<string, unknown>),
         },
         updatedAttributes: await encryptionHelper.optionallyEncryptAttributes(
           type,

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/update.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/apis/update.ts
@@ -247,9 +247,8 @@ export const executeUpdate = async <T>(
     // therefor we can safely process with the "standard" update sequence.
 
     const updatedAttributes = mergeForUpdate({
-      // @ts-expect-error upgrade typescript v4.9.5
       targetAttributes: {
-        ...migrated!.attributes,
+        ...(migrated!.attributes as Record<string, unknown>),
       },
       updatedAttributes: await encryptionHelper.optionallyEncryptAttributes(
         type,

--- a/packages/core/saved-objects/core-saved-objects-common/src/server_types.ts
+++ b/packages/core/saved-objects/core-saved-objects-common/src/server_types.ts
@@ -66,7 +66,7 @@ export interface SavedObjectReference {
 export interface SavedObject<T = unknown> {
   /** The ID of this Saved Object, guaranteed to be unique for all objects of the same `type` */
   id: string;
-  /**  The type of Saved Object. Each plugin can define it's own custom Saved Object types. */
+  /**  The type of Saved Object. Each plugin can define its own custom Saved Object types. */
   type: string;
   /** An opaque version number which changes on each successful write operation. Can be used for implementing optimistic concurrency control. */
   version?: string;


### PR DESCRIPTION
## Summary

Part of #176153: Removes `@ts-expect-error` from the saved objects' paths

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
