### PR TITLE
[Part of #176153] Server mocks

### DIFF
--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -145,8 +145,9 @@ export type CustomRequestHandlerMock<T> = {
   [Key in keyof T]: T[Key] extends Promise<unknown> ? T[Key] : Promise<T[Key]>;
 };
 
-const createCustomRequestHandlerContextMock = <T>(contextParts: T): CustomRequestHandlerMock<T> => {
-  // @ts-expect-error upgrade typescript v4.9.5
+const createCustomRequestHandlerContextMock = <T extends Record<string, unknown>>(
+  contextParts: T
+): CustomRequestHandlerMock<T> => {
   const mock = Object.entries(contextParts).reduce(
     (context, [key, value]) => {
       // @ts-expect-error type matching from inferred types is hard

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/__mocks__/request_context.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/__mocks__/request_context.ts
@@ -28,7 +28,7 @@ export const createMockClients = () => {
 
 type MockClients = ReturnType<typeof createMockClients>;
 
-const convertRequestContextMock = <T>(context: T) => {
+const convertRequestContextMock = <T extends Record<string, unknown>>(context: T) => {
   return coreMock.createCustomRequestHandlerContext(context);
 };
 


### PR DESCRIPTION
## Summary

Part of #176153. Fixing `/src/core/server/mocks.ts`


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
