### PR TITLE
[ML] Single Metric Viewer embeddable: ensure detector index is passed to chart correctly

### DIFF
--- a/x-pack/plugins/ml/public/embeddables/single_metric_viewer/embeddable_single_metric_viewer_container.tsx
+++ b/x-pack/plugins/ml/public/embeddables/single_metric_viewer/embeddable_single_metric_viewer_container.tsx
@@ -60,7 +60,6 @@ export const EmbeddableSingleMetricViewerContainer: FC<
   const [chartWidth, setChartWidth] = useState<number>(0);
   const [zoom, setZoom] = useState<AppStateZoom | undefined>();
   const [selectedForecastId, setSelectedForecastId] = useState<string | undefined>();
-  const [detectorIndex, setDetectorIndex] = useState<number>(0);
   const [selectedJob, setSelectedJob] = useState<MlJob | undefined>();
   const [autoZoomDuration, setAutoZoomDuration] = useState<number | undefined>();
   const [jobsLoaded, setJobsLoaded] = useState(false);
@@ -140,10 +139,6 @@ export const EmbeddableSingleMetricViewerContainer: FC<
        */
 
       switch (action) {
-        case APP_STATE_ACTION.SET_DETECTOR_INDEX:
-          setDetectorIndex(payload);
-          break;
-
         case APP_STATE_ACTION.SET_FORECAST_ID:
           setSelectedForecastId(payload);
           setZoom(undefined);
@@ -159,7 +154,7 @@ export const EmbeddableSingleMetricViewerContainer: FC<
       }
     },
 
-    [setZoom, setDetectorIndex, setSelectedForecastId]
+    [setZoom, setSelectedForecastId]
   );
 
   const containerPadding = 10;
@@ -191,7 +186,7 @@ export const EmbeddableSingleMetricViewerContainer: FC<
               lastRefresh={lastRefresh ?? 0}
               previousRefresh={previousRefresh}
               selectedJobId={selectedJobId}
-              selectedDetectorIndex={detectorIndex}
+              selectedDetectorIndex={data.selectedDetectorIndex}
               selectedEntities={data.selectedEntities}
               selectedForecastId={selectedForecastId}
               tableInterval="auto"


### PR DESCRIPTION
## Summary

This PR fixes bug where `selectedDetectorIndex` was not being passed to the chart component correctly and always defaulted to the first detector. 



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->