### PR TITLE
[Response Ops][Alerting] Add managed: true to meta for alerting API keys

### DIFF
--- a/x-pack/plugins/alerting/server/rules_client_factory.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client_factory.test.ts
@@ -243,11 +243,19 @@ test('createAPIKey() returns an API key when security is enabled', async () => {
     id: 'abc',
     name: '',
   });
-  const createAPIKeyResult = await constructorCall.createAPIKey();
+  const createAPIKeyResult = await constructorCall.createAPIKey('test');
   expect(createAPIKeyResult).toEqual({
     apiKeysEnabled: true,
     result: { api_key: '123', id: 'abc', name: '' },
   });
+  expect(securityPluginStart.authc.apiKeys.grantAsInternalUser).toHaveBeenCalledWith(
+    expect.any(Object),
+    {
+      metadata: { managed: true },
+      name: 'test',
+      role_descriptors: {},
+    }
+  );
 });
 
 test('createAPIKey() throws when security plugin createAPIKey throws an error', async () => {

--- a/x-pack/plugins/alerting/server/rules_client_factory.ts
+++ b/x-pack/plugins/alerting/server/rules_client_factory.ts
@@ -146,7 +146,7 @@ export class RulesClientFactory {
         // privileges
         const createAPIKeyResult = await securityPluginStart.authc.apiKeys.grantAsInternalUser(
           request,
-          { name, role_descriptors: {} }
+          { name, role_descriptors: {}, metadata: { managed: true } }
         );
         if (!createAPIKeyResult) {
           return { apiKeysEnabled: false };


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/179163

## Summary

This PR adds `managed:true` to the meta field when creating API keys a rule.


### To verify

- Create a rule
- Go to the [API key page](http://localhost:5601/app/management/security/api_keys/) and verify that the managed tag is visible in the ui
- Use dev tools and refresh the page to inspect the api_key request, verify that `metadata: { managed: true }`
