### PR TITLE
[PoC] new help center

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
@@ -41,6 +41,7 @@ import { CollapsibleNav } from './collapsible_nav';
 import { HeaderBadge } from './header_badge';
 import { HeaderBreadcrumbs } from './header_breadcrumbs';
 import { HeaderHelpMenu } from './header_help_menu';
+import { HeaderHelpCenterTrigger } from './header_help_center';
 import { HeaderLogo } from './header_logo';
 import { HeaderNavControls } from './header_nav_controls';
 import { HeaderActionMenu, useHeaderActionMenuMounter } from './header_action_menu';
@@ -160,6 +161,7 @@ export function Header({
                     kibanaVersion={kibanaVersion}
                     navigateToUrl={application.navigateToUrl}
                   />,
+                  <HeaderHelpCenterTrigger helpExtension$={observables.helpExtension$} />,
                   <HeaderNavControls navControls$={observables.navControlsRight$} />,
                 ],
               },

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
@@ -161,7 +161,12 @@ export function Header({
                     kibanaVersion={kibanaVersion}
                     navigateToUrl={application.navigateToUrl}
                   />,
-                  <HeaderHelpCenterTrigger helpExtension$={observables.helpExtension$} />,
+                  <HeaderHelpCenterTrigger
+                    docLinks={docLinks}
+                    breadCrumbs$={observables.breadcrumbs$}
+                    helpExtension$={observables.helpExtension$}
+                    helpSupportUrl$={observables.helpSupportUrl$}
+                  />,
                   <HeaderNavControls navControls$={observables.navControlsRight$} />,
                 ],
               },

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.test.tsx
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.tsx
@@ -13,6 +13,7 @@ import { type ChromeHelpExtension } from '@kbn/core-chrome-browser';
 import {
   EuiText,
   EuiTitle,
+  EuiLink,
   EuiIcon,
   EuiPortal,
   EuiSplitPanel,
@@ -75,12 +76,16 @@ export const HeaderHelpCenterTrigger = ({ helpExtension$ }: IHeaderHelpCenterTri
 type IHelpCenterPosition = Pick<CSSObject, 'top' | 'left'> | Pick<CSSObject, 'top' | 'right'>;
 
 interface IHeaderHelpCenter {
+  width?: CSSObject['width'];
+  height?: CSSObject['height'];
   onClose: () => void;
   defaultPosition?: IHelpCenterPosition;
   helpExtension: ChromeHelpExtension;
 }
 
 const HeaderHelpCenter = ({
+  width = 654,
+  height = 800,
   onClose,
   helpExtension,
   defaultPosition = { top: 'var(--kbnHeaderOffset)', right: '0%' },
@@ -91,7 +96,7 @@ const HeaderHelpCenter = ({
   );
   const [helpCenterElm, setHelpCenterElm] = useState<HTMLElement | null>(null);
   const [helpCenterStyling, setHelpCenterStyling] = useState<CSSObject>({
-    width: 654,
+    width,
     position: 'fixed',
     zIndex: 9999999, // TODO: confirm if there's a global zIndex
     ...(Object.keys(persistedPosition).length ? persistedPosition : defaultPosition),
@@ -167,8 +172,8 @@ const HeaderHelpCenter = ({
   return (
     <EuiFlexGroup ref={setHelpCenterElm} css={helpCenterStyling}>
       <EuiFlexItem>
-        <EuiSplitPanel.Outer>
-          <EuiSplitPanel.Inner>
+        <EuiSplitPanel.Outer css={{ height }}>
+          <EuiSplitPanel.Inner grow={false}>
             <EuiFlexGroup
               justifyContent="spaceBetween"
               alignItems="center"
@@ -202,10 +207,29 @@ const HeaderHelpCenter = ({
               <p>{content}</p>
             </EuiText>
           </EuiSplitPanel.Inner>
-          <EuiSplitPanel.Inner grow={false}>
-            <EuiText>
-              <p>Footer</p>
-            </EuiText>
+          <EuiSplitPanel.Inner grow={false} css={{ position: 'relative' }}>
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="http://www.elastic.co" target="_blank">
+                  Support
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="http://www.elastic.co" target="_blank">
+                  Give Feedback
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiLink href="http://www.elastic.co" target="_blank">
+                  Browse all the docs
+                </EuiLink>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiIcon
+              type="scale"
+              size="xxl"
+              css={{ position: 'absolute', right: 0, bottom: 0, cursor: 'nwse-resize' }}
+            />
           </EuiSplitPanel.Inner>
         </EuiSplitPanel.Outer>
       </EuiFlexItem>

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.tsx
@@ -32,7 +32,9 @@ export const HeaderHelpCenterTrigger = ({ helpExtension$ }: IHeaderHelpCenterTri
   const [helpExtension, setHelpExtension] = useState<ChromeHelpExtension>();
 
   useEffect(() => {
-    helpExtension$.subscribe(setHelpExtension);
+    const subscription = helpExtension$.subscribe(setHelpExtension);
+
+    return () => subscription.unsubscribe();
   }, [helpExtension$]);
 
   const togglePortal = () => {

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_center.tsx
@@ -65,21 +65,27 @@ export const HeaderHelpCenterTrigger = ({ helpExtension$ }: IHeaderHelpCenterTri
         })}
         onClick={togglePortal}
       >
-        <EuiIcon type={'questionInCircle'} size="m" />
+        <EuiIcon type={'questionInCircle'} size="l" />
       </EuiHeaderSectionItemButton>
       {portal}
     </div>
   );
 };
 
+type IHelpCenterPosition = Pick<CSSObject, 'top' | 'left'> | Pick<CSSObject, 'top' | 'right'>;
+
 interface IHeaderHelpCenter {
   onClose: () => void;
+  defaultPosition?: IHelpCenterPosition;
   helpExtension: ChromeHelpExtension;
 }
 
-const HeaderHelpCenter = ({ onClose, helpExtension }: IHeaderHelpCenter) => {
+const HeaderHelpCenter = ({
+  onClose,
+  helpExtension,
+  defaultPosition = { top: 'var(--kbnHeaderOffset)', right: '0%' },
+}: IHeaderHelpCenter) => {
   const positionPersistenceKey = useRef('help_center_position');
-  // TODO: add fallback for when there's no persisted position
   const persistedPosition = JSON.parse(
     localStorage.getItem(positionPersistenceKey.current) || '{}'
   );
@@ -88,10 +94,10 @@ const HeaderHelpCenter = ({ onClose, helpExtension }: IHeaderHelpCenter) => {
     width: 654,
     position: 'fixed',
     zIndex: 9999999, // TODO: confirm if there's a global zIndex
-    ...persistedPosition,
+    ...(Object.keys(persistedPosition).length ? persistedPosition : defaultPosition),
   });
 
-  const dragEndPosition = useRef<Rx.Observable<{ position: { left: number; top: number } }>>();
+  const dragEndPosition = useRef<Rx.Observable<{ position: IHelpCenterPosition }>>();
 
   useEffect(() => {
     if (helpCenterElm) {
@@ -128,7 +134,7 @@ const HeaderHelpCenter = ({ onClose, helpExtension }: IHeaderHelpCenter) => {
               }),
               Rx.map(function (data) {
                 requestAnimationFrame(() => {
-                  setHelpCenterStyling((prevElmStyling) => ({
+                  setHelpCenterStyling(({ right, ...prevElmStyling }) => ({
                     ...prevElmStyling,
                     top: data.position.top,
                     left: data.position.left,


### PR DESCRIPTION
## Summary

PoC to explore kibana help center redesign. The focus here has been to mostly validate the UI and understand how we might leverage existing information (breadcrumbs and helpExtension information other teams have setup) to generate some sort of heuristics to determine how to display contextual documentation to the user leveraging the existing doc links existing within the project. 

In leveraging breadcrumbs, two properties are in use the `deepLink` because it is of the form `app:subSection` and the `href` for the link that maps to the breadcrumb location within Kibana. This is very much a naive approach as is just experimental to determine how much work needs to be done still to hit the expectation for the design specs provided.


## Visuals
![Help center scaffold](https://github.com/elastic/kibana/assets/7893459/6e5088f7-66d5-4e48-a313-19e31bc8538e)

![Help center with contextual information](https://github.com/elastic/kibana/assets/7893459/9f83d24c-3074-4b41-be24-13ffa30b81d2)



<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->
