### PR TITLE
[ES|QL] fix job path

### DIFF
--- a/.buildkite/scripts/steps/esql_grammar_sync.sh
+++ b/.buildkite/scripts/steps/esql_grammar_sync.sh
@@ -113,7 +113,7 @@ main () {
 
   git checkout -b "$BRANCH_NAME"
 
-  git add esql/antlr/*
+  git add antlr/*
   git commit -m "Update ES|QL grammars"
 
   report_main_step "Changes committed. Creating pull request."


### PR DESCRIPTION
## Summary

After packaging the ES|QL grammar stuff the `git add` didn't change accordingly for the new path, hence the error.
This PR fixes it.