### PR TITLE
[Lens] Not display the timeRange error for ES|QL charts

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -1489,7 +1489,9 @@ export class Embeddable
     const input = this.getInput();
 
     // if at least one indexPattern is time based, then the Lens embeddable requires the timeRange prop
+    // this is necessary for the dataview embeddable but not the ES|QL one
     if (
+      !Boolean(this.isTextBasedLanguage()) &&
       input.timeRange == null &&
       indexPatterns.some((indexPattern) => indexPattern.isTimeBased())
     ) {


### PR DESCRIPTION
## Summary

fixes a problem that happens sometimes in the Obs ai assistant when generating an ES|QL chart,

![image (28)](https://github.com/elastic/kibana/assets/17003240/1120da32-685f-4d6c-a709-a738f39f3e73)

The ES|QL charts do not follow this logic. We don't have date histograms here, we are just mapping columns to dimensions. It is fine to not give a timeRange even if the adhoc dataview is timebased.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->