### PR TITLE
[8.13] [Discover] Unskip runtime field tests (#179627)

### DIFF
--- a/test/functional/apps/discover/group4/_runtime_fields_editor.ts
+++ b/test/functional/apps/discover/group4/_runtime_fields_editor.ts
@@ -35,6 +35,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     await fieldEditor.enableValue();
     await fieldEditor.typeScript("emit('abc')");
     await fieldEditor.save();
+    await fieldEditor.waitUntilClosed();
     await PageObjects.header.waitUntilLoadingHasFinished();
   };
 
@@ -51,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async () => {
       await security.testUser.restoreDefaults();
       await kibanaServer.importExport.unload('test/functional/fixtures/kbn_archiver/discover');
-      await kibanaServer.savedObjects.clean({ types: ['saved-search'] });
+      await kibanaServer.savedObjects.cleanStandardList();
     });
 
     it('allows adding custom label to existing fields', async function () {
@@ -60,6 +61,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await fieldEditor.enableCustomLabel();
       await fieldEditor.setCustomLabel(customLabel);
       await fieldEditor.save();
+      await fieldEditor.waitUntilClosed();
       await PageObjects.header.waitUntilLoadingHasFinished();
       expect((await PageObjects.unifiedFieldList.getAllFieldNames()).includes(customLabel)).to.be(
         true
@@ -67,11 +69,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.unifiedFieldList.clickFieldListItemAdd('bytes');
       expect(await PageObjects.discover.getDocHeader()).to.have.string(customLabel);
     });
-
     it('allows creation of a new field', async function () {
       const field = '_runtimefield';
       await createRuntimeField(field);
-      await retry.waitForWithTimeout('fieldNames to include runtimefield', 5000, async () => {
+
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.waitForDocTableLoadingComplete();
+      await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
+
+      await retry.waitFor('fieldNames to include runtimefield', async () => {
         const fieldNames = await PageObjects.unifiedFieldList.getAllFieldNames();
         return fieldNames.includes(field);
       });
@@ -85,8 +91,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await fieldEditor.setName(newFieldName, true);
       await fieldEditor.save();
       await fieldEditor.confirmSave();
+      await fieldEditor.waitUntilClosed();
       await PageObjects.header.waitUntilLoadingHasFinished();
       await PageObjects.discover.waitForDocTableLoadingComplete();
+      await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
       await retry.waitForWithTimeout('fieldNames to include edits', 5000, async () => {
         const fieldNames = await PageObjects.unifiedFieldList.getAllFieldNames();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Discover] Unskip runtime field tests (#179627)](https://github.com/elastic/kibana/pull/179627)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2024-03-31T18:22:32Z","message":"[Discover] Unskip runtime field tests (#179627)\n\n- Closes https://github.com/elastic/kibana/issues/179297\r\n- Closes https://github.com/elastic/kibana/issues/179310\r\n\r\n90x\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5582","sha":"cd9a0c294d34052df3659882d33fd6dd480788d0","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:DataDiscovery","backport:prev-minor","v8.14.0"],"number":179627,"url":"https://github.com/elastic/kibana/pull/179627","mergeCommit":{"message":"[Discover] Unskip runtime field tests (#179627)\n\n- Closes https://github.com/elastic/kibana/issues/179297\r\n- Closes https://github.com/elastic/kibana/issues/179310\r\n\r\n90x\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5582","sha":"cd9a0c294d34052df3659882d33fd6dd480788d0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179627","number":179627,"mergeCommit":{"message":"[Discover] Unskip runtime field tests (#179627)\n\n- Closes https://github.com/elastic/kibana/issues/179297\r\n- Closes https://github.com/elastic/kibana/issues/179310\r\n\r\n90x\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5582","sha":"cd9a0c294d34052df3659882d33fd6dd480788d0"}}]}] BACKPORT-->