### PR TITLE
[ML] Unskip a11y tests and fix datavisualizer test

### DIFF
--- a/x-pack/plugins/ml/public/application/datavisualizer/datavisualizer_selector.tsx
+++ b/x-pack/plugins/ml/public/application/datavisualizer/datavisualizer_selector.tsx
@@ -22,6 +22,7 @@ import {
   EuiTextAlign,
 } from '@elastic/eui';
 
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useTimefilter } from '@kbn/ml-date-picker';
 import { isFullLicense } from '../license';
@@ -182,6 +183,12 @@ export const DatavisualizerSelector: FC = () => {
                         />
                       }
                       tooltipPosition={'right'}
+                      aria-label={i18n.translate(
+                        'xpack.ml.datavisualizer.selector.technicalPreviewBadge.ariaLabel',
+                        {
+                          defaultMessage: 'ES|QL is in technical preview.',
+                        }
+                      )}
                     />
                   </>
                 </EuiTextAlign>

--- a/x-pack/test/accessibility/apps/group2/ml.ts
+++ b/x-pack/test/accessibility/apps/group2/ml.ts
@@ -48,8 +48,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/172598
-      describe.skip('with data loaded', function () {
+      describe('with data loaded', function () {
         const dfaOutlierResultsJobId = 'iph_outlier_a11y';
         const ecIndexName = 'ft_module_sample_ecommerce';
         const ihpIndexName = 'ft_ihp_outlier';


### PR DESCRIPTION
## Summary

Unskips the ML accessibility tests skipped in https://github.com/elastic/kibana/issues/17259 following the change made to  `EuiIcon` in https://github.com/elastic/eui/pull/7606 in EUI v93.5.1.

Also fixes a missing aria-label on the tech preview badge on the data visualizer selector page which would otherwise cause an accessibility test failure.

🟢  50x  flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5600


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))




