### PR TITLE
[ObsAiAssistant] Add “Manage connectors” button to flyout

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
@@ -149,7 +149,7 @@ export function ChatActionsMenu({
 
                 <EuiButtonEmpty
                   flush="left"
-                  size="xs"
+                  size="s"
                   data-test-subj="settingsTabGoToConnectorsButton"
                   href={http.basePath.prepend(
                     `/app/management/insightsAndAlerting/triggersActionsConnectors/connectors`

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
@@ -7,14 +7,7 @@
 
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import {
-  EuiButtonEmpty,
-  EuiButtonIcon,
-  EuiContextMenu,
-  EuiPanel,
-  EuiPopover,
-  EuiToolTip,
-} from '@elastic/eui';
+import { EuiButtonIcon, EuiContextMenu, EuiPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
 import { ConnectorSelectorBase } from '@kbn/observability-ai-assistant-plugin/public';
 import { useKibana } from '../../hooks/use_kibana';
 import { getSettingsHref } from '../../utils/get_settings_href';
@@ -146,20 +139,6 @@ export function ChatActionsMenu({
             content: (
               <EuiPanel>
                 <ConnectorSelectorBase {...connectors} />
-
-                <EuiButtonEmpty
-                  flush="left"
-                  size="s"
-                  data-test-subj="settingsTabGoToConnectorsButton"
-                  href={http.basePath.prepend(
-                    `/app/management/insightsAndAlerting/triggersActionsConnectors/connectors`
-                  )}
-                >
-                  {i18n.translate(
-                    'xpack.observabilityAiAssistant.settingsPage.goToConnectorsButtonLabel',
-                    { defaultMessage: 'Manage connectors' }
-                  )}
-                </EuiButtonEmpty>
               </EuiPanel>
             ),
           },

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
@@ -7,7 +7,14 @@
 
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon, EuiContextMenu, EuiPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiContextMenu,
+  EuiPanel,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
 import { ConnectorSelectorBase } from '@kbn/observability-ai-assistant-plugin/public';
 import { useKibana } from '../../hooks/use_kibana';
 import { getSettingsHref } from '../../utils/get_settings_href';
@@ -26,10 +33,16 @@ export function ChatActionsMenu({
   onCopyConversationClick: () => void;
 }) {
   const {
-    application: { navigateToUrl },
+    application: { navigateToUrl, navigateToApp },
     http,
   } = useKibana().services;
   const [isOpen, setIsOpen] = useState(false);
+
+  const handleNavigateToConnectors = () => {
+    navigateToApp('management', {
+      path: '/insightsAndAlerting/triggersActionsConnectors/connectors',
+    });
+  };
 
   const toggleActionsMenu = () => {
     setIsOpen(!isOpen);
@@ -139,6 +152,18 @@ export function ChatActionsMenu({
             content: (
               <EuiPanel>
                 <ConnectorSelectorBase {...connectors} />
+
+                <EuiButtonEmpty
+                  flush="left"
+                  size="xs"
+                  data-test-subj="settingsTabGoToConnectorsButton"
+                  onClick={handleNavigateToConnectors}
+                >
+                  {i18n.translate(
+                    'xpack.observabilityAiAssistant.settingsPage.goToConnectorsButtonLabel',
+                    { defaultMessage: 'Manage connectors' }
+                  )}
+                </EuiButtonEmpty>
               </EuiPanel>
             ),
           },

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
@@ -149,7 +149,7 @@ export function ChatActionsMenu({
 
                 <EuiButtonEmpty
                   flush="left"
-                  size="s"
+                  size="xs"
                   data-test-subj="settingsTabGoToConnectorsButton"
                   href={http.basePath.prepend(
                     `/app/management/insightsAndAlerting/triggersActionsConnectors/connectors`

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_actions_menu.tsx
@@ -7,7 +7,14 @@
 
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiButtonIcon, EuiContextMenu, EuiPanel, EuiPopover, EuiToolTip } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiContextMenu,
+  EuiPanel,
+  EuiPopover,
+  EuiToolTip,
+} from '@elastic/eui';
 import { ConnectorSelectorBase } from '@kbn/observability-ai-assistant-plugin/public';
 import { useKibana } from '../../hooks/use_kibana';
 import { getSettingsHref } from '../../utils/get_settings_href';
@@ -139,6 +146,20 @@ export function ChatActionsMenu({
             content: (
               <EuiPanel>
                 <ConnectorSelectorBase {...connectors} />
+
+                <EuiButtonEmpty
+                  flush="left"
+                  size="s"
+                  data-test-subj="settingsTabGoToConnectorsButton"
+                  href={http.basePath.prepend(
+                    `/app/management/insightsAndAlerting/triggersActionsConnectors/connectors`
+                  )}
+                >
+                  {i18n.translate(
+                    'xpack.observabilityAiAssistant.settingsPage.goToConnectorsButtonLabel',
+                    { defaultMessage: 'Manage connectors' }
+                  )}
+                </EuiButtonEmpty>
               </EuiPanel>
             ),
           },

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
@@ -14,8 +14,13 @@ import { PersistedSettings } from './persisted_settings';
 export function SettingsTab() {
   const {
     application: { navigateToApp },
-    http,
   } = useAppContext();
+
+  const handleNavigateToConnectors = () => {
+    navigateToApp('management', {
+      path: '/insightsAndAlerting/triggersActionsConnectors/connectors',
+    });
+  };
 
   const handleNavigateToSpacesConfiguration = () => {
     navigateToApp('management', {
@@ -86,9 +91,7 @@ export function SettingsTab() {
         <EuiFormRow fullWidth>
           <EuiButton
             data-test-subj="settingsTabGoToConnectorsButton"
-            href={http.basePath.prepend(
-              `/app/management/insightsAndAlerting/triggersActionsConnectors/connectors`
-            )}
+            onClick={handleNavigateToConnectors}
           >
             {i18n.translate(
               'xpack.observabilityAiAssistantManagement.settingsPage.goToConnectorsButtonLabel',

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
@@ -14,13 +14,8 @@ import { PersistedSettings } from './persisted_settings';
 export function SettingsTab() {
   const {
     application: { navigateToApp },
+    http,
   } = useAppContext();
-
-  const handleNavigateToConnectors = () => {
-    navigateToApp('management', {
-      path: '/insightsAndAlerting/triggersActionsConnectors/connectors',
-    });
-  };
 
   const handleNavigateToSpacesConfiguration = () => {
     navigateToApp('management', {
@@ -91,7 +86,9 @@ export function SettingsTab() {
         <EuiFormRow fullWidth>
           <EuiButton
             data-test-subj="settingsTabGoToConnectorsButton"
-            onClick={handleNavigateToConnectors}
+            href={http.basePath.prepend(
+              `/app/management/insightsAndAlerting/triggersActionsConnectors/connectors`
+            )}
           >
             {i18n.translate(
               'xpack.observabilityAiAssistantManagement.settingsPage.goToConnectorsButtonLabel',


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/179380

This adds a link "Manage connectors" to the flyout where users can select a connector.

![image](https://github.com/elastic/kibana/assets/209966/8016b1d2-84d7-4372-909e-636677c0de4d)
