### PR TITLE
Add .puppeteerrc

### DIFF
--- a/.puppeteerrc
+++ b/.puppeteerrc
@@ -1,0 +1,1 @@
+skipDownload: true

--- a/src/dev/build/tasks/copy_legacy_source_task.ts
+++ b/src/dev/build/tasks/copy_legacy_source_task.ts
@@ -21,6 +21,7 @@ export const CopyLegacySource: Task = {
     const select = [
       'yarn.lock',
       '.npmrc',
+      '.puppeteerrc',
       'config/kibana.yml',
       'config/node.options',
       '.i18nrc.json',


### PR DESCRIPTION
Puppeteer uses cosmiconfig to load configuration files.  We're seeing permissions issues for various reasons due to the global search strategy employed by puppeteer.

This should short circuit configuration lookups outside of the Kibana directory.

Closes https://github.com/elastic/kibana/issues/168639

https://pptr.dev/api/puppeteer.configuration 

Release note
Fixes an issue with Kibana looking for a configuration file outside of the Kibana home directory, potentially preventing startup due to insufficient permissions.

<!--ONMERGE {"backportTargets":["7.17","8.13"]} ONMERGE-->