### PR TITLE
[Playground]- Setup Error Handling 

### DIFF
--- a/x-pack/plugins/search_playground/common/types.ts
+++ b/x-pack/plugins/search_playground/common/types.ts
@@ -43,6 +43,10 @@ export interface ChatRequestData {
 }
 
 export enum ErrorCode {
-  INVALID_API_KEY = 'invalid_api_key',
-  UNCAUGHT_EXCEPTION = 'uncaught_exception',
+  API_KEY_ERROR = 'api_key_error',
+  UNSUPPORTED_LOCATION_ERROR = 'unsupported_location_error',
+  RATE_LIMIT_OR_QUOTA_ERROR = 'rate_limit_or_quota_error',
+  ENGINE_OVERLOADED_ERROR = 'engine_overloaded_error',
+  UNCAUGHT_EXCEPTION_ERROR = 'uncaught_exception_error',
+  ENGINE_OVERLOADED = 'ENGINE_OVERLOADED',
 }

--- a/x-pack/plugins/search_playground/common/types.ts
+++ b/x-pack/plugins/search_playground/common/types.ts
@@ -41,3 +41,8 @@ export interface ChatRequestData {
   source_fields: string;
   doc_size: number;
 }
+
+export enum ErrorCode {
+  INVALID_API_KEY = 'invalid_api_key',
+  UNCAUGHT_EXCEPTION = 'uncaught_exception',
+}

--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -89,6 +89,10 @@ export const Chat = () => {
     });
   };
 
+  const regenerateMessages = () => {
+    reload();
+  };
+
   if (showStartPage) {
     return <StartNewChat onStartClick={() => setShowStartPage(false)} />;
   }

--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -56,7 +56,7 @@ export const Chat = () => {
     handleSubmit,
     getValues,
   } = useFormContext<ChatForm>();
-  const { messages, append, stop: stopRequest, setMessages, reload } = useChat();
+  const { messages, append, stop: stopRequest, setMessages, reload, error } = useChat();
   const selectedIndicesCount = watch(ChatFormFields.indices, []).length;
   const messagesRef = useAutoBottomScroll([showStartPage]);
 
@@ -87,9 +87,18 @@ export const Chat = () => {
         role: MessageRole.system,
         content: 'You can start chat now',
       },
+      ...(error
+        ? [
+            {
+              id: uuidv4(),
+              role: MessageRole.system,
+              content: 'Please verify if you have correct OPENAI API key and retry again.',
+            },
+          ]
+        : []),
       ...transformFromChatMessages(messages),
     ],
-    [messages]
+    [messages, error]
   );
 
   const regenerateMessages = () => {

--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -60,6 +60,16 @@ export const Chat = () => {
   const selectedIndicesCount = watch(ChatFormFields.indices, []).length;
   const messagesRef = useAutoBottomScroll([showStartPage]);
 
+  const buildFormData = (formData: ChatForm) => ({
+    prompt: formData[ChatFormFields.prompt],
+    indices: formData[ChatFormFields.indices].join(),
+    api_key: formData[ChatFormFields.openAIKey],
+    citations: formData[ChatFormFields.citations],
+    elasticsearchQuery: JSON.stringify(formData[ChatFormFields.elasticsearchQuery]),
+    summarization_model:
+      formData[ChatFormFields.summarizationModel] ?? SummarizationModelName.gpt3_5_turbo_1106,
+  });
+
   const onSubmit = async (data: ChatForm) => {
     await append(
       { content: data.question, role: MessageRole.user, createdAt: new Date() },

--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -140,7 +140,7 @@ export const Chat = () => {
                 <EuiFlexItem grow={false}>
                   <EuiButtonEmpty
                     iconType="sparkles"
-                    disabled={chatMessages.length <= 1}
+                    disabled={chatMessages.length <= 1 || !!error}
                     onClick={regenerateMessages}
                   >
                     <FormattedMessage
@@ -152,7 +152,7 @@ export const Chat = () => {
                 <EuiFlexItem grow={false}>
                   <EuiButtonEmpty
                     iconType="refresh"
-                    disabled={chatMessages.length <= 1}
+                    disabled={chatMessages.length <= 1 || !!error}
                     onClick={() => {
                       setMessages([]);
                     }}

--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -59,16 +59,7 @@ export const Chat = () => {
   const { messages, append, stop: stopRequest, setMessages, reload, error } = useChat();
   const selectedIndicesCount = watch(ChatFormFields.indices, []).length;
   const messagesRef = useAutoBottomScroll([showStartPage]);
-
-  const buildFormData = (formData: ChatForm) => ({
-    prompt: formData[ChatFormFields.prompt],
-    indices: formData[ChatFormFields.indices].join(),
-    api_key: formData[ChatFormFields.openAIKey],
-    citations: formData[ChatFormFields.citations],
-    elasticsearchQuery: JSON.stringify(formData[ChatFormFields.elasticsearchQuery]),
-    summarization_model:
-      formData[ChatFormFields.summarizationModel] ?? SummarizationModelName.gpt3_5_turbo_1106,
-  });
+  const [isRegenerating, setIsRegenerating] = useState<boolean>(false);
 
   const onSubmit = async (data: ChatForm) => {
     await append(
@@ -87,29 +78,20 @@ export const Chat = () => {
         role: MessageRole.system,
         content: 'You can start chat now',
       },
-      ...(error
-        ? [
-            {
-              id: uuidv4(),
-              role: MessageRole.system,
-              content: 'Please verify if you have correct OPENAI API key and retry again.',
-            },
-          ]
-        : []),
       ...transformFromChatMessages(messages),
     ],
-    [messages, error]
+    [messages]
   );
 
-  const regenerateMessages = () => {
+  const regenerateMessages = async () => {
+    setIsRegenerating(true);
+
     const formData = getValues();
-    reload({
+    await reload({
       data: buildFormData(formData),
     });
-  };
 
-  const regenerateMessages = () => {
-    reload();
+    setIsRegenerating(false);
   };
 
   if (showStartPage) {
@@ -197,9 +179,9 @@ export const Chat = () => {
                   <QuestionInput
                     value={field.value}
                     onChange={field.onChange}
-                    isDisabled={isSubmitting}
+                    isDisabled={isSubmitting || isRegenerating}
                     button={
-                      isSubmitting ? (
+                      isSubmitting || isRegenerating ? (
                         <EuiButtonIcon
                           aria-label={i18n.translate(
                             'xpack.searchPlayground.chat.stopButtonAriaLabel',

--- a/x-pack/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { EuiFormRow, EuiIcon, EuiTextArea, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { isEmpty } from 'lodash';
 
 interface InstructionsFieldProps {
   value?: string;
@@ -49,6 +50,7 @@ export const InstructionsField: React.FC<InstructionsFieldProps> = ({ value, onC
         value={value}
         onChange={handlePromptChange}
         fullWidth
+        isInvalid={isEmpty(value)}
       />
     </EuiFormRow>
   );

--- a/x-pack/plugins/search_playground/public/hooks/use_ai_assist_chat.ts
+++ b/x-pack/plugins/search_playground/public/hooks/use_ai_assist_chat.ts
@@ -52,8 +52,15 @@ const getStreamedResponse = async (
     appendMessage(message) {
       mutate([...chatRequest.messages, message], false);
     },
-    handleFailure() {
-      mutate(previousMessages, false);
+    handleFailure(errorMessage) {
+      const systemErrorMessage = {
+        id: uuidv4(),
+        content: errorMessage,
+        role: MessageRole.system,
+        createdAt: new Date(),
+      };
+      // concating the last question and error message with existing chat history
+      mutate([...previousMessages, chatRequest.messages.slice(-1)[0], systemErrorMessage], false);
     },
     onUpdate(merged) {
       mutate([...chatRequest.messages, ...merged], false);

--- a/x-pack/plugins/search_playground/public/utils/api.ts
+++ b/x-pack/plugins/search_playground/public/utils/api.ts
@@ -42,15 +42,15 @@ export async function fetchApi({
 
   const apiRequest = typeof api === 'string' ? fetch(api, requestInit) : api(requestInit);
 
-  const apiResponse = await apiRequest.catch((error) => {
+  const apiResponse = await apiRequest.catch(async (error) => {
     handleFailure();
-    throw error;
+    let errorMessage = 'Failed to fetch the chat messages';
+    if (error.response) {
+      errorMessage =
+        (await error.response?.json())?.message ?? 'Failed to fetch the chat response.';
+    }
+    throw new Error(errorMessage);
   });
-
-  if (!apiResponse.ok) {
-    handleFailure();
-    throw new Error((await apiResponse.text()) || 'Failed to fetch the chat response.');
-  }
 
   if (!apiResponse.body) {
     throw new Error('The response body is empty.');

--- a/x-pack/plugins/search_playground/public/utils/api.ts
+++ b/x-pack/plugins/search_playground/public/utils/api.ts
@@ -24,7 +24,7 @@ export async function fetchApi({
   headers?: HeadersInit;
   appendMessage: (message: Message) => void;
   abortController?: () => AbortController | null;
-  handleFailure: () => void;
+  handleFailure: (error: string) => void;
   onUpdate: (mergedMessages: Message[]) => void;
 }) {
   const requestInit = {
@@ -43,12 +43,12 @@ export async function fetchApi({
   const apiRequest = typeof api === 'string' ? fetch(api, requestInit) : api(requestInit);
 
   const apiResponse = await apiRequest.catch(async (error) => {
-    handleFailure();
     let errorMessage = 'Failed to fetch the chat messages';
     if (error.response) {
       errorMessage =
         (await error.response?.json())?.message ?? 'Failed to fetch the chat response.';
     }
+    handleFailure(errorMessage);
     throw new Error(errorMessage);
   });
 

--- a/x-pack/plugins/search_playground/public/utils/transform_to_messages.ts
+++ b/x-pack/plugins/search_playground/public/utils/transform_to_messages.ts
@@ -14,7 +14,7 @@ export const transformFromChatMessages = (messages: UseChatHelpers['messages']):
       id,
       content,
       createdAt,
-      role: role === MessageRole.assistant ? MessageRole.assistant : MessageRole.user,
+      role,
     };
 
     if (role === MessageRole.assistant) {

--- a/x-pack/plugins/search_playground/server/routes.ts
+++ b/x-pack/plugins/search_playground/server/routes.ts
@@ -23,7 +23,7 @@ import {
   SearchPlaygroundPluginStartDependencies,
   ErrorCode,
 } from './types';
-import { createError, SearchPlaygroundError } from './utils/create_error';
+import { createError } from './utils/create_error';
 import { isInvalidApiKeyException } from './utils/exceptions';
 
 export function createRetriever(esQuery: string) {

--- a/x-pack/plugins/search_playground/server/utils/create_error.ts
+++ b/x-pack/plugins/search_playground/server/utils/create_error.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KibanaResponseFactory } from '@kbn/core-http-server';
+
+import { ErrorCode } from '../types';
+
+export interface SearchPlaygroundError {
+  errorCode: ErrorCode;
+  message: string;
+  statusCode: number;
+}
+
+export function createError({
+  errorCode,
+  message,
+  response,
+  statusCode,
+}: SearchPlaygroundError & {
+  response: KibanaResponseFactory;
+}) {
+  return response.customError({
+    body: {
+      attributes: {
+        error_code: errorCode,
+      },
+      message,
+    },
+    statusCode,
+  });
+}

--- a/x-pack/plugins/search_playground/server/utils/error_handler.ts
+++ b/x-pack/plugins/search_playground/server/utils/error_handler.ts
@@ -6,13 +6,23 @@
  */
 
 import { RequestHandlerWrapper } from '@kbn/core-http-server';
+import { i18n } from '@kbn/i18n';
+import { ErrorCode } from '../types';
+import { createError } from './create_error';
 
 export const errorHandler: RequestHandlerWrapper = (handler) => {
   return async (context, request, response) => {
     try {
       return await handler(context, request, response);
     } catch (e) {
-      throw e;
+      return createError({
+        errorCode: ErrorCode.UNCAUGHT_EXCEPTION_ERROR,
+        message: i18n.translate('xpack.searchPlayground.server.routes.uncaughtExceptionError', {
+          defaultMessage: 'Playground encountered an error.',
+        }),
+        response,
+        statusCode: 500,
+      });
     }
   };
 };

--- a/x-pack/plugins/search_playground/server/utils/exceptions.ts
+++ b/x-pack/plugins/search_playground/server/utils/exceptions.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface SearchPlaygroundOpenAIResponseError {
+  status: number;
+  code: string;
+}
+
+export const isInvalidApiKeyException = (error: SearchPlaygroundOpenAIResponseError) =>
+  error.status === 401;

--- a/x-pack/plugins/search_playground/server/utils/exceptions.ts
+++ b/x-pack/plugins/search_playground/server/utils/exceptions.ts
@@ -12,3 +12,12 @@ export interface SearchPlaygroundOpenAIResponseError {
 
 export const isInvalidApiKeyException = (error: SearchPlaygroundOpenAIResponseError) =>
   error.status === 401;
+
+export const isInvalidLocationSupport = (error: SearchPlaygroundOpenAIResponseError) =>
+  error.status === 403;
+
+export const isRateLimiteOrQuotaError = (error: SearchPlaygroundOpenAIResponseError) =>
+  error.status === 429;
+
+export const isEngineOverloadError = (error: SearchPlaygroundOpenAIResponseError) =>
+  error.status === 503;


### PR DESCRIPTION
## Summary

This PR contains:
- Disable question field and send button to can not send message while `regenerating`.
- Adding helper functionality for error messages in BE.
- Adding helper functionality in FE


![Screenshot 2024-04-02 at 5 16 13 PM](https://github.com/elastic/kibana/assets/150824886/eb2c9e13-8b01-4d12-9801-5879e4d8e2bd)


![Screenshot 2024-04-02 at 5 16 43 PM](https://github.com/elastic/kibana/assets/150824886/27f0005d-c986-49ba-9d1a-6ae1f5c75344)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
