### PR TITLE
[Console] Fix hook for setting initial value in Monaco editor

### DIFF
--- a/src/plugins/console/public/application/containers/editor/monaco/monaco_editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/monaco/monaco_editor.tsx
@@ -27,11 +27,11 @@ export const MonacoEditor = ({ initialTextValue }: EditorProps) => {
 
   const [value, setValue] = useState(initialTextValue);
 
-  const setInitialValue = useSetInitialValue({ initialTextValue, setValue, toasts });
+  const setInitialValue = useSetInitialValue;
 
   useEffect(() => {
-    setInitialValue();
-  }, [setInitialValue]);
+    setInitialValue({ initialTextValue, setValue, toasts });
+  }, [initialTextValue, setInitialValue, toasts]);
 
   return (
     <div

--- a/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
@@ -75,19 +75,17 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
     loadBufferFromRemote(url);
   }, 200);
 
+  window.addEventListener('hashchange', onHashChange);
+
+  const loadFromParam = readLoadFromParam();
+
+  if (loadFromParam) {
+    loadBufferFromRemote(loadFromParam);
+  } else {
+    setValue(initialTextValue || DEFAULT_INPUT_VALUE);
+  }
+
   return () => {
-    window.addEventListener('hashchange', onHashChange);
-
-    const loadFromParam = readLoadFromParam();
-
-    if (loadFromParam) {
-      loadBufferFromRemote(loadFromParam);
-    } else {
-      setValue(initialTextValue || DEFAULT_INPUT_VALUE);
-    }
-
-    return () => {
-      window.removeEventListener('hashchange', onHashChange);
-    };
+    window.removeEventListener('hashchange', onHashChange);
   };
 };


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/elastic/kibana/pull/178899 where we added a hook for setting the initial value in the Monaco editor in Console. However, the hook introduced a bug - it wasn't possible to type anything in the editor as every re-render called the function in the hook, which set the value in the editor to be the initial value. This PR fixes this.



