### PR TITLE
[Reporting] update logs and docs on headless browser connection

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -10,39 +10,13 @@ For security, you grant users access to the {report-features} and secure the rep
 with TLS/SSL encryption. Additionally, you can install graphical packages into the operating system
 to enable the {kib} server to have screenshotting capabilities.
 
-* <<install-reporting-packages>>
 * <<grant-user-access>>
 * <<reporting-roles-user-api>>
 * <<grant-user-access-basic>>
 * <<grant-user-access-external-provider>>
 * <<securing-reporting>>
-
-[float]
-[[install-reporting-packages]]
-=== Install the reporting packages
-
-Make sure the {kib} server operating system has the appropriate packages installed for the distribution.
-
-If you are using RHEL operating systems, install the following packages:
-
-* `ipa-gothic-fonts`
-* `xorg-x11-fonts-100dpi`
-* `xorg-x11-fonts-75dpi`
-* `xorg-x11-utils`
-* `xorg-x11-fonts-cyrillic`
-* `xorg-x11-fonts-Type1`
-* `xorg-x11-fonts-misc`
-* `fontconfig`
-* `freetype`
-
-If you are using Ubuntu/Debian systems, install the following packages:
-
-* `fonts-liberation`
-* `libfontconfig1`
-* `libnss3`
-
-The reporting plugin has a built-in utility to check for common issues, such as missing dependencies. See
-<<reporting-diagnostics>> for more information.
+* <<install-reporting-packages>>
+* <<set-reporting-server-host>>
 
 [float]
 [[grant-user-access]]
@@ -231,3 +205,44 @@ For more information, see {ref}/notification-settings.html#ssl-notification-sett
 Once you've enabled SSL for {kib}, all requests to the reporting endpoints must include valid credentials.
 
 For more information on sharing reports, direct links, and more, refer to <<reporting-getting-started, Reporting and sharing>>.
+
+[float]
+[[install-reporting-packages]]
+=== Install the dependencies for the headless browser
+
+If using PNG/PDF {report-features}, make sure the {kib} server operating system has the appropriate packages installed for the distribution.
+
+If you are using RHEL operating systems, install the following packages:
+
+* `ipa-gothic-fonts`
+* `xorg-x11-fonts-100dpi`
+* `xorg-x11-fonts-75dpi`
+* `xorg-x11-utils`
+* `xorg-x11-fonts-cyrillic`
+* `xorg-x11-fonts-Type1`
+* `xorg-x11-fonts-misc`
+* `fontconfig`
+* `freetype`
+
+If you are using Ubuntu/Debian systems, install the following packages:
+
+* `fonts-liberation`
+* `libfontconfig1`
+* `libnss3`
+
+The screenshotting plugin used for {reporting-features} has a built-in utility to check for common issues, such as missing dependencies. See
+<<reporting-diagnostics>> for more information.
+
+[float]
+[[set-reporting-server-host]]
+=== Set the `server.host` for the headless browser
+
+If using PNG/PDF {report-features} in a production environment, it is preferred to use the setting of
+`server.host: 0.0.0.0` in the `kibana.yml` configuration file. This allows the headless browser used for
+PDF/PNG reporting to reach {kib} over a local interface, while also allowing the {kib} server to listen on
+outward-facing network interfaces, as it makes the {kib} server accessible from any network interface on the
+machine. Make sure that no firewall rules or other routing rules prevent local services from accessing this
+address.
+
+For the most reliable configuration of PDF/PNG {report-features}, consider installing {kib} using <<docker, Docker>>, or
+using <<set-up-on-cloud, Elastic Cloud>>.

--- a/x-pack/plugins/reporting/server/config/create_config.ts
+++ b/x-pack/plugins/reporting/server/config/create_config.ts
@@ -45,10 +45,7 @@ export function createConfig(
     ipaddr.isValid(kibanaServerHostname) &&
     !sum(ipaddr.parse(kibanaServerHostname).toByteArray())
   ) {
-    logger.info(
-      `Overriding server host address "0.0.0.0" in Reporting runtime config,` +
-        ` using "xpack.reporting.kibanaServer.hostname: localhost".`
-    );
+    // A silent override to use "localhost" instead of "0.0.0.0" for connection of the headless browser
     kibanaServerHostname = 'localhost';
   }
   // kibanaServer.port, default to server.port


### PR DESCRIPTION
## Summary

This resolves some issues we've seen over confusion on configuration and refused access to Kibana while generating a PNG/PDF report.
