### PR TITLE
use child combinator for even higher specificity

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/components/vis_types/markdown/vis.js
+++ b/src/plugins/vis_types/timeseries/public/application/components/vis_types/markdown/vis.js
@@ -64,19 +64,17 @@ function MarkdownVisualization(props) {
     markdown = (
       <div className="tvbMarkdown" data-test-subj="tsvbMarkdown">
         {markdownError && <ErrorComponent error={markdownError} />}
-        <ClassNames>
-          {({ css, cx }) => (
-            <div
-              className={cx(
-                contentClasses,
-                // wrapping select for markdown body to make sure selector specificity wins over base styles
-                css(`.kbnMarkdown__body {
-                  ${model.markdown_css}
-                }`)
-              )}
-            >
-              <div>
-                {!markdownError && (
+        {!markdownError && (
+          <ClassNames>
+            {({ css, cx }) => (
+              <div className={cx(contentClasses)}>
+                <div
+                  css={css`
+                    > * {
+                      ${model.markdown_css}
+                    }
+                  `}
+                >
                   <Markdown
                     onRender={initialRender}
                     openLinksInNewTab={model.markdown_openLinksInNewTab}
@@ -84,11 +82,11 @@ function MarkdownVisualization(props) {
                   >
                     {markdownSource}
                   </Markdown>
-                )}
+                </div>
               </div>
-            </div>
-          )}
-        </ClassNames>
+            )}
+          </ClassNames>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/179498

Given a user provided a style declaration of `> * { background: green }`, the styles generated were of the following format

<img width="876" alt="Screenshot 2024-04-02 at 22 32 35" src="https://github.com/elastic/kibana/assets/7893459/d3250b5f-9302-43f6-b6da-354233337b5b">

and applied like so;

<img width="856" alt="Screenshot 2024-04-02 at 22 32 23" src="https://github.com/elastic/kibana/assets/7893459/bc27f8b9-f9b3-4fdc-b43f-f4f45e8bc15e">

Given this is way the generated style gets applied to the markup, the provided user styles wasn't going to get applied.

This PR introduces a fix that rather leverages the child combinator selector, this accounts for specificity  in that the class emotion generates becomes more or less the namespace for the styles provided by the user for the visualization markdown content, especially considering how the styles do get generated.

With that in mind, defining the following declaration gets applied properly; 

<img width="2540" alt="Screenshot 2024-04-03 at 10 20 32" src="https://github.com/elastic/kibana/assets/7893459/fab0634c-dbed-4867-be8d-0a58dedd0b78">


<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->
