### PR TITLE
Fix loading default query on the rule details page alerts table and view in app URL for without group by rules

### DIFF
--- a/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/helpers/get_group.test.ts
+++ b/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/helpers/get_group.test.ts
@@ -101,5 +101,9 @@ describe('getGroup', () => {
     it('should return empty array if fields and values are empty', () => {
       expect(getGroups([], [])).toEqual([]);
     });
+
+    it('should return empty array if fields and values are undefined', () => {
+      expect(getGroups()).toEqual([]);
+    });
   });
 });

--- a/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/helpers/get_group.ts
+++ b/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/helpers/get_group.ts
@@ -34,7 +34,7 @@ export const getGroupFilters = (groups?: Group[], groupFieldName?: string): Filt
   return getGroupQueries(groups, groupFieldName).map((query) => ({ meta: {}, query }));
 };
 
-export const getGroups = (fields: string[], values: string[]): Group[] => {
+export const getGroups = (fields: string[] = [], values: string[] = []): Group[] => {
   return fields.map((_, index) => ({
     field: fields[index],
     value: values[index],

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
@@ -135,7 +135,7 @@ describe('ObservabilityAlertSearchBar', () => {
       status: 'all',
     });
 
-    expect(mockedOnEsQueryChange).toHaveBeenCalledWith({
+    const esQueryChangeParams = {
       bool: {
         filter: [
           {
@@ -160,7 +160,10 @@ describe('ObservabilityAlertSearchBar', () => {
         must_not: [],
         should: [],
       },
-    });
+    };
+    expect(mockedOnEsQueryChange).toHaveBeenCalledTimes(2);
+    expect(mockedOnEsQueryChange).toHaveBeenNthCalledWith(1, esQueryChangeParams);
+    expect(mockedOnEsQueryChange).toHaveBeenNthCalledWith(2, esQueryChangeParams);
   });
 
   it('should include filters in es query', async () => {

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.tsx
@@ -99,6 +99,7 @@ export function ObservabilityAlertSearchBar({
             from: rangeFrom,
           },
           kuery,
+          queries: [...getAlertStatusQuery(status), ...defaultSearchQueries],
           filters,
         })
       );
@@ -108,7 +109,17 @@ export function ObservabilityAlertSearchBar({
       });
       onKueryChange(DEFAULT_QUERY_STRING);
     }
-  }, [filters, kuery, onEsQueryChange, onKueryChange, rangeFrom, rangeTo, toasts]);
+  }, [
+    defaultSearchQueries,
+    filters,
+    kuery,
+    onEsQueryChange,
+    onKueryChange,
+    rangeFrom,
+    rangeTo,
+    status,
+    toasts,
+  ]);
 
   const onSearchBarParamsChange = useCallback<
     (query: {

--- a/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_search_bar/alert_search_bar.tsx
@@ -101,6 +101,7 @@ export function ObservabilityAlertSearchBar({
           kuery,
           queries: [...getAlertStatusQuery(status), ...defaultSearchQueries],
           filters,
+          config: getEsQueryConfig(uiSettings),
         })
       );
     } catch (error) {
@@ -118,6 +119,7 @@ export function ObservabilityAlertSearchBar({
     rangeFrom,
     rangeTo,
     status,
+    uiSettings,
     toasts,
   ]);
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/179903

## Summary

This PR fixes:
1. Not applying default queries correctly on the first render by including `queries: [...getAlertStatusQuery(status), ...defaultSearchQueries]` in useEffect.

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/ab6f53e9-1ac7-4abf-b93c-da8de868c85c)|![image](https://github.com/elastic/kibana/assets/12370520/760e1ca6-1ef1-4612-a635-2092d68db14e)|

2. Not showing view in app URL for the rules that does not have group by field, by allowing `undefined` fields in `getGroups`.

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/fba89c4a-275c-4c8b-ac84-dedc8ca109e9)|![image](https://github.com/elastic/kibana/assets/12370520/ccd48bee-cc5e-4e11-bf68-215b41565cd5)|