### PR TITLE
Fix retries for parallel_serverless Cypress tests

### DIFF
--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -478,14 +478,26 @@ ${JSON.stringify(cyCustomEnv, null, 2)}
         ),
         ...retryResults,
       ] as CypressCommandLine.CypressRunResult[]);
-      const hasFailedTests = _.some(
-        // only fail the job if retry failed as well
-        retryResults,
-        (result) =>
-          (result as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
-          (result as CypressCommandLine.CypressRunResult)?.totalFailed
-      );
-      if (hasFailedTests) {
+      const hasFailedTests = (
+        runResults: Array<
+          | CypressCommandLine.CypressFailedRunResult
+          | CypressCommandLine.CypressRunResult
+          | undefined
+        >
+      ) =>
+        _.some(
+          // only fail the job if retry failed as well
+          runResults,
+          (result) =>
+            (result as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
+            (result as CypressCommandLine.CypressRunResult)?.totalFailed
+        );
+
+      const hasFailedInitialTests = hasFailedTests(initialResults);
+      const hasFailedRetryTests = hasFailedTests(retryResults);
+
+      // If the initialResults had failures and failedSpecFilePaths was not populated properly return errors
+      if (hasFailedRetryTests || (hasFailedInitialTests && !retryResults.length)) {
         throw createFailError('Not all tests passed');
       }
     },

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -488,9 +488,9 @@ ${JSON.stringify(cyCustomEnv, null, 2)}
         _.some(
           // only fail the job if retry failed as well
           runResults,
-          (result) =>
-            (result as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
-            (result as CypressCommandLine.CypressRunResult)?.totalFailed
+          (runResult) =>
+            (runResult as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
+            (runResult as CypressCommandLine.CypressRunResult)?.totalFailed
         );
 
       const hasFailedInitialTests = hasFailedTests(initialResults);

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
@@ -655,6 +655,8 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
                   log.info(`${id} : Deleting project ${PROJECT_NAME}...`);
                   await deleteSecurityProject(project.id, PROJECT_NAME, API_KEY);
                 } catch (error) {
+                  // False positive
+                  // eslint-disable-next-line require-atomic-updates
                   result = error;
                   failedSpecFilePaths.push(filePath);
                 }
@@ -695,9 +697,9 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
         _.some(
           // only fail the job if retry failed as well
           runResults,
-          (result) =>
-            (result as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
-            (result as CypressCommandLine.CypressRunResult)?.totalFailed
+          (runResult) =>
+            (runResult as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
+            (runResult as CypressCommandLine.CypressRunResult)?.totalFailed
         );
 
       const hasFailedInitialTests = hasFailedTests(initialResults);

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
@@ -648,11 +648,15 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
                       env: cyCustomEnv,
                     },
                   });
+                  if ((result as CypressCommandLine.CypressRunResult)?.totalFailed) {
+                    failedSpecFilePaths.push(filePath);
+                  }
                   // Delete serverless project
                   log.info(`${id} : Deleting project ${PROJECT_NAME}...`);
                   await deleteSecurityProject(project.id, PROJECT_NAME, API_KEY);
                 } catch (error) {
                   result = error;
+                  failedSpecFilePaths.push(filePath);
                 }
               }
               return result;
@@ -681,14 +685,26 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
         ),
         ...retryResults,
       ] as CypressCommandLine.CypressRunResult[]);
-      const hasFailedTests = _.some(
-        // only fail the job if retry failed as well
-        retryResults,
-        (result) =>
-          (result as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
-          (result as CypressCommandLine.CypressRunResult)?.totalFailed
-      );
-      if (hasFailedTests) {
+      const hasFailedTests = (
+        runResults: Array<
+          | CypressCommandLine.CypressFailedRunResult
+          | CypressCommandLine.CypressRunResult
+          | undefined
+        >
+      ) =>
+        _.some(
+          // only fail the job if retry failed as well
+          runResults,
+          (result) =>
+            (result as CypressCommandLine.CypressFailedRunResult)?.status === 'failed' ||
+            (result as CypressCommandLine.CypressRunResult)?.totalFailed
+        );
+
+      const hasFailedInitialTests = hasFailedTests(initialResults);
+      const hasFailedRetryTests = hasFailedTests(retryResults);
+
+      // If the initialResults had failures and failedSpecFilePaths was not populated properly return errors
+      if (hasFailedRetryTests || (hasFailedInitialTests && !retryResults.length)) {
         throw createFailError('Not all tests passed');
       }
     },


### PR DESCRIPTION
## Summary

Follow up for https://github.com/elastic/kibana/pull/179585

Fixes missed `parallel_serverless` changes