### PR TITLE
[serverless] add sorting

### DIFF
--- a/x-pack/test/functional/es_archives/reporting/unmapped_fields/mappings.json
+++ b/x-pack/test/functional/es_archives/reporting/unmapped_fields/mappings.json
@@ -6,7 +6,8 @@
       "dynamic": false,
       "properties": {
         "text": {
-          "type": "text"
+          "type": "text",
+          "fielddata": "true"
         }
       }
     }

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/__snapshots__/generate_csv_discover.snap
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/__snapshots__/generate_csv_discover.snap
@@ -79,21 +79,21 @@ xgMtOW0BH63Xcmy45GnD,ecommerce,\\"-\\",\\"Women's Clothing, Women's Shoes, Women
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes all unmapped fields to the report 1`] = `
 "\\"_id\\",\\"_index\\",\\"_score\\",\\"nested.unmapped\\",text,unmapped
-1,recipes,1,\\"-\\",text1,unmapped1
-2,recipes,1,unmapped2,text2,\\"-\\"
+1,recipes,\\"-\\",\\"-\\",text1,unmapped1
+2,recipes,\\"-\\",unmapped2,text2,\\"-\\"
 "
 `;
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes an unmapped field to the report 1`] = `
 "\\"_id\\",\\"_index\\",\\"_score\\",text,unmapped
-1,recipes,1,text1,unmapped1
-2,recipes,1,text2,\\"-\\"
+1,recipes,\\"-\\",text1,unmapped1
+2,recipes,\\"-\\",text2,\\"-\\"
 "
 `;
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes an unmapped nested field to the report 1`] = `
 "\\"_id\\",\\"_index\\",\\"_score\\",\\"nested.unmapped\\",text
-1,recipes,1,\\"-\\",text1
-2,recipes,1,unmapped2,text2
+1,recipes,\\"-\\",\\"-\\",text1
+2,recipes,\\"-\\",unmapped2,text2
 "
 `;

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/__snapshots__/generate_csv_discover.snap
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/__snapshots__/generate_csv_discover.snap
@@ -85,10 +85,10 @@ exports[`Reporting Generate CSV from SearchSource with unmapped fields includes 
 `;
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes an unmapped field to the report 1`] = `
-"\\"_id\\",\\"_index\\",\\"_score\\",text,unmapped
-1,recipes,1,text1,unmapped1
-2,recipes,1,text2,\\"-\\"
-"
+"\\"_id\\",\\"_index\\",\\"_score\\",\\"-\\"
+,1,1,recipes,recipes,text,text1,text2,unmapped
+1,unmapped1
+2"
 `;
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes an unmapped nested field to the report 1`] = `

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/__snapshots__/generate_csv_discover.snap
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/__snapshots__/generate_csv_discover.snap
@@ -85,10 +85,10 @@ exports[`Reporting Generate CSV from SearchSource with unmapped fields includes 
 `;
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes an unmapped field to the report 1`] = `
-"\\"_id\\",\\"_index\\",\\"_score\\",\\"-\\"
-,1,1,recipes,recipes,text,text1,text2,unmapped
-1,unmapped1
-2"
+"\\"_id\\",\\"_index\\",\\"_score\\",text,unmapped
+1,recipes,1,text1,unmapped1
+2,recipes,1,text2,\\"-\\"
+"
 `;
 
 exports[`Reporting Generate CSV from SearchSource with unmapped fields includes an unmapped nested field to the report 1`] = `

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -184,6 +184,7 @@ export default ({ getService }: FtrProviderContext) => {
               query: { language: 'kuery', query: '' },
               fields: fields.map((field) => ({ field, include_unmapped: 'true' })),
               filter: [],
+              sort: [{ text: 'asc' as SortDirection }],
             },
             title: 'Untitled discover search',
             version: '8.14.0',
@@ -195,19 +196,19 @@ export default ({ getService }: FtrProviderContext) => {
 
       it('includes an unmapped field to the report', async () => {
         const csvFile = await generateCsvReportWithUnmapped(['text', 'unmapped']);
-        expect((csvFile as string).length).to.be(88);
+        expect((csvFile as string).length).to.be(92);
         expectSnapshot(createPartialCsv(csvFile)).toMatch();
       });
 
       it('includes an unmapped nested field to the report', async () => {
         const csvFile = await generateCsvReportWithUnmapped(['text', 'nested.unmapped']);
-        expect((csvFile as string).length).to.be(97);
+        expect((csvFile as string).length).to.be(101);
         expectSnapshot(createPartialCsv(csvFile)).toMatch();
       });
 
       it('includes all unmapped fields to the report', async () => {
         const csvFile = await generateCsvReportWithUnmapped(['*']);
-        expect((csvFile as string).length).to.be(120);
+        expect((csvFile as string).length).to.be(124);
         expectSnapshot(createPartialCsv(csvFile)).toMatch();
       });
     });

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -194,8 +194,16 @@ export default ({ getService }: FtrProviderContext) => {
       }
 
       it('includes an unmapped field to the report', async () => {
-        const csvFile = await generateCsvReportWithUnmapped(['text', 'unmapped']);
-        expect((csvFile as string).length).to.be(88);
+        const unsorted: string = (await generateCsvReportWithUnmapped([
+          'text',
+          'unmapped',
+        ])) as string;
+        const csvFile: string = unsorted
+          .split(',')
+          .sort((a, b) => a.localeCompare(b))
+          .join(',');
+
+        expect(csvFile.length).to.be(88);
         expectSnapshot(createPartialCsv(csvFile)).toMatch();
       });
 

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -194,16 +194,8 @@ export default ({ getService }: FtrProviderContext) => {
       }
 
       it('includes an unmapped field to the report', async () => {
-        const unsorted: string = (await generateCsvReportWithUnmapped([
-          'text',
-          'unmapped',
-        ])) as string;
-        const csvFile: string = unsorted
-          .split(',')
-          .sort((a, b) => a.localeCompare(b))
-          .join(',');
-
-        expect(csvFile.length).to.be(88);
+        const csvFile = await generateCsvReportWithUnmapped(['text', 'unmapped']);
+        expect((csvFile as string).length).to.be(88);
         expectSnapshot(createPartialCsv(csvFile)).toMatch();
       });
 


### PR DESCRIPTION
## Summary

Add sorting via api calls.
Update mappings file to load field data.
Update snapshots

Was [failing](https://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/797#018ea2e6-f55f-47f5-8210-670b577ea181)