### PR TITLE
[Infra][Lens] Remove fields list from the ad-hoc data view object in lens attributes

### DIFF
--- a/packages/kbn-lens-embeddable-utils/config_builder/utils.ts
+++ b/packages/kbn-lens-embeddable-utils/config_builder/utils.ts
@@ -88,7 +88,7 @@ export function buildReferences(dataviews: Record<string, DataView>) {
 const getAdhocDataView = (dataView: DataView): Record<string, DataViewSpec> => {
   return {
     [dataView.id ?? uuidv4()]: {
-      ...dataView.toSpec(),
+      ...dataView.toSpec(false),
     },
   };
 };


### PR DESCRIPTION
Fixes https://github.com/elastic/observability-dev/issues/3312

## Summary

This PR updates the call to the toSpec function within the Lens attributes builder. The objective is to avoid generating the fields list, which might include the conflictDescriptions field containing arrays of field names. This change aims to reduce the object size, especially when there are numerous conflicts present.

The change prevents errors when Lens tries to store the data view object in the session storage in the `navigateToPrefilledEditor` function.


### How to test/reproduce the problem

- Start a local Kibana instance
- Start a local metricbeat instance with system module enabled (to make the hosts view work)
- Run this [script](https://gist.github.com/crespocarlos/4e6d6601446da74f20bbb22ce03e3130) to generate mapping conflicts
- Clean the `EMBEDDABLE_STATE_TRANSFER` variable in the session storage
- Change the index pattern in Infrastructure settings, including the `test_index*` pattern
- Navigate to Infrastructure > Hosts
- Open Lens from any chart