### PR TITLE
[Fleet] Skip 10m wait after agent upgrade if agent cleared watching state

### DIFF
--- a/x-pack/plugins/fleet/common/services/is_agent_upgradeable.test.ts
+++ b/x-pack/plugins/fleet/common/services/is_agent_upgradeable.test.ts
@@ -393,21 +393,6 @@ describe('Fleet - getNotUpgradeableMessage', () => {
       )
     ).toBeUndefined();
   });
-
-  it('if the agent reports upgradeable but is in watching state', () => {
-    expect(
-      getNotUpgradeableMessage(
-        getAgent({
-          version: '8.12.0',
-          upgradeable: true,
-          minutesSinceUpgrade: 11,
-          upgradeDetails: { state: 'UPG_WATCHING' } as any,
-        })
-      )
-    ).toContain(
-      'agent was recently ugraded and is being monitored. Please wait until the monitoring state is cleared.'
-    );
-  });
 });
 
 describe('hasAgentBeenUpgradedRecently', () => {

--- a/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
+++ b/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
@@ -30,7 +30,6 @@ export const DOWNGRADE_NOT_ALLOWED_ERROR = `agent does not support downgrades.`;
 export const LATEST_VERSION_NOT_VALID_ERROR = 'latest version is not valid.';
 export const AGENT_ALREADY_ON_LATEST_ERROR = `agent is already running on the latest available version.`;
 export const AGENT_ON_GREATER_VERSION_ERROR = `agent is running on a version greater than the latest available version.`;
-export const WATCHING_STATE_ERROR = `agent was recently ugraded and is being monitored. Please wait until the monitoring state is cleared.`;
 
 export function isAgentUpgradeAvailable(agent: Agent, latestAgentVersion?: string): boolean {
   return (
@@ -108,9 +107,6 @@ export const getNotUpgradeableMessage = (
   }
   if (!agent.local_metadata.elastic.agent.upgradeable) {
     return NOT_UPGRADEABLE_ERROR;
-  }
-  if (isAgentInWatchingState(agent)) {
-    return WATCHING_STATE_ERROR;
   }
   if (isAgentUpgrading(agent)) {
     return ALREADY_UPGRADED_ERROR;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/176910
Closes https://github.com/elastic/kibana/issues/179741

Updated agent upgradeable check to consider the new `UPG_WATCHING` state in upgrade details. For agents version 8.12+, upgrade is immediately allowed after watching state is cleared. For agents with lower version, the 10m wait is preserved after upgrade.

To verify:
- enroll an agent with version 8.11.0
- upgrade to 8.11.4
- verify that the 10m wait is still there after upgrade before allowing another upgrade
- upgrade to 8.12.2
- verify that the agent can't be upgraded while the watching state is active
- verify that the agent can be upgraded again as soon as the watching state clears (no more 10m wait for agents 8.12+)

<img width="1284" alt="image" src="https://github.com/elastic/kibana/assets/90178898/243ee69d-fbef-4012-96b3-2c7ad75be5d2">
<img width="1307" alt="image" src="https://github.com/elastic/kibana/assets/90178898/5708e356-2999-4493-bbed-b6bd7b6758c2">
<img width="1251" alt="image" src="https://github.com/elastic/kibana/assets/90178898/fc52ac27-6d4b-4b16-b221-47f196950d0d">

<img width="1298" alt="image" src="https://github.com/elastic/kibana/assets/90178898/91eec4af-7beb-4de7-bc8a-e80210adedea">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->