### PR TITLE
Minimize use of `cliArgs.serverless`

### DIFF
--- a/packages/kbn-config/src/config_service.ts
+++ b/packages/kbn-config/src/config_service.ts
@@ -310,7 +310,7 @@ export class ConfigService {
       {
         dev: this.env.mode.dev,
         prod: this.env.mode.prod,
-        serverless: this.env.cliArgs.serverless === true,
+        serverless: this.env.packageInfo.buildFlavor === 'serverless',
         ...this.env.packageInfo,
       },
       `config validation of [${namespace}]`


### PR DESCRIPTION
## Summary

Resolves #155912

The original issue pointed to many other places, but they have been removed over time. This was the last place where we reached out to it (other than the Env class, where accessing it is necessary).


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
