### PR TITLE
[Security Solution][Detection Engine] fixes getIndexPatternFromESQLQuery utility when parsing  ES|QL queries with wildcards

### DIFF
--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -79,6 +79,11 @@ describe('sql/esql query helpers', () => {
 
       const idxPattern10 = getIndexPatternFromESQLQuery('FROM foo-1, remote_cluster:foo-2, foo-3');
       expect(idxPattern10).toBe('foo-1, remote_cluster:foo-2, foo-3');
+
+      const idxPattern11 = getIndexPatternFromESQLQuery(
+        'FROM foo-1, foo-2 | where event.reason like "*Disable: changed from [true] to [false]*"'
+      );
+      expect(idxPattern11).toBe('foo-1, foo-2');
     });
   });
 

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -27,12 +27,13 @@ export function getIndexPatternFromSQLQuery(sqlQuery?: string): string {
 
 // retrieves the index pattern from the aggregate query for ES|QL
 export function getIndexPatternFromESQLQuery(esql?: string): string {
-  const splitFroms = esql?.split(new RegExp(/FROM\s/, 'ig'));
+  let fromPipe = (esql || '').split('|')[0];
+  const splitFroms = fromPipe?.split(new RegExp(/FROM\s/, 'ig'));
   const fromsLength = splitFroms?.length ?? 0;
   if (splitFroms && splitFroms?.length > 2) {
-    esql = `${splitFroms[fromsLength - 2]} FROM ${splitFroms[fromsLength - 1]}`;
+    fromPipe = `${splitFroms[fromsLength - 2]} FROM ${splitFroms[fromsLength - 1]}`;
   }
-  const parsedString = esql?.replaceAll('`', '');
+  const parsedString = fromPipe?.replaceAll('`', '');
   // case insensitive match for the index pattern
   const regex = new RegExp(/FROM\s+([(\w*:)?\w*-.!@$^()~;\s]+)/, 'i');
   const matches = parsedString?.match(regex);


### PR DESCRIPTION
## Summary

- fixes https://github.com/elastic/kibana/issues/176749

Query like this not parsed correctly by `getIndexPatternFromESQLQuery`, which returns empty string`""`

```
from reproissue-* [metadata _id, _index]
| where event.action == "edit monitoring policy"
| where event.reason like "*Disable: changed from [true] to [false]*"
```

This leads to Security Detection rules execution's failure, described in ticket above.
This PR fixes issue and adds unit test to for this specific use case.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
