### PR TITLE
[Console Monaco] Add support for loading from a URL

### DIFF
--- a/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
@@ -46,17 +46,17 @@ export const useSetInitialValue = async (params: SetInitialValueParams) => {
 
   const loadBufferFromRemote = async (url: string) => {
     // Normalize and encode the URL to avoid issues with spaces and other special characters.
-    const encodedUrl = new URL(url).toString();
-    if (/^https?:\/\//.test(encodedUrl)) {
-      if (/^https?:\/\/www.elastic.co\//.test(encodedUrl)) {
+    const encodedUrl = new URL(url);
+    if (encodedUrl.protocol === 'https:') {
+      if (encodedUrl.hostname === 'www.elastic.co') {
         const resp = await fetch(url);
         const data = await resp.text();
-        setValue(`${initialTextValue}\n${data}`);
+        setValue(`${initialTextValue}\n\n${data}`);
       } else {
         toasts.addWarning(
           i18n.translate('console.loadFromDataUnrecognizedUrlErrorMessage', {
             defaultMessage:
-              'Only URLs with the Elastic domain (elastic.co) can be loaded in Console.',
+              'Only URLs with the Elastic domain (www.elastic.co) can be loaded in Console.',
           })
         );
       }

--- a/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
@@ -45,11 +45,17 @@ export const useSetInitialValue = async (params: SetInitialValueParams) => {
   const { initialTextValue, setValue, toasts } = params;
 
   const loadBufferFromRemote = async (url: string) => {
-    // Normalize and encode the URL to avoid issues with spaces and other special characters.
-    const encodedUrl = new URL(url);
-    if (encodedUrl.protocol === 'https:') {
-      if (encodedUrl.hostname === 'www.elastic.co') {
-        const resp = await fetch(url);
+    if (/^https?:\/\//.test(url)) {
+      // Check if this is a valid URL
+      try {
+        new URL(url);
+      } catch (e) {
+        return;
+      }
+      // Parse the URL to avoid issues with spaces and other special characters.
+      const parsedURL = new URL(url);
+      if (parsedURL.origin === 'https://www.elastic.co') {
+        const resp = await fetch(parsedURL);
         const data = await resp.text();
         setValue(`${initialTextValue}\n\n${data}`);
       } else {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/179906

## Summary

This PR adds support for loading a Console snippet from a URL through the `load_from` parameter. It utilizes the native `fetch` function to fetch the URL. For protection against malicious URLs, only Elastic domain (www.elastic.co) is accepted.

**How to test:**
1. Create a `config/kibana.dev.yml` file (if one doesn't exist already) and add the line: `console.dev.enableMonaco: true`
2. Start Es with `yarn es snapshot` and Kibana with `yarn start`.
3. Navigate to Console with a `load_from` parameter specifying a valid Elastic docs URL. For example, navigating to `app/dev_tools#/console?load_from=https://www.elastic.co/guide/en/elasticsearch/reference/current/snippets/2935.console` (this is the snippet from this [docs page](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html)) should load the following snippet in Console:

```
GET /my-index-000001/_search
```

4. Try loading a URL with a non-Elastic domain (e.g. `app/dev_tools#/console?load_from=https://www.test.co`). There should be a warning toast displayed explaining that only Elastic domain is allowed:


<img width="1491" alt="Screenshot 2024-04-04 at 17 58 42" src="https://github.com/elastic/kibana/assets/59341489/d39d954b-ee57-4b64-b1c6-49ae975f4bbe">



<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

-->