### PR TITLE
Fix text settings to be honored in Canvas markdown elements

### DIFF
--- a/packages/shared-ux/markdown/impl/README.mdx
+++ b/packages/shared-ux/markdown/impl/README.mdx
@@ -11,6 +11,7 @@ date: 2022-10-03
 
 This markdown component uses the **EuiMarkdownEditor** and **EuiMarkdownFormat** managed by `@elastic/eui`. If `readOnly` is set to true, and `markdownContent` or `children` are set, then the component renders **EuiMarkdownFormat** text. Otherwise the component will render the **EuiMarkdownEditor**. The height of the component can be set, but in order the control the width of the component, you can place the `<Markdown />` component in another component.
 Markdown extends all the EuiMarkdownEditorProps except for the `editorId`, `uiPlugins`, and `MarkdownFormatProps`.
+Like the legacy React `<Markdown>` component, `style` can be set but will only be passed to **EuiMarkdownFormat**.
 
 ## Component Properties 
 

--- a/packages/shared-ux/markdown/impl/markdown.test.tsx
+++ b/packages/shared-ux/markdown/impl/markdown.test.tsx
@@ -33,4 +33,16 @@ describe('shared ux markdown component', () => {
     render(<Markdown markdownContent={exampleMarkdownContent} />);
     expect(screen.getByTestId('euiMarkdownEditorToolbar')).toBeInTheDocument();
   });
+
+  it('renders EuiMarkdownEditor without style passed', () => {
+    render(<Markdown style={{ color: 'red' }} data-test-subj="editor" />);
+    expect(screen.getByTestId('editor')).not.toHaveStyle({ color: 'red' });
+  });
+
+  it('renders EuiMarkdownFormat with style passed', () => {
+    render(
+      <Markdown style={{ color: 'red' }} data-test-subj="format" markdownContent="test" readOnly />
+    );
+    expect(screen.getByTestId('format')).toHaveStyle({ color: 'red' });
+  });
 });

--- a/packages/shared-ux/markdown/impl/markdown.tsx
+++ b/packages/shared-ux/markdown/impl/markdown.tsx
@@ -92,6 +92,8 @@ export const Markdown = ({
         parsingPluginList={_parsingPlugins}
         processingPluginList={openLinksInNewTab ? processingPlugins : undefined}
         data-test-subj={restProps['data-test-subj']}
+        // There was a trick to pass style as a part of props in the legacy React <Markdown> component
+        style={restProps.style}
       >
         {children ?? markdownContent!}
       </EuiMarkdownFormat>


### PR DESCRIPTION
Closes #179940

## Summary

This PR fixes #179940 by passing `style` to `EuiMarkdownFormat`.

The `style` could be set through `props` in the legacy React `<Markdown>` component, but the ability was lost as a result of [migration to the new shared ux markdown](https://github.com/elastic/kibana/issues/174290).

https://github.com/elastic/kibana/blob/f5bd489c5ff9c676c4f861c42da6ea99ae350832/src/plugins/kibana_react/public/markdown/markdown.tsx#L84-L95

The minimal code added through this PR imitates the lost ability above for the following usage - i.e. `style` set to `<Markdown>` with `readOnly`.

https://github.com/elastic/kibana/blob/091f486ab05863258cf2f3fa18ea0c59097dee80/x-pack/plugins/canvas/canvas_plugin_src/renderers/markdown/index.tsx#L35-L40

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Fix text settings to be honored in Canvas markdown elements

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->