### PR TITLE
[csp] updated policy for form action in reporting mode

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -60,6 +60,9 @@ NOTE: The `frame-ancestors` directive can also be configured by using
 <<server-securityResponseHeaders-disableEmbedding, `server.securityResponseHeaders.disableEmbedding`>>. In that case, that takes precedence and any values in `csp.frame_ancestors`
 are ignored.
 
+`csp.report_to.form_action`::
+Add sources for the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action[Content Security Policy `form-action` directive] in reporting mode.
+
 `csp.report_uri`::
 Add sources for the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri[Content Security Policy `report-uri` directive].
 

--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -60,7 +60,7 @@ NOTE: The `frame-ancestors` directive can also be configured by using
 <<server-securityResponseHeaders-disableEmbedding, `server.securityResponseHeaders.disableEmbedding`>>. In that case, that takes precedence and any values in `csp.frame_ancestors`
 are ignored.
 
-`csp.report_to.form_action`::
+`csp.report_only.form_action`::
 Add sources for the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action[Content Security Policy `form-action` directive] in reporting mode.
 
 `csp.report_uri`::

--- a/packages/core/http/core-http-server-internal/src/csp/config.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/config.ts
@@ -83,6 +83,13 @@ const configSchema = schema.object(
     report_to: schema.arrayOf(schema.string(), {
       defaultValue: [],
     }),
+    report_only: schema.maybe(
+      schema.object({
+        form_action: schema.arrayOf(schema.string(), {
+          defaultValue: [],
+        }),
+      })
+    ),
     strict: schema.boolean({ defaultValue: true }),
     warnLegacyBrowsers: schema.boolean({ defaultValue: true }),
     disableEmbedding: schema.oneOf([schema.literal<boolean>(false)], { defaultValue: false }),

--- a/packages/core/http/core-http-server-internal/src/csp/config.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/config.ts
@@ -87,6 +87,7 @@ const configSchema = schema.object(
       schema.object({
         form_action: schema.arrayOf(schema.string(), {
           defaultValue: [],
+          validate: getDirectiveValidator({ allowNone: false, allowNonce: false }),
         }),
       })
     ),

--- a/packages/core/http/core-http-server-internal/src/csp/csp_config.test.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_config.test.ts
@@ -35,7 +35,7 @@ describe('CspConfig', () => {
         "disableEmbedding": false,
         "disableUnsafeEval": true,
         "header": "script-src 'report-sample' 'self'; worker-src 'report-sample' 'self' blob:; style-src 'report-sample' 'self' 'unsafe-inline'",
-        "reportOnlyHeader": "form-action 'self'",
+        "reportOnlyHeader": "form-action 'report-sample' 'self'",
         "strict": true,
         "warnLegacyBrowsers": true,
       }

--- a/packages/core/http/core-http-server-internal/src/csp/csp_config.test.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_config.test.ts
@@ -35,6 +35,7 @@ describe('CspConfig', () => {
         "disableEmbedding": false,
         "disableUnsafeEval": true,
         "header": "script-src 'report-sample' 'self'; worker-src 'report-sample' 'self' blob:; style-src 'report-sample' 'self' 'unsafe-inline'",
+        "reportOnlyHeader": "form-action 'self'",
         "strict": true,
         "warnLegacyBrowsers": true,
       }

--- a/packages/core/http/core-http-server-internal/src/csp/csp_config.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_config.ts
@@ -25,6 +25,7 @@ export class CspConfig implements ICspConfig {
   public readonly warnLegacyBrowsers: boolean;
   public readonly disableEmbedding: boolean;
   public readonly header: string;
+  public readonly reportOnlyHeader: string;
 
   /**
    * Returns the default CSP configuration when passed with no config
@@ -36,7 +37,10 @@ export class CspConfig implements ICspConfig {
       this.#directives.clearDirectiveValues('frame-ancestors');
       this.#directives.addDirectiveValue('frame-ancestors', `'self'`);
     }
-    this.header = this.#directives.getCspHeader();
+    const { enforceHeader, reportOnlyHeader } = this.#directives.getCspHeadersByDisposition();
+    this.header = enforceHeader;
+    this.reportOnlyHeader = reportOnlyHeader;
+
     this.strict = rawCspConfig.strict;
     this.disableUnsafeEval = rawCspConfig.disableUnsafeEval;
     this.warnLegacyBrowsers = rawCspConfig.warnLegacyBrowsers;

--- a/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
@@ -20,7 +20,15 @@ export type CspDirectiveName =
   | 'frame-src'
   | 'img-src'
   | 'report-uri'
-  | 'report-to';
+  | 'report-to'
+  | 'form-action';
+
+/**
+ * The default report only directives rules
+ */
+export const defaultReportOnlyRules: Partial<Record<CspDirectiveName, string[]>> = {
+  'form-action': [`'self'`],
+};
 
 /**
  * The default directives rules that are always applied
@@ -56,6 +64,19 @@ export class CspDirectives {
 
   clearDirectiveValues(directiveName: CspDirectiveName) {
     this.directives.delete(directiveName);
+  }
+
+  getCspHeadersByDisposition() {
+    const reportOnlyHeader = Object.entries(defaultReportOnlyRules)
+      .reduce<string[]>((acc, [name, values]) => {
+        return [...acc, [name, ...values].join(' ')];
+      }, [])
+      .join('; ');
+
+    return {
+      enforceHeader: this.getCspHeader(),
+      reportOnlyHeader,
+    };
   }
 
   getCspHeader() {

--- a/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
@@ -52,35 +52,42 @@ export const additionalRules: Partial<Record<CspDirectiveName, string[]>> = {
   'frame-src': [`'self'`],
 };
 
+interface CspConfigDirectives {
+  enforceDirectives: Map<CspDirectiveName, string[]>;
+  reportOnlyDirectives: Map<CspDirectiveName, string[]>;
+}
+
 export class CspDirectives {
   private readonly directives = new Map<CspDirectiveName, Set<string>>();
+  private readonly reportOnlyDirectives = new Map<CspDirectiveName, Set<string>>();
 
-  addDirectiveValue(directiveName: CspDirectiveName, directiveValue: string) {
-    if (!this.directives.has(directiveName)) {
-      this.directives.set(directiveName, new Set());
+  addDirectiveValue(directiveName: CspDirectiveName, directiveValue: string, enforce = true) {
+    const directivesMap = enforce ? this.directives : this.reportOnlyDirectives;
+
+    if (!directivesMap.has(directiveName)) {
+      directivesMap.set(directiveName, new Set());
     }
-    this.directives.get(directiveName)!.add(normalizeDirectiveValue(directiveValue));
+    directivesMap.get(directiveName)!.add(normalizeDirectiveValue(directiveValue));
   }
 
   clearDirectiveValues(directiveName: CspDirectiveName) {
     this.directives.delete(directiveName);
+    this.reportOnlyDirectives.delete(directiveName);
   }
 
   getCspHeadersByDisposition() {
-    const reportOnlyHeader = Object.entries(defaultReportOnlyRules)
-      .reduce<string[]>((acc, [name, values]) => {
-        return [...acc, [name, ...values].join(' ')];
-      }, [])
-      .join('; ');
-
     return {
-      enforceHeader: this.getCspHeader(),
-      reportOnlyHeader,
+      enforceHeader: this.headerFromDirectives(this.directives),
+      reportOnlyHeader: this.headerFromDirectives(this.reportOnlyDirectives),
     };
   }
 
   getCspHeader() {
-    return [...this.directives.entries()]
+    return this.headerFromDirectives(this.directives);
+  }
+
+  private headerFromDirectives(directives: Map<CspDirectiveName, Set<string>>): string {
+    return [...directives.entries()]
       .map(([name, values]) => {
         return [name, ...values].join(' ');
       })
@@ -104,60 +111,87 @@ export class CspDirectives {
       });
     });
 
+    // combining `default` report only directive configurations
+    Object.entries(defaultReportOnlyRules).forEach(([key, values]) => {
+      values?.forEach((value) => {
+        cspDirectives.addDirectiveValue(key as CspDirectiveName, value, false);
+      });
+    });
+
     // adding per-directive configuration
-    const additiveConfig = parseConfigDirectives(config);
-    [...additiveConfig.entries()].forEach(([directiveName, directiveValues]) => {
+    const { enforceDirectives, reportOnlyDirectives } = parseConfigDirectives(config);
+
+    for (const [directiveName, directiveValues] of enforceDirectives.entries()) {
       const additionalValues = additionalRules[directiveName] ?? [];
       [...additionalValues, ...directiveValues].forEach((value) => {
         cspDirectives.addDirectiveValue(directiveName, value);
       });
-    });
+    }
+
+    for (const [directiveName, directiveValues] of reportOnlyDirectives.entries()) {
+      directiveValues.forEach((value) => {
+        cspDirectives.addDirectiveValue(directiveName, value, false);
+      });
+    }
 
     return cspDirectives;
   }
 }
 
-const parseConfigDirectives = (cspConfig: CspConfigType): Map<CspDirectiveName, string[]> => {
-  const map = new Map<CspDirectiveName, string[]>();
+const parseConfigDirectives = (cspConfig: CspConfigType): CspConfigDirectives => {
+  const enforceDirectives = new Map<CspDirectiveName, string[]>();
+  const reportOnlyDirectives = new Map<CspDirectiveName, string[]>();
 
   if (cspConfig.script_src?.length) {
-    map.set('script-src', cspConfig.script_src);
+    enforceDirectives.set('script-src', cspConfig.script_src);
   }
   if (cspConfig.disableUnsafeEval !== true) {
-    map.set('script-src', ["'unsafe-eval'", ...(map.get('script-src') ?? [])]);
+    enforceDirectives.set('script-src', [
+      "'unsafe-eval'",
+      ...(enforceDirectives.get('script-src') ?? []),
+    ]);
   }
   if (cspConfig.worker_src?.length) {
-    map.set('worker-src', cspConfig.worker_src);
+    enforceDirectives.set('worker-src', cspConfig.worker_src);
   }
   if (cspConfig.style_src?.length) {
-    map.set('style-src', cspConfig.style_src);
+    enforceDirectives.set('style-src', cspConfig.style_src);
   }
   if (cspConfig.connect_src?.length) {
-    map.set('connect-src', cspConfig.connect_src);
+    enforceDirectives.set('connect-src', cspConfig.connect_src);
   }
   if (cspConfig.default_src?.length) {
-    map.set('default-src', cspConfig.default_src);
+    enforceDirectives.set('default-src', cspConfig.default_src);
   }
   if (cspConfig.font_src?.length) {
-    map.set('font-src', cspConfig.font_src);
+    enforceDirectives.set('font-src', cspConfig.font_src);
   }
   if (cspConfig.frame_src?.length) {
-    map.set('frame-src', cspConfig.frame_src);
+    enforceDirectives.set('frame-src', cspConfig.frame_src);
   }
   if (cspConfig.img_src?.length) {
-    map.set('img-src', cspConfig.img_src);
+    enforceDirectives.set('img-src', cspConfig.img_src);
   }
   if (cspConfig.frame_ancestors?.length) {
-    map.set('frame-ancestors', cspConfig.frame_ancestors);
+    enforceDirectives.set('frame-ancestors', cspConfig.frame_ancestors);
   }
   if (cspConfig.report_uri?.length) {
-    map.set('report-uri', cspConfig.report_uri);
+    enforceDirectives.set('report-uri', cspConfig.report_uri);
+    reportOnlyDirectives.set('report-to', cspConfig.report_uri);
   }
   if (cspConfig.report_to?.length) {
-    map.set('report-to', cspConfig.report_to);
+    enforceDirectives.set('report-to', cspConfig.report_to);
+    reportOnlyDirectives.set('report-to', cspConfig.report_to);
   }
 
-  return map;
+  if (cspConfig.report_only?.form_action?.length) {
+    reportOnlyDirectives.set('form-action', cspConfig.report_only?.form_action);
+  }
+
+  return {
+    enforceDirectives,
+    reportOnlyDirectives,
+  };
 };
 
 const keywordTokens = [

--- a/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
@@ -27,7 +27,7 @@ export type CspDirectiveName =
  * The default report only directives rules
  */
 export const defaultReportOnlyRules: Partial<Record<CspDirectiveName, string[]>> = {
-  'form-action': [`'self'`],
+  'form-action': [`'report-sample'`, `'self'`],
 };
 
 /**

--- a/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
+++ b/packages/core/http/core-http-server-internal/src/csp/csp_directives.ts
@@ -177,7 +177,7 @@ const parseConfigDirectives = (cspConfig: CspConfigType): CspConfigDirectives =>
   }
   if (cspConfig.report_uri?.length) {
     enforceDirectives.set('report-uri', cspConfig.report_uri);
-    reportOnlyDirectives.set('report-to', cspConfig.report_uri);
+    reportOnlyDirectives.set('report-uri', cspConfig.report_uri);
   }
   if (cspConfig.report_to?.length) {
     enforceDirectives.set('report-to', cspConfig.report_to);

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
@@ -395,7 +395,13 @@ describe('customHeaders pre-response handler', () => {
   it('adds the kbn-name and Content-Security-Policy headers to the response', () => {
     const config = createConfig({
       name: 'my-server-name',
-      csp: { strict: true, warnLegacyBrowsers: true, disableEmbedding: true, header: 'foo' },
+      csp: {
+        strict: true,
+        warnLegacyBrowsers: true,
+        disableEmbedding: true,
+        header: 'foo',
+        reportOnlyHeader: 'bar',
+      },
     });
     const handler = createCustomHeadersPreResponseHandler(config as HttpConfig);
 
@@ -405,6 +411,7 @@ describe('customHeaders pre-response handler', () => {
     expect(toolkit.next).toHaveBeenCalledWith({
       headers: {
         'Content-Security-Policy': 'foo',
+        'Content-Security-Policy-Report-Only': 'bar',
         'kbn-name': 'my-server-name',
       },
     });
@@ -413,7 +420,13 @@ describe('customHeaders pre-response handler', () => {
   it('adds the security headers and custom headers defined in the configuration', () => {
     const config = createConfig({
       name: 'my-server-name',
-      csp: { strict: true, warnLegacyBrowsers: true, disableEmbedding: true, header: 'foo' },
+      csp: {
+        strict: true,
+        warnLegacyBrowsers: true,
+        disableEmbedding: true,
+        header: 'foo',
+        reportOnlyHeader: 'bar',
+      },
       securityResponseHeaders: {
         headerA: 'value-A',
         headerB: 'value-B', // will be overridden by the custom response header below
@@ -430,6 +443,7 @@ describe('customHeaders pre-response handler', () => {
     expect(toolkit.next).toHaveBeenCalledWith({
       headers: {
         'Content-Security-Policy': 'foo',
+        'Content-Security-Policy-Report-Only': 'bar',
         'kbn-name': 'my-server-name',
         headerA: 'value-A',
         headerB: 'x',
@@ -440,10 +454,17 @@ describe('customHeaders pre-response handler', () => {
   it('do not allow overwrite of the kbn-name and Content-Security-Policy headers if defined in custom headders ', () => {
     const config = createConfig({
       name: 'my-server-name',
-      csp: { strict: true, warnLegacyBrowsers: true, disableEmbedding: true, header: 'foo' },
+      csp: {
+        strict: true,
+        warnLegacyBrowsers: true,
+        disableEmbedding: true,
+        header: 'foo',
+        reportOnlyHeader: 'bar',
+      },
       customResponseHeaders: {
         'kbn-name': 'custom-name',
         'Content-Security-Policy': 'custom-csp',
+        'Content-Security-Policy-Report-Only': 'bar',
         headerA: 'value-A',
         headerB: 'value-B',
       },
@@ -457,6 +478,7 @@ describe('customHeaders pre-response handler', () => {
       headers: {
         'kbn-name': 'my-server-name',
         'Content-Security-Policy': 'foo',
+        'Content-Security-Policy-Report-Only': 'bar',
         headerA: 'value-A',
         headerB: 'value-B',
       },

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
@@ -86,13 +86,14 @@ export const createCustomHeadersPreResponseHandler = (config: HttpConfig): OnPre
     name: serverName,
     securityResponseHeaders,
     customResponseHeaders,
-    csp: { header: cspHeader },
+    csp: { header: cspHeader, reportOnlyHeader: cspReportOnlyHeader },
   } = config;
 
   const additionalHeaders = {
     ...securityResponseHeaders,
     ...customResponseHeaders,
     'Content-Security-Policy': cspHeader,
+    'Content-Security-Policy-Report-Only': cspReportOnlyHeader,
     [KIBANA_NAME_HEADER]: serverName,
   };
 

--- a/packages/core/http/core-http-server/src/csp.ts
+++ b/packages/core/http/core-http-server/src/csp.ts
@@ -34,5 +34,9 @@ export interface ICspConfig {
    */
   readonly header: string;
 
+  /**
+   * The CSP rules in a formatted directives string for use
+   * in a `Content-Security-Policy-Report-Only` header.
+   */
   readonly reportOnlyHeader: string;
 }

--- a/packages/core/http/core-http-server/src/csp.ts
+++ b/packages/core/http/core-http-server/src/csp.ts
@@ -33,4 +33,6 @@ export interface ICspConfig {
    * in a `Content-Security-Policy` header.
    */
   readonly header: string;
+
+  readonly reportOnlyHeader: string;
 }

--- a/src/core/server/integration_tests/http/lifecycle.test.ts
+++ b/src/core/server/integration_tests/http/lifecycle.test.ts
@@ -1474,7 +1474,7 @@ describe('OnPreResponse', () => {
 });
 
 describe('runs with default preResponse handlers', () => {
-  it('does not allow overwriting of the "kbn-name" and "Content-Security-Policy" headers', async () => {
+  it('does not allow overwriting of the "kbn-name", "Content-Security-Policy" and  "Content-Security-Policy-Report-Only" headers', async () => {
     const { server: innerServer, createRouter } = await server.setup(setupDeps);
     const router = createRouter('/');
 
@@ -1484,6 +1484,7 @@ describe('runs with default preResponse handlers', () => {
           foo: 'bar',
           'kbn-name': 'hijacked!',
           'Content-Security-Policy': 'hijacked!',
+          'Content-Security-Policy-Report-Only': 'hijacked!',
         },
       })
     );
@@ -1495,6 +1496,9 @@ describe('runs with default preResponse handlers', () => {
     expect(response.header['kbn-name']).toBe('kibana');
     expect(response.header['content-security-policy']).toBe(
       `script-src 'report-sample' 'self' 'unsafe-eval'; worker-src 'report-sample' 'self' blob:; style-src 'report-sample' 'self' 'unsafe-inline'`
+    );
+    expect(response.header['content-security-policy-report-only']).toBe(
+      `form-action 'report-sample' 'self'`
     );
   });
 });

--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -39,6 +39,7 @@ kibana_vars=(
     csp.frame_ancestors
     csp.report_uri
     csp.report_to
+    csp.report_only.form_action
     data.autocomplete.valueSuggestions.terminateAfter
     data.autocomplete.valueSuggestions.timeout
     data.search.asyncSearch.waitForCompletion

--- a/x-pack/plugins/security/server/authentication/authentication_service.test.ts
+++ b/x-pack/plugins/security/server/authentication/authentication_service.test.ts
@@ -784,6 +784,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/login?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2Fapp%2Fsome',
           },
@@ -809,6 +810,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/logout?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2Fapp%2Fsome',
           },
@@ -836,6 +838,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/login?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2F',
           },
@@ -882,6 +885,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/login?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2Fapp%2Fsome',
           },
@@ -907,6 +911,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/logout?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2Fapp%2Fsome',
           },
@@ -934,6 +939,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/login?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2F',
           },
@@ -978,6 +984,7 @@ describe('AuthenticationService', () => {
           body: 'rendered-view',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
           },
         });
 
@@ -1010,6 +1017,7 @@ describe('AuthenticationService', () => {
           body: 'rendered-view',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
           },
         });
 
@@ -1045,6 +1053,7 @@ describe('AuthenticationService', () => {
           body: 'rendered-view',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
           },
         });
 
@@ -1099,6 +1108,7 @@ describe('AuthenticationService', () => {
           body: 'rendered-view',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
           },
         });
 
@@ -1140,6 +1150,7 @@ describe('AuthenticationService', () => {
           body: '<div/>',
           headers: {
             'Content-Security-Policy': CspConfig.DEFAULT.header,
+            'Content-Security-Policy-Report-Only': CspConfig.DEFAULT.reportOnlyHeader,
             Refresh:
               '0;url=/mock-server-basepath/login?msg=UNAUTHENTICATED&next=%2Fmock-server-basepath%2F',
           },

--- a/x-pack/plugins/security/server/authentication/authentication_service.ts
+++ b/x-pack/plugins/security/server/authentication/authentication_service.ts
@@ -228,7 +228,10 @@ export class AuthenticationService {
             originalURL,
             customBranding: customBrandingValue,
           }),
-          headers: { 'Content-Security-Policy': http.csp.header },
+          headers: {
+            'Content-Security-Policy': http.csp.header,
+            'Content-Security-Policy-Report-Only': http.csp.reportOnlyHeader,
+          },
         });
       }
 
@@ -241,6 +244,7 @@ export class AuthenticationService {
         body: '<div/>',
         headers: {
           'Content-Security-Policy': http.csp.header,
+          'Content-Security-Policy-Report-Only': http.csp.reportOnlyHeader,
           Refresh: `0;url=${http.basePath.prepend(
             `${
               needsToLogout ? '/logout' : '/login'

--- a/x-pack/plugins/security/server/authorization/authorization_service.tsx
+++ b/x-pack/plugins/security/server/authorization/authorization_service.tsx
@@ -194,7 +194,13 @@ export class AuthorizationService {
             />
           );
 
-          return toolkit.render({ body, headers: { 'Content-Security-Policy': http.csp.header } });
+          return toolkit.render({
+            body,
+            headers: {
+              'Content-Security-Policy': http.csp.header,
+              'Content-Security-Policy-Report-Only': http.csp.reportOnlyHeader,
+            },
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

1. Added `Content-Security-Policy-Report-Only` header.
2. Set `form-action` to `self` in reporting mode.
3. Created [visualization for report only CSP violation](https://stack-telemetry.elastic.dev/s/kibana-platform-security/app/dashboards#/view/f6bb1300-0bb7-11ee-adde-d5df298171dd?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:'2024-04-03T22:00:00.000Z',to:'2024-04-05T21:30:00.000Z'))). 
Generated a couple of reports for testing, here is [telemetry data](https://stack-telemetry.elastic.dev/s/kibana-platform-security/app/discover#/?_g=(filters:!(),time:(from:now-24h%2Fh,to:now))&_a=(columns:!(timestamp),filters:!(('$state':(store:appState),meta:(alias:'Expected%20CSP%20violation',disabled:!f,index:'14413084-88e4-4fd4-82ba-a69c8b72ec95',negate:!t,params:!((meta:(alias:!n,disabled:!f,field:effectiveDirective,index:'14413084-88e4-4fd4-82ba-a69c8b72ec95',key:effectiveDirective,negate:!f,params:(query:script-src-elem),type:phrase),query:(match_phrase:(effectiveDirective:script-src-elem))),(meta:(alias:!n,disabled:!f,field:blockedURL,index:'14413084-88e4-4fd4-82ba-a69c8b72ec95',key:blockedURL,negate:!f,params:(query:inline),type:phrase),query:(match_phrase:(blockedURL:inline))),('$state':(store:appState),meta:(alias:!n,disabled:!f,field:lineNumber,index:'14413084-88e4-4fd4-82ba-a69c8b72ec95',key:lineNumber,negate:!f,params:(query:'286'),type:phrase),query:(match_phrase:(lineNumber:'286')))),relation:AND,type:combined),query:())),index:'14413084-88e4-4fd4-82ba-a69c8b72ec95',interval:auto,query:(language:kuery,query:'disposition%20:%20%22report%22%20'),sort:!(!(timestamp,desc)))).
4. Added `csp.report_only.form_action` field for additional csp policy configuration.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

__Fixes: https://github.com/elastic/kibana/issues/179220__

## Release note
Added `Content-Security-Policy-Report-Only` header support.