### PR TITLE
[apm] Add observabilityAIAssistant to required bundles

### DIFF
--- a/x-pack/plugins/observability_solution/apm/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/apm/kibana.jsonc
@@ -57,7 +57,8 @@
       "kibanaUtils",
       "ml",
       "observability",
-      "maps"
+      "maps",
+      "observabilityAIAssistant"
     ]
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/178330 and https://github.com/elastic/kibana/pull/180032

This should unblock main for real.