### PR TITLE
fix filtering empty strings in / out

### DIFF
--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.test.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.test.ts
@@ -47,7 +47,7 @@ describe('filter manager utilities', () => {
     test('without formatter empty value', () => {
       const filter = { meta: { value: '' } } as PhraseFilter;
       const result = getPhraseDisplayValue(filter);
-      expect(result).toMatchInlineSnapshot(`""`);
+      expect(result).toMatchInlineSnapshot(`"Empty string"`);
     });
 
     test('without formatter with undefined value', () => {

--- a/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
+++ b/src/plugins/data/public/query/filter_manager/lib/mappers/map_phrase.ts
@@ -16,6 +16,7 @@ import {
   isPhraseFilter,
 } from '@kbn/es-query';
 import { FieldFormat } from '@kbn/field-formats-plugin/common';
+import { i18n } from '@kbn/i18n';
 
 const getScriptedPhraseValue = (filter: PhraseFilter) =>
   get(filter, ['query', 'script', 'script', 'params', 'value']);
@@ -26,6 +27,11 @@ export function getPhraseDisplayValue(
   fieldType?: string
 ): string {
   const value = filter.meta.value ?? filter.meta.params?.query;
+
+  if (typeof value === 'string' && value.length === 0) {
+    return i18n.translate('data.filter.filterBar.emptyString', { defaultMessage: 'Empty string' });
+  }
+
   const updatedValue = fieldType === 'number' && !value ? 0 : value;
   if (formatter?.convert) {
     return formatter.convert(updatedValue);

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/use_hover_action_items.tsx
@@ -130,12 +130,8 @@ export const useHoverActionItems = ({
      * In the case of `DisableOverflowButton`, we show filters only when topN is NOT opened. As after topN button is clicked, the chart panel replace current hover actions in the hover actions' popover, so we have to hide all the actions.
      * in the case of `EnableOverflowButton`, we only need to hide all the items in the overflow popover as the chart's panel opens in the overflow popover, so non-overflowed actions are not affected.
      */
-    return (
-      values != null &&
-      (enableOverflowButton || (!showTopN && !enableOverflowButton)) &&
-      !isCaseView
-    );
-  }, [enableOverflowButton, hideFilters, isCaseView, showTopN, values]);
+    return (enableOverflowButton || (!showTopN && !enableOverflowButton)) && !isCaseView;
+  }, [enableOverflowButton, hideFilters, isCaseView, showTopN]);
   const shouldDisableColumnToggle = (isObjectArray && field !== 'geo_point') || isCaseView;
 
   const showTopNBtn = useMemo(

--- a/x-pack/plugins/security_solution/public/common/demo_data/timeline.ts
+++ b/x-pack/plugins/security_solution/public/common/demo_data/timeline.ts
@@ -1114,4 +1114,31 @@ export const demoTimelineData: TimelineItem[] = [
       },
     },
   },
+  {
+    _id: '33',
+    data: [
+      { field: '@timestamp', value: ['2018-11-10T19:03:25.937Z'] },
+      { field: 'event.severity', value: ['3'] },
+      { field: 'event.category', value: ['Access'] },
+      { field: 'host.name', value: [''] },
+      { field: 'source.ip', value: ['192.168.0.6'] },
+      { field: 'destination.ip', value: ['192.168.0.3'] },
+      { field: 'destination.bytes', value: ['123456'] },
+    ],
+    ecs: {
+      _id: '6',
+      timestamp: '2018-11-10T19:03:25.937Z',
+      host: { name: ['braden.davis'], ip: ['192.168.0.1'] },
+      event: {
+        id: ['6'],
+        category: ['Access'],
+        type: ['HTTP Request'],
+        module: ['nginx'],
+        severity: [3],
+      },
+      source: { ip: ['192.168.0.6'], port: [80] },
+      destination: { ip: ['192.168.0.3'], port: [6343] },
+      geo: { region_name: ['xx'], country_iso_code: ['xx'] },
+    },
+  },
 ];

--- a/x-pack/plugins/security_solution/public/common/lib/kuery/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kuery/index.ts
@@ -52,8 +52,12 @@ export const convertKueryToElasticSearchQuery = (
 export const isNumber = (value: PrimitiveOrArrayOfPrimitives): value is number =>
   !isNaN(Number(value));
 
-export const convertDateFieldToQuery = (field: string, value: PrimitiveOrArrayOfPrimitives) =>
-  `${field}: ${isNumber(value) ? value : new Date(value.toString()).valueOf()}`;
+export const convertDateFieldToQuery = (field: string, value: PrimitiveOrArrayOfPrimitives) => {
+  if (!(isNumber(value) || typeof value === 'string')) {
+    throw new Error(`invalid value used to construct Date object, value type: ${typeof value}`);
+  }
+  return `${field}: ${isNumber(value) ? value : new Date(value.toString()).valueOf()}`;
+};
 
 export const getBaseFields = memoizeOne((browserFields: BrowserFields): string[] => {
   const baseFields = get('base', browserFields);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/__snapshots__/empty_string_column_renderer.test.tsx.snap
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/__snapshots__/empty_string_column_renderer.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`empty_column_renderer renders correctly against snapshot 1`] = `
+exports[`empty_string_column_renderer renders correctly against snapshot 1`] = `
 <span>
   <DraggableWrapper
     dataProvider={
@@ -8,21 +8,22 @@ exports[`empty_column_renderer renders correctly against snapshot 1`] = `
         "and": Array [],
         "enabled": true,
         "excluded": true,
-        "id": "empty-column-renderer-draggable-wrapper-test-source_ip-1-source_ip",
+        "id": "empty-string-column-renderer-draggable-wrapper-test-host_name-1-host_name",
         "kqlQuery": "",
-        "name": "source.ip: null",
+        "name": "host.name: null",
         "queryMatch": Object {
-          "displayValue": "—",
-          "field": "source.ip",
+          "displayValue": "(Empty string)",
+          "field": "host.name",
           "operator": ":*",
           "value": "",
         },
       }
     }
     isDraggable={true}
-    key="empty-column-renderer-draggable-wrapper-test-source.ip-1-source.ip"
+    key="empty-string-column-renderer-draggable-wrapper-test-host.name-1-host.name"
     render={[Function]}
     scopeId="test"
+    truncate={false}
   />
 </span>
 `;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/empty_string_column_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/empty_string_column_renderer.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { shallow } from 'enzyme';
+import { cloneDeep } from 'lodash/fp';
+import React from 'react';
+
+import type { TimelineNonEcsData } from '../../../../../../common/search_strategy/timeline';
+import { defaultHeaders, mockTimelineData } from '../../../../../common/mock';
+import '../../../../../common/mock/match_media';
+import { emptyStringColumnRenderer } from './empty_string_column_renderer';
+
+jest.mock('../../../../../common/lib/kibana');
+
+describe('empty_string_column_renderer', () => {
+  let mockDatum: TimelineNonEcsData[];
+  const _id = mockTimelineData[0]._id;
+
+  beforeEach(() => {
+    mockDatum = cloneDeep(mockTimelineData[32].data);
+  });
+
+  test('should return isInstance true if host.name is an array of empty strings', () => {
+    expect(emptyStringColumnRenderer.isInstance('host.name', mockDatum)).toBe(true);
+  });
+
+  test('should return isInstance true if host.name is NOT an array of empty strings', () => {
+    expect(emptyStringColumnRenderer.isInstance('source.ip', mockDatum)).toBe(false);
+  });
+
+  test('renders correctly against snapshot', () => {
+    const emptyColumn = emptyStringColumnRenderer.renderColumn({
+      columnName: 'host.name',
+      eventId: _id,
+      values: [''],
+      field: defaultHeaders.find((h) => h.id === 'host.name')!,
+      scopeId: 'test',
+    });
+    const wrapper = shallow(<span>{emptyColumn}</span>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/empty_string_column_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/empty_string_column_renderer.tsx
@@ -13,25 +13,29 @@ import {
   DragEffects,
 } from '../../../../../common/components/drag_and_drop/draggable_wrapper';
 import { escapeDataProviderId } from '../../../../../common/components/drag_and_drop/helpers';
-import { getEmptyValue } from '../../../../../common/components/empty_value';
+import { getEmptyString } from '../../../../../common/components/empty_value';
 import { EXISTS_OPERATOR } from '../../data_providers/data_provider';
 import { Provider } from '../../data_providers/provider';
 import type { ColumnRenderer } from './column_renderer';
 import { parseQueryValue } from './parse_query_value';
 
-export const dataNotExistsAtColumn = (columnName: string, data: TimelineNonEcsData[]): boolean =>
-  data.findIndex((item) => item.field === columnName) === -1;
+/**
+ * Checks if all values are empty strings for given columnName
+ */
+export const isColumnValueAnEmptyString = (
+  columnName: string,
+  data: TimelineNonEcsData[]
+): boolean =>
+  !!data.find(({ field }) => field === columnName)?.value?.every((value) => value === '');
 
-export const emptyColumnRenderer: ColumnRenderer = {
-  isInstance: (columnName: string, data: TimelineNonEcsData[]) =>
-    dataNotExistsAtColumn(columnName, data),
+export const emptyStringColumnRenderer: ColumnRenderer = {
+  isInstance: isColumnValueAnEmptyString,
   renderColumn: ({
     columnName,
     eventId,
     field,
     isDraggable = true,
     scopeId,
-    truncate,
   }: {
     columnName: string;
     eventId: string;
@@ -45,13 +49,13 @@ export const emptyColumnRenderer: ColumnRenderer = {
         dataProvider={{
           enabled: true,
           id: escapeDataProviderId(
-            `empty-column-renderer-draggable-wrapper-${scopeId}-${columnName}-${eventId}-${field.id}`
+            `empty-string-column-renderer-draggable-wrapper-${scopeId}-${columnName}-${eventId}-${field.id}`
           ),
           name: `${columnName}: ${parseQueryValue(null)}`,
           queryMatch: {
             field: field.id,
             value: '',
-            displayValue: getEmptyValue(),
+            displayValue: getEmptyString(),
             operator: EXISTS_OPERATOR,
           },
           excluded: true,
@@ -59,20 +63,20 @@ export const emptyColumnRenderer: ColumnRenderer = {
           and: [],
         }}
         isDraggable={isDraggable}
-        key={`empty-column-renderer-draggable-wrapper-${scopeId}-${columnName}-${eventId}-${field.id}`}
+        key={`empty-string-column-renderer-draggable-wrapper-${scopeId}-${columnName}-${eventId}-${field.id}`}
         render={(dataProvider, _, snapshot) =>
           snapshot.isDragging ? (
             <DragEffects>
               <Provider dataProvider={dataProvider} />
             </DragEffects>
           ) : (
-            <span>{getEmptyValue()}</span>
+            <span>{getEmptyString()}</span>
           )
         }
-        truncate={truncate}
+        truncate={false}
         scopeId={scopeId}
       />
     ) : (
-      <span>{getEmptyValue()}</span>
+      <span>{getEmptyString()}</span>
     ),
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/index.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/index.ts
@@ -19,6 +19,7 @@ import { threatMatchRowRenderer } from './cti/threat_match_row_renderer';
 import { reasonColumnRenderer } from './reason_column_renderer';
 import { eventSummaryColumnRenderer } from './event_summary_column_renderer';
 import { userProfileColumnRenderer } from './user_profile_renderer';
+import { emptyStringColumnRenderer } from './empty_string_column_renderer';
 
 // The row renderers are order dependent and will return the first renderer
 // which returns true from its isInstance call. The bottom renderers which
@@ -37,6 +38,7 @@ export const defaultRowRenderers: RowRenderer[] = [
 ];
 
 export const columnRenderers: ColumnRenderer[] = [
+  emptyStringColumnRenderer,
   reasonColumnRenderer,
   eventSummaryColumnRenderer,
   userProfileColumnRenderer,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/parse_query_value.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/parse_query_value.ts
@@ -10,12 +10,12 @@ import { isObject, isNumber } from 'lodash/fp';
 export const parseQueryValue = (
   value: string | number | object | undefined | null
 ): string | number => {
-  if (value == null) {
+  if (value === '') {
     return '';
   } else if (isObject(value)) {
     return JSON.stringify(value);
   } else if (isNumber(value)) {
     return value;
   }
-  return value.toString();
+  return `${value}`;
 };

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_for_value.tsx
@@ -38,9 +38,7 @@ const FilterForValueButton: React.FC<FilterForValueProps> = React.memo(
   }) => {
     const filterForValueFn = useCallback(() => {
       const makeFilter = (currentVal: string | null | undefined) =>
-        currentVal?.length === 0
-          ? createFilter(field, undefined, false, dataViewId)
-          : createFilter(field, currentVal, false, dataViewId);
+        createFilter(field, currentVal, false, dataViewId);
       const filters = Array.isArray(value)
         ? value.map((currentVal: string | null | undefined) => makeFilter(currentVal))
         : makeFilter(value);

--- a/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
+++ b/x-pack/plugins/timelines/public/components/hover_actions/actions/filter_out_value.tsx
@@ -37,9 +37,8 @@ const FilterOutValueButton: React.FC<HoverActionComponentProps & FilterValueFnAr
   }) => {
     const filterOutValueFn = useCallback(() => {
       const makeFilter = (currentVal: string | null | undefined) =>
-        currentVal == null || currentVal?.length === 0
-          ? createFilter(field, null, false, dataViewId)
-          : createFilter(field, currentVal, true, dataViewId);
+        createFilter(field, currentVal, true, dataViewId);
+
       const filters = Array.isArray(value)
         ? value.map((currentVal: string | null | undefined) => makeFilter(currentVal))
         : makeFilter(value);

--- a/x-pack/plugins/timelines/public/components/hover_actions/utils.ts
+++ b/x-pack/plugins/timelines/public/components/hover_actions/utils.ts
@@ -27,8 +27,9 @@ export const createFilter = (
   negate: boolean = false,
   index?: string
 ): Filter => {
-  const queryValue = value != null ? (Array.isArray(value) ? value[0] : value) : null;
-  return queryValue != null
+  const queryValue = value !== null ? (Array.isArray(value) ? value[0] : value) : null;
+
+  return queryValue !== null
     ? {
         meta: {
           alias: null,
@@ -59,7 +60,7 @@ export const createFilter = (
           alias: null,
           disabled: false,
           key,
-          negate: value === undefined,
+          negate,
           type: 'exists',
           value: 'exists',
           index,


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/kibana/issues/127709

![image](https://github.com/elastic/kibana/assets/11671118/d8ede86f-c82f-47ce-b49b-e2611b0ed6c6)

Note that empty cell renderer's behaviour has been changed to not convert null values to anything, we pass them down as is from now on.

Testing:
```
PUT /my_index
{
  "mappings": {
    "properties": {
      "@timestamp": {
        "type": "date"
      },
      "process.name": {
        "type": "keyword"
      }
    }
  }
}

POST /my_index/_doc
{
  "process.name": "",
  "@timestamp": "2024-04-04T11:01:26.085Z"
}
```

Then change timeline data view to match your new index. `process.name` should be rendered as empty string, that you should be able to filter in / filter out as a phrase filter, vs. exists it used to be before.