### PR TITLE
[BK] Add missed schedules from recreated pipelines

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
@@ -42,3 +42,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      schedules:
+        Daily 6 am UTC:
+          cronline: 0 5 * * *
+          message: Daily 6 am UTC
+          branch: main

--- a/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
@@ -33,6 +33,7 @@ spec:
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true
+        trigger_mode: none
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
@@ -46,3 +46,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      schedules:
+        Weekly build:
+          cronline: 0 0 * * 1 America/New_York
+          message: Weekly build
+          branch: main


### PR DESCRIPTION
## Summary
While recreating the pipelines through #179822 for some reason, my automation script missed adding the schedules.

This PR is adding the previously present schedules. 