### PR TITLE
revert markdown migration for canvas

### DIFF
--- a/x-pack/plugins/canvas/canvas_plugin_src/renderers/markdown/index.tsx
+++ b/x-pack/plugins/canvas/canvas_plugin_src/renderers/markdown/index.tsx
@@ -11,7 +11,7 @@ import { CoreTheme } from '@kbn/core/public';
 import { Observable } from 'rxjs';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { defaultTheme$ } from '@kbn/presentation-util-plugin/common';
-import { Markdown } from '@kbn/shared-ux-markdown';
+import { Markdown } from '@kbn/kibana-react-plugin/public';
 import { StartInitializer } from '../../plugin';
 import { RendererStrings } from '../../../i18n';
 import { Return as Config } from '../../functions/browser/markdown';
@@ -29,24 +29,20 @@ export const getMarkdownRenderer =
     render(domNode, config, handlers) {
       const fontStyle = config.font ? config.font.spec : {};
 
-      if (config.content) {
-        ReactDOM.render(
-          <KibanaThemeProvider theme={{ theme$ }}>
-            <Markdown
-              className="canvasMarkdown"
-              style={fontStyle as CSSProperties}
-              openLinksInNewTab={config.openLinksInNewTab}
-              readOnly
-            >
-              {config.content}
-            </Markdown>
-          </KibanaThemeProvider>,
-          domNode,
-          () => handlers.done()
-        );
+      ReactDOM.render(
+        <KibanaThemeProvider theme={{ theme$ }}>
+          <Markdown
+            className="canvasMarkdown"
+            style={fontStyle as CSSProperties}
+            markdown={config.content}
+            openLinksInNewTab={config.openLinksInNewTab}
+          />
+        </KibanaThemeProvider>,
+        domNode,
+        () => handlers.done()
+      );
 
-        handlers.onDestroy(() => ReactDOM.unmountComponentAtNode(domNode));
-      }
+      handlers.onDestroy(() => ReactDOM.unmountComponentAtNode(domNode));
     },
   });
 

--- a/x-pack/plugins/canvas/tsconfig.json
+++ b/x-pack/plugins/canvas/tsconfig.json
@@ -87,7 +87,6 @@
     "@kbn/reporting-server",
     "@kbn/reporting-export-types-pdf-common",
     "@kbn/code-editor",
-    "@kbn/shared-ux-markdown",
     "@kbn/presentation-containers",
     "@kbn/presentation-publishing",
   ],


### PR DESCRIPTION
## Summary

Reverts the Markdown migration from the legacy component for Canvas Workpad, as the migration resulted in regression in the functionality in relation to custom styling provided by the user and also reported missing text. 

P.S. Contains changes from the PR https://github.com/elastic/kibana/pull/180053

<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->