### PR TITLE
[Security Solution] fix endpoint filter flyout shown behind timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/event_filters_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/event_filters_flyout.tsx
@@ -7,7 +7,6 @@
 
 import React, { memo, useMemo, useEffect, useCallback, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-
 import {
   EuiFlyout,
   EuiFlyoutHeader,
@@ -19,6 +18,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTextColor,
+  useEuiTheme,
 } from '@elastic/eui';
 import { lastValueFrom } from 'rxjs';
 
@@ -46,6 +46,8 @@ export interface EventFiltersFlyoutProps {
 
 export const EventFiltersFlyout: React.FC<EventFiltersFlyoutProps> = memo(
   ({ onCancel: onClose, data, ...flyoutProps }) => {
+    const { euiTheme } = useEuiTheme();
+
     const toasts = useToasts();
     const http = useHttp();
 
@@ -173,6 +175,8 @@ export const EventFiltersFlyout: React.FC<EventFiltersFlyoutProps> = memo(
         onClose={handleOnClose}
         data-test-subj="eventFiltersCreateFlyout"
         {...flyoutProps}
+        // EUI TODO: This z-index override of EuiOverlayMask is a workaround, and ideally should be resolved with a cleaner UI/UX flow long-term
+        maskProps={{ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }} // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">

--- a/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/event_filters_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/event_filters/view/components/event_filters_flyout.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo, useMemo, useEffect, useCallback, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import {
   EuiFlyout,
   EuiFlyoutHeader,
@@ -18,7 +19,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTextColor,
-  useEuiTheme,
 } from '@elastic/eui';
 import { lastValueFrom } from 'rxjs';
 
@@ -46,8 +46,6 @@ export interface EventFiltersFlyoutProps {
 
 export const EventFiltersFlyout: React.FC<EventFiltersFlyoutProps> = memo(
   ({ onCancel: onClose, data, ...flyoutProps }) => {
-    const { euiTheme } = useEuiTheme();
-
     const toasts = useToasts();
     const http = useHttp();
 
@@ -175,8 +173,6 @@ export const EventFiltersFlyout: React.FC<EventFiltersFlyoutProps> = memo(
         onClose={handleOnClose}
         data-test-subj="eventFiltersCreateFlyout"
         {...flyoutProps}
-        // EUI TODO: This z-index override of EuiOverlayMask is a workaround, and ideally should be resolved with a cleaner UI/UX flow long-term
-        maskProps={{ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }} // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/flyout/footer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/flyout/footer.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { EuiFlyoutFooter, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlyoutFooter, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { find } from 'lodash/fp';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { isActiveTimeline } from '../../../../../helpers';
@@ -52,6 +52,8 @@ export const FlyoutFooterComponent = ({
   scopeId,
   refetchFlyoutData,
 }: FlyoutFooterProps) => {
+  const { euiTheme } = useEuiTheme();
+
   const alertId = detailsEcsData?.kibana?.alert ? detailsEcsData?._id : null;
   const ruleIndexRaw = useMemo(
     () =>
@@ -165,7 +167,12 @@ export const FlyoutFooterComponent = ({
           />
         )}
       {isAddEventFilterModalOpen && detailsEcsData != null && (
-        <EventFiltersFlyout data={detailsEcsData} onCancel={closeAddEventFilterModal} />
+        <EventFiltersFlyout
+          data={detailsEcsData}
+          onCancel={closeAddEventFilterModal}
+          // EUI TODO: This z-index override of EuiOverlayMask is a workaround, and ideally should be resolved with a cleaner UI/UX flow long-term
+          maskProps={{ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }} // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
+        />
       )}
       {isOsqueryFlyoutOpenWithAgentId && detailsEcsData != null && (
         <OsqueryFlyout

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/flyout/footer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/flyout/footer.tsx
@@ -53,6 +53,10 @@ export const FlyoutFooterComponent = ({
   refetchFlyoutData,
 }: FlyoutFooterProps) => {
   const { euiTheme } = useEuiTheme();
+  const flyoutZIndex = useMemo(
+    () => ({ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }),
+    [euiTheme]
+  );
 
   const alertId = detailsEcsData?.kibana?.alert ? detailsEcsData?._id : null;
   const ruleIndexRaw = useMemo(
@@ -171,7 +175,7 @@ export const FlyoutFooterComponent = ({
           data={detailsEcsData}
           onCancel={closeAddEventFilterModal}
           // EUI TODO: This z-index override of EuiOverlayMask is a workaround, and ideally should be resolved with a cleaner UI/UX flow long-term
-          maskProps={{ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }} // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
+          maskProps={flyoutZIndex} // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
         />
       )}
       {isOsqueryFlyoutOpenWithAgentId && detailsEcsData != null && (


### PR DESCRIPTION
## Summary

This PR fixes an issue introduced in [this PR](https://github.com/elastic/kibana/pull/177087) where - in order to get the expandable flyout to work within timeline - we had to modify the `z-index` of the timeline modal ([here](https://github.com/elastic/kibana/pull/177087/files#diff-a4fef8db9f9e4c1a86b8fcc0f859b10420a1ff0c1c5c091eace92cf0643ca58c)) as well as the _secondary flyouts_ accessed through the `Take action` button in the flyout's footer.

Obviously I had missed this endpoint filter flyout.

https://github.com/elastic/kibana/assets/17276605/66fa62ce-6dde-43e5-b79b-9620b5c21d98

https://github.com/elastic/kibana/issues/179879