### PR TITLE
[Security Solution] bring back event renderer in document details flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.test.tsx
@@ -15,6 +15,7 @@ import {
   EVENT_CATEGORY_DESCRIPTION_TEST_ID,
   REASON_TITLE_TEST_ID,
   MITRE_ATTACK_TITLE_TEST_ID,
+  EVENT_RENDERER_TEST_ID,
 } from './test_ids';
 import { TestProviders } from '../../../../common/mock';
 import { AboutSection } from './about_section';
@@ -111,6 +112,8 @@ describe('<AboutSection />', () => {
       expect(
         queryByTestId(`${EVENT_CATEGORY_DESCRIPTION_TEST_ID}-behavior`)
       ).not.toBeInTheDocument();
+
+      expect(getByTestId(EVENT_RENDERER_TEST_ID)).toBeInTheDocument();
     });
   });
 
@@ -136,6 +139,8 @@ describe('<AboutSection />', () => {
       expect(queryByTestId(EVENT_KIND_DESCRIPTION_TEST_ID)).not.toBeInTheDocument();
 
       expect(getByTestId(`${EVENT_CATEGORY_DESCRIPTION_TEST_ID}-behavior`)).toBeInTheDocument();
+
+      expect(getByTestId(EVENT_RENDERER_TEST_ID)).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -20,6 +20,7 @@ import { useRightPanelContext } from '../context';
 import { isEcsAllowedValue } from '../utils/event_utils';
 import { EventCategoryDescription } from './event_category_description';
 import { EventKindDescription } from './event_kind_description';
+import { EventRenderer } from './event_renderer';
 
 const KEY = 'about';
 
@@ -53,6 +54,7 @@ export const AboutSection: FC = memo(() => {
             // if event kind is not event, show a higher level description on event kind
             <EventKindDescription eventKind={eventKind} />
           ))}
+        <EventRenderer />
       </>
     );
 


### PR DESCRIPTION
## Summary

This PR brings back the EventRenderer that was mistakenly removed [here in this PR](https://github.com/elastic/kibana/pull/178746/files#diff-7de8f19ea416a84d110249a31fc871c1eb8f6917c862b785128b0b652d27b5a4L22). Thanks @christineweng for noticing!

Added some unit tests to make sure this does not happen again.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios