### PR TITLE
[ML] Single Metric Viewer in dashboards: ensure the detector index is set correctly for 'Open' action

### DIFF
--- a/x-pack/plugins/ml/public/ui_actions/open_in_single_metric_viewer_action.tsx
+++ b/x-pack/plugins/ml/public/ui_actions/open_in_single_metric_viewer_action.tsx
@@ -59,7 +59,7 @@ export function createOpenInSingleMetricViewerAction(
 
       if (isSingleMetricViewerEmbeddableContext(context)) {
         const { embeddable } = context;
-        const { jobIds, query$, selectedEntities } = embeddable;
+        const { jobIds, query$, selectedEntities, selectedDetectorIndex } = embeddable;
 
         return locator.getUrl(
           {
@@ -75,6 +75,7 @@ export function createOpenInSingleMetricViewerAction(
               jobIds: jobIds.getValue(),
               query: query$?.getValue(),
               entities: selectedEntities?.getValue(),
+              detectorIndex: selectedDetectorIndex?.getValue(),
             },
           },
           { absolute: true }


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/179364

This PR ensures the detector index is set correctly the url in the `Open in single metric viewer` action to link from dashboards to ML > Single metric viewer.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


