### PR TITLE
[Security Solution] AI Assistant - Turn streaming on by default

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant-common/impl/capabilities/index.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/capabilities/index.ts
@@ -15,5 +15,4 @@ export type AssistantFeatures = { [K in keyof typeof defaultAssistantFeatures]: 
  */
 export const defaultAssistantFeatures = Object.freeze({
   assistantModelEvaluation: false,
-  assistantStreamingEnabled: false,
 });

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
@@ -18,5 +18,5 @@ import { z } from 'zod';
 
 export type GetCapabilitiesResponse = z.infer<typeof GetCapabilitiesResponse>;
 export const GetCapabilitiesResponse = z.object({
-  assistantModelEvaluation: z.boolean().optional(),
+  assistantModelEvaluation: z.boolean(),
 });

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
@@ -18,6 +18,5 @@ import { z } from 'zod';
 
 export type GetCapabilitiesResponse = z.infer<typeof GetCapabilitiesResponse>;
 export const GetCapabilitiesResponse = z.object({
-  assistantModelEvaluation: z.boolean(),
-  assistantStreamingEnabled: z.boolean(),
+  assistantModelEvaluation: z.boolean().optional(),
 });

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
@@ -21,11 +21,8 @@ paths:
                 properties:
                   assistantModelEvaluation:
                     type: boolean
-                  assistantStreamingEnabled:
-                    type: boolean
                 required:
-                  - assistantModelEvaluation
-                  - assistantStreamingEnabled
+                  - assistantModelEvaluation=
         '400':
           description: Generic Error
           content:

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
@@ -22,7 +22,7 @@ paths:
                   assistantModelEvaluation:
                     type: boolean
                 required:
-                  - assistantModelEvaluation=
+                  - assistantModelEvaluation
         '400':
           description: Generic Error
           content:

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
@@ -44,7 +44,7 @@ export interface ConversationSettingsProps {
   http: HttpSetup;
   onSelectedConversationChange: (conversation?: Conversation) => void;
   selectedConversation?: Conversation;
-  setAssistantStreamingEnabled: React.Dispatch<React.SetStateAction<boolean | undefined>>;
+  setAssistantStreamingEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   setConversationSettings: React.Dispatch<React.SetStateAction<Record<string, Conversation>>>;
   setConversationsSettingsBulkActions: React.Dispatch<
     React.SetStateAction<ConversationsBulkActions>
@@ -351,7 +351,6 @@ export const ConversationSettings: React.FC<ConversationSettingsProps> = React.m
         setConversationsSettingsBulkActions,
       ]
     );
-    console.log('conversationSettings', { assistantStreamingEnabled });
     return (
       <>
         <EuiTitle size={'s'}>
@@ -427,16 +426,16 @@ export const ConversationSettings: React.FC<ConversationSettingsProps> = React.m
               />
             </EuiFormRow>
           )}
-        <EuiSpacer size="xs" />
+        <EuiSpacer size="s" />
         <EuiTitle size={'s'}>
           <h2>{i18n.SETTINGS_ALL_TITLE}</h2>
         </EuiTitle>
         <EuiSpacer size="xs" />
         <EuiText size={'s'}>{i18n.SETTINGS_ALL_DESCRIPTION}</EuiText>
         <EuiHorizontalRule margin={'s'} />
-        <EuiFormRow display="rowCompressed" hasChildLabel={false}>
+        <EuiFormRow display="rowCompressed" label={i18n.STREAMING_TITLE}>
           <EuiSwitch
-            label={<EuiText size="xs">{i18n.STREAMING_TITLE}</EuiText>}
+            label={<EuiText size="xs">{i18n.STREAMING_HELP_TEXT_TITLE}</EuiText>}
             checked={assistantStreamingEnabled}
             onChange={(e) => setAssistantStreamingEnabled(e.target.checked)}
             compressed

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
@@ -433,7 +433,7 @@ export const ConversationSettings: React.FC<ConversationSettingsProps> = React.m
         <EuiSpacer size="xs" />
         <EuiText size={'s'}>{i18n.SETTINGS_ALL_DESCRIPTION}</EuiText>
         <EuiHorizontalRule margin={'s'} />
-        <EuiFormRow display="rowCompressed" label={i18n.STREAMING_TITLE}>
+        <EuiFormRow fullWidth display="rowCompressed" label={i18n.STREAMING_TITLE}>
           <EuiSwitch
             label={<EuiText size="xs">{i18n.STREAMING_HELP_TEXT_TITLE}</EuiText>}
             checked={assistantStreamingEnabled}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
@@ -426,7 +426,7 @@ export const ConversationSettings: React.FC<ConversationSettingsProps> = React.m
               />
             </EuiFormRow>
           )}
-        <EuiSpacer size="s" />
+        <EuiSpacer size="l" />
         <EuiTitle size={'s'}>
           <h2>{i18n.SETTINGS_ALL_TITLE}</h2>
         </EuiTitle>

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/conversation_settings.tsx
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiLink, EuiTitle, EuiText, EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
+import {
+  EuiFormRow,
+  EuiLink,
+  EuiTitle,
+  EuiText,
+  EuiHorizontalRule,
+  EuiSpacer,
+  EuiSwitch,
+} from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 
 import { HttpSetup } from '@kbn/core-http-browser';
@@ -32,9 +40,11 @@ export interface ConversationSettingsProps {
   conversationSettings: Record<string, Conversation>;
   conversationsSettingsBulkActions: ConversationsBulkActions;
   defaultConnector?: AIConnector;
+  assistantStreamingEnabled: boolean;
   http: HttpSetup;
   onSelectedConversationChange: (conversation?: Conversation) => void;
   selectedConversation?: Conversation;
+  setAssistantStreamingEnabled: React.Dispatch<React.SetStateAction<boolean | undefined>>;
   setConversationSettings: React.Dispatch<React.SetStateAction<Record<string, Conversation>>>;
   setConversationsSettingsBulkActions: React.Dispatch<
     React.SetStateAction<ConversationsBulkActions>
@@ -48,12 +58,14 @@ export interface ConversationSettingsProps {
 export const ConversationSettings: React.FC<ConversationSettingsProps> = React.memo(
   ({
     allSystemPrompts,
+    assistantStreamingEnabled,
     defaultConnector,
     selectedConversation,
     onSelectedConversationChange,
     conversationSettings,
     http,
     isDisabled = false,
+    setAssistantStreamingEnabled,
     setConversationSettings,
     conversationsSettingsBulkActions,
     setConversationsSettingsBulkActions,
@@ -339,7 +351,7 @@ export const ConversationSettings: React.FC<ConversationSettingsProps> = React.m
         setConversationsSettingsBulkActions,
       ]
     );
-
+    console.log('conversationSettings', { assistantStreamingEnabled });
     return (
       <>
         <EuiTitle size={'s'}>
@@ -415,6 +427,21 @@ export const ConversationSettings: React.FC<ConversationSettingsProps> = React.m
               />
             </EuiFormRow>
           )}
+        <EuiSpacer size="xs" />
+        <EuiTitle size={'s'}>
+          <h2>{i18n.SETTINGS_ALL_TITLE}</h2>
+        </EuiTitle>
+        <EuiSpacer size="xs" />
+        <EuiText size={'s'}>{i18n.SETTINGS_ALL_DESCRIPTION}</EuiText>
+        <EuiHorizontalRule margin={'s'} />
+        <EuiFormRow display="rowCompressed" hasChildLabel={false}>
+          <EuiSwitch
+            label={<EuiText size="xs">{i18n.STREAMING_TITLE}</EuiText>}
+            checked={assistantStreamingEnabled}
+            onChange={(e) => setAssistantStreamingEnabled(e.target.checked)}
+            compressed
+          />
+        </EuiFormRow>
       </>
     );
   }

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/translations.ts
@@ -31,7 +31,7 @@ export const SETTINGS_ALL_TITLE = i18n.translate(
 export const SETTINGS_ALL_DESCRIPTION = i18n.translate(
   'xpack.elasticAssistant.assistant.conversations.settings.settingsAllDescription',
   {
-    defaultMessage: 'These settings apply to all conversations',
+    defaultMessage: 'These settings apply to all conversations.',
   }
 );
 

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/conversations/conversation_settings/translations.ts
@@ -21,6 +21,20 @@ export const SETTINGS_DESCRIPTION = i18n.translate(
   }
 );
 
+export const SETTINGS_ALL_TITLE = i18n.translate(
+  'xpack.elasticAssistant.assistant.conversations.settings.settingsAllTitle',
+  {
+    defaultMessage: 'All conversations',
+  }
+);
+
+export const SETTINGS_ALL_DESCRIPTION = i18n.translate(
+  'xpack.elasticAssistant.assistant.conversations.settings.settingsAllDescription',
+  {
+    defaultMessage: 'These settings apply to all conversations',
+  }
+);
+
 export const CONNECTOR_TITLE = i18n.translate(
   'xpack.elasticAssistant.assistant.conversations.settings.connectorTitle',
   {
@@ -39,5 +53,19 @@ export const SETTINGS_PROMPT_HELP_TEXT_TITLE = i18n.translate(
   'xpack.elasticAssistant.assistant.conversations.settings.promptHelpTextTitle',
   {
     defaultMessage: 'Context provided as part of every conversation',
+  }
+);
+
+export const STREAMING_TITLE = i18n.translate(
+  'xpack.elasticAssistant.assistant.conversations.settings.streamingTitle',
+  {
+    defaultMessage: 'Streaming',
+  }
+);
+
+export const STREAMING_HELP_TEXT_TITLE = i18n.translate(
+  'xpack.elasticAssistant.assistant.conversations.settings.streamingHelpTextTitle',
+  {
+    defaultMessage: 'Controls whether streaming responses are used in conversations',
   }
 );

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/assistant_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/assistant_settings.tsx
@@ -85,8 +85,6 @@ export const AssistantSettings: React.FC<Props> = React.memo(
       actionTypeRegistry,
       modelEvaluatorEnabled,
       http,
-      assistantStreamingEnabled,
-      setAssistantStreamingEnabled,
       selectedSettingsTab,
       setSelectedSettingsTab,
     } = useAssistantContext();
@@ -99,6 +97,8 @@ export const AssistantSettings: React.FC<Props> = React.memo(
       knowledgeBase,
       quickPromptSettings,
       systemPromptSettings,
+      assistantStreamingEnabled,
+      setUpdatedAssistantStreamingEnabled,
       setUpdatedDefaultAllow,
       setUpdatedDefaultAllowReplacement,
       setUpdatedKnowledgeBaseSettings,
@@ -302,7 +302,7 @@ export const AssistantSettings: React.FC<Props> = React.memo(
                     selectedConversation={selectedConversation}
                     isDisabled={selectedConversation == null}
                     assistantStreamingEnabled={assistantStreamingEnabled}
-                    setAssistantStreamingEnabled={setAssistantStreamingEnabled}
+                    setAssistantStreamingEnabled={setUpdatedAssistantStreamingEnabled}
                     onSelectedConversationChange={onHandleSelectedConversationChange}
                     http={http}
                   />

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/assistant_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/assistant_settings.tsx
@@ -85,6 +85,8 @@ export const AssistantSettings: React.FC<Props> = React.memo(
       actionTypeRegistry,
       modelEvaluatorEnabled,
       http,
+      assistantStreamingEnabled,
+      setAssistantStreamingEnabled,
       selectedSettingsTab,
       setSelectedSettingsTab,
     } = useAssistantContext();
@@ -299,6 +301,8 @@ export const AssistantSettings: React.FC<Props> = React.memo(
                     allSystemPrompts={systemPromptSettings}
                     selectedConversation={selectedConversation}
                     isDisabled={selectedConversation == null}
+                    assistantStreamingEnabled={assistantStreamingEnabled}
+                    setAssistantStreamingEnabled={setAssistantStreamingEnabled}
                     onSelectedConversationChange={onHandleSelectedConversationChange}
                     http={http}
                   />

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_settings_updater.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_settings_updater.test.tsx
@@ -35,10 +35,13 @@ const initialDefaultAllowReplacement = ['replacement1'];
 const setAllQuickPromptsMock = jest.fn();
 const setAllSystemPromptsMock = jest.fn();
 const setDefaultAllowMock = jest.fn();
+const setAssistantStreamingEnabled = jest.fn();
 const setDefaultAllowReplacementMock = jest.fn();
 const setKnowledgeBaseMock = jest.fn();
 const reportAssistantSettingToggled = jest.fn();
 const mockValues = {
+  assistantStreamingEnabled: true,
+  setAssistantStreamingEnabled,
   assistantTelemetry: { reportAssistantSettingToggled },
   allSystemPrompts: mockSystemPrompts,
   allQuickPrompts: mockQuickPrompts,
@@ -69,6 +72,7 @@ const updatedValues = {
     isEnabledKnowledgeBase: false,
     latestAlerts: DEFAULT_LATEST_ALERTS,
   },
+  assistantStreamingEnabled: false,
 };
 
 jest.mock('../../../assistant_context', () => {
@@ -95,6 +99,7 @@ describe('useSettingsUpdater', () => {
         setUpdatedDefaultAllow,
         setUpdatedDefaultAllowReplacement,
         setUpdatedKnowledgeBaseSettings,
+        setUpdatedAssistantStreamingEnabled,
         resetSettings,
       } = result.current;
 
@@ -105,6 +110,7 @@ describe('useSettingsUpdater', () => {
       setUpdatedDefaultAllow(updatedValues.defaultAllow);
       setUpdatedDefaultAllowReplacement(updatedValues.defaultAllowReplacement);
       setUpdatedKnowledgeBaseSettings(updatedValues.knowledgeBase);
+      setUpdatedAssistantStreamingEnabled(updatedValues.assistantStreamingEnabled);
 
       expect(result.current.conversationSettings).toEqual(updatedValues.conversations);
       expect(result.current.quickPromptSettings).toEqual(updatedValues.allQuickPrompts);
@@ -112,6 +118,9 @@ describe('useSettingsUpdater', () => {
       expect(result.current.defaultAllow).toEqual(updatedValues.defaultAllow);
       expect(result.current.defaultAllowReplacement).toEqual(updatedValues.defaultAllowReplacement);
       expect(result.current.knowledgeBase).toEqual(updatedValues.knowledgeBase);
+      expect(result.current.assistantStreamingEnabled).toEqual(
+        updatedValues.assistantStreamingEnabled
+      );
 
       resetSettings();
 
@@ -121,6 +130,9 @@ describe('useSettingsUpdater', () => {
       expect(result.current.defaultAllow).toEqual(mockValues.defaultAllow);
       expect(result.current.defaultAllowReplacement).toEqual(mockValues.defaultAllowReplacement);
       expect(result.current.knowledgeBase).toEqual(mockValues.knowledgeBase);
+      expect(result.current.assistantStreamingEnabled).toEqual(
+        mockValues.assistantStreamingEnabled
+      );
     });
   });
 

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_settings_updater.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_settings_updater.tsx
@@ -124,13 +124,18 @@ export const useSettingsUpdater = (
       knowledgeBase.isEnabledKnowledgeBase !== updatedKnowledgeBaseSettings.isEnabledKnowledgeBase;
     const didUpdateRAGAlerts =
       knowledgeBase.isEnabledRAGAlerts !== updatedKnowledgeBaseSettings.isEnabledRAGAlerts;
-    if (didUpdateKnowledgeBase || didUpdateRAGAlerts) {
+    const didUpdateAssistantStreamingEnabled =
+      assistantStreamingEnabled !== updatedAssistantStreamingEnabled;
+    if (didUpdateKnowledgeBase || didUpdateRAGAlerts || didUpdateAssistantStreamingEnabled) {
       assistantTelemetry?.reportAssistantSettingToggled({
         ...(didUpdateKnowledgeBase
           ? { isEnabledKnowledgeBase: updatedKnowledgeBaseSettings.isEnabledKnowledgeBase }
           : {}),
         ...(didUpdateRAGAlerts
           ? { isEnabledRAGAlerts: updatedKnowledgeBaseSettings.isEnabledRAGAlerts }
+          : {}),
+        ...(didUpdateAssistantStreamingEnabled
+          ? { assistantStreamingEnabled: updatedAssistantStreamingEnabled }
           : {}),
       });
     }
@@ -152,6 +157,7 @@ export const useSettingsUpdater = (
     knowledgeBase.isEnabledRAGAlerts,
     updatedAssistantStreamingEnabled,
     updatedKnowledgeBaseSettings,
+    assistantStreamingEnabled,
     setAssistantStreamingEnabled,
     setKnowledgeBase,
     setDefaultAllow,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_settings_updater.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/use_settings_updater/use_settings_updater.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../api/conversations/use_bulk_actions_conversations';
 
 interface UseSettingsUpdater {
+  assistantStreamingEnabled: boolean;
   conversationSettings: Record<string, Conversation>;
   conversationsSettingsBulkActions: ConversationsBulkActions;
   defaultAllow: string[];
@@ -32,6 +33,7 @@ interface UseSettingsUpdater {
   setUpdatedKnowledgeBaseSettings: React.Dispatch<React.SetStateAction<KnowledgeBaseConfig>>;
   setUpdatedQuickPromptSettings: React.Dispatch<React.SetStateAction<QuickPrompt[]>>;
   setUpdatedSystemPromptSettings: React.Dispatch<React.SetStateAction<Prompt[]>>;
+  setUpdatedAssistantStreamingEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   saveSettings: () => Promise<boolean>;
 }
 
@@ -50,6 +52,8 @@ export const useSettingsUpdater = (
     setAllSystemPrompts,
     setDefaultAllow,
     setDefaultAllowReplacement,
+    assistantStreamingEnabled,
+    setAssistantStreamingEnabled,
     setKnowledgeBase,
     http,
     toasts,
@@ -73,6 +77,8 @@ export const useSettingsUpdater = (
   const [updatedDefaultAllow, setUpdatedDefaultAllow] = useState<string[]>(defaultAllow);
   const [updatedDefaultAllowReplacement, setUpdatedDefaultAllowReplacement] =
     useState<string[]>(defaultAllowReplacement);
+  const [updatedAssistantStreamingEnabled, setUpdatedAssistantStreamingEnabled] =
+    useState<boolean>(assistantStreamingEnabled);
   // Knowledge Base
   const [updatedKnowledgeBaseSettings, setUpdatedKnowledgeBaseSettings] =
     useState<KnowledgeBaseConfig>(knowledgeBase);
@@ -85,12 +91,14 @@ export const useSettingsUpdater = (
     setConversationsSettingsBulkActions({});
     setUpdatedQuickPromptSettings(allQuickPrompts);
     setUpdatedKnowledgeBaseSettings(knowledgeBase);
+    setUpdatedAssistantStreamingEnabled(assistantStreamingEnabled);
     setUpdatedSystemPromptSettings(allSystemPrompts);
     setUpdatedDefaultAllow(defaultAllow);
     setUpdatedDefaultAllowReplacement(defaultAllowReplacement);
   }, [
     allQuickPrompts,
     allSystemPrompts,
+    assistantStreamingEnabled,
     conversations,
     defaultAllow,
     defaultAllowReplacement,
@@ -126,6 +134,7 @@ export const useSettingsUpdater = (
           : {}),
       });
     }
+    setAssistantStreamingEnabled(updatedAssistantStreamingEnabled);
     setKnowledgeBase(updatedKnowledgeBaseSettings);
     setDefaultAllow(updatedDefaultAllow);
     setDefaultAllowReplacement(updatedDefaultAllowReplacement);
@@ -141,7 +150,9 @@ export const useSettingsUpdater = (
     toasts,
     knowledgeBase.isEnabledKnowledgeBase,
     knowledgeBase.isEnabledRAGAlerts,
+    updatedAssistantStreamingEnabled,
     updatedKnowledgeBaseSettings,
+    setAssistantStreamingEnabled,
     setKnowledgeBase,
     setDefaultAllow,
     updatedDefaultAllow,
@@ -156,6 +167,7 @@ export const useSettingsUpdater = (
     defaultAllow: updatedDefaultAllow,
     defaultAllowReplacement: updatedDefaultAllowReplacement,
     knowledgeBase: updatedKnowledgeBaseSettings,
+    assistantStreamingEnabled: updatedAssistantStreamingEnabled,
     quickPromptSettings: updatedQuickPromptSettings,
     resetSettings,
     systemPromptSettings: updatedSystemPromptSettings,
@@ -163,6 +175,7 @@ export const useSettingsUpdater = (
     setUpdatedDefaultAllow,
     setUpdatedDefaultAllowReplacement,
     setUpdatedKnowledgeBaseSettings,
+    setUpdatedAssistantStreamingEnabled,
     setUpdatedQuickPromptSettings,
     setUpdatedSystemPromptSettings,
     setConversationSettings,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/constants.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/constants.tsx
@@ -12,6 +12,7 @@ export const QUICK_PROMPT_LOCAL_STORAGE_KEY = 'quickPrompts';
 export const SYSTEM_PROMPT_LOCAL_STORAGE_KEY = 'systemPrompts';
 export const LAST_CONVERSATION_TITLE_LOCAL_STORAGE_KEY = 'lastConversationTitle';
 export const KNOWLEDGE_BASE_LOCAL_STORAGE_KEY = 'knowledgeBase';
+export const STREAMING_LOCAL_STORAGE_KEY = 'streaming';
 
 /** The default `n` latest alerts, ordered by risk score, sent as context to the assistant */
 export const DEFAULT_LATEST_ALERTS = 20;

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -33,6 +33,7 @@ import {
   KNOWLEDGE_BASE_LOCAL_STORAGE_KEY,
   LAST_CONVERSATION_TITLE_LOCAL_STORAGE_KEY,
   QUICK_PROMPT_LOCAL_STORAGE_KEY,
+  STREAMING_LOCAL_STORAGE_KEY,
   SYSTEM_PROMPT_LOCAL_STORAGE_KEY,
 } from './constants';
 import { CONVERSATIONS_TAB, SettingsTabs } from '../assistant/settings/assistant_settings';
@@ -138,6 +139,7 @@ export interface UseAssistantContext {
   setAllSystemPrompts: React.Dispatch<React.SetStateAction<Prompt[] | undefined>>;
   setDefaultAllow: React.Dispatch<React.SetStateAction<string[]>>;
   setDefaultAllowReplacement: React.Dispatch<React.SetStateAction<string[]>>;
+  setAssistantStreamingEnabled: React.Dispatch<React.SetStateAction<boolean | undefined>>;
   setKnowledgeBase: React.Dispatch<React.SetStateAction<KnowledgeBaseConfig | undefined>>;
   setLastConversationTitle: React.Dispatch<React.SetStateAction<string | undefined>>;
   setSelectedSettingsTab: React.Dispatch<React.SetStateAction<SettingsTabs>>;
@@ -203,6 +205,15 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
   );
 
   /**
+   * Local storage for streaming configuration, prefixed by assistant nameSpace
+   */
+  // can be undefined from localStorage, if not defined, default to true
+  const [localStorageStreaming, setLocalStorageStreaming] = useLocalStorage<boolean>(
+    `${nameSpace}.${STREAMING_LOCAL_STORAGE_KEY}`,
+    true
+  );
+
+  /**
    * Prompt contexts are used to provide components a way to register and make their data available to the assistant.
    */
   const [promptContexts, setPromptContexts] = useState<Record<string, PromptContext>>({});
@@ -258,7 +269,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
 
   // Fetch assistant capabilities
   const { data: capabilities } = useCapabilities({ http, toasts });
-  const { assistantModelEvaluation: modelEvaluatorEnabled, assistantStreamingEnabled } =
+  const { assistantModelEvaluation: modelEvaluatorEnabled } =
     capabilities ?? defaultAssistantFeatures;
 
   const value = useMemo(
@@ -266,7 +277,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       actionTypeRegistry,
       alertsIndexPattern,
       assistantAvailability,
-      assistantStreamingEnabled,
       assistantTelemetry,
       augmentMessageCodeBlocks,
       allQuickPrompts: localStorageQuickPrompts ?? [],
@@ -288,6 +298,9 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       nameSpace,
       registerPromptContext,
       selectedSettingsTab,
+      // can be undefined from localStorage, if not defined, default to true
+      assistantStreamingEnabled: localStorageStreaming ?? true,
+      setAssistantStreamingEnabled: setLocalStorageStreaming,
       setAllQuickPrompts: setLocalStorageQuickPrompts,
       setAllSystemPrompts: setLocalStorageSystemPrompts,
       setDefaultAllow,
@@ -307,7 +320,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       actionTypeRegistry,
       alertsIndexPattern,
       assistantAvailability,
-      assistantStreamingEnabled,
       assistantTelemetry,
       augmentMessageCodeBlocks,
       localStorageQuickPrompts,
@@ -329,6 +341,8 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       nameSpace,
       registerPromptContext,
       selectedSettingsTab,
+      localStorageStreaming,
+      setLocalStorageStreaming,
       setLocalStorageQuickPrompts,
       setLocalStorageSystemPrompts,
       setDefaultAllow,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/types.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/types.tsx
@@ -79,6 +79,7 @@ export interface AssistantTelemetry {
   reportAssistantSettingToggled: (params: {
     isEnabledKnowledgeBase?: boolean;
     isEnabledRAGAlerts?: boolean;
+    assistantStreamingEnabled?: boolean;
   }) => void;
 }
 

--- a/x-pack/plugins/elastic_assistant/server/routes/capabilities/get_capabilities_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/capabilities/get_capabilities_route.ts
@@ -57,7 +57,6 @@ export const getCapabilitiesRoute = (router: IRouter<ElasticAssistantRequestHand
             logger,
           });
           const registeredFeatures = assistantContext.getRegisteredFeatures(pluginName);
-          console.log('registeredFeatures??', registeredFeatures);
           return response.ok({ body: registeredFeatures });
         } catch (err) {
           const error = transformError(err);

--- a/x-pack/plugins/elastic_assistant/server/routes/capabilities/get_capabilities_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/capabilities/get_capabilities_route.ts
@@ -57,7 +57,7 @@ export const getCapabilitiesRoute = (router: IRouter<ElasticAssistantRequestHand
             logger,
           });
           const registeredFeatures = assistantContext.getRegisteredFeatures(pluginName);
-
+          console.log('registeredFeatures??', registeredFeatures);
           return response.ok({ body: registeredFeatures });
         } catch (err) {
           const error = transformError(err);

--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.test.ts
@@ -46,7 +46,6 @@ describe('Post Evaluate Route', () => {
     it('returns a 404 if evaluate feature is not registered', async () => {
       context.elasticAssistant.getRegisteredFeatures.mockReturnValueOnce({
         assistantModelEvaluation: false,
-        assistantStreamingEnabled: false,
       });
 
       const response = await server.inject(

--- a/x-pack/plugins/elastic_assistant/server/services/app_context.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/services/app_context.test.ts
@@ -54,7 +54,6 @@ describe('AppContextService', () => {
       appContextService.start(mockAppContext);
       appContextService.registerFeatures('super', {
         assistantModelEvaluation: true,
-        assistantStreamingEnabled: true,
       });
       appContextService.stop();
 
@@ -104,7 +103,6 @@ describe('AppContextService', () => {
       const pluginName = 'pluginName';
       const features: AssistantFeatures = {
         assistantModelEvaluation: true,
-        assistantStreamingEnabled: true,
       };
 
       appContextService.start(mockAppContext);
@@ -119,12 +117,10 @@ describe('AppContextService', () => {
       const pluginOne = 'plugin1';
       const featuresOne: AssistantFeatures = {
         assistantModelEvaluation: true,
-        assistantStreamingEnabled: false,
       };
       const pluginTwo = 'plugin2';
       const featuresTwo: AssistantFeatures = {
         assistantModelEvaluation: false,
-        assistantStreamingEnabled: true,
       };
 
       appContextService.start(mockAppContext);
@@ -139,11 +135,9 @@ describe('AppContextService', () => {
       const pluginName = 'pluginName';
       const featuresOne: AssistantFeatures = {
         assistantModelEvaluation: true,
-        assistantStreamingEnabled: false,
       };
       const featuresTwo: AssistantFeatures = {
         assistantModelEvaluation: false,
-        assistantStreamingEnabled: true,
       };
 
       appContextService.start(mockAppContext);

--- a/x-pack/plugins/elastic_assistant/server/services/app_context.ts
+++ b/x-pack/plugins/elastic_assistant/server/services/app_context.ts
@@ -102,7 +102,11 @@ class AppContextService {
    * @param pluginName
    */
   public getRegisteredFeatures(pluginName: string): AssistantFeatures {
+    console.log('this.registeredFeatures', this.registeredFeatures);
+    console.log('pluginName', pluginName);
+
     const features = this.registeredFeatures?.get(pluginName) ?? defaultAssistantFeatures;
+    console.log('featuresfeatures', features);
 
     this.logger?.debug('AppContextService:getRegisteredFeatures');
     this.logger?.debug(`pluginName: ${pluginName}`);

--- a/x-pack/plugins/elastic_assistant/server/services/app_context.ts
+++ b/x-pack/plugins/elastic_assistant/server/services/app_context.ts
@@ -102,11 +102,7 @@ class AppContextService {
    * @param pluginName
    */
   public getRegisteredFeatures(pluginName: string): AssistantFeatures {
-    console.log('this.registeredFeatures', this.registeredFeatures);
-    console.log('pluginName', pluginName);
-
     const features = this.registeredFeatures?.get(pluginName) ?? defaultAssistantFeatures;
-    console.log('featuresfeatures', features);
 
     this.logger?.debug('AppContextService:getRegisteredFeatures');
     this.logger?.debug(`pluginName: ${pluginName}`);

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -47,11 +47,6 @@ export const allowedExperimentalValues = Object.freeze({
   extendedRuleExecutionLoggingEnabled: false,
 
   /**
-   * Enables streaming for Security AI Assistant - non-langchain only (knowledge base off)
-   */
-  assistantStreamingEnabled: false,
-
-  /**
    * Enables the SOC trends timerange and stats on D&R page
    */
   socTrendsEnabled: false,

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/ai_assistant/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/ai_assistant/index.ts
@@ -99,5 +99,12 @@ export const assistantSettingToggledEvent: TelemetryEvent = {
         optional: true,
       },
     },
+    assistantStreamingEnabled: {
+      type: 'boolean',
+      _meta: {
+        description: 'Is streaming enabled',
+        optional: true,
+      },
+    },
   },
 };

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/ai_assistant/types.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/ai_assistant/types.ts
@@ -28,6 +28,7 @@ export interface ReportAssistantQuickPromptParams {
 export interface ReportAssistantSettingToggledParams {
   isEnabledKnowledgeBase?: boolean;
   isEnabledRAGAlerts?: boolean;
+  assistantStreamingEnabled?: boolean;
 }
 
 export type ReportAssistantTelemetryEventParams =

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -559,7 +559,6 @@ export class Plugin implements ISecuritySolutionPlugin {
     plugins.elasticAssistant.registerTools(APP_UI_ID, getAssistantTools());
     plugins.elasticAssistant.registerFeatures(APP_UI_ID, {
       assistantModelEvaluation: config.experimentalFeatures.assistantModelEvaluation,
-      assistantStreamingEnabled: config.experimentalFeatures.assistantStreamingEnabled,
     });
 
     if (this.lists && plugins.taskManager && plugins.fleet) {


### PR DESCRIPTION
## Summary

Needs https://github.com/elastic/kibana/pull/174126 to merge first

Move streaming feature flag to assistant settings, and defaults it to true

<img width="792" alt="Screenshot 2024-04-04 at 3 26 12 PM" src="https://github.com/elastic/kibana/assets/6935300/f0c4a94f-9e1f-4ca8-8c1d-f0605c9de03a">

