### PR TITLE
Reenable serverless Discover CSV tests

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -160,8 +160,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // FAILING ES PROMOTION SERVERLESS: https://github.com/elastic/kibana/issues/180010
-    describe.skip('with unmapped fields', () => {
+    describe('with unmapped fields', () => {
       before(async () => {
         await esArchiver.load(archives.unmappedFields.data);
         await kibanaServer.importExport.load(archives.unmappedFields.savedObjects);


### PR DESCRIPTION
## Summary

This PR reenables the serverless Discover CSV tests.

### Details

* The tests were failing for a new serverless ES image due to a change in default shards
* The tests have been actually fixed in #179901
* Due to the way how the ES pipeline picks up Kibana changes for their verification, it took a while for this fix to take effect (actually needed to wait for the next daily scheduled run)
* In the mean time, the test appeared to still be failing, so it was skipped entirely, see #180010
* With the ES serverless promotion now done, the skipped (and already fixed) test suite can be reenabled

Closes #180010