### PR TITLE
[Search] Fix connectors table eye icon for Crawlers

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
@@ -165,10 +165,15 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
           type: 'icon',
         },
         {
-          description: i18n.translate(
-            'xpack.enterpriseSearch.content.connectors.connectorTable.columns.actions.viewIndex',
-            { defaultMessage: 'View this connector' }
-          ),
+          description: isCrawler
+            ? i18n.translate(
+                'xpack.enterpriseSearch.content.connectors.connectorTable.columns.actions.viewCrawler',
+                { defaultMessage: 'View this crawler' }
+              )
+            : i18n.translate(
+                'xpack.enterpriseSearch.content.connectors.connectorTable.columns.actions.viewIndex',
+                { defaultMessage: 'View this connector' }
+              ),
           enabled: (connector) => !!connector.index_name,
           icon: 'eye',
           isPrimary: false,
@@ -183,11 +188,22 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
               }
             ),
           onClick: (connector) => {
-            navigateToUrl(
-              generateEncodedPath(CONNECTOR_DETAIL_PATH, {
-                connectorId: connector.id,
-              })
-            );
+            if (isCrawler) {
+              // crawler always has an index this is to satisfy TS
+              if (connector.index_name) {
+                navigateToUrl(
+                  generateEncodedPath(SEARCH_INDEX_PATH, {
+                    indexName: connector.index_name,
+                  })
+                );
+              }
+            } else {
+              navigateToUrl(
+                generateEncodedPath(CONNECTOR_DETAIL_PATH, {
+                  connectorId: connector.id,
+                })
+              );
+            }
           },
           type: 'icon',
         },


### PR DESCRIPTION
## Summary

Fix connectors table "eye" icon route for crawlers.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->