### PR TITLE
Open panel title edit flyout only when panel title is clicked

### DIFF
--- a/src/plugins/presentation_panel/public/panel_component/panel_header/presentation_panel_title.test.tsx
+++ b/src/plugins/presentation_panel/public/panel_component/panel_header/presentation_panel_title.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { usePresentationPanelTitleClickHandler } from './presentation_panel_title';
+
+describe('usePresentationPanelTitleClickHandler', () => {
+  it('returns null when there is no element to attach listeners to', () => {
+    const { result } = renderHook(usePresentationPanelTitleClickHandler);
+
+    expect(result.current).toBe(null);
+  });
+
+  it('calls the click subscribe handler when the enter button is clicked on the provided element', async () => {
+    const mockedClickHandler = jest.fn();
+
+    const TestComponent = ({ onClickHandler }: { onClickHandler: () => void }) => {
+      const [$elm, setElm] = useState<HTMLElement | null>(null);
+      const onClick$ = usePresentationPanelTitleClickHandler($elm);
+
+      useEffect(() => {
+        const subscription = onClick$?.subscribe(onClickHandler);
+
+        return () => subscription?.unsubscribe();
+      }, [onClick$, onClickHandler]);
+
+      return (
+        <div data-test-subj="syntheticClick" ref={setElm}>
+          Hello World
+        </div>
+      );
+    };
+
+    render(<TestComponent onClickHandler={mockedClickHandler} />);
+
+    fireEvent.keyDown(await screen.findByTestId('syntheticClick'), {
+      key: 'Enter',
+      code: 'Enter',
+      charCode: 13,
+    });
+
+    expect(mockedClickHandler).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/plugins/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -34,8 +34,9 @@ import { openCustomizePanelFlyout } from '../../panel_actions/customize_panel_ac
 const createDocumentMouseMoveListener = once(() => fromEvent<MouseEvent>(document, 'mousemove'));
 const createDocumentMouseUpListener = once(() => fromEvent<MouseEvent>(document, 'mouseup'));
 
-const usePresentationPanelTitleClickHandler = (titleElmRef?: HTMLElement) => {
+export const usePresentationPanelTitleClickHandler = (titleElmRef: HTMLElement | null) => {
   const onClick = useRef<Observable<{ dragged: boolean }> | null>(null);
+  const [initialized, setInitialized] = useState(false);
 
   const mouseup = createDocumentMouseUpListener();
   const mousemove = createDocumentMouseMoveListener();
@@ -68,10 +69,12 @@ const usePresentationPanelTitleClickHandler = (titleElmRef?: HTMLElement) => {
         keydown.pipe(takeWhile((kd) => kd.key === 'Enter')).pipe(map(() => ({ dragged: false }))),
         mousedragExclusiveClick$
       );
+
+      setInitialized(true);
     }
   }, [mousemove, mouseup, titleElmRef]);
 
-  return titleElmRef ? onClick.current : null;
+  return initialized ? onClick.current : null;
 };
 
 export const PresentationPanelTitle = ({

--- a/src/plugins/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
+++ b/src/plugins/presentation_panel/public/panel_component/panel_header/presentation_panel_title.tsx
@@ -38,11 +38,10 @@ export const usePresentationPanelTitleClickHandler = (titleElmRef: HTMLElement |
   const onClick = useRef<Observable<{ dragged: boolean }> | null>(null);
   const [initialized, setInitialized] = useState(false);
 
-  const mouseup = createDocumentMouseUpListener();
-  const mousemove = createDocumentMouseMoveListener();
-
   useEffect(() => {
     if (titleElmRef) {
+      const mouseup = createDocumentMouseUpListener();
+      const mousemove = createDocumentMouseMoveListener();
       const mousedown = fromEvent<MouseEvent>(titleElmRef, 'mousedown');
       const keydown = fromEvent<KeyboardEvent>(titleElmRef, 'keydown');
 
@@ -72,7 +71,7 @@ export const usePresentationPanelTitleClickHandler = (titleElmRef: HTMLElement |
 
       setInitialized(true);
     }
-  }, [mousemove, mouseup, titleElmRef]);
+  }, [titleElmRef]);
 
   return initialized ? onClick.current : null;
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/104224

This PR resolves this issue by listening on the events triggered that typically lead up to a click so that when a panel is dragged with the panel title area being the target for the drag action, the click the hander that triggers the panel title edit is not invoked. This is also combined with listening in on keyboard `keydown` event to cater for interactions that aren't happening with a pointer to provide the illusion of a click.

## Visuals
![ScreenRecording2024-04-05at13 02 25-ezgif com-video-to-gif-converter](https://github.com/elastic/kibana/assets/7893459/7858a173-c842-47ad-af6b-47966c363acf)


<!--  ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->
