### PR TITLE
[Search] Fix crawlers page showing connectors after delete.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_logic.ts
@@ -191,6 +191,10 @@ export const ConnectorsLogic = kea<MakeLogicType<ConnectorsValues, ConnectorsAct
           searchQuery,
           size: meta.page.size,
         }),
+        fetchConnectors: (state, payload) => ({
+          ...state,
+          ...payload,
+        }),
         onPaginate: (state, { newPageIndex }) => ({
           ...state,
           from: (newPageIndex - 1) * state.size,


### PR DESCRIPTION
## Summary

Crawlers page was showing connectors after a successful delete.

Fix Connectors Logic to include last "fetchConnectors" state, therefore next time it is called without a change, it would bring correct results.

Before
https://github.com/elastic/kibana/assets/1410658/87e06d3c-15e1-4b67-817f-49d800a9a6ae

After
https://github.com/elastic/kibana/assets/1410658/bbe380f5-56b4-4da0-b5d7-ad95d5ab63d8


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->