### PR TITLE
fix: [Integrations > Add integration][AXE-CORE]: Scrollable regions must be keyboard accessible

### DIFF
--- a/x-pack/plugins/fleet/public/components/platform_selector.tsx
+++ b/x-pack/plugins/fleet/public/components/platform_selector.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import styled from 'styled-components';
 import {
   EuiText,
   EuiSpacer,
@@ -46,11 +45,6 @@ interface Props {
   fleetServerHost?: string;
   onCopy?: () => void;
 }
-
-// Otherwise the copy button is over the text
-const CommandCode = styled.pre({
-  overflow: 'auto',
-});
 
 export const PlatformSelector: React.FunctionComponent<Props> = ({
   linuxCommand,
@@ -233,8 +227,9 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
               css={`
                 max-width: 1100px;
               `}
+              whiteSpace="pre"
             >
-              <CommandCode>{commandsByPlatform[platform]}</CommandCode>
+              {commandsByPlatform[platform]}
             </EuiCodeBlock>
 
             <EuiSpacer size="s" />


### PR DESCRIPTION
Closes: https://github.com/elastic/security-team/issues/8980

## Description

The [axe browser plugin](https://deque.com/axe) is reporting some scrollable regions are not keyboard accessible. This isn't happening in all integrations, but did happen in the Amazon DynamoDB, so I'll use that as my example. Screenshot below.

### Steps to recreate

1. Create a new Security Serverless project if none exist
2. When the project is ready, open it and go to Integrations, under the Project Settings in the lower left navigation
3. Search for DynamoDB in the Integrations, and click on the card
4. Click "Add Amazon DynamoDB" to load the prompt page
5. Click "Install Elastic Agent"
6. Run an axe check from your dev tools

### What was done?: 

1. Extra `pre` wrapper was removed. 
2. `whiteSpace="pre"` was added to correctly handle `copy button is over the text` case

### Screens: 

![image](https://github.com/elastic/kibana/assets/20072247/7cba726e-9996-447d-89b4-127c0693dfe3)

`Code Block` fully accessible using the keyboard
 

