### PR TITLE
[Canvas] Add access: tag to fns endpoint

### DIFF
--- a/x-pack/plugins/canvas/server/feature.ts
+++ b/x-pack/plugins/canvas/server/feature.ts
@@ -30,6 +30,7 @@ export function getCanvasFeature(plugins: { reporting?: ReportingStart }): Kiban
     privileges: {
       all: {
         app: ['canvas', 'kibana'],
+        api: ['canvasFns'],
         catalogue: ['canvas'],
         savedObject: {
           all: ['canvas-workpad', 'canvas-element'],
@@ -39,6 +40,7 @@ export function getCanvasFeature(plugins: { reporting?: ReportingStart }): Kiban
       },
       read: {
         app: ['canvas', 'kibana'],
+        api: ['canvasFns'],
         catalogue: ['canvas'],
         savedObject: {
           all: [],

--- a/x-pack/plugins/canvas/server/routes/functions/functions.ts
+++ b/x-pack/plugins/canvas/server/routes/functions/functions.ts
@@ -21,7 +21,7 @@ export function initializeGetFunctionsRoute(deps: RouteInitializerDeps) {
     .get({
       path: API_ROUTE_FUNCTIONS,
       access: 'internal',
-      options: { tags: ['access:canvas'] },
+      options: { tags: ['access:canvasFns'] },
     })
     .addVersion({ version: '1', validate: false }, async (context, request, response) => {
       const functions = expressions.getFunctions('canvas');

--- a/x-pack/plugins/canvas/server/routes/functions/functions.ts
+++ b/x-pack/plugins/canvas/server/routes/functions/functions.ts
@@ -21,6 +21,7 @@ export function initializeGetFunctionsRoute(deps: RouteInitializerDeps) {
     .get({
       path: API_ROUTE_FUNCTIONS,
       access: 'internal',
+      options: { tags: ['access:canvas'] },
     })
     .addVersion({ version: '1', validate: false }, async (context, request, response) => {
       const functions = expressions.getFunctions('canvas');


### PR DESCRIPTION
## Summary
This PR locks down the Canvas `/fns` endpoint to the Canvas `read` /  `all` privilege. A user without this privilege will not be able to access the canvas `/fns` endpoint.