### PR TITLE
[BK] Add template for pipeline defs

### DIFF
--- a/.buildkite/pipeline-resource-definitions/_template/template.yml
+++ b/.buildkite/pipeline-resource-definitions/_template/template.yml
@@ -1,0 +1,72 @@
+###
+# For more information on authoring pipeline definitions,
+# follow the guides at https://docs.elastic.dev/ci/getting-started-with-buildkite-at-elastic
+###
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  # This will be the URL slug in Backstage UI as:
+  #  https://backstage.elastic.dev/catalog/default/resource/bk-kibana-your-pipeline-name
+  # bk-pipeline-<pipeline-name-slugified>
+  name: bk-kibana-your-pipeline-name
+  # This will be displayed in the Backstage UI
+  description: '<Describe your pipeline here>'
+  links:
+      # These are relevant links to your pipeline that will be listed in the Backstage UI
+      # The URL slug here is the .spec.implementation.metadata.name field slugified
+    - url: 'https://buildkite.com/elastic/kibana-your-pipeline-name'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  # The owner team's github group name in the format 'group:<github-group-name>'
+  owner: 'group:github-group-name'
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      # <context / pipeline name> - this will be displayed in the Buildkite UI as title
+      #  and this will be slugified to form the URL in the Backstage UI
+      name: kibana / your pipeline name
+      # This will appear as description on the Buildkite UI
+      description: '<Describe your pipeline here>'
+    spec:
+      # Environment variables that will be set for the pipeline
+      env:
+        # Slack channel to send notifications to, if ELASTIC_SLACK_NOTIFICATIONS_ENABLED = 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#team-slack-channel-name'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+
+      allow_rebuilds: false
+      branch_configuration: main
+      default_branch: main
+      repository: elastic/kibana
+      # Point to a pipeline implementation, detailing the pipeline steps to run
+      pipeline_file: .buildkite/pipelines/your-pipeline-name.yml
+      skip_intermediate_builds: false
+      provider_settings:
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: true
+        trigger_mode: none
+      # Teams and their access levels to the pipeline,
+      # please keep [kibana-operations, appex-qa, kibana-tech-leads] as MANAGE_BUILD_AND_READ
+      #         and [everyone] as BUILD_AND_READ
+      teams:
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        appex-qa:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-tech-leads:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+      # Scheduled runs for the pipeline
+      schedules:
+        Daily 6 am UTC:
+          cronline: 0 5 * * *
+          message: Daily 6 am UTC
+          branch: main
+          # Optionally, set schedule-specific env-vars here
+          env:
+            SCHEDULED: 'true'

--- a/.buildkite/pipeline-resource-definitions/fix-location-collection.ts
+++ b/.buildkite/pipeline-resource-definitions/fix-location-collection.ts
@@ -11,7 +11,7 @@ import jsYaml from 'js-yaml';
 import path from 'path';
 import { execSync } from 'child_process';
 
-const EXCLUDE_LIST = ['locations.yml'];
+const EXCLUDE_LIST = ['locations.yml', '_template/template.yml'];
 const REPO_FILES_BASE = 'https://github.com/elastic/kibana/blob/main';
 
 type BackstageLocationResource = object & {

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -220,3 +220,6 @@ spec:
           access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+# Please avoid creating new kibana pipelines in this file to avoid bloating.
+# Instead, create a new file in the pipeline-resource-definitions directory, and wire it in through the locations.yml file.


### PR DESCRIPTION
## Summary
This is to aid new pipeline creation by example.

# How to create a pipeline in the new system
The following section will highlight the main steps for setting up a new Buildkite pipeline in Kibana, using the backstage-based RRE definitions - this is according to the to-be state of the migration, so we only encourage following this way of creating new pipelines from now on.

The following steps can be done in a single pull request, but the step-by-step guide aims to explain the parts that go together.

## Create a pipeline definition ([example](https://github.com/elastic/kibana/blob/78cc5fdb8230aed561b22fcadda2f182f4dbba1f/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml))
In this step, you need to author a file that will be the basis for the Buildkite pipeline. You can either copy and adjust a template from `.buildkite/pipeline-resource-definitions/_template/template.yml` or create a new file and follow the guides around buildkite from https://docs.elastic.dev/ci/getting-started-with-buildkite-at-elastic.

Place your pipeline definition to `.buildkite/pipeline-resource-definitions/`, then add the created file’s path to `.buildkite/pipeline-resource-definitions/locations.yml` so that Backstage can locate the new resource.

When the PR is merged, Backstage will find this file, and soon the corresponding pipeline will appear in Buildkite, containing a single step: upload your pipeline implementation or run the script that should output the pipeline steps to stdout.


## Create a pipeline implementation ([example](https://github.com/elastic/kibana/blob/78cc5fdb8230aed561b22fcadda2f182f4dbba1f/.buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml))
When you create your pipeline definition, you will need to point to an implementation file, with the `pipeline_file` field. If this is a `.yml` file, it will be uploaded to buildkite as is. If it’s a runnable file, it will be ran, and it should output the pipeline steps that should be uploaded. The latter is a form of dynamically generating pipeline steps based on run conditions, while the former is the simpler way of creating a pipeline.

Place your pipeline implementation in `.buildkite/pipelines/` adding context with the folder structure.

Create your implementation with the new system in mind: there are no longer agent queues, so you need to request agents with a detailed request in the `agents` field, defined either globally at the top of the file, or per-step.

Usecases that want to make use of the kibana context (by running kibana scripts or the buildkite utilities), usually need a similar agent targeting rule:
```yaml
  agents:
   image: family/kibana-ubuntu-2004
   imageProject: elastic-images-qa
   provider: gcp
   machineType: n2-standard-2
```

Omitting the agent targeting will result in the standard k8s executor, bare and simple - it’s faster and cheaper if your command doesn’t require kibana’s context (e.g.: triggering other jobs, or uploading other files).

*All Buildkite-related information you find here: https://docs.elastic.dev/ci/user-guide applies.*

## Implement behavior ([example](https://github.com/elastic/kibana/tree/78cc5fdb8230aed561b22fcadda2f182f4dbba1f/.buildkite/scripts/serverless/create_deploy_tag))
Design your steps for the pipeline following the documentation for Buildkite (https://buildkite.com/docs/pipelines/defining-steps). 
Invoke bash or javascript code from your steps, implement your code in a fashion that fits your case the best, but keep an eye out for maintainability and debuggability - so it’s good practise to have your scripts work locally as CLIs, with `DRY_RUN` functionality enabled.

## Merge & verify behaviour
When you’re ready, set your PR up, and merge. A few minutes after merge, your resources should start appearing: first on [Backstage](https://backstage.elastic.dev/), then on [Buildkite](https://buildkite.com/elastic/).
Verify-adjust-iterate, your updates should be synchronized in the same fashion.