### PR TITLE
[Build] Skip FIPS build for artifact pipelines

### DIFF
--- a/.buildkite/scripts/steps/artifacts/build.sh
+++ b/.buildkite/scripts/steps/artifacts/build.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 source .buildkite/scripts/steps/artifacts/env.sh
 
 echo "--- Build Kibana artifacts"
-node scripts/build --all-platforms --debug --docker-cross-compile "${BUILD_ARGS[@]}"
+node scripts/build --all-platforms --debug --docker-cross-compile --skip-docker-fips "${BUILD_ARGS[@]}"
 
 echo "--- Extract default i18n messages"
 mkdir -p target/i18n


### PR DESCRIPTION
## Summary

These pipelines are building the FIPS artifacts which is not necessary currently (see the artifacts tab in BK):

[kibana / artifacts snapshot](https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4149#018eadeb-98e0-42ea-a520-001b40bffbda)
[kibana / artifacts staging](https://buildkite.com/elastic/kibana-artifacts-staging/builds/3001#018eaf00-04b2-410f-9ae8-3a19beddce4b)