### PR TITLE
[Search] [Playground] Switch off condensing question flow for first question

### DIFF
--- a/x-pack/plugins/search_playground/server/routes.test.ts
+++ b/x-pack/plugins/search_playground/server/routes.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createRetriever } from './routes';
+
+describe('createRetriever', () => {
+  test('works when the question has quotes', () => {
+    const esQuery = '{"query": {"match": {"text": "{query}"}}}';
+    const question = 'How can I "do something" with quotes?';
+
+    const retriever = createRetriever(esQuery);
+    const result = retriever(question);
+
+    expect(result).toEqual({ match: { text: 'How can I "do something" with quotes?' } });
+  });
+});

--- a/x-pack/plugins/search_playground/server/utils/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/utils/conversational_chain.test.ts
@@ -174,7 +174,7 @@ describe('conversational chain', () => {
     );
   });
 
-  fit('should cope with quotes in the query', async () => {
+  it('should cope with quotes in the query', async () => {
     await createTestChain(
       ['rewrite "the" question', 'the final answer'],
       [

--- a/x-pack/plugins/search_playground/server/utils/conversational_chain.ts
+++ b/x-pack/plugins/search_playground/server/utils/conversational_chain.ts
@@ -75,7 +75,7 @@ class ConversationalChainFn {
     const question = messages[messages.length - 1]!.content;
     const retrievedDocs: Document[] = [];
 
-    let retrievalChain: Runnable = RunnableLambda.from((input) => '');
+    let retrievalChain: Runnable = RunnableLambda.from(() => '');
 
     if (this.options.rag) {
       const retriever = new ElasticsearchRetriever({
@@ -107,11 +107,15 @@ class ConversationalChainFn {
       retrievalChain = retriever.pipe(buildContext);
     }
 
-    const standaloneQuestionChain = RunnableSequence.from([
-      condenseQuestionPrompt,
-      this.options.model,
-      new StringOutputParser(),
-    ]);
+    let standaloneQuestionChain: Runnable = RunnableLambda.from((input) => input.question);
+
+    if (previousMessages.length > 0) {
+      standaloneQuestionChain = RunnableSequence.from([
+        condenseQuestionPrompt,
+        this.options.model,
+        new StringOutputParser(),
+      ]);
+    }
 
     const prompt = ChatPromptTemplate.fromTemplate(this.options.prompt);
 


### PR DESCRIPTION
Two changes where:
- condensing question LLM flow is rewriting the question with quotes and breaking the parsing. This escapes quotes.
- skipping the condensing question function when theres no chat history