### PR TITLE
add data view refs to dever data view field

### DIFF
--- a/src/plugins/data_views/common/data_views/data_view_lazy.ts
+++ b/src/plugins/data_views/common/data_views/data_view_lazy.ts
@@ -131,13 +131,16 @@ export class DataViewLazy extends AbstractDataView {
           return col;
         }
         if (!cachedField) {
-          cachedField = new DataViewField({
-            ...field,
-            count: this.fieldAttrs?.[field.name]?.count,
-            customLabel: this.fieldAttrs?.[field.name]?.customLabel,
-            customDescription: this.fieldAttrs?.[field.name]?.customDescription,
-            shortDotsEnable: this.shortDotsEnable,
-          });
+          cachedField = new DataViewField(
+            {
+              ...field,
+              count: this.fieldAttrs?.[field.name]?.count,
+              customLabel: this.fieldAttrs?.[field.name]?.customLabel,
+              customDescription: this.fieldAttrs?.[field.name]?.customDescription,
+              shortDotsEnable: this.shortDotsEnable,
+            },
+            this
+          );
           this.fieldCache.set(field.name, cachedField);
         }
         col[field.name] = cachedField;
@@ -296,17 +299,20 @@ export class DataViewLazy extends AbstractDataView {
       fld.spec.type = castEsToKbnFieldTypeName(fieldType);
       fld.spec.esTypes = [fieldType];
     } else {
-      fld = new DataViewField({
-        name: fieldName,
-        runtimeField: runtimeFieldSpec,
-        type: castEsToKbnFieldTypeName(fieldType),
-        esTypes: [fieldType],
-        aggregatable: true,
-        searchable: true,
-        count: config.popularity ?? 0,
-        readFromDocValues: false,
-        shortDotsEnable: this.shortDotsEnable,
-      });
+      fld = new DataViewField(
+        {
+          name: fieldName,
+          runtimeField: runtimeFieldSpec,
+          type: castEsToKbnFieldTypeName(fieldType),
+          esTypes: [fieldType],
+          aggregatable: true,
+          searchable: true,
+          count: config.popularity ?? 0,
+          readFromDocValues: false,
+          shortDotsEnable: this.shortDotsEnable,
+        },
+        this
+      );
       this.fieldCache.set(fieldName, fld);
     }
 
@@ -388,15 +394,18 @@ export class DataViewLazy extends AbstractDataView {
       if (fld && !fld.scripted && fld.isMapped) {
         this.fieldCache.delete(field.name);
       }
-      fld = new DataViewField({
-        ...field,
-        scripted: true,
-        searchable: false,
-        aggregatable: false,
-        count: this.fieldAttrs?.[field.name]?.count,
-        customLabel: this.fieldAttrs?.[field.name]?.customLabel,
-        customDescription: this.fieldAttrs?.[field.name]?.customDescription,
-      });
+      fld = new DataViewField(
+        {
+          ...field,
+          scripted: true,
+          searchable: false,
+          aggregatable: false,
+          count: this.fieldAttrs?.[field.name]?.count,
+          customLabel: this.fieldAttrs?.[field.name]?.customLabel,
+          customDescription: this.fieldAttrs?.[field.name]?.customDescription,
+        },
+        this
+      );
       this.fieldCache.set(field.name, fld);
       dataViewFields[field.name] = fld;
     });
@@ -434,13 +443,16 @@ export class DataViewLazy extends AbstractDataView {
         fld.spec.runtimeField = undefined; // unset if it was a runtime field but now mapped
         fld.spec.isMapped = true;
       } else {
-        fld = new DataViewField({
-          ...field,
-          count: this.fieldAttrs?.[field.name]?.count,
-          customLabel: this.fieldAttrs?.[field.name]?.customLabel,
-          customDescription: this.fieldAttrs?.[field.name]?.customDescription,
-          shortDotsEnable: this.shortDotsEnable,
-        });
+        fld = new DataViewField(
+          {
+            ...field,
+            count: this.fieldAttrs?.[field.name]?.count,
+            customLabel: this.fieldAttrs?.[field.name]?.customLabel,
+            customDescription: this.fieldAttrs?.[field.name]?.customDescription,
+            shortDotsEnable: this.shortDotsEnable,
+          },
+          this
+        );
         this.fieldCache.set(field.name, fld);
       }
       dataViewFields[field.name] = fld;

--- a/src/plugins/data_views/common/fields/data_view_field.test.ts
+++ b/src/plugins/data_views/common/fields/data_view_field.test.ts
@@ -12,13 +12,15 @@ import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { FieldSpec, RuntimeField } from '../types';
 import { FieldFormat } from '@kbn/field-formats-plugin/common';
 
+const fakeDataView = {} as DataView;
+
 describe('Field', function () {
   function flatten(obj: Record<string, any>) {
     return JSON.parse(JSON.stringify(obj));
   }
 
   function getField(values = {}) {
-    return new DataViewField({ ...fieldValues, ...values });
+    return new DataViewField({ ...fieldValues, ...values }, fakeDataView);
   }
 
   const fieldValues = {
@@ -146,12 +148,12 @@ describe('Field', function () {
   });
 
   it('exports the property to JSON', () => {
-    const field = new DataViewField(fieldValues);
+    const field = new DataViewField(fieldValues, fakeDataView);
     expect(flatten(field)).toMatchSnapshot();
   });
 
   it('spec snapshot', () => {
-    const field = new DataViewField(fieldValues);
+    const field = new DataViewField(fieldValues, fakeDataView);
     const getFormatterForField = () =>
       ({
         toJSON: () => ({

--- a/src/plugins/data_views/common/fields/data_view_field.ts
+++ b/src/plugins/data_views/common/fields/data_view_field.ts
@@ -10,6 +10,7 @@ import { KbnFieldType, getKbnFieldType } from '@kbn/field-types';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
 import { DataViewFieldBase } from '@kbn/es-query';
 import type { RuntimeFieldSpec } from '../types';
+import type { AbstractDataView } from '../data_views/abstract_data_views';
 import { FieldSpec, DataView } from '..';
 import {
   shortenDottedString,
@@ -36,6 +37,7 @@ export interface ToSpecConfig {
  */
 export class DataViewField implements DataViewFieldBase {
   readonly spec: FieldSpec;
+  private readonly dataView: AbstractDataView;
   // not writable or serialized
   /**
    * Kbn field type, used mainly for formattering.
@@ -47,10 +49,11 @@ export class DataViewField implements DataViewFieldBase {
    * @constructor
    * @param spec Configuration for the field
    */
-  constructor(spec: FieldSpec) {
+  constructor(spec: FieldSpec, dataView: AbstractDataView) {
     this.spec = { ...spec, type: spec.name === '_source' ? '_source' : spec.type };
 
     this.kbnFieldType = getKbnFieldType(spec.type);
+    this.dataView = dataView;
   }
 
   // writable attrs

--- a/src/plugins/data_views/common/fields/field_list.ts
+++ b/src/plugins/data_views/common/fields/field_list.ts
@@ -75,7 +75,8 @@ export interface IIndexPatternFieldList extends Array<DataViewField> {
 // To be removed in the future
 export const fieldList = (
   specs: FieldSpec[] = [],
-  shortDotsEnable = false
+  shortDotsEnable = false,
+  dataView: DataView
 ): IIndexPatternFieldList => {
   class FldList extends Array<DataViewField> implements IIndexPatternFieldList {
     private byName: FieldMap = new Map();
@@ -101,7 +102,7 @@ export const fieldList = (
       ...(this.groups.get(type) || new Map()).values(),
     ];
     public readonly add = (field: FieldSpec): DataViewField => {
-      const newField = new DataViewField({ ...field, shortDotsEnable });
+      const newField = new DataViewField({ ...field, shortDotsEnable }, dataView);
       this.push(newField);
       this.setByName(newField);
       this.setByGroup(newField);
@@ -117,7 +118,7 @@ export const fieldList = (
     };
 
     public readonly update = (field: FieldSpec) => {
-      const newField = new DataViewField(field);
+      const newField = new DataViewField(field, dataView);
       const index = this.findIndex((f) => f.name === newField.name);
       this.splice(index, 1, newField);
       this.setByName(newField);


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
