### PR TITLE
[Tests] skip failing response-too-large test

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1348,7 +1348,9 @@ export const runActionTestSuite = ({
       );
     });
 
-    it('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
+    // consistently breaking in CI:
+    // https://github.com/elastic/kibana/issues/167288
+    it.skip('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
       const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
       const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
 


### PR DESCRIPTION
## Summary
cc: @elastic/kibana-core 

skip response-too-large test (https://github.com/elastic/kibana/issues/167288)
