### PR TITLE
[DOCS] Adds the 7.17.20 release note

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ Review important information about the {kib} 7.17.x releases.
 // Best practices:
 // * When there are changes to kibana.yml settings, include the links to the new settings.
 
+* <<release-notes-7.17.20>>
 * <<release-notes-7.17.19>>
 * <<release-notes-7.17.18>>
 * <<release-notes-7.17.17>>
@@ -89,6 +90,14 @@ Review important information about the {kib} 7.17.x releases.
 //* <<release-notes-7.0.0-alpha1>>
 
 --
+[[release-notes-7.17.20]]
+== {kib} 7.17.20
+
+[float]
+[[fixes-v7.17.20]]
+=== Bug fixes and enhancements
+There are no user-facing changes in the 7.17.20 release.
+
 [[release-notes-7.17.19]]
 == {kib} 7.17.19
 


### PR DESCRIPTION
Adds the 7.17.20 release note which just states there are no user-facing changes in this release. 
![Screenshot 2024-04-08 at 12 10 10](https://github.com/elastic/kibana/assets/61687663/a28d5de1-0aab-45cc-9173-c8862f61e322)
