### PR TITLE
[Security Solution] Allows to execute Cypress tests using projects with overridden images

### DIFF
--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
@@ -100,7 +100,8 @@ const getApiKeyFromElasticCloudJsonFile = (): string | undefined => {
 async function createSecurityProject(
   projectName: string,
   apiKey: string,
-  productTypes: ProductType[]
+  productTypes: ProductType[],
+  commit: string
 ): Promise<Project | undefined> {
   const body: CreateProjectRequestBody = {
     name: projectName,
@@ -110,10 +111,12 @@ async function createSecurityProject(
 
   log.info(`Kibana override flag equals to ${process.env.KIBANA_MKI_USE_LATEST_COMMIT}!`);
   if (
-    process.env.KIBANA_MKI_USE_LATEST_COMMIT &&
-    process.env.KIBANA_MKI_USE_LATEST_COMMIT === '1'
+    (process.env.KIBANA_MKI_USE_LATEST_COMMIT &&
+      process.env.KIBANA_MKI_USE_LATEST_COMMIT === '1') ||
+    commit
   ) {
-    const kibanaOverrideImage = `${process.env.BUILDKITE_COMMIT?.substring(0, 12)}`;
+    const override = commit ? commit : process.env.BUILDKITE_COMMIT;
+    const kibanaOverrideImage = `${override?.substring(0, 12)}`;
     log.info(
       `Overriding Kibana image in the MKI with docker.elastic.co/kibana-ci/kibana-serverless:sec-sol-qg-${kibanaOverrideImage}`
     );
@@ -446,6 +449,11 @@ export const cli = () => {
           alias: 'ca',
           type: 'boolean',
           default: true,
+        })
+        .option('commit', {
+          alias: 'c',
+          type: 'string',
+          default: '',
         });
 
       log.info(`
@@ -466,6 +474,7 @@ ${JSON.stringify(argv, null, 2)}
       const tier: string = argv.tier;
       const endpointAddon: boolean = argv.endpointAddon;
       const cloudAddon: boolean = argv.cloudAddon;
+      const commit: string = argv.commit;
 
       log.info(`
 ----------------------------------------------
@@ -551,7 +560,12 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
 
               log.info(`${id}: Creating project ${PROJECT_NAME}...`);
               // Creating project for the test to run
-              const project = await createSecurityProject(PROJECT_NAME, API_KEY, productTypes);
+              const project = await createSecurityProject(
+                PROJECT_NAME,
+                API_KEY,
+                productTypes,
+                commit
+              );
 
               if (!project) {
                 log.info('Failed to create project.');

--- a/x-pack/test/security_solution_cypress/cypress/README.md
+++ b/x-pack/test/security_solution_cypress/cypress/README.md
@@ -303,7 +303,10 @@ For test developing or test debugging purposes, you need to modify the configura
 
 ### Running serverless tests locally pointing to a MKI project created in QA environment (Second Quality Gate)
 
-Run the tests with the following yarn scripts from `x-pack/test/security_solution_cypress`:
+Note that when using any of the below scripts, the tests are going to be executed through an MKI project with the version that is currently available in QA. If you need to use
+a specific commit (i.e. debugging a failing tests on the periodic pipeline), check the section: `Running serverless tests locally pointing to a MKI project created in QA environment with an overridden image`.
+
+Run the tests with the following yarn scripts from `x-pack/test/security_solution_cypress`: 
 
 | Script Name | Description |
 | ----------- | ----------- |
@@ -312,9 +315,9 @@ Run the tests with the following yarn scripts from `x-pack/test/security_solutio
 | cypress:run:qa:serverless:explore | Runs all tests tagged as SERVERLESS in the `e2e/explore` directory in headless mode using the QA environment and real MKI prorjects. |
 | cypress:run:qa:serverless:investigations | Runs all tests tagged as SERVERLESS in the `e2e/investigations` directory in headless mode using the QA environment and reak MKI projects. |
 | cypress:run:qa:serverless:rule_management | Runs all tests tagged as SERVERLESS in the `e2e/detection_response/rule_management` directory, excluding `e2e/detection_response/rule_management/prebuilt_rules` in headless mode using the QA environment and reak MKI projects. |
-| cypress:run:qa:serverless:rule_management:prebuilt_rules | Runs all tests tagged as SERVERLESS in the `e2e/detection_response/rule_management/prebuilt_rules` directory in headless mode using the QA environment and reak MKI projects. |
+| cypress:run:qa:serverless:rule_management:prebuilt_rules | Runs all tests tagged as SERVERLESS in the `e2e/detection_response/rule_management/prebuilt_rules` directory in headless mode using the QA environment and real MKI projects. |
 | cypress:run:qa:serverless:detection_engine | Runs all tests tagged as SERVERLESS in the `e2e/detection_response/detection_engine` directory, excluding `e2e/detection_response/detection_engine/exceptions` in headless mode using the QA environment and reak MKI projects. |
-| cypress:run:qa:serverless:detection_engine:prebuilt_rules | Runs all tests tagged as SERVERLESS in the `e2e/detection_response/detection_engine/exceptions` directory in headless mode using the QA environment and reak MKI projects. |
+| cypress:run:qa:serverless:detection_engine:prebuilt_rules | Runs all tests tagged as SERVERLESS in the `e2e/detection_response/detection_engine/exceptions` directory in headless mode using the QA environment and real MKI projects. |
 | cypress:run:qa:serverless:ai_assistant | Runs all tests tagged as SERVERLESS in the `e2e/ai_assistant` directory in headless mode using the QA environment and reak MKI projects. |
 
 
@@ -354,6 +357,17 @@ Store the email and password of the account you used to login in the QA Environm
   }
 }
 ```
+
+### Running serverless tests locally pointing to a MKI project created in QA environment with an overridden image
+
+In order to execute Cypress using a project wih an overridden image, you need to first make sure that the image is created (if you need to debug a failing test of the periodic pipeline, the image is already created you just need to check the commit that was used).
+
+You need to have everything setup as mentioned above in `Setup required`. Once the setup is ready you just need to execute Cypress with the following option:
+
+```
+yarn cypress:open:qa:serverless --commit <commitHash>
+```
+
 
 #### Testing with different roles 
 

--- a/x-pack/test/security_solution_cypress/cypress/README.md
+++ b/x-pack/test/security_solution_cypress/cypress/README.md
@@ -362,6 +362,8 @@ Store the email and password of the account you used to login in the QA Environm
 
 In order to execute Cypress using a project wih an overridden image, you need to first make sure that the image is created (if you need to debug a failing test of the periodic pipeline, the image is already created you just need to check the commit that was used).
 
+In order to check for the existance of an image check: https://container-library.elastic.co/r/kibana-ci, if the image with the commit you want to use does not exist **DON'T USE THE COMMIT FLAG SINCE YOU MAY CAUSE A MAJOR ISSUE IN CONTROL PLANE**.
+
 You need to have everything setup as mentioned above in `Setup required`. Once the setup is ready you just need to execute Cypress with the following option:
 
 ```

--- a/x-pack/test/security_solution_cypress/cypress/README.md
+++ b/x-pack/test/security_solution_cypress/cypress/README.md
@@ -362,7 +362,7 @@ Store the email and password of the account you used to login in the QA Environm
 
 In order to execute Cypress using a project wih an overridden image, you need to first make sure that the image is created (if you need to debug a failing test of the periodic pipeline, the image is already created you just need to check the commit that was used).
 
-In order to check for the existance of an image check: https://container-library.elastic.co/r/kibana-ci, if the image with the commit you want to use does not exist **DON'T USE THE COMMIT FLAG SINCE YOU MAY CAUSE A MAJOR ISSUE IN CONTROL PLANE**.
+In order to check for the existance of an image check: https://container-library.elastic.co/r/kibana-ci, if the image with the commit you want to use does not exist **DON'T USE THE COMMIT FLAG SINCE YOU MAY CAUSE A MAJOR ISSUE IN CONTROL PLANE > CAUSE A BULK OF ALERTS IN CONTROL PLANE** and the project will not be functional.
 
 You need to have everything setup as mentioned above in `Setup required`. Once the setup is ready you just need to execute Cypress with the following option:
 


### PR DESCRIPTION
## Summary

To make sure that our Cypress tests are working fine on MKI environments we are executing them in our periodic pipeline. 
When the pipeline is triggered, we built a new image of the latest commit available in main, we create a project in QA overriding the image and we execute our Cypress tests using that created project.

Currently our  `yarn cypress:open:qa:serverless` script, creates a project in QA using the last available version, so, if there is a test failing in the periodic pipeline, currently there is no easy way to execute it in our locals.

To facilitate this work, this PR we are introducing the `commit` option. 


## How to test it
Setup a valid Elastic Cloud API key for QA environment:
1. Navigate to QA environment.
2. Click on the `User menu button` located on the top right of the header.
3. Click on `Organization`.
4. Click on the `API keys` tab.
5. Click on `Create API key` button.
6. Add a name, set an expiration date, assign an organization owner role.
7. Click on `Create API key`
8. Save the value of the key
Store the saved key on `~/.elastic/cloud.json` using the following format:

```json
{
  "api_key": {
    "qa": "<API_KEY>"
  }
}
```

Store the email and password of the account you used to login in the QA Environment at the root directory of your Kibana project on `.ftr/role_users.json`, using the following format:

```json
{
  "admin": {
    "email": "<email>",
    "password": "<password>"
  }
}
```

From the `x-pack/test/security_solution_cypress` you can execute the following command making sure that the commit you want to use has an available image already.

In order to check for the existance of an image check: https://container-library.elastic.co/r/kibana-ci, if the image with the commit you want to use does not exist **DON'T USE THE COMMIT FLAG SINCE YOU MAY CAUSE A MAJOR ISSUE IN CONTROL PLANE > CAUSE A BULK OF ALERTS IN CONTROL PLANE** and the project will not be functional.

```cli
yarn cypress:open:qa:serverless --commit <commitHash>
```

