### PR TITLE
[SLO][POC] Improving Severity Burn Rate Rule

### DIFF
--- a/packages/kbn-alerts-as-data-utils/src/schemas/generated/observability_slo_schema.ts
+++ b/packages/kbn-alerts-as-data-utils/src/schemas/generated/observability_slo_schema.ts
@@ -84,6 +84,7 @@ const ObservabilitySloAlertOptional = rt.partial({
   'slo.id': schemaString,
   'slo.instanceId': schemaString,
   'slo.revision': schemaStringOrNumber,
+  'slo.serverityHistory': schemaUnknownArray,
 });
 
 // prettier-ignore

--- a/x-pack/packages/kbn-data-forge/example_config/fake_stack.yaml
+++ b/x-pack/packages/kbn-data-forge/example_config/fake_stack.yaml
@@ -4,36 +4,27 @@ elasticsearch:
 
 kibana:
   installAssets: true
+  host: "http://localhost:5601/kibana"
 
 indexing:
   dataset: "fake_stack"
-  eventsPerCycle: 200
+  eventsPerCycle: 50
   reduceWeekendTrafficBy: 0.5
 
 schedule:
   # Start with good events
   - template: "good"
-    start: "now-14d"
-    end: "now-6d-5h-3m"
-    eventsPerCycle: 200
-    randomness: 0.2
-  - template: "connectionTimeout"
-    start: "now-6d-5h-3m"
-    end: "now-6d-4h-44m"
-    eventsPerCycle: 200
-    randomness: 0.2
-  - template: "good"
-    start: "now-6d-4h-44m"
-    end: "now-1d"
-    eventsPerCycle: 200
-    randomness: 0.2
+    start: "now-72h"
+    end: "now-120m"
+    eventsPerCycle: 50
+    randomness: 0.8
   - template: "bad"
-    start: "now-1d"
-    end: "now-1d+45m"
-    eventsPerCycle: 200
-    randomness: 0.2
+    start: "now-120m"
+    end: "now-105m"
+    eventsPerCycle: 50
+    randomness: 0.8
   - template: "good"
-    start: "now-1d+45m"
+    start: "now-105m"
     end: false
-    eventsPerCycle: 200
-    randomness: 0.2
+    eventsPerCycle: 50
+    randomness: 0.8

--- a/x-pack/plugins/observability_solution/slo/common/constants.ts
+++ b/x-pack/plugins/observability_solution/slo/common/constants.ts
@@ -49,6 +49,14 @@ export const SUPPRESSED_PRIORITY_ACTION = {
   }),
 };
 
+export const IMPROVING_PRIORITY_ACTION_ID = 'slo.burnRate.improving';
+export const IMPROVING_PRIORITY_ACTION = {
+  id: IMPROVING_PRIORITY_ACTION_ID,
+  name: i18n.translate('xpack.slo.alerting.burnRate.improvingPriorityAction', {
+    defaultMessage: 'Improving',
+  }),
+};
+
 export const SLO_MODEL_VERSION = 2;
 export const SLO_RESOURCES_VERSION = 3.2;
 export const SLO_RESOURCES_VERSION_MAJOR = 3;

--- a/x-pack/plugins/observability_solution/slo/common/field_names/slo.ts
+++ b/x-pack/plugins/observability_solution/slo/common/field_names/slo.ts
@@ -8,5 +8,11 @@
 export const SLO_ID_FIELD = 'slo.id';
 export const SLO_REVISION_FIELD = 'slo.revision';
 export const SLO_INSTANCE_ID_FIELD = 'slo.instanceId';
+export const SLO_SERVERITY_HISTORY_FIELD = 'slo.serverityHistory';
 
-export const SLO_BURN_RATE_AAD_FIELDS = [SLO_ID_FIELD, SLO_REVISION_FIELD, SLO_INSTANCE_ID_FIELD];
+export const SLO_BURN_RATE_AAD_FIELDS = [
+  SLO_ID_FIELD,
+  SLO_REVISION_FIELD,
+  SLO_INSTANCE_ID_FIELD,
+  SLO_SERVERITY_HISTORY_FIELD,
+];

--- a/x-pack/plugins/observability_solution/slo/common/types.ts
+++ b/x-pack/plugins/observability_solution/slo/common/types.ts
@@ -14,3 +14,15 @@ export const DependencyRT = t.type({
 export const DependenciesRT = t.array(DependencyRT);
 
 export type Dependency = t.OutputOf<typeof DependencyRT>;
+
+export interface InstanceHistoryRecord {
+  actionGroup: string;
+  improvingFrom?: string;
+  suppressed?: boolean;
+  timerange: { from: number; to?: number };
+}
+
+export interface InstanceHistory {
+  instanceId: string;
+  history: InstanceHistoryRecord[];
+}

--- a/x-pack/plugins/observability_solution/slo/public/components/slo/burn_rate/alert_details/alert_details_app_section.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/components/slo/burn_rate/alert_details/alert_details_app_section.tsx
@@ -75,8 +75,8 @@ export default function AlertDetailsAppSection({
   return (
     <EuiFlexGroup direction="column" data-test-subj="overviewSection">
       <ErrorRatePanel alert={alert} slo={slo} isLoading={isLoading} />
-      <CustomAlertDetailsPanel alert={alert} slo={slo} rule={rule} />
       <SeverityHistory alert={alert} slo={slo} isLoading={isLoading} />
+      <CustomAlertDetailsPanel alert={alert} slo={slo} rule={rule} />
       <AlertsHistoryPanel alert={alert} rule={rule} slo={slo} isLoading={isLoading} />
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/observability_solution/slo/public/components/slo/burn_rate/alert_details/alert_details_app_section.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/components/slo/burn_rate/alert_details/alert_details_app_section.tsx
@@ -10,15 +10,17 @@ import { Rule } from '@kbn/alerting-plugin/common';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect } from 'react';
 import { AlertSummaryField, TopAlert } from '@kbn/observability-plugin/public';
+import { ObservabilitySloAlert } from '@kbn/alerts-as-data-utils';
 import { useKibana } from '../../../../utils/kibana_react';
 import { useFetchSloDetails } from '../../../../hooks/use_fetch_slo_details';
 import { BurnRateRuleParams } from '../../../../typings/slo';
 import { AlertsHistoryPanel } from './components/alerts_history/alerts_history_panel';
 import { ErrorRatePanel } from './components/error_rate/error_rate_panel';
 import { CustomAlertDetailsPanel } from './components/custom_panels/custom_panels';
+import { SeverityHistory } from './components/severity_history/severity_history';
 
 export type BurnRateRule = Rule<BurnRateRuleParams>;
-export type BurnRateAlert = TopAlert;
+export type BurnRateAlert = TopAlert<ObservabilitySloAlert>;
 
 interface AppSectionProps {
   alert: BurnRateAlert;
@@ -74,6 +76,7 @@ export default function AlertDetailsAppSection({
     <EuiFlexGroup direction="column" data-test-subj="overviewSection">
       <ErrorRatePanel alert={alert} slo={slo} isLoading={isLoading} />
       <CustomAlertDetailsPanel alert={alert} slo={slo} rule={rule} />
+      <SeverityHistory alert={alert} slo={slo} isLoading={isLoading} />
       <AlertsHistoryPanel alert={alert} rule={rule} slo={slo} isLoading={isLoading} />
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/observability_solution/slo/public/components/slo/burn_rate/alert_details/components/severity_history/severity_history.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/components/slo/burn_rate/alert_details/components/severity_history/severity_history.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback } from 'react';
+import { GetSLOResponse } from '@kbn/slo-schema';
+import { css, keyframes } from '@emotion/react';
+import {
+  EuiBadge,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+  useEuiBackgroundColorCSS,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import moment from 'moment';
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { BurnRateAlert } from '../../alert_details_app_section';
+import { InstanceHistoryRecord } from '../../../../../../../common/types';
+import {
+  ALERT_ACTION,
+  HIGH_PRIORITY_ACTION,
+  LOW_PRIORITY_ACTION,
+  MEDIUM_PRIORITY_ACTION,
+} from '../../../../../../../common/constants';
+
+interface SeverityHistoryProps {
+  alert: BurnRateAlert;
+  slo?: GetSLOResponse;
+  isLoading: boolean;
+}
+
+interface HistoryItem {
+  severity: string;
+  startedAt: Date;
+  endedAt: Date | null;
+  status: string;
+  durationInMs: number;
+}
+
+export function SeverityHistory({ alert, slo, isLoading }: SeverityHistoryProps) {
+  const dateFormat = useUiSetting<string>('dateFormat');
+  const colorStyles = useEuiBackgroundColorCSS();
+
+  const getRowProps = useCallback(
+    (item: HistoryItem) => {
+      if (!item.endedAt && alert.active) {
+        const pulse = keyframes`
+        0%, 100% {
+          background-color: #fff;
+        }
+        50% {
+         ${colorStyles.danger};
+        }
+      `;
+        return {
+          css: css`
+            animation: ${pulse} 2s infinite;
+          `,
+        };
+      }
+
+      return {};
+    },
+    [alert, colorStyles]
+  );
+
+  const cellRenderForStartedAt = useCallback(
+    (startedAt: Date) => moment(startedAt).format(dateFormat),
+    [dateFormat]
+  );
+
+  const cellRenderForEndedAt = useCallback(
+    (endedAt: Date | null) => {
+      if (endedAt == null && !alert.active) {
+        return moment(alert.lastUpdated).format(dateFormat);
+      }
+      if (endedAt == null) {
+        return (
+          <EuiBadge color="danger">
+            {i18n.translate('xpack.slo.burnRateRule.alertDetails.activeBadgeLabel', {
+              defaultMessage: 'Active',
+            })}
+          </EuiBadge>
+        );
+      }
+      return moment(endedAt).format(dateFormat);
+    },
+    [alert, dateFormat]
+  );
+
+  if (isLoading) {
+    return null;
+  }
+  if (!slo) {
+    return null;
+  }
+
+  const history: InstanceHistoryRecord[] =
+    (alert.fields['slo.serverityHistory'] as InstanceHistoryRecord[]) ||
+    ([] as InstanceHistoryRecord[]);
+
+  const items: HistoryItem[] = history.map((event) => {
+    const isImproving = event.improvingFrom != null;
+    const from = event.timerange.from;
+    const to = event.timerange.to ?? Date.now();
+    return {
+      severity: event.actionGroup,
+      startedAt: new Date(from),
+      endedAt: to !== Date.now() ? new Date(to) : null,
+      status: isImproving ? 'Improving' : 'Degrading',
+      durationInMs: to - from,
+    };
+  });
+
+  const columns: Array<EuiBasicTableColumn<HistoryItem>> = [
+    {
+      field: 'status',
+      name: 'Status',
+      render: (status: string) => {
+        return <EuiBadge color={status === 'Degrading' ? 'warning' : 'success'}>{status}</EuiBadge>;
+      },
+    },
+    {
+      field: 'severity',
+      name: 'Severity',
+      render: (actionGroup: string) => {
+        return (
+          <EuiBadge color={getSeverityColorByActionGroup(actionGroup)}>
+            {getSeverityLabelByActionGroup(actionGroup)}
+          </EuiBadge>
+        );
+      },
+    },
+    {
+      field: 'durationInMs',
+      name: 'Duration',
+      render: (durationInMs: number) => (
+        <strong>{moment.duration(durationInMs, 'ms').humanize()}</strong>
+      ),
+    },
+    {
+      field: 'startedAt',
+      name: 'Started at',
+      render: cellRenderForStartedAt,
+    },
+    {
+      field: 'endedAt',
+      name: 'Ended at',
+      render: cellRenderForEndedAt,
+    },
+  ];
+
+  return (
+    <EuiPanel paddingSize="m" color="transparent" hasBorder>
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexGroup direction="column" gutterSize="none">
+          <EuiFlexGroup direction="row" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiTitle size="xs">
+                <h2>
+                  {i18n.translate(
+                    'xpack.slo.burnRateRule.alertDetailsAppSection.severityHistory.title',
+                    {
+                      defaultMessage: 'Severity history',
+                      values: { sloName: slo.name },
+                    }
+                  )}
+                </h2>
+              </EuiTitle>
+              <EuiSpacer size="m" />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiBasicTable items={items.reverse()} columns={columns} rowProps={getRowProps} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}
+
+function getSeverityLabelByActionGroup(actionGroup: string) {
+  switch (actionGroup) {
+    case HIGH_PRIORITY_ACTION.id:
+      return HIGH_PRIORITY_ACTION.name;
+    case MEDIUM_PRIORITY_ACTION.id:
+      return MEDIUM_PRIORITY_ACTION.name;
+    case LOW_PRIORITY_ACTION.id:
+      return LOW_PRIORITY_ACTION.name;
+    default:
+      return ALERT_ACTION.name;
+  }
+}
+
+function getSeverityColorByActionGroup(actionGroup: string) {
+  switch (actionGroup) {
+    case HIGH_PRIORITY_ACTION.id:
+      return 'warning';
+    case MEDIUM_PRIORITY_ACTION.id:
+      return 'primary';
+    case LOW_PRIORITY_ACTION.id:
+      return 'success';
+    default:
+      return 'danger';
+  }
+}

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -376,7 +376,7 @@ describe('BurnRateRuleExecutor', () => {
         previousStartedAt: null,
         rule: {} as SanitizedRuleConfig,
         spaceId: 'irrelevant',
-        state: {},
+        state: { history: [] },
         flappingSettings: DEFAULT_FLAPPING_SETTINGS,
         getTimeRange,
       });

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/field_map.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/field_map.ts
@@ -9,6 +9,7 @@ import {
   SLO_ID_FIELD,
   SLO_INSTANCE_ID_FIELD,
   SLO_REVISION_FIELD,
+  SLO_SERVERITY_HISTORY_FIELD,
 } from '../../../../common/field_names/slo';
 
 export const sloRuleFieldMap = {
@@ -25,6 +26,11 @@ export const sloRuleFieldMap = {
   [SLO_INSTANCE_ID_FIELD]: {
     type: 'keyword',
     array: false,
+    required: false,
+  },
+  [SLO_SERVERITY_HISTORY_FIELD]: {
+    type: 'object',
+    array: true,
     required: false,
   },
 };

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/lib/compute_action_group.test.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/lib/compute_action_group.test.ts
@@ -1,0 +1,334 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import {
+  ALERT_ACTION,
+  HIGH_PRIORITY_ACTION,
+  IMPROVING_PRIORITY_ACTION,
+  SUPPRESSED_PRIORITY_ACTION,
+} from '../../../../../common/constants';
+import { computeActionGroup } from './compute_action_group';
+import { InstanceHistory } from '../../../../../common/types';
+
+const STARTED_AT = new Date();
+const startedAtPlus1m = moment(STARTED_AT).add(1, 'm').toDate();
+
+describe('computeActionGroup()', () => {
+  describe('degrading', () => {
+    it('should return a new history event on first execution', () => {
+      const history: InstanceHistory[] = [];
+      const instanceId = 'example.com';
+      const actionGroup = ALERT_ACTION.id;
+
+      expect(computeActionGroup(STARTED_AT, history, instanceId, actionGroup, false)).toEqual({
+        actionGroup: ALERT_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup: ALERT_ACTION.id,
+          suppressed: false,
+          timerange: { from: STARTED_AT.valueOf() },
+        },
+        historyRecord: {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      });
+    });
+
+    it('should return an existing history event on second execution with same actionGroup', () => {
+      const instanceId = 'example.com';
+      const actionGroup = ALERT_ACTION.id;
+      const history: InstanceHistory[] = [
+        {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      ];
+
+      expect(
+        computeActionGroup(
+          moment(STARTED_AT).add(1, 'm').toDate(),
+          history,
+          instanceId,
+          actionGroup,
+          false
+        )
+      ).toEqual({
+        actionGroup: ALERT_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup: ALERT_ACTION.id,
+          suppressed: false,
+          timerange: { from: STARTED_AT.valueOf() },
+        },
+        historyRecord: history[0],
+      });
+    });
+
+    it('should return an new history event on second execution with degrading actionGroup', () => {
+      const instanceId = 'example.com';
+      const actionGroup = ALERT_ACTION.id;
+      const history: InstanceHistory[] = [
+        {
+          instanceId,
+          history: [
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      ];
+
+      expect(computeActionGroup(startedAtPlus1m, history, instanceId, actionGroup, false)).toEqual({
+        actionGroup: ALERT_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup: ALERT_ACTION.id,
+          suppressed: false,
+          timerange: { from: startedAtPlus1m.valueOf() },
+        },
+        historyRecord: {
+          instanceId,
+          history: [
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf(), to: startedAtPlus1m.valueOf() },
+            },
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: startedAtPlus1m.valueOf() },
+            },
+          ],
+        },
+      });
+    });
+  });
+  describe('degrading and suppressed', () => {
+    it('should return a new history event on first execution that is suppressed', () => {
+      const history: InstanceHistory[] = [];
+      const instanceId = 'example.com';
+      const actionGroup = ALERT_ACTION.id;
+
+      expect(computeActionGroup(STARTED_AT, history, instanceId, actionGroup, true)).toEqual({
+        actionGroup: SUPPRESSED_PRIORITY_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup: ALERT_ACTION.id,
+          suppressed: true,
+          timerange: { from: STARTED_AT.valueOf() },
+        },
+        historyRecord: {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: true,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      });
+    });
+
+    it('should return an existing history event on second execution with same actionGroup', () => {
+      const instanceId = 'example.com';
+      const actionGroup = ALERT_ACTION.id;
+      const history: InstanceHistory[] = [
+        {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: true,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      ];
+
+      expect(
+        computeActionGroup(
+          moment(STARTED_AT).add(1, 'm').toDate(),
+          history,
+          instanceId,
+          actionGroup,
+          true
+        )
+      ).toEqual({
+        actionGroup: SUPPRESSED_PRIORITY_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup: ALERT_ACTION.id,
+          suppressed: true,
+          timerange: { from: STARTED_AT.valueOf() },
+        },
+        historyRecord: history[0],
+      });
+    });
+
+    it('should return an new history event on second execution with degrading actionGroup', () => {
+      const instanceId = 'example.com';
+      const actionGroup = ALERT_ACTION.id;
+      const history: InstanceHistory[] = [
+        {
+          instanceId,
+          history: [
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      ];
+
+      expect(computeActionGroup(startedAtPlus1m, history, instanceId, actionGroup, true)).toEqual({
+        actionGroup: SUPPRESSED_PRIORITY_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup: ALERT_ACTION.id,
+          suppressed: true,
+          timerange: { from: startedAtPlus1m.valueOf() },
+        },
+        historyRecord: {
+          instanceId,
+          history: [
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf(), to: startedAtPlus1m.valueOf() },
+            },
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: true,
+              timerange: { from: startedAtPlus1m.valueOf() },
+            },
+          ],
+        },
+      });
+    });
+  });
+  describe('improving', () => {
+    it('should return a new improving history event', () => {
+      const instanceId = 'example.com';
+      const actionGroup = HIGH_PRIORITY_ACTION.id;
+      const history: InstanceHistory[] = [
+        {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf() },
+            },
+          ],
+        },
+      ];
+
+      expect(
+        computeActionGroup(
+          moment(STARTED_AT).add(1, 'm').toDate(),
+          history,
+          instanceId,
+          actionGroup,
+          false
+        )
+      ).toEqual({
+        actionGroup: IMPROVING_PRIORITY_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup,
+          improvingFrom: ALERT_ACTION.id,
+          suppressed: false,
+          timerange: { from: startedAtPlus1m.valueOf() },
+        },
+        historyRecord: {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf(), to: startedAtPlus1m.valueOf() },
+            },
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              improvingFrom: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: startedAtPlus1m.valueOf() },
+            },
+          ],
+        },
+      });
+    });
+    it('should return the latest improving history event when nothing changed', () => {
+      const instanceId = 'example.com';
+      const actionGroup = HIGH_PRIORITY_ACTION.id;
+      const history: InstanceHistory[] = [
+        {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf(), to: startedAtPlus1m.valueOf() },
+            },
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              improvingFrom: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: startedAtPlus1m.valueOf() },
+            },
+          ],
+        },
+      ];
+
+      expect(
+        computeActionGroup(
+          moment(STARTED_AT).add(2, 'm').toDate(),
+          history,
+          instanceId,
+          actionGroup,
+          false
+        )
+      ).toEqual({
+        actionGroup: IMPROVING_PRIORITY_ACTION.id,
+        latestHistoryEvent: {
+          actionGroup,
+          improvingFrom: ALERT_ACTION.id,
+          suppressed: false,
+          timerange: { from: startedAtPlus1m.valueOf() },
+        },
+        historyRecord: {
+          instanceId,
+          history: [
+            {
+              actionGroup: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: STARTED_AT.valueOf(), to: startedAtPlus1m.valueOf() },
+            },
+            {
+              actionGroup: HIGH_PRIORITY_ACTION.id,
+              improvingFrom: ALERT_ACTION.id,
+              suppressed: false,
+              timerange: { from: startedAtPlus1m.valueOf() },
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/lib/compute_action_group.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/lib/compute_action_group.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ALERT_ACTION,
+  HIGH_PRIORITY_ACTION,
+  IMPROVING_PRIORITY_ACTION,
+  LOW_PRIORITY_ACTION,
+  MEDIUM_PRIORITY_ACTION,
+  SUPPRESSED_PRIORITY_ACTION,
+} from '../../../../../common/constants';
+import { InstanceHistory, InstanceHistoryRecord } from '../../../../../common/types';
+
+const serverityLevelLookup = {
+  [ALERT_ACTION.id]: 4,
+  [HIGH_PRIORITY_ACTION.id]: 3,
+  [MEDIUM_PRIORITY_ACTION.id]: 2,
+  [LOW_PRIORITY_ACTION.id]: 1,
+};
+
+function createDefaultHistoryEvent(startedAt: Date, actionGroup: string, shouldSuppress: boolean) {
+  return {
+    actionGroup,
+    suppressed: shouldSuppress,
+    timerange: { from: startedAt.valueOf() },
+  };
+}
+
+export function computeActionGroup(
+  startedAt: Date,
+  history: InstanceHistory[],
+  instanceId: string,
+  actionGroup: string,
+  shouldSuppress: boolean
+): {
+  actionGroup: string;
+  latestHistoryEvent: InstanceHistoryRecord;
+  historyRecord: InstanceHistory;
+} {
+  const historyRecord = history.find((record) => record.instanceId === instanceId);
+  if (historyRecord) {
+    const latestHistoryEvent = historyRecord.history.pop();
+
+    if (latestHistoryEvent) {
+      const lastSeverity = serverityLevelLookup[latestHistoryEvent.actionGroup];
+      const currentSeverity = serverityLevelLookup[actionGroup];
+
+      // Improving from the previous action group
+      if (lastSeverity > currentSeverity) {
+        latestHistoryEvent.timerange.to = Date.now();
+        historyRecord.history.push({
+          ...latestHistoryEvent,
+          timerange: { ...latestHistoryEvent.timerange, to: startedAt.valueOf() },
+        });
+        const nextHistoryEvent = {
+          actionGroup,
+          improvingFrom: latestHistoryEvent.actionGroup,
+          suppressed: false,
+          timerange: { from: startedAt.valueOf() },
+        };
+        historyRecord.history.push(nextHistoryEvent);
+        return {
+          actionGroup: IMPROVING_PRIORITY_ACTION.id,
+          latestHistoryEvent: nextHistoryEvent,
+          historyRecord,
+        };
+      }
+
+      // Nothing has changed, still improving
+      if (latestHistoryEvent.improvingFrom && latestHistoryEvent.improvingFrom !== actionGroup) {
+        historyRecord.history.push(latestHistoryEvent);
+        return { actionGroup: IMPROVING_PRIORITY_ACTION.id, latestHistoryEvent, historyRecord };
+      }
+
+      // If the action group has changed, stop the current history event and start a new one
+      if (latestHistoryEvent.actionGroup !== actionGroup) {
+        historyRecord.history.push({
+          ...latestHistoryEvent,
+          timerange: { ...latestHistoryEvent.timerange, to: startedAt.valueOf() },
+        });
+        const nextHistoryEvent = {
+          actionGroup,
+          suppressed: shouldSuppress,
+          timerange: { from: startedAt.valueOf() },
+        };
+        historyRecord.history.push(nextHistoryEvent);
+        return {
+          actionGroup: shouldSuppress ? SUPPRESSED_PRIORITY_ACTION.id : actionGroup,
+          latestHistoryEvent: nextHistoryEvent,
+          historyRecord,
+        };
+      }
+
+      // Nothing has changed
+      historyRecord.history.push(latestHistoryEvent);
+      return {
+        actionGroup: shouldSuppress ? SUPPRESSED_PRIORITY_ACTION.id : actionGroup,
+        latestHistoryEvent,
+        historyRecord,
+      };
+    }
+  }
+
+  const historyEvent = createDefaultHistoryEvent(startedAt, actionGroup, shouldSuppress);
+  return {
+    actionGroup: shouldSuppress ? SUPPRESSED_PRIORITY_ACTION.id : actionGroup,
+    latestHistoryEvent: historyEvent,
+    historyRecord: { instanceId, history: [historyEvent] },
+  };
+}

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
@@ -22,6 +22,7 @@ import { SLO_RULE_REGISTRATION_CONTEXT } from '../../../common/constants';
 import {
   ALERT_ACTION,
   HIGH_PRIORITY_ACTION,
+  IMPROVING_PRIORITY_ACTION,
   LOW_PRIORITY_ACTION,
   MEDIUM_PRIORITY_ACTION,
   SUPPRESSED_PRIORITY_ACTION,
@@ -80,6 +81,7 @@ export function sloBurnRateRuleType(
       MEDIUM_PRIORITY_ACTION,
       LOW_PRIORITY_ACTION,
       SUPPRESSED_PRIORITY_ACTION,
+      IMPROVING_PRIORITY_ACTION,
     ],
     category: DEFAULT_APP_CATEGORIES.observability.id,
     producer: sloFeatureId,
@@ -100,6 +102,8 @@ export function sloBurnRateRuleType(
         { name: 'sloName', description: sloNameActionVariableDescription },
         { name: 'sloInstanceId', description: sloInstanceIdActionVariableDescription },
         { name: 'suppressedAction', description: suppressedActionVariableDescription },
+        { name: 'previousActionGroup', description: previousActionGroupActionVariableDescription },
+        { name: 'improvedActionGroup', description: improvedActionGroupActionVariableDescription },
       ],
     },
     alerts: {
@@ -178,5 +182,20 @@ export const suppressedActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.suppressedActionDescription',
   {
     defaultMessage: 'The suppressed action group.',
+  }
+);
+export const previousActionGroupActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.previousActionGroupDescription',
+  {
+    defaultMessage:
+      'The action group from the previous execution. Only available as part of the "Improving" action group.',
+  }
+);
+
+export const improvedActionGroupActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.improvedActionGroupDescription',
+  {
+    defaultMessage:
+      'The action group that would have triggerd. Only available as part of the "Improving" action group.',
   }
 );

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
@@ -104,6 +104,7 @@ export function sloBurnRateRuleType(
         { name: 'suppressedAction', description: suppressedActionVariableDescription },
         { name: 'previousActionGroup', description: previousActionGroupActionVariableDescription },
         { name: 'improvedActionGroup', description: improvedActionGroupActionVariableDescription },
+        { name: 'isDegrading', description: improvedActionGroupActionVariableDescription },
       ],
     },
     alerts: {
@@ -187,8 +188,7 @@ export const suppressedActionVariableDescription = i18n.translate(
 export const previousActionGroupActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.previousActionGroupDescription',
   {
-    defaultMessage:
-      'The action group from the previous execution. Only available as part of the "Improving" action group.',
+    defaultMessage: 'The action group from the previous execution.',
   }
 );
 
@@ -197,5 +197,12 @@ export const improvedActionGroupActionVariableDescription = i18n.translate(
   {
     defaultMessage:
       'The action group that would have triggerd. Only available as part of the "Improving" action group.',
+  }
+);
+
+export const isDegradingActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.isDegradingDescription',
+  {
+    defaultMessage: 'Set to true when the alert is in a degrading state',
   }
 );

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/types.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/types.ts
@@ -17,6 +17,7 @@ import {
   LOW_PRIORITY_ACTION,
   SUPPRESSED_PRIORITY_ACTION,
 } from '../../../../common/constants';
+import { InstanceHistory } from '../../../../common/types';
 
 export enum AlertStates {
   OK,
@@ -42,7 +43,9 @@ export type BurnRateRuleParams = {
   windows: WindowSchema[];
   dependencies?: Dependency[];
 } & Record<string, any>;
-export type BurnRateRuleTypeState = RuleTypeState; // no specific rule state
+export type BurnRateRuleTypeState = RuleTypeState & {
+  history: InstanceHistory[];
+}; // no specific rule state
 export type BurnRateAlertState = AlertState; // no specific alert state
 export type BurnRateAlertContext = AlertContext; // no specific alert context
 export type BurnRateAllowedActionGroups = ActionGroupIdsOf<


### PR DESCRIPTION
## Summary

This PR introduces a new feature for the burn rate rule that introduces a new action group called "improving". When the SLO burn rate moves to a lower severity, instead of scheduling the lower severity action, the rule will now schedule an "Improving" action and set two context variables to indicate which severity action would have triggered (`context.improvedActionGroup`) and which severity action it improved from (`contect.previousActionGroup`).

This PR also introduces a new "Severity history" section on the Burn Rate Rule alert details page which will give a timeline of the different severities of the alert.

![image](https://github.com/elastic/kibana/assets/41702/6ce8c845-79e2-4fe1-a923-a1ad7be4fad3)
