### PR TITLE
Adding func for regeneration

### DIFF
--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -59,6 +59,7 @@ export const Chat = () => {
   const { messages, append, stop: stopRequest, setMessages, reload } = useChat();
   const selectedIndicesCount = watch(ChatFormFields.indices, []).length;
   const messagesRef = useAutoBottomScroll([showStartPage]);
+  const [isRegenerating, setIsRegenerating] = useState<boolean>(false);
 
   const onSubmit = async (data: ChatForm) => {
     await append(
@@ -82,11 +83,15 @@ export const Chat = () => {
     [messages]
   );
 
-  const regenerateMessages = () => {
+  const regenerateMessages = async () => {
+    setIsRegenerating(true);
+
     const formData = getValues();
-    reload({
+    await reload({
       data: buildFormData(formData),
     });
+
+    setIsRegenerating(false);
   };
 
   if (showStartPage) {
@@ -171,9 +176,9 @@ export const Chat = () => {
                   <QuestionInput
                     value={field.value}
                     onChange={field.onChange}
-                    isDisabled={isSubmitting}
+                    isDisabled={isSubmitting || isRegenerating}
                     button={
-                      isSubmitting ? (
+                      isSubmitting || isRegenerating ? (
                         <EuiButtonIcon
                           aria-label={i18n.translate(
                             'xpack.searchPlayground.chat.stopButtonAriaLabel',

--- a/x-pack/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { EuiFormRow, EuiIcon, EuiTextArea, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { isEmpty } from 'lodash';
 
 interface InstructionsFieldProps {
   value?: string;
@@ -49,6 +50,7 @@ export const InstructionsField: React.FC<InstructionsFieldProps> = ({ value, onC
         value={value}
         onChange={handlePromptChange}
         fullWidth
+        isInvalid={isEmpty(value)}
       />
     </EuiFormRow>
   );

--- a/x-pack/plugins/search_playground/public/components/summarization_panel/summarization_panel.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/summarization_panel.tsx
@@ -31,7 +31,6 @@ export const SummarizationPanel: React.FC = () => {
         <Controller
           name={ChatFormFields.openAIKey}
           control={control}
-          defaultValue=""
           render={({ field }) => (
             <OpenAIKeyFlyOut
               openAPIKey={field.value}
@@ -57,8 +56,8 @@ export const SummarizationPanel: React.FC = () => {
       <Controller
         name={ChatFormFields.prompt}
         control={control}
-        defaultValue=""
         render={({ field }) => <InstructionsField value={field.value} onChange={field.onChange} />}
+        rules={{ required: true }}
       />
 
       <Controller


### PR DESCRIPTION
## Summary

Small changes on Playground chat regeneration process:
- Disabled `Question box` when regenerate responses
- Enable `stop` button to stop regenerate responses

![Screenshot 2024-04-08 at 12 32 07 PM](https://github.com/elastic/kibana/assets/150824886/6d71716e-ac4f-4a64-9fb8-ea18e87a0aa5)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
