### PR TITLE
[CI] Add integration tests ES serverless verification

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -2,7 +2,6 @@
 
 ### Parameters for this job:
 # PUBLISH_DOCKER_TAG: if set to 1/true, passing runs will promote the tested ES Serverless tag to latest-verified.
-# PUBLISH_MANIFEST: if set to 1/true, passing runs will upload the manifest attesting what (kibana + es) combination was used in the test
 # SKIP_VERIFICATION: if set to 1/true, it will skip running all tests
 # SKIP_CYPRESS: if set to 1/true, it will skip running the cypress tests
 # FTR_EXTRA_ARGS: a string argument, if passed, it will be forwarded verbatim to the FTR run script

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -63,7 +63,7 @@ steps:
         timeout_in_minutes: 10
         env:
           LIMIT_CONFIG_TYPE: 'integration'
-          JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+          JEST_INTEGRATION_SCRIPT: 'TEST_ES_SERVERLESS_IMAGE=$ES_SERVERLESS_IMAGE .buildkite/scripts/steps/test/jest_integration.sh'
         retry:
           automatic:
             - exit_status: '*'

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -39,7 +39,7 @@ steps:
             - exit_status: '-1'
               limit: 3
 
-      - label: "Pick Test Group Run Order - Serverless FTR"
+      - label: "Pick Test Group Run Order (FTR + Integration)"
         command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
         agents:
           queue: kibana-default
@@ -47,28 +47,14 @@ steps:
         timeout_in_minutes: 10
         env:
           FTR_CONFIGS_SCRIPT: 'TEST_ES_SERVERLESS_IMAGE=$ES_SERVERLESS_IMAGE .buildkite/scripts/steps/test/ftr_configs.sh'
+          JEST_INTEGRATION_SCRIPT: 'TEST_ES_SERVERLESS_IMAGE=$ES_SERVERLESS_IMAGE .buildkite/scripts/steps/test/jest_integration.sh'
           FTR_CONFIG_PATTERNS: '**/test_serverless/**'
           FTR_EXTRA_ARGS: '$FTR_EXTRA_ARGS'
-          LIMIT_CONFIG_TYPE: 'functional'
+          LIMIT_CONFIG_TYPE: 'functional,integration'
         retry:
           automatic:
             - exit_status: '*'
               limit: 1
-
-      - label: "Pick Test Group Run Order - Jest Integration"
-        command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
-        agents:
-          queue: kibana-default
-        depends_on: build
-        timeout_in_minutes: 10
-        env:
-          LIMIT_CONFIG_TYPE: 'integration'
-          JEST_INTEGRATION_SCRIPT: 'TEST_ES_SERVERLESS_IMAGE=$ES_SERVERLESS_IMAGE .buildkite/scripts/steps/test/jest_integration.sh'
-        retry:
-          automatic:
-            - exit_status: '*'
-              limit: 1
-
 
       - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
         label: 'Serverless Entity Analytics - Security Solution Cypress Tests'

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -40,7 +40,7 @@ steps:
             - exit_status: '-1'
               limit: 3
 
-      - label: "Pick Test Group Run Order"
+      - label: "Pick Test Group Run Order - Serverless FTR"
         command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
         agents:
           queue: kibana-default
@@ -55,6 +55,21 @@ steps:
           automatic:
             - exit_status: '*'
               limit: 1
+
+      - label: "Pick Test Group Run Order - Jest Integration"
+        command: .buildkite/scripts/steps/test/pick_test_group_run_order.sh
+        agents:
+          queue: kibana-default
+        depends_on: build
+        timeout_in_minutes: 10
+        env:
+          LIMIT_CONFIG_TYPE: 'integration'
+          JEST_INTEGRATION_SCRIPT: '.buildkite/scripts/steps/test/jest_integration.sh'
+        retry:
+          automatic:
+            - exit_status: '*'
+              limit: 1
+
 
       - command: .buildkite/scripts/steps/functional/security_serverless_entity_analytics.sh
         label: 'Serverless Entity Analytics - Security Solution Cypress Tests'

--- a/packages/core/test-helpers/core-test-helpers-kbn-server/src/create_serverless_root.ts
+++ b/packages/core/test-helpers/core-test-helpers-kbn-server/src/create_serverless_root.ts
@@ -77,6 +77,9 @@ function createServerlessES() {
   });
   const es = new Cluster({ log });
   const esPort = esTestConfig.getPort();
+  const esServerlessImageParams = parseEsServerlessImageOverride(
+    esTestConfig.getESServerlessImage()
+  );
   return {
     es,
     start: async () => {
@@ -88,7 +91,7 @@ function createServerlessES() {
         clean: true,
         kill: true,
         waitForReady: true,
-        image: esTestConfig.getESServerlessImage(),
+        ...esServerlessImageParams,
         // security is enabled by default, if needed kibana requires serviceAccountToken
         esArgs: ['xpack.security.enabled=false'],
       });
@@ -155,4 +158,21 @@ function createServerlessKibana(settings = {}, cliArgs: Partial<CliArgs> = {}) {
     ...cliArgs,
     serverless: true,
   });
+}
+
+function parseEsServerlessImageOverride(dockerImageOrTag: string | undefined): {
+  image?: string;
+  tag?: string;
+} {
+  if (!dockerImageOrTag) {
+    return {};
+  } else if (dockerImageOrTag.includes(':')) {
+    return {
+      image: dockerImageOrTag,
+    };
+  } else {
+    return {
+      tag: dockerImageOrTag,
+    };
+  }
 }

--- a/packages/core/test-helpers/core-test-helpers-kbn-server/src/create_serverless_root.ts
+++ b/packages/core/test-helpers/core-test-helpers-kbn-server/src/create_serverless_root.ts
@@ -88,6 +88,7 @@ function createServerlessES() {
         clean: true,
         kill: true,
         waitForReady: true,
+        image: esTestConfig.getESServerlessImage(),
         // security is enabled by default, if needed kibana requires serviceAccountToken
         esArgs: ['xpack.security.enabled=false'],
       });


### PR DESCRIPTION
## Summary
Prior to this change, we've only run Serverless-related FTR tests on the [ES Serverless verification & promotion job](https://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote). This was not exactly complete coverage, by this, we've left out some of the serverless tests in the jest-integration set.

This PR adds running (the complete) Jest Integration test set on the verification pipeline (we currently don't have a way to filter for serverless-related tests only), and this required the integration test startup code to start respecting the ES Serverless docker image override we use in the test setup.

Fixes: https://github.com/elastic/kibana-operations/issues/90