### PR TITLE
[dx] Tweak profiling to include the webpack visualization from CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1519,6 +1519,7 @@
     "@types/vinyl-fs": "^3.0.2",
     "@types/watchpack": "^1.1.5",
     "@types/webpack": "^4.41.3",
+    "@types/webpack-bundle-analyzer": "^4.7.0",
     "@types/webpack-env": "^1.15.3",
     "@types/webpack-merge": "^4.1.5",
     "@types/webpack-sources": "^0.1.4",

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -20,6 +20,7 @@ import * as UiSharedDepsSrc from '@kbn/ui-shared-deps-src';
 import StatoscopeWebpackPlugin from '@statoscope/webpack-plugin';
 // @ts-expect-error
 import VisualizerPlugin from 'webpack-visualizer-plugin2';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 import { Bundle, BundleRemotes, WorkerConfig, parseDllManifest } from '../common';
 import { BundleRemotesPlugin } from './bundle_remotes_plugin';
@@ -92,6 +93,12 @@ export function getWebpackConfig(
               saveReportTo: `${bundle.outputDir}/${bundle.id}.statoscope.html`,
             }),
             new VisualizerPlugin({ filename: `${bundle.id}.visualizer.html` }),
+            new BundleAnalyzerPlugin({
+              analyzerMode: 'static',
+              reportFilename: `${bundle.id}.analyzer.html`,
+              openAnalyzer: false,
+              logLevel: 'silent',
+            }),
           ]
         : []),
       // @ts-ignore something is wrong with the StatoscopeWebpackPlugin type.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10812,6 +10812,15 @@
     "@types/node" "*"
     chokidar "^2.1.2"
 
+"@types/webpack-bundle-analyzer@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz#fe199e724ce3d38705f6f1ba4d62429b7c360541"
+  integrity sha512-c5i2ThslSNSG8W891BRvOd/RoCjI2zwph8maD22b1adtSns20j+0azDDMCK06DiVrzTgnwiDl5Ntmu1YRJw8Sg==
+  dependencies:
+    "@types/node" "*"
+    tapable "^2.2.0"
+    webpack "^5"
+
 "@types/webpack-env@^1.15.3", "@types/webpack-env@^1.16.0":
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.3.tgz#b776327a73e561b71e7881d0cd6d34a1424db86a"


### PR DESCRIPTION
## Summary

CI produces a report from the `webpack-bundle-analyzer`, which is really helpful.  Unfortunately, there's no easy way to produce the report locally when using `--profile`.  This tweak produces that report so someone can see the effect of changes before adding them to a PR, (and running an expense CI job).
