### PR TITLE
fix: [Dashboard > Data Quality][SCREEN READER]: Headings must be properly nested for usability

### DIFF
--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/pattern/pattern_summary/pattern_label/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/pattern/pattern_summary/pattern_label/index.tsx
@@ -56,7 +56,7 @@ const PatternLabelComponent: React.FC<Props> = ({
       <EuiFlexItem grow={false}>
         <EuiToolTip content={i18n.PATTERN_OR_INDEX_TOOLTIP}>
           <EuiTitle size="s">
-            <h4>{pattern}</h4>
+            <h2>{pattern}</h2>
           </EuiTitle>
         </EuiToolTip>
       </EuiFlexItem>


### PR DESCRIPTION
Closes: https://github.com/elastic/security-team/issues/8640

## Description

The Data Quality Dashboard has a number of headings that are improperly nested (wrong level). This makes for a more difficult screen reader experience; a large number of screen reader users [primarily navigate by headings](https://webaim.org/projects/screenreadersurvey9/#finding).

### Steps to recreate

1. Open [Data Quality dashboard](https://kibana.siem.estc.dev/app/security/data_quality)
2. Open [HeadingsMap extension](https://chromewebstore.google.com/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi?pli=1) or your preferred screen reader
3. If using a screen reader, traverse the page by headings only to hear the perceived importance of information


### What was done?: 
1. `h4` was replaced to `h2` for `PatternLabelComponent`

