### PR TITLE
Changed console.log to unsafeConsole.log in interactive plugin setup

### DIFF
--- a/src/plugins/interactive_setup/server/plugin.ts
+++ b/src/plugins/interactive_setup/server/plugin.ts
@@ -16,6 +16,7 @@ import type {
   PluginInitializerContext,
   PrebootPlugin,
 } from '@kbn/core/server';
+import { unsafeConsole } from '@kbn/security-hardening';
 import { getDataPath } from '@kbn/utils';
 
 import type { ConfigSchema, ConfigType } from './config';
@@ -129,8 +130,8 @@ export class InteractiveSetupPlugin implements PrebootPlugin {
           const { protocol, hostname, port } = core.http.getServerInfo();
           const url = `${protocol}://${hostname}:${port}${pathname}?code=${verificationCode.code}`;
 
-          // eslint-disable-next-line no-console
-          console.log(`
+          // eslint-disable-next-line @kbn/eslint/no_unsafe_console
+          unsafeConsole.log(`
 
 ${chalk.whiteBright.bold(`${chalk.cyanBright('i')} Kibana has not been configured.`)}
 

--- a/src/plugins/interactive_setup/server/verification_code.ts
+++ b/src/plugins/interactive_setup/server/verification_code.ts
@@ -10,6 +10,7 @@ import chalk from 'chalk';
 import crypto from 'crypto';
 
 import type { Logger } from '@kbn/core/server';
+import { unsafeConsole } from '@kbn/security-hardening';
 
 import { VERIFICATION_CODE_LENGTH } from '../common';
 
@@ -37,8 +38,8 @@ export class VerificationCode {
     );
 
     if (code === undefined) {
-      // eslint-disable-next-line no-console
-      console.log(`
+      // eslint-disable-next-line @kbn/eslint/no_unsafe_console
+      unsafeConsole.log(`
 
 Your verification code is: ${highlightedCode}
 
@@ -51,8 +52,8 @@ Your verification code is: ${highlightedCode}
       this.logger.error(
         `Invalid verification code '${code}' provided. ${this.remainingAttempts} attempts left.`
       );
-      // eslint-disable-next-line no-console
-      console.log(`
+      // eslint-disable-next-line @kbn/eslint/no_unsafe_console
+      unsafeConsole.log(`
 
 Your verification code is: ${highlightedCode}
 

--- a/src/plugins/interactive_setup/tsconfig.json
+++ b/src/plugins/interactive_setup/tsconfig.json
@@ -25,6 +25,7 @@
     "@kbn/core-preboot-server",
     "@kbn/react-kibana-context-theme",
     "@kbn/core-theme-browser",
+    "@kbn/security-hardening",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Changed `console.log` to `unsafeConsole.log` in interactive plugin setup.
Made a [build](https://buildkite.com/elastic/kibana-pull-request/builds/202449#018ec743-e2c7-4266-851a-c89736151701) for all platforms and checked out distribution for Mac.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

__Fixes: https://github.com/elastic/kibana/issues/179673__

## Release note
Fixed escaped terminal codes logging in interactive plugin setup.
