### PR TITLE
[serverless] skip "GET should get updated labels after dynamically up…

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/observability/telemetry/telemetry_config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/telemetry/telemetry_config.ts
@@ -31,7 +31,9 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
       expect(body).toMatchObject(baseConfig);
     });
 
-    it('GET should get updated labels after dynamically updating them', async () => {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/180348
+    it.skip('GET should get updated labels after dynamically updating them', async function () {
+      this.tags(['failsOnMKI']);
       await supertest
         .put('/internal/core/_settings')
         .set(svlCommonApi.getInternalRequestHeader())

--- a/x-pack/test_serverless/api_integration/test_suites/observability/telemetry/telemetry_config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/telemetry/telemetry_config.ts
@@ -12,7 +12,9 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
   const svlCommonApi = getService('svlCommonApi');
   const supertest = getService('supertest');
 
-  describe('/api/telemetry/v2/config API Telemetry config', () => {
+  // failsOnMKI, see https://github.com/elastic/kibana/issues/180348
+  describe('/api/telemetry/v2/config API Telemetry config', function () {
+    this.tags(['failsOnMKI']);
     const baseConfig = {
       allowChangingOptInStatus: false,
       optIn: true,
@@ -31,9 +33,7 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
       expect(body).toMatchObject(baseConfig);
     });
 
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/180348
-    it.skip('GET should get updated labels after dynamically updating them', async function () {
-      this.tags(['failsOnMKI']);
+    it('GET should get updated labels after dynamically updating them', async () => {
       await supertest
         .put('/internal/core/_settings')
         .set(svlCommonApi.getInternalRequestHeader())

--- a/x-pack/test_serverless/api_integration/test_suites/security/telemetry/telemetry_config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/telemetry/telemetry_config.ts
@@ -31,7 +31,9 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
       expect(body).toMatchObject(baseConfig);
     });
 
-    it('GET should get updated labels after dynamically updating them', async () => {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/180348
+    it('GET should get updated labels after dynamically updating them', async function () {
+      this.tags(['failsOnMKI']);
       await supertest
         .put('/internal/core/_settings')
         .set(svlCommonApi.getInternalRequestHeader())

--- a/x-pack/test_serverless/api_integration/test_suites/security/telemetry/telemetry_config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/telemetry/telemetry_config.ts
@@ -12,7 +12,10 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
   const svlCommonApi = getService('svlCommonApi');
   const supertest = getService('supertest');
 
-  describe('/api/telemetry/v2/config API Telemetry config', () => {
+  // failsOnMKI, see https://github.com/elastic/kibana/issues/180348
+  describe('/api/telemetry/v2/config API Telemetry config', function () {
+    this.tags(['failsOnMKI']);
+
     const baseConfig = {
       allowChangingOptInStatus: false,
       optIn: true,
@@ -31,9 +34,7 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
       expect(body).toMatchObject(baseConfig);
     });
 
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/180348
-    it('GET should get updated labels after dynamically updating them', async function () {
-      this.tags(['failsOnMKI']);
+    it('GET should get updated labels after dynamically updating them', async () => {
       await supertest
         .put('/internal/core/_settings')
         .set(svlCommonApi.getInternalRequestHeader())


### PR DESCRIPTION
## Summary

skip "GET should get updated labels after dynamically updating them" for 
oblt and security suites

Details about the failures in https://github.com/elastic/kibana/issues/180348