### PR TITLE
[8.13] Fix threat intel edit filters (#179607)

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -61,12 +61,15 @@ export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionTemplateW
       getTimelineShowStatus(state, TimelineId.active)
     );
     const [routeProps] = useRouteSpy();
-    const isNotEmpty = !rest.isEmptyState;
     const isPreview = routeProps?.pageName === SecurityPageName.rulesCreate;
 
     // The bottomBar by default has a set 'dark' colorMode that doesn't match the global colorMode from the Advanced Settings
     // To keep the mode in sync, we pass in the globalColorMode to the bottom bar here
     const { euiTheme, colorMode: globalColorMode } = useEuiTheme();
+
+    // There is some logic in the StyledKibanaPageTemplate that checks for children presence, and we dont even need to render the children
+    // here if isEmptyState is set
+    const isNotEmpty = !rest.isEmptyState;
 
     /*
      * StyledKibanaPageTemplate is a styled EuiPageTemplate. Security solution currently passes the header

--- a/x-pack/plugins/threat_intelligence/public/mocks/mock_security_context.tsx
+++ b/x-pack/plugins/threat_intelligence/public/mocks/mock_security_context.tsx
@@ -27,6 +27,9 @@ export const getSecuritySolutionContextMock = (): SecuritySolutionPluginContext 
     ({ children }) =>
       <div>{children}</div>,
   sourcererDataView: {
+    sourcererDataView: {
+      id: 'security-solution-default',
+    },
     browserFields: {},
     selectedPatterns: [],
     indexPattern: { fields: [], title: '' },

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_in.test.tsx
@@ -18,6 +18,8 @@ import {
   FilterInContextMenu,
 } from './filter_in';
 
+import { TestProvidersComponent } from '../../../mocks/test_providers';
+
 jest.mock('../../indicators/hooks/use_filters_context');
 
 const mockIndicator: Indicator = generateMockIndicator();
@@ -33,20 +35,27 @@ describe('<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction />'
   });
 
   it('should render null (wrong data input)', () => {
-    const { container } = render(<FilterInButtonIcon data={''} field={mockField} />);
+    const { container } = render(<FilterInButtonIcon data={''} field={mockField} />, {
+      wrapper: TestProvidersComponent,
+    });
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should render null (wrong field input)', () => {
-    const { container } = render(<FilterInButtonIcon data={mockIndicator} field={''} />);
+    const { container } = render(<FilterInButtonIcon data={mockIndicator} field={''} />, {
+      wrapper: TestProvidersComponent,
+    });
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should render one EuiButtonIcon', () => {
     const { getByTestId } = render(
-      <FilterInButtonIcon data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />
+      <FilterInButtonIcon data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toHaveClass('euiButtonIcon');
@@ -54,7 +63,10 @@ describe('<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction />'
 
   it('should render one EuiButtonEmpty', () => {
     const { getByTestId } = render(
-      <FilterInButtonEmpty data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />
+      <FilterInButtonEmpty data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toHaveClass('euiButtonEmpty');
@@ -62,7 +74,10 @@ describe('<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction />'
 
   it('should render one EuiContextMenuItem (for EuiContextMenu use)', () => {
     const { getByTestId } = render(
-      <FilterInContextMenu data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />
+      <FilterInContextMenu data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toHaveClass('euiContextMenuItem');
@@ -83,7 +98,10 @@ describe('<FilterInButtonIcon /> <FilterInContextMenu /> <FilterInCellAction />'
         field={mockField}
         Component={mockComponent}
         data-test-subj={TEST_ID}
-      />
+      />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toBeInTheDocument();

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/components/filter_out.test.tsx
@@ -17,6 +17,7 @@ import {
   FilterOutCellAction,
   FilterOutContextMenu,
 } from './filter_out';
+import { TestProvidersComponent } from '../../../mocks/test_providers';
 
 jest.mock('../../indicators/hooks/use_filters_context');
 
@@ -33,20 +34,27 @@ describe('<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu
   });
 
   it('should render an empty component (wrong data input)', () => {
-    const { container } = render(<FilterOutButtonIcon data={''} field={mockField} />);
+    const { container } = render(<FilterOutButtonIcon data={''} field={mockField} />, {
+      wrapper: TestProvidersComponent,
+    });
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should render an empty component (wrong field input)', () => {
-    const { container } = render(<FilterOutButtonIcon data={mockIndicator} field={''} />);
+    const { container } = render(<FilterOutButtonIcon data={mockIndicator} field={''} />, {
+      wrapper: TestProvidersComponent,
+    });
 
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should render one EuiButtonIcon', () => {
     const { getByTestId } = render(
-      <FilterOutButtonIcon data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />
+      <FilterOutButtonIcon data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toHaveClass('euiButtonIcon');
@@ -54,7 +62,10 @@ describe('<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu
 
   it('should render one EuiButtonEmpty', () => {
     const { getByTestId } = render(
-      <FilterOutButtonEmpty data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />
+      <FilterOutButtonEmpty data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toHaveClass('euiButtonEmpty');
@@ -62,7 +73,10 @@ describe('<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu
 
   it('should render one EuiContextMenuItem (for EuiContextMenu use)', () => {
     const { getByTestId } = render(
-      <FilterOutContextMenu data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />
+      <FilterOutContextMenu data={mockIndicator} field={mockField} data-test-subj={TEST_ID} />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toHaveClass('euiContextMenuItem');
@@ -83,7 +97,10 @@ describe('<FilterOutButtonIcon /> <FilterOutButtonEmpty /> <FilterOutContextMenu
         field={mockField}
         Component={mockComponent}
         data-test-subj={TEST_ID}
-      />
+      />,
+      {
+        wrapper: TestProvidersComponent,
+      }
     );
 
     expect(getByTestId(TEST_ID)).toBeInTheDocument();

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.test.ts
@@ -14,6 +14,9 @@ import {
 import { TestProvidersComponent } from '../../../mocks/test_providers';
 import { useFilterInOut, UseFilterInValue } from './use_filter_in_out';
 import { FilterIn } from '../utils/filter';
+import { updateFiltersArray } from '../utils/filter';
+
+jest.mock('../utils/filter', () => ({ updateFiltersArray: jest.fn() }));
 
 describe('useFilterInOut()', () => {
   let hookResult: RenderHookResult<{}, UseFilterInValue, Renderer<unknown>>;
@@ -52,5 +55,29 @@ describe('useFilterInOut()', () => {
     });
 
     expect(hookResult.result.current).toHaveProperty('filterFn');
+  });
+
+  describe('calling filterFn', () => {
+    it('should call dependencies ', () => {
+      const indicator: string = '0.0.0.0';
+      const field: string = 'threat.indicator.name';
+      const filterType = FilterIn;
+
+      hookResult = renderHook(() => useFilterInOut({ indicator, field, filterType }), {
+        wrapper: TestProvidersComponent,
+      });
+
+      expect(hookResult.result.current).toHaveProperty('filterFn');
+
+      hookResult.result.current.filterFn?.();
+
+      expect(jest.mocked(updateFiltersArray)).toHaveBeenCalledWith(
+        [],
+        'threat.indicator.name',
+        '0.0.0.0',
+        undefined,
+        'security-solution-default'
+      );
+    });
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.ts
@@ -11,6 +11,7 @@ import { fieldAndValueValid, getIndicatorFieldAndValue } from '../../indicators/
 import { useIndicatorsFiltersContext } from '../../indicators/hooks/use_filters_context';
 import { Indicator } from '../../../../common/types/indicator';
 import { FilterIn, FilterOut, updateFiltersArray } from '../utils/filter';
+import { useSourcererDataView } from '../../indicators/hooks/use_sourcerer_data_view';
 
 export interface UseFilterInParam {
   /**
@@ -44,6 +45,7 @@ export const useFilterInOut = ({
   filterType,
 }: UseFilterInParam): UseFilterInValue => {
   const { filterManager } = useIndicatorsFiltersContext();
+  const { sourcererDataView } = useSourcererDataView();
 
   const { key, value } =
     typeof indicator === 'string'
@@ -52,9 +54,15 @@ export const useFilterInOut = ({
 
   const filterFn = useCallback((): void => {
     const existingFilters = filterManager.getFilters();
-    const newFilters: Filter[] = updateFiltersArray(existingFilters, key, value, filterType);
+    const newFilters: Filter[] = updateFiltersArray(
+      existingFilters,
+      key,
+      value,
+      filterType,
+      sourcererDataView?.id
+    );
     filterManager.setFilters(newFilters);
-  }, [filterManager, filterType, key, value]);
+  }, [filterManager, filterType, key, sourcererDataView?.id, value]);
 
   if (!fieldAndValueValid(key, value)) {
     return {} as unknown as UseFilterInValue;

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/utils/filter.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/utils/filter.ts
@@ -17,7 +17,17 @@ export const FilterOut = false;
  * @param negate Set to true when we create a negated filter (e.g. NOT threat.indicator.type: url)
  * @returns The new {@link Filter}
  */
-const createFilter = (key: string, value: string, negate: boolean): Filter => ({
+const createFilter = ({
+  key,
+  value,
+  negate,
+  index,
+}: {
+  key: string;
+  value: string;
+  negate: boolean;
+  index?: string;
+}): Filter => ({
   meta: {
     alias: null,
     negate,
@@ -25,6 +35,7 @@ const createFilter = (key: string, value: string, negate: boolean): Filter => ({
     type: 'phrase',
     key,
     params: { query: value },
+    index,
   },
   query: { match_phrase: { [key]: value } },
 });
@@ -71,9 +82,10 @@ export const updateFiltersArray = (
   existingFilters: Filter[],
   key: string,
   value: string | null,
-  filterType: boolean
+  filterType: boolean,
+  index?: string
 ): Filter[] => {
-  const newFilter = createFilter(key, value as string, !filterType);
+  const newFilter = createFilter({ key, value: value as string, negate: !filterType, index });
 
   const filter: Filter | undefined = filterExistsInFiltersArray(
     existingFilters,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Fix threat intel edit filters (#179607)](https://github.com/elastic/kibana/pull/179607)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Luke G","email":"11671118+lgestc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-02T11:46:07Z","message":"Fix threat intel edit filters (#179607)\n\n## Summary\r\n\r\nThe following PR needs to be merged first:\r\nhttps://github.com/elastic/kibana/pull/178701\r\n\r\nThis fixes\r\nhttps://github.com/elastic/kibana/issues/174764#issuecomment-1992363217\r\nand https://github.com/elastic/kibana/issues/179030\r\n\r\n**To reproduce:**\r\n\r\nAdd whatever filter in the Threat Intelligence (via table filter in),\r\nthen click it (in the top bar) - filter edit popover is not filled in\r\nwith data.\r\n\r\nOn Alerts page though, it is filled in correctly - and it should look\r\nlike that on TI:\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/11671118/0de5f076-83dd-48f3-810b-75d1572536e3)","sha":"da697032c7ba74a2bba8338f64354cb6b0393ea5","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","Team:Threat Hunting:Investigations","backport:prev-minor","8.14 candidate","v8.14.0"],"number":179607,"url":"https://github.com/elastic/kibana/pull/179607","mergeCommit":{"message":"Fix threat intel edit filters (#179607)\n\n## Summary\r\n\r\nThe following PR needs to be merged first:\r\nhttps://github.com/elastic/kibana/pull/178701\r\n\r\nThis fixes\r\nhttps://github.com/elastic/kibana/issues/174764#issuecomment-1992363217\r\nand https://github.com/elastic/kibana/issues/179030\r\n\r\n**To reproduce:**\r\n\r\nAdd whatever filter in the Threat Intelligence (via table filter in),\r\nthen click it (in the top bar) - filter edit popover is not filled in\r\nwith data.\r\n\r\nOn Alerts page though, it is filled in correctly - and it should look\r\nlike that on TI:\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/11671118/0de5f076-83dd-48f3-810b-75d1572536e3)","sha":"da697032c7ba74a2bba8338f64354cb6b0393ea5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179607","number":179607,"mergeCommit":{"message":"Fix threat intel edit filters (#179607)\n\n## Summary\r\n\r\nThe following PR needs to be merged first:\r\nhttps://github.com/elastic/kibana/pull/178701\r\n\r\nThis fixes\r\nhttps://github.com/elastic/kibana/issues/174764#issuecomment-1992363217\r\nand https://github.com/elastic/kibana/issues/179030\r\n\r\n**To reproduce:**\r\n\r\nAdd whatever filter in the Threat Intelligence (via table filter in),\r\nthen click it (in the top bar) - filter edit popover is not filled in\r\nwith data.\r\n\r\nOn Alerts page though, it is filled in correctly - and it should look\r\nlike that on TI:\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/11671118/0de5f076-83dd-48f3-810b-75d1572536e3)","sha":"da697032c7ba74a2bba8338f64354cb6b0393ea5"}}]}] BACKPORT-->