### PR TITLE
[Security Solution] Disable v2 transform names

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/utils/package_v2.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/package_v2.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import semverLte from 'semver/functions/lte';
+// import semverLte from 'semver/functions/lte';
 
 // switch to "v2" logic
-const MIN_ENDPOINT_PACKAGE_V2_VERSION = '8.14.0-prerelease.1';
+// const MIN_ENDPOINT_PACKAGE_V2_VERSION = '8.14.0-prerelease.1';
 export function isEndpointPackageV2(version: string) {
-  return semverLte(MIN_ENDPOINT_PACKAGE_V2_VERSION, version);
+  return false;
 }


### PR DESCRIPTION
## Summary

Endpoint unattended transforms were reverted (https://github.com/elastic/endpoint-package/pull/489)  so the version number expected here is no longer valid.

This switches back to using the standard transform names indefinitely


