### PR TITLE
[Obs AI Assistant] Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -588,9 +588,9 @@ test/common/plugins/newsfeed @elastic/kibana-core
 src/plugins/no_data_page @elastic/appex-sharedux
 x-pack/plugins/notifications @elastic/appex-sharedux
 packages/kbn-object-versioning @elastic/appex-sharedux
-x-pack/plugins/observability_solution/observability_ai_assistant_app @elastic/obs-knowledge-team
-x-pack/plugins/observability_solution/observability_ai_assistant_management @elastic/obs-knowledge-team
-x-pack/plugins/observability_solution/observability_ai_assistant @elastic/obs-knowledge-team
+x-pack/plugins/observability_solution/observability_ai_assistant_app @elastic/obs-ai-assistant
+x-pack/plugins/observability_solution/observability_ai_assistant_management @elastic/obs-ai-assistant
+x-pack/plugins/observability_solution/observability_ai_assistant @elastic/obs-ai-assistant
 x-pack/packages/observability/alert_details @elastic/obs-ux-management-team
 x-pack/packages/observability/alerting_test_data @elastic/obs-ux-management-team
 x-pack/test/cases_api_integration/common/plugins/observability @elastic/response-ops

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-plugin",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": "@elastic/obs-ai-assistant",
   "plugin": {
     "id": "observabilityAIAssistant",
     "server": true,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-app-plugin",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": "@elastic/obs-ai-assistant",
   "plugin": {
     "id": "observabilityAIAssistantApp",
     "server": true,
@@ -23,7 +23,7 @@
       "licensing",
       "ml"
     ],
-    "requiredBundles": [ "kibanaReact" ],
+    "requiredBundles": ["kibanaReact"],
     "optionalPlugins": ["cloud"],
     "extraPublicDirs": []
   }

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/observability-ai-assistant-management-plugin",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": "@elastic/obs-ai-assistant",
   "plugin": {
     "id": "observabilityAiAssistantManagement",
     "server": false,


### PR DESCRIPTION
This updates the code owner for the ai assistant plugins to `obs-ai-assistant` (previously `obs-knowledge-team`)