### PR TITLE
[Security Solution] Bug fixing, LangChain and error persistence

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.test.ts
@@ -200,10 +200,14 @@ describe('callAgentExecutor', () => {
       const onLlmResponse = jest.fn();
       await callAgentExecutor({ ...defaultProps, onLlmResponse, isStream: true });
 
-      expect(onLlmResponse).toHaveBeenCalledWith('hello', {
-        traceId: undefined,
-        transactionId: undefined,
-      });
+      expect(onLlmResponse).toHaveBeenCalledWith(
+        'hello',
+        {
+          traceId: undefined,
+          transactionId: undefined,
+        },
+        false
+      );
     });
   });
 });

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
@@ -184,7 +184,7 @@ export const callAgentExecutor: AgentExecutor<true | false> = async ({
                 }
               },
               handleChainEnd(outputs, runId, parentRunId) {
-                // if parentRunId is null, this is the end of the stream
+                // if parentRunId is undefined, this is the end of the stream
                 if (!parentRunId) {
                   handleStreamEnd(outputs.output);
                 }

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
@@ -145,12 +145,16 @@ export const callAgentExecutor: AgentExecutor<true | false> = async ({
 
     let didEnd = false;
 
-    const handleStreamEnd = (finalResponse: string) => {
+    const handleStreamEnd = (finalResponse: string, isError = false) => {
       if (onLlmResponse) {
-        onLlmResponse(finalResponse, {
-          transactionId: streamingSpan?.transaction?.ids?.['transaction.id'],
-          traceId: streamingSpan?.ids?.['trace.id'],
-        });
+        onLlmResponse(
+          finalResponse,
+          {
+            transactionId: streamingSpan?.transaction?.ids?.['transaction.id'],
+            traceId: streamingSpan?.ids?.['trace.id'],
+          },
+          isError
+        );
       }
       streamEnd();
       didEnd = true;
@@ -179,8 +183,11 @@ export const callAgentExecutor: AgentExecutor<true | false> = async ({
                   message += payload;
                 }
               },
-              handleChainEnd(llmResult) {
-                handleStreamEnd(llmResult.output);
+              handleChainEnd(outputs, runId, parentRunId) {
+                // if parentRunId is null, this is the end of the stream
+                if (!parentRunId) {
+                  handleStreamEnd(outputs.output);
+                }
               },
             },
             apmTracer,
@@ -202,7 +209,7 @@ export const callAgentExecutor: AgentExecutor<true | false> = async ({
         }
         logger.error(`Error streaming from LangChain: ${error.message}`);
         push({ payload: error.message, type: 'content' });
-        handleStreamEnd(error.message);
+        handleStreamEnd(error.message, true);
       });
 
     return responseWithHeaders;

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
@@ -34,7 +34,11 @@ export interface AgentExecutorParams<T extends boolean> {
   onNewReplacements?: (newReplacements: Replacements) => void;
   replacements: Replacements;
   isStream?: T;
-  onLlmResponse?: (content: string, traceData?: Message['traceData']) => Promise<void>;
+  onLlmResponse?: (
+    content: string,
+    traceData?: Message['traceData'],
+    isError?: boolean
+  ) => Promise<void>;
   request: KibanaRequest<unknown, unknown, ExecuteConnectorRequestBody>;
   size?: number;
   elserId?: string;

--- a/x-pack/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -70,6 +70,7 @@ export const postActionsConnectorExecuteRoute = (
         const assistantContext = await context.elasticAssistant;
         const logger: Logger = assistantContext.logger;
         const telemetry = assistantContext.telemetry;
+        let onLlmResponse;
 
         try {
           const authenticatedUser = assistantContext.getCurrentUser();
@@ -85,7 +86,6 @@ export const postActionsConnectorExecuteRoute = (
             latestReplacements = { ...latestReplacements, ...newReplacements };
           };
 
-          let onLlmResponse;
           let prevMessages;
           let newMessage: Pick<Message, 'content' | 'role'> | undefined;
           const conversationId = request.body.conversationId;
@@ -154,7 +154,8 @@ export const postActionsConnectorExecuteRoute = (
 
             onLlmResponse = async (
               content: string,
-              traceData: Message['traceData'] = {}
+              traceData: Message['traceData'] = {},
+              isError = false
             ): Promise<void> => {
               if (updatedConversation) {
                 await dataClient?.appendConversationMessages({
@@ -166,6 +167,7 @@ export const postActionsConnectorExecuteRoute = (
                         replacements: latestReplacements,
                       }),
                       traceData,
+                      isError,
                     }),
                   ],
                 });
@@ -290,6 +292,9 @@ export const postActionsConnectorExecuteRoute = (
         } catch (err) {
           logger.error(err);
           const error = transformError(err);
+          if (onLlmResponse) {
+            onLlmResponse(error.message, {}, true);
+          }
           telemetry.reportEvent(INVOKE_ASSISTANT_ERROR_EVENT.eventType, {
             isEnabledKnowledgeBase: request.body.isEnabledKnowledgeBase,
             isEnabledRAGAlerts: request.body.isEnabledRAGAlerts,


### PR DESCRIPTION
## Summary

1. Fixes error persistence by adding `onLlmResponse` to the catch in `post_actions_connector_exectue.ts`
2. Fixes bug in streaming LangChain related to ending the stream/saving the response. We end the stream when `handleChainEnd` is called. However, this can be called multiple times. Add a check to only call `handleStreamEnd` when `parentRunId` is `undefined`, indicating the end of the stream
 
## To test error persistence bug

1. Create a connector with a bad API key. 
2. Select the connector in the assistant. 
3. Send a message. 
4. Ensure error response shows
5. Change conversation
6. come back to original conversation
7. Ensure error response remains

## To test `handleChainEnd` bug

1. Create an azure connector
2. Select the connector in the assistant. 
3. Enable KB
4. Ensure streaming is enabled
5. Send a message asking for ESQL query: `How can I build an ES|QL query to calculate the 99th, 95th, and 75th percentile bytes from logstash indices, broken down by the 10 most popular hosts?`
6. Ensure assistant streams a nice response
5. Change conversation
6. come back to original conversation
7. Ensure response is stored to conversation storage
