### PR TITLE
[Security Assistant] Fixes LangSmith support for specifying configuration via env vars

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api/index.tsx
@@ -80,8 +80,10 @@ export const fetchConnectorExecuteAction = async ({
     replacements,
     isEnabledKnowledgeBase,
     isEnabledRAGAlerts,
-    langSmithProject: traceOptions?.langSmithProject,
-    langSmithApiKey: traceOptions?.langSmithApiKey,
+    langSmithProject:
+      traceOptions?.langSmithProject === '' ? undefined : traceOptions?.langSmithProject,
+    langSmithApiKey:
+      traceOptions?.langSmithApiKey === '' ? undefined : traceOptions?.langSmithApiKey,
     ...optionalRequestParams,
   };
 

--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/utils.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/utils.ts
@@ -124,7 +124,7 @@ export const getLangSmithTracer = ({
       return [];
     }
     const lcTracer = new LangChainTracer({
-      projectName: projectName ?? getLangSmithDefaultProject(), // Shows as the 'test' run's 'name' in langsmith ui
+      projectName, // Shows as the 'test' run's 'name' in langsmith ui
       exampleId,
       client: new Client({ apiKey }),
     });
@@ -148,20 +148,5 @@ export const isLangSmithEnabled = (): boolean => {
     return config.apiKey != null;
   } catch (e) {
     return false;
-  }
-};
-
-/**
- * Returns the default LangSmith project as defined in env vars. This is LangSmith's default way of storing
- * configuration. See https://github.com/elastic/kibana/pull/180227 for storage of configuration in sessionStorage
- */
-export const getLangSmithDefaultProject = (): string => {
-  const defaultProject = 'default';
-  try {
-    return typeof process !== 'undefined'
-      ? process.env?.LANGCHAIN_PROJECT ?? defaultProject
-      : defaultProject;
-  } catch (e) {
-    return defaultProject;
   }
 };

--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/utils.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/utils.ts
@@ -124,7 +124,7 @@ export const getLangSmithTracer = ({
       return [];
     }
     const lcTracer = new LangChainTracer({
-      projectName: projectName ?? 'default', // Shows as the 'test' run's 'name' in langsmith ui
+      projectName: projectName ?? getLangSmithDefaultProject(), // Shows as the 'test' run's 'name' in langsmith ui
       exampleId,
       client: new Client({ apiKey }),
     });
@@ -148,5 +148,20 @@ export const isLangSmithEnabled = (): boolean => {
     return config.apiKey != null;
   } catch (e) {
     return false;
+  }
+};
+
+/**
+ * Returns the default LangSmith project as defined in env vars. This is LangSmith's default way of storing
+ * configuration. See https://github.com/elastic/kibana/pull/180227 for storage of configuration in sessionStorage
+ */
+export const getLangSmithDefaultProject = (): string => {
+  const defaultProject = 'default';
+  try {
+    return typeof process !== 'undefined'
+      ? process.env?.LANGCHAIN_PROJECT ?? defaultProject
+      : defaultProject;
+  } catch (e) {
+    return defaultProject;
   }
 };


### PR DESCRIPTION
## Summary

With https://github.com/elastic/kibana/pull/180227, LangSmith configuration (Project & API Key) could no longer be specified using environment variables when working locally. This fixes that issue, which was caused by sending `''` for `langSmithProject` and `langSmithApiKey` instead of `undefined`. 

To test, set the below env vars, then start kibana. Be sure to not have the UI trace options set as shown in https://github.com/elastic/kibana/pull/180227.


```
# LangChain LangSmith
export LANGCHAIN_TRACING_V2=true
export LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
export LANGCHAIN_API_KEY="🫣"
export LANGCHAIN_PROJECT="Best Project Ever"
```


