### PR TITLE
[Security solution][Defend Workflows] Enable skipped tests

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifact_tabs_in_policy_details.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifact_tabs_in_policy_details.cy.ts
@@ -59,8 +59,7 @@ const visitArtifactTab = (tabId: string) => {
   cy.get(`#${tabId}`).click();
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/171644
-describe.skip('Artifact tabs in Policy Details page', { tags: ['@ess', '@serverless'] }, () => {
+describe('Artifact tabs in Policy Details page', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
   before(() => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
@@ -31,9 +31,7 @@ const loginWithoutAccess = (url: string) => {
   loadPage(url);
 };
 
-// Flaky: https://github.com/elastic/kibana/issues/171168
-// Failing: See https://github.com/elastic/kibana/issues/171168
-describe.skip('Artifacts pages', { tags: ['@ess', '@serverless'] }, () => {
+describe('Artifacts pages', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
   before(() => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/results.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/results.cy.ts
@@ -14,8 +14,7 @@ import { indexEndpointRuleAlerts } from '../../tasks/index_endpoint_rule_alerts'
 
 import { login, ROLE } from '../../tasks/login';
 
-// FLAKY: https://github.com/elastic/kibana/issues/171665
-describe.skip('Results', { tags: ['@ess', '@serverless'] }, () => {
+describe('Results', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
   let alertData: ReturnTypeFromChainable<typeof indexEndpointRuleAlerts> | undefined;
   const [endpointAgentId, endpointHostname] = generateRandomStringName(2);

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/responder.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/responder.cy.ts
@@ -21,8 +21,7 @@ import { indexNewCase } from '../../tasks/index_new_case';
 import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
 import { indexEndpointRuleAlerts } from '../../tasks/index_endpoint_rule_alerts';
 
-// Failing: See https://github.com/elastic/kibana/issues/169894
-describe.skip('When accessing Endpoint Response Console', { tags: ['@ess', '@serverless'] }, () => {
+describe('When accessing Endpoint Response Console', { tags: ['@ess', '@serverless'] }, () => {
   const performResponderSanityChecks = () => {
     openResponderActionLogFlyout();
     // Ensure the popover in the action log date quick select picker is accessible

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_actions_history.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_actions_history.cy.ts
@@ -10,8 +10,7 @@ import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
 import { login } from '../../tasks/login';
 import { loadPage } from '../../tasks/common';
 
-// Failing: See https://github.com/elastic/kibana/issues/172549
-describe.skip('Response actions history page', { tags: ['@ess', '@serverless'] }, () => {
+describe('Response actions history page', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts>;
 
   before(() => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/endpoint_list_with_security_essentials.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/endpoint_list_with_security_essentials.cy.ts
@@ -15,8 +15,7 @@ import {
   visitEndpointList,
 } from '../../screens';
 
-// Failing: See https://github.com/elastic/kibana/issues/171643
-describe.skip(
+describe(
   'When on the Endpoint List in Security Essentials PLI',
   {
     tags: ['@serverless'],

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/roles/essentials_with_endpoint.roles.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/roles/essentials_with_endpoint.roles.cy.ts
@@ -23,8 +23,7 @@ import {
   ensurePolicyDetailsPageAuthzAccess,
 } from '../../../screens';
 
-// Failing: See https://github.com/elastic/kibana/issues/170985
-describe.skip(
+describe(
   'Roles for Security Essential PLI with Endpoint Essentials addon',
   {
     tags: ['@serverless'],

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -85,9 +85,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     return tableData;
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/170357
-  // FLAKY: https://github.com/elastic/kibana/issues/173670
-  describe.skip('endpoint list', function () {
+  describe('endpoint list', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -16,8 +16,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
-  // FLAKY: https://github.com/elastic/kibana/issues/180401
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -28,9 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const endpointTestResources = getService('endpointTestResources');
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/171653
-  // FLAKY: https://github.com/elastic/kibana/issues/171654
-  describe.skip('When on the Endpoint Policy Details Page', function () {
+  describe('When on the Endpoint Policy Details Page', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
@@ -16,8 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const endpointTestResources = getService('endpointTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/171666
-  describe.skip('Endpoint `execute` response action', function () {
+  describe('Endpoint `execute` response action', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
## Summary
Reenable Defend Workflows skipped tests.

Closes following issues:
closes https://github.com/elastic/kibana/issues/180401
closes https://github.com/elastic/kibana/issues/171654
closes https://github.com/elastic/kibana/issues/171666
closes https://github.com/elastic/kibana/issues/170357
closes https://github.com/elastic/kibana/issues/171665
closes https://github.com/elastic/kibana/issues/169894
closes https://github.com/elastic/kibana/issues/172549
closes https://github.com/elastic/kibana/issues/171644
closes https://github.com/elastic/kibana/issues/170985
closes https://github.com/elastic/kibana/issues/171643
closes https://github.com/elastic/kibana/issues/171168
closes https://github.com/elastic/kibana/issues/173670
closes https://github.com/elastic/kibana/issues/171653


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
