### PR TITLE
[Serverless] Adjust serverless configs

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/observability/config.feature_flags.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/config.feature_flags.ts
@@ -26,5 +26,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/config.feature_flags.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/config.feature_flags.ts
@@ -26,5 +26,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/config.ts
@@ -19,7 +19,7 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
   // defined in MKI control plane
   kbnServerArgs: ['--xpack.uptime.service.manifestUrl=mockDevUrl'],
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/config.ts
@@ -19,7 +19,7 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
   // defined in MKI control plane
   kbnServerArgs: ['--xpack.uptime.service.manifestUrl=mockDevUrl'],
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
@@ -20,7 +20,7 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
 
   kbnServerArgs,
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
@@ -20,7 +20,7 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
 
   kbnServerArgs,
 });

--- a/x-pack/test_serverless/api_integration/test_suites/security/config.feature_flags.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/config.feature_flags.ts
@@ -24,5 +24,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/api_integration/test_suites/security/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/config.ts
@@ -17,5 +17,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts
@@ -18,7 +18,7 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.nlp.enabled=true'],
 
   kbnServerArgs,
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.examples.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.examples.ts
@@ -23,5 +23,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.examples.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.examples.ts
@@ -23,5 +23,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
@@ -30,5 +30,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
@@ -30,5 +30,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.ts
@@ -17,6 +17,6 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
   kbnServerArgs: [],
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.ts
@@ -17,6 +17,6 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=true'],
   kbnServerArgs: [],
 });

--- a/x-pack/test_serverless/functional/test_suites/security/config.examples.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/config.examples.ts
@@ -23,5 +23,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/functional/test_suites/security/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/config.feature_flags.ts
@@ -28,5 +28,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/functional/test_suites/security/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/config.ts
@@ -17,5 +17,5 @@ export default createTestConfig({
 
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
-  esServerArgs: ['xpack.ml.nlp.enabled=false'],
+  esServerArgs: ['xpack.ml.nlp.enabled=true'],
 });

--- a/x-pack/test_serverless/functional/test_suites/security/ml/trained_models_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ml/trained_models_list.ts
@@ -30,8 +30,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await ml.testExecution.logTestStep(
           'should display the stats bar and the analytics table with no trained models'
         );
-        await ml.trainedModels.assertStats(0);
-        await ml.trainedModelsTable.assertTableIsNotPopulated();
+        await ml.trainedModels.assertStats(1);
+        await ml.trainedModelsTable.assertTableIsPopulated();
       });
     });
   });


### PR DESCRIPTION
## Summary

Adjust the serverless security configs (all of them) and then fix the tests.

Modify the configs as https://github.com/elastic/kibana/pull/175358 and then instead of skipping the tests, adjust the assertion - with the models now loaded, the expected value is 1 instead of 0