### PR TITLE
[Fleet] added Fleet synthetic check to staging quality gates

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
@@ -21,6 +21,19 @@ steps:
         EC_REGION: aws-us-east-1
         RETRY_TESTS_ON_FAIL: "true"
       message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-staging.yaml)"
+  
+  - label: ":rocket: Fleet synthetic monitor to check the long standing project"
+    trigger: "serverless-quality-gates"
+    build:
+      message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-staging.yaml)"
+      env:
+        TARGET_ENV: staging
+        CHECK_SYNTHETICS: true
+        CHECK_SYNTHETICS_TAG: "fleet"
+        CHECK_SYNTHETICS_MINIMUM_RUNS: 3
+        MAX_FAILURES: 2
+        CHECK_SYNTHETIC_MAX_POLL: 50
+    soft_fail: true
 
   - wait: ~
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/3065

Added Fleet synthetic monitor check to Kibana staging quality gates.
It has been stable in the past two weeks, added with soft fail for now.

This monitor verifies that a long running project is healthy in staging. It aims to flag issues if there is a breaking change in Kibana / Fleet plugin.