### PR TITLE
[7.17] Upgrading express from 4.17.3 --> 4.19.2 (#180373)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13644,9 +13644,9 @@ expose-loader@^0.7.5:
   integrity sha512-iPowgKUZkTPX5PznYsmifVj9Bob0w2wTHVkt/eYNPSzyebkUgIedmskf/kcfEIWpiWjg3JRjnW+a17XypySMuw==
 
 express@^4.17.1, express@^4.17.3:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
-  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
+  integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Upgrading express from 4.17.3 --> 4.19.2 (#180373)](https://github.com/elastic/kibana/pull/180373)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-10T12:13:17Z","message":"Upgrading express from 4.17.3 --> 4.19.2 (#180373)\n\n## Summary\r\n\r\nUpgrading `express` from 4.17.3. to 4.19.2\r\n\r\n\r\n[Changelog](https://github.com/expressjs/express/compare/4.17.3...4.19.2)","sha":"ba2c27c95afb08936397e50be15d738a117b98f4","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v8.14.0"],"number":180373,"url":"https://github.com/elastic/kibana/pull/180373","mergeCommit":{"message":"Upgrading express from 4.17.3 --> 4.19.2 (#180373)\n\n## Summary\r\n\r\nUpgrading `express` from 4.17.3. to 4.19.2\r\n\r\n\r\n[Changelog](https://github.com/expressjs/express/compare/4.17.3...4.19.2)","sha":"ba2c27c95afb08936397e50be15d738a117b98f4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/180373","number":180373,"mergeCommit":{"message":"Upgrading express from 4.17.3 --> 4.19.2 (#180373)\n\n## Summary\r\n\r\nUpgrading `express` from 4.17.3. to 4.19.2\r\n\r\n\r\n[Changelog](https://github.com/expressjs/express/compare/4.17.3...4.19.2)","sha":"ba2c27c95afb08936397e50be15d738a117b98f4"}},{"url":"https://github.com/elastic/kibana/pull/180462","number":180462,"branch":"8.13","state":"OPEN"}]}] BACKPORT-->