### PR TITLE
[7.17] Fix upgrade assistant warning for optional roles and roleTemplate properties (#179818)

### DIFF
--- a/x-pack/plugins/reporting/server/deprecations/reporting_role.ts
+++ b/x-pack/plugins/reporting/server/deprecations/reporting_role.ts
@@ -202,8 +202,11 @@ async function getRoleMappingsDeprecations(
   const roleMappingsWithReportingRole: string[] = Object.entries(roleMappings).reduce(
     (roleSet, current) => {
       const [roleName, role] = current;
-      const foundMapping = role.roles.find((roll) => deprecatedRoles.includes(roll));
-      return foundMapping ? [...roleSet, `${roleName}[${foundMapping}]`] : roleSet;
+      const foundMapping = role.roles?.find((roll) => deprecatedRoles.includes(roll));
+      if (foundMapping) {
+        roleSet.push(`${roleName}[${foundMapping}]`);
+      }
+      return roleSet;
     },
     [] as string[]
   );

--- a/x-pack/plugins/security/server/deprecations/kibana_user_role.ts
+++ b/x-pack/plugins/security/server/deprecations/kibana_user_role.ts
@@ -160,7 +160,7 @@ async function getRoleMappingsDeprecations(
   }
 
   const roleMappingsWithKibanaUserRole = Object.entries(roleMappings)
-    .filter(([, roleMapping]) => roleMapping.roles.includes(KIBANA_USER_ROLE_NAME))
+    .filter(([, roleMapping]) => roleMapping.roles?.includes(KIBANA_USER_ROLE_NAME))
     .map(([mappingName]) => mappingName);
   if (roleMappingsWithKibanaUserRole.length === 0) {
     return [];

--- a/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.ts
+++ b/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.ts
@@ -103,7 +103,7 @@ export function defineKibanaUserRoleDeprecationRoutes({ router, logger }: RouteD
       }
 
       const roleMappingsWithKibanaUserRole = Object.entries(roleMappings).filter(([, mapping]) =>
-        mapping.roles.includes(KIBANA_USER_ROLE_NAME)
+        mapping.roles?.includes(KIBANA_USER_ROLE_NAME)
       );
 
       if (roleMappingsWithKibanaUserRole.length === 0) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix upgrade assistant warning for optional roles and roleTemplate properties (#179818)](https://github.com/elastic/kibana/pull/179818)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
