### PR TITLE
[ML] AIOps: Stabilize performance journey for log rate analysis.

### DIFF
--- a/x-pack/performance/journeys_e2e/aiops_log_rate_analysis.ts
+++ b/x-pack/performance/journeys_e2e/aiops_log_rate_analysis.ts
@@ -14,19 +14,27 @@ export const journey = new Journey({
   kbnArchives: ['x-pack/performance/kbn_archives/large_arrays_data_view'],
   esArchives: ['x-pack/test/functional/es_archives/large_arrays'],
 })
-  .step('Go to AIOps Log Rate Analysis', async ({ page, kbnUrl }) => {
-    // Navigate to Log Rate Analysis with a prepopulated url state that runs
-    // the analysis directly on page load without any necessary user interactions.
+  .step('Go to AIOps Log Rate Analysis', async ({ page, kbnUrl, kibanaPage }) => {
+    // Navigate to Log Rate Analysis with just a prepopulated time range.
     await page.goto(
       kbnUrl.get(
-        `app/ml/aiops/log_rate_analysis?index=${dataView.id}&_g=%28refreshInterval%3A%28pause%3A%21t%2Cvalue%3A60000%29%2Ctime%3A%28from%3A%272019-07-01T15%3A35%3A38.700Z%27%2Cto%3A%272019-07-05T15%3A35%3A38.700Z%27%29%29&_a=%28logRateAnalysis%3A%28filters%3A%21%28%29%2CsearchQuery%3A%28match_all%3A%28%29%29%2CsearchQueryLanguage%3Akuery%2CsearchString%3A%27%27%2Cwp%3A%28bMax%3A1562198400000%2CbMin%3A1562097600000%2CdMax%3A1562270400000%2CdMin%3A1562234400000%29%29%29`
+        `app/ml/aiops/log_rate_analysis?index=${dataView.id}&_g=%28refreshInterval%3A%28pause%3A%21t%2Cvalue%3A60000%29%2Ctime%3A%28from%3A%272019-07-01T15%3A35%3A38.700Z%27%2Cto%3A%272019-07-05T15%3A35%3A38.700Z%27%29%29&_a=%28logRateAnalysis%3A%28filters%3A%21%28%29%2CsearchQuery%3A%28match_all%3A%28%29%29%2CsearchQueryLanguage%3Akuery%2CsearchString%3A%27%27%29%29`
       )
     );
 
     // Wait for the AIOps Log Rate Analysis page wrapper to load
     await page.waitForSelector(subj('aiopsLogRateAnalysisPage'));
+    await page.waitForSelector(subj('aiopsDocumentCountChart'));
+    // Wait for the histogram chart to load
+    await kibanaPage.waitForCharts({
+      parentLocator: subj('aiopsDocumentCountChart'),
+      count: 1,
+    });
+    await page.waitForSelector(subj('aiopsNoWindowParametersEmptyPrompt'));
   })
-  .step('Run AIOps Log Rate Analysis', async ({ page, kbnUrl }) => {
-    // Wait for the analysis to complete with extended timeout, this one tracks a known issue with slow frequent_item_sets performance.
+  .step('Run AIOps Log Rate Analysis', async ({ page }) => {
+    // Select the chart and click in the area where the spike is located to trigger log rate analysis.
+    const chart = await page.locator(subj('aiopsDocumentCountChart'));
+    await chart.click({ position: { x: 710, y: 50 } });
     await page.waitForSelector(subj('aiopsAnalysisComplete'), { timeout: 120000 });
   });


### PR DESCRIPTION
## Summary

Changes the flow of the performance journey for log rate analysis a bit: Previously we prepopulated the URL so the analysis would run right away. This update reduces the options stored in the URL to just load the page with the correct time range. The second step then clicks on the spike in the chart to intentionally start the analysis. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
