### PR TITLE
[CI] Backport service account activation to 7.17

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/create_manifest.js
+++ b/.buildkite/scripts/steps/es_snapshots/create_manifest.js
@@ -80,6 +80,7 @@ const { BASE_BUCKET_DAILY } = require('./bucket_config.js');
       set -euo pipefail
 
       echo '--- Upload files to GCS'
+      .buildkite/scripts/common/activate_service_account.sh ${BASE_BUCKET_DAILY}
       cd "${destination}"
       gsutil -m cp -r *.* gs://${BASE_BUCKET_DAILY}/${DESTINATION}
       cp manifest.json manifest-latest.json

--- a/.buildkite/scripts/steps/es_snapshots/promote_manifest.js
+++ b/.buildkite/scripts/steps/es_snapshots/promote_manifest.js
@@ -18,6 +18,7 @@ const { BASE_BUCKET_DAILY, BASE_BUCKET_PERMANENT } = require('./bucket_config.js
       throw Error('Manifest URL missing');
     }
 
+    const projectRoot = process.cwd();
     const tempDir = fs.mkdtempSync('snapshot-promotion');
     process.chdir(tempDir);
 
@@ -39,9 +40,11 @@ const { BASE_BUCKET_DAILY, BASE_BUCKET_PERMANENT } = require('./bucket_config.js
       `
       set -euo pipefail
       cp manifest.json manifest-latest-verified.json
+      ${projectRoot}/.buildkite/scripts/common/activate_service_account.sh ${BASE_BUCKET_DAILY}
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp manifest-latest-verified.json gs://${BASE_BUCKET_DAILY}/${version}/
       rm manifest.json
       cp manifest-permanent.json manifest.json
+      ${projectRoot}/.buildkite/scripts/common/activate_service_account.sh ${BASE_BUCKET_PERMANENT}
       gsutil -m cp -r gs://${bucket}/* gs://${BASE_BUCKET_PERMANENT}/${version}/
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp manifest.json gs://${BASE_BUCKET_PERMANENT}/${version}/
     `,


### PR DESCRIPTION
## Summary
The backport script probably missed backporting of these lines because of the file name differences (`*.ts <-> *.js`).

This will hopefully unblock 7.17's snapshot build: https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/3866#018ec868-0d9c-412d-9b60-92ea2dc64dcb