### PR TITLE
[7.17][CI] Update pipeline-lib version to adapt agent targeting rule branching in test grouping

### DIFF
--- a/.buildkite/package-lock.json
+++ b/.buildkite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kibana-buildkite",
       "version": "1.0.0",
       "dependencies": {
-        "kibana-buildkite-library": "elastic/kibana-buildkite-library#8119df13d542b3dafab9ed2ccb0dbcbc9592d308"
+        "kibana-buildkite-library": "elastic/kibana-buildkite-library#1f0381a052a62da9af4e341db8eab9548fc8a4ea"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -406,10 +406,9 @@
       }
     },
     "node_modules/kibana-buildkite-library": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/elastic/kibana-buildkite-library.git#8119df13d542b3dafab9ed2ccb0dbcbc9592d308",
-      "integrity": "sha512-GKt7whi0F5CdBDh11D/HW0GIUmKBJRkj8SMwuPrD7uHRxx3npcGGV9KTYLDQMuaJrT5F/f8KdshevoImz75PBA==",
-      "license": "MIT",
+      "version": "1.1.1",
+      "resolved": "git+ssh://git@github.com/elastic/kibana-buildkite-library.git#1f0381a052a62da9af4e341db8eab9548fc8a4ea",
+      "integrity": "sha512-wOwMxLa8i1S5A17MoJWnGJPTncNNyEi5F52QFT56JO9vEz1495dKr04NcS2brd1eIIHx1b+1Jeua8PYNswRvTQ==",
       "dependencies": {
         "@octokit/rest": "^18.10.0",
         "axios": "^1.6.3",
@@ -932,9 +931,9 @@
       }
     },
     "kibana-buildkite-library": {
-      "version": "git+ssh://git@github.com/elastic/kibana-buildkite-library.git#8119df13d542b3dafab9ed2ccb0dbcbc9592d308",
-      "integrity": "sha512-GKt7whi0F5CdBDh11D/HW0GIUmKBJRkj8SMwuPrD7uHRxx3npcGGV9KTYLDQMuaJrT5F/f8KdshevoImz75PBA==",
-      "from": "kibana-buildkite-library@elastic/kibana-buildkite-library#8119df13d542b3dafab9ed2ccb0dbcbc9592d308",
+      "version": "git+ssh://git@github.com/elastic/kibana-buildkite-library.git#1f0381a052a62da9af4e341db8eab9548fc8a4ea",
+      "integrity": "sha512-wOwMxLa8i1S5A17MoJWnGJPTncNNyEi5F52QFT56JO9vEz1495dKr04NcS2brd1eIIHx1b+1Jeua8PYNswRvTQ==",
+      "from": "kibana-buildkite-library@elastic/kibana-buildkite-library#1f0381a052a62da9af4e341db8eab9548fc8a4ea",
       "requires": {
         "@octokit/rest": "^18.10.0",
         "axios": "^1.6.3",

--- a/.buildkite/package.json
+++ b/.buildkite/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "kibana-buildkite-library": "elastic/kibana-buildkite-library#8119df13d542b3dafab9ed2ccb0dbcbc9592d308"
+    "kibana-buildkite-library": "elastic/kibana-buildkite-library#1f0381a052a62da9af4e341db8eab9548fc8a4ea"
   }
 }


### PR DESCRIPTION
## Summary
This is effectively the backport of https://github.com/elastic/kibana/pull/180078 to 7.17 through the pipeline-lib. 
This is required so that the `pick_test_group_run_order` functionality will start to respect the new running environment and request agents with full agent targeting rules instead of queues.