### PR TITLE
[7.17] fix(NA): cwd path for child script on create manifest

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/create_manifest.js
+++ b/.buildkite/scripts/steps/es_snapshots/create_manifest.js
@@ -70,6 +70,7 @@ const { BASE_BUCKET_DAILY } = require('./bucket_config.js');
       archives: manifestEntries,
     };
 
+    const projectRoot = process.cwd();
     const manifestJSON = JSON.stringify(manifest, null, 2);
     fs.writeFileSync(`${destination}/manifest.json`, manifestJSON);
 
@@ -80,7 +81,7 @@ const { BASE_BUCKET_DAILY } = require('./bucket_config.js');
       set -euo pipefail
 
       echo '--- Upload files to GCS'
-      .buildkite/scripts/common/activate_service_account.sh ${BASE_BUCKET_DAILY}
+      ${projectRoot}/.buildkite/scripts/common/activate_service_account.sh ${BASE_BUCKET_DAILY}
       cd "${destination}"
       gsutil -m cp -r *.* gs://${BASE_BUCKET_DAILY}/${DESTINATION}
       cp manifest.json manifest-latest.json


### PR DESCRIPTION
This PR completely backports what was done at https://github.com/elastic/kibana/pull/176781 but for 7.17