### PR TITLE
[ci/on-merge] Wait for quick checks and build to complete

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -39,6 +39,19 @@ steps:
         - exit_status: '*'
           limit: 1
 
+  - command: .buildkite/scripts/steps/quick_checks.sh
+    label: 'Quick Checks'
+    agents:
+      queue: n2-2-spot
+    key: quick_checks
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
+  - wait
+
   - command: .buildkite/scripts/steps/on_merge_api_docs.sh
     label: Check Public API Docs
     key: public-api-docs
@@ -358,16 +371,6 @@ steps:
       queue: n2-16-spot
     key: linting_with_types
     timeout_in_minutes: 90
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-
-  - command: .buildkite/scripts/steps/quick_checks.sh
-    label: 'Quick Checks'
-    agents:
-      queue: n2-2-spot
-    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -23,7 +23,6 @@ steps:
     label: 'Quick Checks'
     agents:
       queue: n2-2-spot
-    key: quick_checks
     timeout_in_minutes: 60
     retry:
       automatic:


### PR DESCRIPTION
Before proceeding with tests.  This is already implemented in the pull request pipeline, and will allow the pipeline to end early if there's lint errors.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->