### PR TITLE
Add ECS data to data views

### DIFF
--- a/src/plugins/data_views/common/fields/data_view_field.ts
+++ b/src/plugins/data_views/common/fields/data_view_field.ts
@@ -140,7 +140,7 @@ export class DataViewField implements DataViewFieldBase {
    */
 
   public get customDescription() {
-    return this.spec.customDescription;
+    return this.spec.customDescription ?? this.spec.ecsDescription;
   }
 
   /**

--- a/src/plugins/data_views/common/types.ts
+++ b/src/plugins/data_views/common/types.ts
@@ -483,6 +483,7 @@ export type FieldSpec = DataViewFieldBase & {
   parentName?: string;
 
   defaultFormatter?: string;
+  ecsDescription?: string;
 };
 
 export type DataViewFieldMap = Record<string, FieldSpec>;

--- a/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
+++ b/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
@@ -34,6 +34,7 @@ export interface FieldDescriptor {
   timeSeriesMetric?: estypes.MappingTimeSeriesMetricType;
   timeSeriesDimension?: boolean;
   defaultFormatter?: string;
+  ecsDescription?: any;
 }
 
 interface FieldSubType {

--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_caps_response.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_caps_response.ts
@@ -7,6 +7,7 @@
  */
 
 import { uniq } from 'lodash';
+import { EcsFlat } from '@elastic/ecs';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { castEsToKbnFieldTypeName } from '@kbn/field-types';
 import { shouldReadFieldFromDocValues } from './should_read_field_from_doc_values';
@@ -156,6 +157,12 @@ export function readFieldCapsResponse(
         timeSeriesMetric: timeSeriesMetricType,
         timeSeriesDimension: capsByType[types[0]].time_series_dimension,
       };
+      if (
+        capsByNameThenType['ecs.version'] &&
+        EcsFlat[fieldName as keyof typeof EcsFlat]?.description
+      ) {
+        field.ecsDescription = EcsFlat[fieldName as keyof typeof EcsFlat].description;
+      }
 
       if (defaultFormatter) {
         field.defaultFormatter = defaultFormatter;

--- a/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
+++ b/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
@@ -108,6 +108,7 @@ const FieldDescriptorSchema = schema.object({
     schema.recordOf(schema.string(), schema.arrayOf(schema.string()))
   ),
   defaultFormatter: schema.maybe(schema.string()),
+  ecsDescription: schema.maybe(schema.string()),
 });
 
 export const validate: FullValidationConfig<any, any, any> = {


### PR DESCRIPTION
## Summary

Exploration what happens if we enrich data view fields data server side with ECS information to display descriptions in the UI:

![image](https://github.com/elastic/kibana/assets/463851/7f825491-5858-4942-8e29-e1dea7e7ecfe)

Note: this can't be shipped as it would add the description to every data view fields request, which would lead to a lot of redundant data being transfered



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
