### PR TITLE
[ML] Transforms: Fix test cleanup

### DIFF
--- a/x-pack/test/api_integration/apis/transform/reauthorize_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/reauthorize_transforms.ts
@@ -41,11 +41,8 @@ export default ({ getService }: FtrProviderContext) => {
   }
 
   async function cleanUpTransform(transformId: string) {
-    const destinationIndex = generateDestIndex(transformId);
-
-    await transform.api.stopTransform(transformId);
     await transform.api.cleanTransformIndices();
-    await transform.api.deleteIndices(destinationIndex);
+    await transform.api.deleteIndices(generateDestIndex(transformId));
   }
 
   // If transform was created with sufficient permissions -> should create and start
@@ -116,8 +113,7 @@ export default ({ getService }: FtrProviderContext) => {
       await transform.securityCommon.clearAllTransformApiKeys();
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/180503
-    describe.skip('single transform reauthorize_transforms', function () {
+    describe('single transform reauthorize_transforms', function () {
       const transformCreatedByViewerId = getTransformIdByUser(USER.TRANSFORM_VIEWER);
 
       beforeEach(async () => {
@@ -216,8 +212,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/180499
-    describe.skip('bulk reauthorize_transforms', function () {
+    describe('bulk reauthorize_transforms', function () {
       const reqBody: ReauthorizeTransformsRequestSchema = [
         USER.TRANSFORM_VIEWER,
         USER.TRANSFORM_POWERUSER,
@@ -236,9 +231,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       afterEach(async () => {
-        await asyncForEach(reqBody, async ({ id }: { id: string }, idx: number) => {
-          await transform.api.stopTransform(id);
-        });
         await transform.api.cleanTransformIndices();
         await asyncForEach(destinationIndices, async (destinationIndex: string) => {
           await transform.api.deleteIndices(destinationIndex);

--- a/x-pack/test/api_integration/apis/transform/schedule_now_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/schedule_now_transforms.ts
@@ -42,7 +42,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       afterEach(async () => {
-        await transform.api.stopTransform(transformId);
         await transform.api.cleanTransformIndices();
         await transform.api.deleteIndices(destinationIndex);
       });
@@ -98,11 +97,7 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/180495
-    // FLAKY: https://github.com/elastic/kibana/issues/180496
-    // FLAKY: https://github.com/elastic/kibana/issues/180497
-    // FLAKY: https://github.com/elastic/kibana/issues/180504
-    describe.skip('bulk schedule', function () {
+    describe('bulk schedule', function () {
       const reqBody: ScheduleNowTransformsRequestSchema = [
         { id: 'bulk_schedule_now_test_1' },
         { id: 'bulk_schedule_now_test_2' },
@@ -117,9 +112,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       afterEach(async () => {
-        await asyncForEach(reqBody, async ({ id }: { id: string }, idx: number) => {
-          await transform.api.stopTransform(id);
-        });
         await transform.api.cleanTransformIndices();
         await asyncForEach(destinationIndices, async (destinationIndex: string) => {
           await transform.api.deleteIndices(destinationIndex);


### PR DESCRIPTION
## Summary

Fixes #180503
Fixes #180499
Fixes #180495
Fixes #180496
Fixes #180497
Fixes #180504

The tests themselves were passing, but the cleanup in the `after` blocks turned out problematic after a [recent update in ES related to stopping transforms](https://github.com/elastic/elasticsearch/pull/106989) using `force`.

Originally we called `stop` on all test transforms and then called the helper function `.cleanTransformIndices();`. For some time now this helper was updated to first both force stop and delete transforms before deleting related indices. So we ended up calling stop twice in some tests! The second stop using force could then return an error if the transform was already stopped. 

This PR fixes the tests by removing the now unnecessary stop commands.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
