### PR TITLE
[CI] Fix agent targeting ES verification's verify step

### DIFF
--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -38,7 +38,10 @@ steps:
     label: 'Default CI Group'
     parallelism: 27
     agents:
-      queue: n2-4
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      machineType: n2-standard-4
     depends_on: build
     timeout_in_minutes: 150
     key: default-cigroup


### PR DESCRIPTION
## Summary
Apparently missed a spot in an agent targeting rule in `verify.yml`, this PR fixes it.

Connected to: #180346 