### PR TITLE
[7.17] Upgrades undici from 5.28.3 to 5.28.4 (#180486)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27618,9 +27618,9 @@ undici-types@~5.26.4:
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici@^5.21.2:
-  version "5.28.3"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
-  integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==
+  version "5.28.4"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
+  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Upgrades undici from 5.28.3 to 5.28.4 (#180486)](https://github.com/elastic/kibana/pull/180486)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sid","email":"siddharthmantri1@gmail.com"},"sourceCommit":{"committedDate":"2024-04-11T11:58:51Z","message":"Upgrades undici from 5.28.3 to 5.28.4 (#180486)\n\n## Summary\r\n\r\nUpgrades `undici` from v5.28.3 to v5.28.4.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"195265cb81b71fc0c0c87c1ae8363e6dac61a227","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v8.14.0"],"number":180486,"url":"https://github.com/elastic/kibana/pull/180486","mergeCommit":{"message":"Upgrades undici from 5.28.3 to 5.28.4 (#180486)\n\n## Summary\r\n\r\nUpgrades `undici` from v5.28.3 to v5.28.4.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"195265cb81b71fc0c0c87c1ae8363e6dac61a227"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/180486","number":180486,"mergeCommit":{"message":"Upgrades undici from 5.28.3 to 5.28.4 (#180486)\n\n## Summary\r\n\r\nUpgrades `undici` from v5.28.3 to v5.28.4.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"195265cb81b71fc0c0c87c1ae8363e6dac61a227"}},{"url":"https://github.com/elastic/kibana/pull/180581","number":180581,"branch":"8.13","state":"OPEN"}]}] BACKPORT-->