### PR TITLE
[Serverless Search] Change default connector name

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/connectors/edit_name.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors/edit_name.tsx
@@ -61,7 +61,12 @@ export const EditName: React.FC<EditNameProps> = ({ connector }) => {
         <>
           <EuiFlexItem grow={false}>
             <EuiTitle data-test-subj="serverlessSearchConnectorName">
-              <h1>{connector.name || CONNECTOR_LABEL}</h1>
+              <h1>
+                {connector.name ||
+                  i18n.translate('xpack.serverlessSearch.connector.chooseName', {
+                    defaultMessage: 'Choose a name for your connector',
+                  })}
+              </h1>
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem


### PR DESCRIPTION
## Summary

This updates the default name for connectors to make clear they can be edited


