### PR TITLE
[ES|QL] Provide the CCS indices on the autosuggestion

### DIFF
--- a/packages/kbn-text-based-editor/src/helpers.test.ts
+++ b/packages/kbn-text-based-editor/src/helpers.test.ts
@@ -12,6 +12,7 @@ import {
   getInlineEditorText,
   getWrappedInPipesCode,
   getIndicesList,
+  getRemoteIndicesList,
 } from './helpers';
 
 describe('helpers', function () {
@@ -279,6 +280,38 @@ describe('helpers', function () {
         { name: '.system1', hidden: true },
         { name: 'logs', hidden: false },
       ]);
+    });
+  });
+
+  describe('getRemoteIndicesList', function () {
+    it('should filter out aliases and hidden indices', async function () {
+      const dataViewsMock = dataViewPluginMocks.createStartContract();
+      const updatedDataViewsMock = {
+        ...dataViewsMock,
+        getIndices: jest.fn().mockResolvedValue([
+          {
+            name: 'remote: alias1',
+            item: {
+              indices: ['index1'],
+            },
+          },
+          {
+            name: 'remote:.system1',
+            item: {
+              name: 'system',
+            },
+          },
+          {
+            name: 'remote:logs',
+            item: {
+              name: 'logs',
+              timestamp_field: '@timestamp',
+            },
+          },
+        ]),
+      };
+      const indices = await getRemoteIndicesList(updatedDataViewsMock);
+      expect(indices).toStrictEqual([{ name: 'remote:logs', hidden: false }]);
     });
   });
 });

--- a/packages/kbn-text-based-editor/src/helpers.ts
+++ b/packages/kbn-text-based-editor/src/helpers.ts
@@ -199,11 +199,9 @@ export const getRemoteIndicesList = async (dataViews: DataViewsPublicPluginStart
     pattern: '*:*',
     isRollupIndex: () => false,
   });
-  const indicesWithNoAliases = indices.filter((source) => !Boolean(source.item.indices));
-
-  const finalIndicesList = indicesWithNoAliases.filter((source) => {
+  const finalIndicesList = indices.filter((source) => {
     const [_, index] = source.name.split(':');
-    return !index.startsWith('.');
+    return !index.startsWith('.') && !Boolean(source.item.indices);
   });
 
   return finalIndicesList.map((source) => ({ name: source.name, hidden: false }));

--- a/packages/kbn-text-based-editor/src/helpers.ts
+++ b/packages/kbn-text-based-editor/src/helpers.ts
@@ -193,6 +193,22 @@ export const getIndicesList = async (dataViews: DataViewsPublicPluginStart) => {
   return indices.map((index) => ({ name: index.name, hidden: index.name.startsWith('.') }));
 };
 
+export const getRemoteIndicesList = async (dataViews: DataViewsPublicPluginStart) => {
+  const indices = await dataViews.getIndices({
+    showAllIndices: false,
+    pattern: '*:*',
+    isRollupIndex: () => false,
+  });
+  const indicesWithNoAliases = indices.filter((source) => !Boolean(source.item.indices));
+
+  const finalIndicesList = indicesWithNoAliases.filter((source) => {
+    const [_, index] = source.name.split(':');
+    return !index.startsWith('.');
+  });
+
+  return finalIndicesList.map((source) => ({ name: source.name, hidden: false }));
+};
+
 // refresh the esql cache entry after 10 minutes
 const CACHE_INVALIDATE_DELAY = 10 * 60 * 1000;
 

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -58,6 +58,7 @@ import {
   getWrappedInPipesCode,
   parseErrors,
   getIndicesList,
+  getRemoteIndicesList,
   clearCacheWhenOld,
 } from './helpers';
 import { EditorFooter } from './editor_footer';
@@ -390,7 +391,9 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
   const esqlCallbacks: ESQLCallbacks = useMemo(
     () => ({
       getSources: async () => {
-        return await getIndicesList(dataViews);
+        const remoteIndices = await getRemoteIndicesList(dataViews);
+        const normalIndices = await getIndicesList(dataViews);
+        return [...normalIndices, ...remoteIndices];
       },
       getFieldsFor: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
         if (queryToExecute) {

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -391,9 +391,11 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
   const esqlCallbacks: ESQLCallbacks = useMemo(
     () => ({
       getSources: async () => {
-        const remoteIndices = await getRemoteIndicesList(dataViews);
-        const normalIndices = await getIndicesList(dataViews);
-        return [...normalIndices, ...remoteIndices];
+        const [remoteIndices, localIndices] = await Promise.all([
+          getRemoteIndicesList(dataViews),
+          getIndicesList(dataViews),
+        ]);
+        return [...localIndices, ...remoteIndices];
       },
       getFieldsFor: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
         if (queryToExecute) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/180577

Fixes the bug where the CCS indices were not displayed in the autocomplete. For testing you have to create an oblt cluster.

![meow](https://github.com/elastic/kibana/assets/17003240/cb69b6e8-74bc-4888-98df-bb4e261c5de9)
