### PR TITLE
[Lens] Improve reporting of contentful render

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -1184,9 +1184,16 @@ export class Embeddable
     }
 
     const hasData = Object.values(this.activeData).some((table) => {
-      const count = table.meta?.statistics?.totalCount || table.rows.length;
-
-      return count > 0;
+      if (
+        table.meta &&
+        table.meta.statistics &&
+        typeof table.meta.statistics.totalCount === 'number'
+      ) {
+        // if totalCount is set, refer to total count
+        return table.meta.statistics.totalCount > 0;
+      }
+      // if not, fall back to check the rows of the table
+      return table.rows.length > 0;
     });
 
     if (hasData) {

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -1184,11 +1184,7 @@ export class Embeddable
     }
 
     const hasData = Object.values(this.activeData).some((table) => {
-      if (
-        table.meta &&
-        table.meta.statistics &&
-        typeof table.meta.statistics.totalCount === 'number'
-      ) {
+      if (table.meta?.statistics?.totalCount != null) {
         // if totalCount is set, refer to total count
         return table.meta.statistics.totalCount > 0;
       }


### PR DESCRIPTION
This is a follow-up of https://github.com/elastic/kibana/pull/179570

In the original PR, a `0` of `totalCount` statistics is not respected and the row count is used instead.

This PR makes sure to always respect the statistics if available, even if the value is 0.