### PR TITLE
[ES|QL] Add more functions to the validator

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -31,7 +31,7 @@ const fields: Array<{ name: string; type: string; suggestedAs?: string }> = [
     'cartesian_point',
     'cartesian_shape',
   ].map((type) => ({
-    name: `${type}Field`,
+    name: `${camelCase(type)}Field`,
     type,
   })),
   { name: 'any#Char$Field', type: 'number', suggestedAs: '`any#Char$Field`' },
@@ -772,6 +772,10 @@ describe('autocomplete', () => {
         'dateField',
         'booleanField',
         'ipField',
+        'geoPointField',
+        'geoShapeField',
+        'cartesianPointField',
+        'cartesianShapeField',
         'any#Char$Field',
         'kubernetes.something.something',
       ]);
@@ -1076,23 +1080,10 @@ describe('autocomplete', () => {
                 i + 1 < (signature.minParams ?? 0) ||
                 signature.params.filter(({ optional }, j) => !optional && j > i).length > i;
 
-              const allSignaturesCompatibleWithPreviousParams = fn.signatures.filter(
-                (_signature) => {
-                  return _signature.params.slice(0, i).every((p, j) => {
-                    if (p.type === 'any') {
-                      return true;
-                    }
-                    return p.type === signature.params[j].type;
-                  });
-                }
-              );
               const allPossibleParamTypes = Array.from(
-                new Set(
-                  allSignaturesCompatibleWithPreviousParams.map((_signature) => {
-                    return _signature.params[i].type;
-                  })
-                )
+                new Set(fn.signatures.map((s) => s.params[i].type))
               );
+
               testSuggestions(
                 `from a | eval ${fn.name}(${Array(i).fill('field').join(', ')}${i ? ',' : ''} )`,
                 param.literalOptions?.length

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
@@ -147,7 +147,7 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
       ],
     },
     {
-      name: 'st_centroid',
+      name: 'st_centroid_agg',
       type: 'agg',
       description: i18n.translate(
         'kbn-esql-validation-autocomplete.esql.definitions.stCentroidDoc',
@@ -161,16 +161,16 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
           params: [{ name: 'column', type: 'cartesian_point', noNestingFunctions: true }],
           returnType: 'cartesian_point',
           examples: [
-            `from index | stats result = st_centroid(cartesian_field)`,
-            `from index | stats st_centroid(cartesian_field)`,
+            `from index | stats result = st_centroid_agg(cartesian_field)`,
+            `from index | stats st_centroid_agg(cartesian_field)`,
           ],
         },
         {
           params: [{ name: 'column', type: 'geo_point', noNestingFunctions: true }],
           returnType: 'geo_point',
           examples: [
-            `from index | stats result = st_centroid(geo_field)`,
-            `from index | stats st_centroid(geo_field)`,
+            `from index | stats result = st_centroid_agg(geo_field)`,
+            `from index | stats st_centroid_agg(geo_field)`,
           ],
         },
       ],

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1498,6 +1498,130 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
       },
     ],
   },
+  {
+    name: 'st_intersects',
+    description: i18n.translate(
+      'kbn-esql-validation-autocomplete.esql.definitions.stIntersectsDoc',
+      {
+        defaultMessage:
+          'Returns true if two geometries intersect. They intersect if they have any point in common, including their interior points (points along lines or within polygons).',
+      }
+    ),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_intersects(geometryA, geometryB)'],
+      },
+    ],
+  },
 ]
   .sort(({ name: a }, { name: b }) => a.localeCompare(b))
   .map((def) => ({

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1651,6 +1651,35 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
       },
     ],
   },
+  {
+    name: 'st_y',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.stYDoc', {
+      defaultMessage:
+        'Extracts the y coordinate from the supplied point. If the points is of type geo_point this is equivalent to extracting the latitude value.',
+    }),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'point',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_y(point)'],
+      },
+      {
+        params: [
+          {
+            name: 'point',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_y(point)'],
+      },
+    ],
+  },
 ]
   .sort(({ name: a }, { name: b }) => a.localeCompare(b))
   .map((def) => ({

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1622,6 +1622,35 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
       },
     ],
   },
+  {
+    name: 'st_x',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.stXDoc', {
+      defaultMessage:
+        'Extracts the x coordinate from the supplied point. If the points is of type geo_point this is equivalent to extracting the longitude value.',
+    }),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'point',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_x(point)'],
+      },
+      {
+        params: [
+          {
+            name: 'point',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_x(point)'],
+      },
+    ],
+  },
 ]
   .sort(({ name: a }, { name: b }) => a.localeCompare(b))
   .map((def) => ({

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1099,6 +1099,44 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
     ],
   },
   {
+    name: 'mv_slice',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mvSliceDoc', {
+      defaultMessage:
+        'Returns a subset of the multivalued field using the start and end index values.',
+    }),
+    signatures: [
+      {
+        params: [
+          { name: 'multivalue', type: 'any' },
+          { name: 'start', type: 'number' },
+          { name: 'end', type: 'number' },
+        ],
+        returnType: 'number',
+        examples: ['row a = [1, 2, 2, 3] | eval a1 = mv_slice(a, 1), a2 = mv_slice(a, 2, 3)'],
+      },
+    ],
+  },
+  {
+    name: 'mv_zip',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mvZipDoc', {
+      defaultMessage:
+        'Combines the values from two multivalued fields with a delimiter that joins them together.',
+    }),
+    signatures: [
+      {
+        params: [
+          { name: 'mvLeft', type: 'string' },
+          { name: 'mvRight', type: 'string' },
+          { name: 'delim', type: 'string' },
+        ],
+        returnType: 'string',
+        examples: [
+          'ROW a = ["x", "y", "z"], b = ["1", "2"] \n| EVAL c = mv_zip(a, b, "-") \n| KEEP a, b, c',
+        ],
+      },
+    ],
+  },
+  {
     name: 'pi',
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.piDoc', {
       defaultMessage: 'The ratio of a circle’s circumference to its diameter.',

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1276,7 +1276,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1290,7 +1290,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1304,7 +1304,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1318,7 +1318,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1332,7 +1332,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1346,7 +1346,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1360,7 +1360,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
       },
       {
         params: [
@@ -1374,7 +1374,127 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           },
         ],
         returnType: 'boolean',
-        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+        examples: ['from index | eval st_within(geometryA, geometryB)'],
+      },
+    ],
+  },
+  {
+    name: 'st_disjoint',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.stDisjointDoc', {
+      defaultMessage: 'Returns whether the two geometries or geometry columns are disjoint.',
+    }),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_disjoint(geometryA, geometryB)'],
       },
     ],
   },

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1258,6 +1258,126 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
       },
     ],
   },
+  {
+    name: 'st_within',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.stWithinDoc', {
+      defaultMessage: 'Returns whether the first geometry is within the second geometry.',
+    }),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+    ],
+  },
 ]
   .sort(({ name: a }, { name: b }) => a.localeCompare(b))
   .map((def) => ({

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -1137,6 +1137,127 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
       },
     ],
   },
+  // begin spatial functions
+  {
+    name: 'st_contains',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.stContainsDoc', {
+      defaultMessage: 'Returns whether the first geometry contains the second geometry.',
+    }),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_point',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'geo_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'geo_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_point',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_point',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+      {
+        params: [
+          {
+            name: 'geomA',
+            type: 'cartesian_shape',
+          },
+          {
+            name: 'geomB',
+            type: 'cartesian_shape',
+          },
+        ],
+        returnType: 'boolean',
+        examples: ['from index | eval st_contains(geometryA, geometryB)'],
+      },
+    ],
+  },
 ]
   .sort(({ name: a }, { name: b }) => a.localeCompare(b))
   .map((def) => ({

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -58,6 +58,20 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
     ],
   },
   {
+    name: 'signum',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.signumDoc', {
+      defaultMessage:
+        'Returns the sign of the given number. It returns -1 for negative numbers, 0 for 0 and 1 for positive numbers.',
+    }),
+    signatures: [
+      {
+        params: [{ name: 'field', type: 'number' }],
+        returnType: 'number',
+        examples: [`from index | eval s = signum(field)`],
+      },
+    ],
+  },
+  {
     name: 'abs',
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.absDoc', {
       defaultMessage: 'Returns the absolute value.',

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -1558,6 +1558,28 @@
       "warning": []
     },
     {
+      "query": "row var = signum(5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row signum(5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = signum(to_integer(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = signum(\"a\")",
+      "error": [
+        "Argument of [signum] must be [number], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = sin(5)",
       "error": [],
       "warning": []
@@ -5619,6 +5641,18 @@
       "warning": []
     },
     {
+      "query": "from a_index | where signum(numberField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where signum(stringField) > 0",
+      "error": [
+        "Argument of [signum] must be [number], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "from a_index | where sin(numberField) > 0",
       "error": [],
       "warning": []
@@ -8177,6 +8211,42 @@
       "query": "from a_index | eval var = rtrim(*)",
       "error": [
         "Using wildcards (*) in rtrim is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = signum(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval signum(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = signum(to_integer(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval signum(stringField)",
+      "error": [
+        "Argument of [signum] must be [number], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval signum(numberField, extraArg)",
+      "error": [
+        "Error: [signum] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = signum(*)",
+      "error": [
+        "Using wildcards (*) in signum is not allowed"
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -2413,6 +2413,50 @@
       "warning": []
     },
     {
+      "query": "row var = st_x(to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_x(to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_x(to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_x(\"a\")",
+      "error": [
+        "Argument of [st_x] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_x(to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_x(to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_x(to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_x(\"a\")",
+      "error": [
+        "Argument of [st_x] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = starts_with(\"a\", \"a\")",
       "error": [],
       "warning": []
@@ -10239,6 +10283,78 @@
       "query": "from a_index | eval st_within(cartesianShapeField, cartesianShapeField, extraArg)",
       "error": [
         "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_x(geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_x(geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_x(to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_x(stringField)",
+      "error": [
+        "Argument of [st_x] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_x(geoPointField, extraArg)",
+      "error": [
+        "Error: [st_x] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_x(*)",
+      "error": [
+        "Using wildcards (*) in st_x is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_x(cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_x(cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_x(to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_x(stringField)",
+      "error": [
+        "Argument of [st_x] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_x(cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_x] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_x(*)",
+      "error": [
+        "Using wildcards (*) in st_x is not allowed"
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -33,8 +33,16 @@
       "type": "cartesian_point"
     },
     {
+      "name": "cartesianShapeField",
+      "type": "cartesian_shape"
+    },
+    {
       "name": "geoPointField",
       "type": "geo_point"
+    },
+    {
+      "name": "geoShapeField",
+      "type": "geo_shape"
     },
     {
       "name": "any#Char$Field",
@@ -1665,6 +1673,190 @@
       "query": "row var = sqrt(\"a\")",
       "error": [
         "Argument of [sqrt] must be [number], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geopoint(\"a\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geopoint(\"a\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianpoint(\"a\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianpoint(\"a\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_contains(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_contains(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [\"a\"] type [string]"
       ],
       "warning": []
     },
@@ -5153,6 +5345,46 @@
       "warning": []
     },
     {
+      "query": "from a_index | where cartesianShapeField IS NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField IS null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField is null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField is NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField IS NOT NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField IS NOT null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField IS not NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where cartesianShapeField Is nOt NuLL",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | where geoPointField IS NULL",
       "error": [],
       "warning": []
@@ -5189,6 +5421,46 @@
     },
     {
       "query": "from a_index | where geoPointField Is nOt NuLL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField IS NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField IS null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField is null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField is NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField IS NOT NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField IS NOT null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField IS not NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where geoShapeField Is nOt NuLL",
       "error": [],
       "warning": []
     },
@@ -6158,6 +6430,41 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval cartesianShapeField IS NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval cartesianShapeField IS null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval cartesianShapeField is null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval cartesianShapeField is NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval cartesianShapeField IS NOT NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval cartesianShapeField IS NOT null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval cartesianShapeField IS not NULL",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval geoPointField IS NULL",
       "error": [],
       "warning": []
@@ -6189,6 +6496,41 @@
     },
     {
       "query": "from a_index | eval geoPointField IS not NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField IS NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField IS null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField is null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField is NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField IS NOT NULL",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField IS NOT null",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval geoShapeField IS not NULL",
       "error": [],
       "warning": []
     },
@@ -8385,6 +8727,246 @@
       "query": "from a_index | eval var = sqrt(*)",
       "error": [
         "Using wildcards (*) in sqrt is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(to_geopoint(stringField), to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoPointField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(to_geopoint(stringField), geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoPointField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(geoShapeField, to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoShapeField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(geoShapeField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(to_cartesianpoint(stringField), to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianPointField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(to_cartesianpoint(stringField), cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianPointField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(cartesianShapeField, to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianShapeField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_contains(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(stringField, stringField)",
+      "error": [
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_contains] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_contains(cartesianShapeField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_contains] function expects exactly 2 arguments, got 3."
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -1861,6 +1861,190 @@
       "warning": []
     },
     {
+      "query": "row var = st_disjoint(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geopoint(\"a\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geopoint(\"a\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianpoint(\"a\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianpoint(\"a\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_disjoint(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_disjoint(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = st_within(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
       "error": [],
       "warning": []
@@ -9151,6 +9335,246 @@
       "query": "from a_index | eval st_contains(cartesianShapeField, cartesianShapeField, extraArg)",
       "error": [
         "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(to_geopoint(stringField), to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoPointField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(to_geopoint(stringField), geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoPointField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(geoShapeField, to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoShapeField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(geoShapeField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(to_cartesianpoint(stringField), to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianPointField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(to_cartesianpoint(stringField), cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianPointField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(cartesianShapeField, to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianShapeField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_disjoint(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(stringField, stringField)",
+      "error": [
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_disjoint] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_disjoint(cartesianShapeField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -2045,6 +2045,190 @@
       "warning": []
     },
     {
+      "query": "row var = st_intersects(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geopoint(\"a\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geopoint(\"a\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianpoint(\"a\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianpoint(\"a\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_intersects(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_intersects(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = st_within(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
       "error": [],
       "warning": []
@@ -9575,6 +9759,246 @@
       "query": "from a_index | eval st_disjoint(cartesianShapeField, cartesianShapeField, extraArg)",
       "error": [
         "Error: [st_disjoint] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(to_geopoint(stringField), to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoPointField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(to_geopoint(stringField), geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoPointField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(geoShapeField, to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoShapeField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(geoShapeField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(to_cartesianpoint(stringField), to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianPointField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(to_cartesianpoint(stringField), cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianPointField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(cartesianShapeField, to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianShapeField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_intersects(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(stringField, stringField)",
+      "error": [
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_intersects] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_intersects(cartesianShapeField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_intersects] function expects exactly 2 arguments, got 3."
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -1861,6 +1861,190 @@
       "warning": []
     },
     {
+      "query": "row var = st_within(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_geopoint(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geopoint(\"a\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_geopoint(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geopoint(\"a\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geoshape(\"POINT (30 10)\"), to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_geoshape(\"POINT (30 10)\"), to_geoshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianpoint(\"a\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianpoint(\"a\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianshape(\"POINT (30 10)\"), to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_within(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(to_cartesianshape(\"POINT (30 10)\"), to_cartesianshape(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_within(\"a\", \"a\")",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = starts_with(\"a\", \"a\")",
       "error": [],
       "warning": []
@@ -8967,6 +9151,246 @@
       "query": "from a_index | eval st_contains(cartesianShapeField, cartesianShapeField, extraArg)",
       "error": [
         "Error: [st_contains] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoPointField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(to_geopoint(stringField), to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoPointField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoPointField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(to_geopoint(stringField), geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoPointField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoShapeField, geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(geoShapeField, to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoShapeField, geoPointField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(geoShapeField, geoShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(geoShapeField, geoShapeField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianPointField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(to_cartesianpoint(stringField), to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianPointField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianPointField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(to_cartesianpoint(stringField), cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianPointField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianShapeField, cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(cartesianShapeField, to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianShapeField, cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_within(cartesianShapeField, cartesianShapeField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(stringField, stringField)",
+      "error": [
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]",
+        "Argument of [st_within] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_within(cartesianShapeField, cartesianShapeField, extraArg)",
+      "error": [
+        "Error: [st_within] function expects exactly 2 arguments, got 3."
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -6886,58 +6886,58 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval var = st_centroid(cartesianPointField)",
+      "query": "from a_index | eval var = st_centroid_agg(cartesianPointField)",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval var = st_centroid(cartesianPointField) > 0",
+      "query": "from a_index | eval var = st_centroid_agg(cartesianPointField) > 0",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval st_centroid(cartesianPointField)",
+      "query": "from a_index | eval st_centroid_agg(cartesianPointField)",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval st_centroid(cartesianPointField) > 0",
+      "query": "from a_index | eval st_centroid_agg(cartesianPointField) > 0",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval var = st_centroid(geoPointField)",
+      "query": "from a_index | eval var = st_centroid_agg(geoPointField)",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval var = st_centroid(geoPointField) > 0",
+      "query": "from a_index | eval var = st_centroid_agg(geoPointField) > 0",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval st_centroid(geoPointField)",
+      "query": "from a_index | eval st_centroid_agg(geoPointField)",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval st_centroid(geoPointField) > 0",
+      "query": "from a_index | eval st_centroid_agg(geoPointField) > 0",
       "error": [
-        "EVAL does not support function st_centroid"
+        "EVAL does not support function st_centroid_agg"
       ],
       "warning": []
     },
@@ -12227,78 +12227,78 @@
       "warning": []
     },
     {
-      "query": "from a_index | stats var = st_centroid(cartesianPointField)",
+      "query": "from a_index | stats var = st_centroid_agg(cartesianPointField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats st_centroid(cartesianPointField)",
+      "query": "from a_index | stats st_centroid_agg(cartesianPointField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = st_centroid(avg(numberField))",
+      "query": "from a_index | stats var = st_centroid_agg(avg(numberField))",
       "error": [
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats st_centroid(avg(numberField))",
+      "query": "from a_index | stats st_centroid_agg(avg(numberField))",
       "error": [
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats st_centroid(stringField)",
+      "query": "from a_index | stats st_centroid_agg(stringField)",
       "error": [
-        "Argument of [st_centroid] must be [cartesian_point], found value [stringField] type [string]"
+        "Argument of [st_centroid_agg] must be [cartesian_point], found value [stringField] type [string]"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = st_centroid(*)",
+      "query": "from a_index | stats var = st_centroid_agg(*)",
       "error": [
-        "Using wildcards (*) in st_centroid is not allowed"
+        "Using wildcards (*) in st_centroid_agg is not allowed"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = st_centroid(geoPointField)",
+      "query": "from a_index | stats var = st_centroid_agg(geoPointField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats st_centroid(geoPointField)",
+      "query": "from a_index | stats st_centroid_agg(geoPointField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = st_centroid(avg(numberField))",
+      "query": "from a_index | stats var = st_centroid_agg(avg(numberField))",
       "error": [
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats st_centroid(avg(numberField))",
+      "query": "from a_index | stats st_centroid_agg(avg(numberField))",
       "error": [
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats st_centroid(stringField)",
+      "query": "from a_index | stats st_centroid_agg(stringField)",
       "error": [
-        "Argument of [st_centroid] must be [cartesian_point], found value [stringField] type [string]"
+        "Argument of [st_centroid_agg] must be [cartesian_point], found value [stringField] type [string]"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = st_centroid(*)",
+      "query": "from a_index | stats var = st_centroid_agg(*)",
       "error": [
-        "Using wildcards (*) in st_centroid is not allowed"
+        "Using wildcards (*) in st_centroid_agg is not allowed"
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -2457,6 +2457,50 @@
       "warning": []
     },
     {
+      "query": "row var = st_y(to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_y(to_geopoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_y(to_geopoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_y(\"a\")",
+      "error": [
+        "Argument of [st_y] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = st_y(to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row st_y(to_cartesianpoint(\"POINT (30 10)\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_y(to_cartesianpoint(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = st_y(\"a\")",
+      "error": [
+        "Argument of [st_y] must be [geo_point], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = starts_with(\"a\", \"a\")",
       "error": [],
       "warning": []
@@ -10355,6 +10399,78 @@
       "query": "from a_index | eval var = st_x(*)",
       "error": [
         "Using wildcards (*) in st_x is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_y(geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_y(geoPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_y(to_geopoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_y(stringField)",
+      "error": [
+        "Argument of [st_y] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_y(geoPointField, extraArg)",
+      "error": [
+        "Error: [st_y] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_y(*)",
+      "error": [
+        "Using wildcards (*) in st_y is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_y(cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_y(cartesianPointField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_y(to_cartesianpoint(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_y(stringField)",
+      "error": [
+        "Argument of [st_y] must be [geo_point], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval st_y(cartesianPointField, extraArg)",
+      "error": [
+        "Error: [st_y] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = st_y(*)",
+      "error": [
+        "Using wildcards (*) in st_y is not allowed"
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -1379,6 +1379,16 @@
       "warning": []
     },
     {
+      "query": "row var = mv_slice(\"a\", 5, 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row mv_slice(\"a\", 5, 5)",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "row var = mv_sort(\"a\", \"asc\")",
       "error": [],
       "warning": []
@@ -1407,6 +1417,30 @@
       "query": "row var = mv_sum(\"a\")",
       "error": [
         "Argument of [mv_sum] must be [number], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_zip(\"a\", \"a\", \"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row mv_zip(\"a\", \"a\", \"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_zip(to_string(\"a\"), to_string(\"a\"), to_string(\"a\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_zip(5, 5, 5)",
+      "error": [
+        "Argument of [mv_zip] must be [string], found value [5] type [number]",
+        "Argument of [mv_zip] must be [string], found value [5] type [number]",
+        "Argument of [mv_zip] must be [string], found value [5] type [number]"
       ],
       "warning": []
     },
@@ -6478,6 +6512,20 @@
       "warning": []
     },
     {
+      "query": "from a_index | where length(mv_zip(stringField, stringField, stringField)) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where length(mv_zip(numberField, numberField, numberField)) > 0",
+      "error": [
+        "Argument of [mv_zip] must be [string], found value [numberField] type [number]",
+        "Argument of [mv_zip] must be [string], found value [numberField] type [number]",
+        "Argument of [mv_zip] must be [string], found value [numberField] type [number]"
+      ],
+      "warning": []
+    },
+    {
       "query": "from a_index | where pi() > 0",
       "error": [],
       "warning": []
@@ -8940,6 +8988,16 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval var = mv_slice(stringField, numberField, numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_slice(stringField, numberField, numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval var = mv_sort(stringField, \"asc\")",
       "error": [],
       "warning": []
@@ -8982,6 +9040,37 @@
       "query": "from a_index | eval var = mv_sum(*)",
       "error": [
         "Using wildcards (*) in mv_sum is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_zip(stringField, stringField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_zip(stringField, stringField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_zip(to_string(stringField), to_string(stringField), to_string(stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_zip(numberField, numberField, numberField)",
+      "error": [
+        "Argument of [mv_zip] must be [string], found value [numberField] type [number]",
+        "Argument of [mv_zip] must be [string], found value [numberField] type [number]",
+        "Argument of [mv_zip] must be [string], found value [numberField] type [number]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_zip(stringField, stringField, stringField, extraArg)",
+      "error": [
+        "Error: [mv_zip] function expects exactly 3 arguments, got 4."
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -19,7 +19,17 @@ import { camelCase } from 'lodash';
 import { getAstAndSyntaxErrors } from '@kbn/esql-ast';
 import { nonNullable } from '../shared/helpers';
 
-const fieldTypes = ['number', 'date', 'boolean', 'ip', 'string', 'cartesian_point', 'geo_point'];
+const fieldTypes = [
+  'number',
+  'date',
+  'boolean',
+  'ip',
+  'string',
+  'cartesian_point',
+  'cartesian_shape',
+  'geo_point',
+  'geo_shape',
+];
 const fields = [
   ...fieldTypes.map((type) => ({ name: `${camelCase(type)}Field`, type })),
   { name: 'any#Char$Field', type: 'number' },
@@ -538,7 +548,11 @@ describe('validation logic', () => {
           .replace(/stringField/g, '"a"')
           .replace(/dateField/g, 'now()')
           .replace(/booleanField/g, 'true')
-          .replace(/ipField/g, 'to_ip("127.0.0.1")');
+          .replace(/ipField/g, 'to_ip("127.0.0.1")')
+          .replace(/geoPointField/g, 'to_geopoint("POINT (30 10)")')
+          .replace(/geoShapeField/g, 'to_geoshape("POINT (30 10)")')
+          .replace(/cartesianPointField/g, 'to_cartesianpoint("POINT (30 10)")')
+          .replace(/cartesianShapeField/g, 'to_cartesianshape("POINT (30 10)")');
       }
 
       for (const { name, alias, signatures, ...defRest } of evalFunctionsDefinitions) {

--- a/test/api_integration/apis/esql/errors.ts
+++ b/test/api_integration/apis/esql/errors.ts
@@ -62,6 +62,9 @@ function createIndexRequest(
           if (type === 'cartesian_point') {
             esType = 'point';
           }
+          if (type === 'cartesian_shape') {
+            esType = 'shape';
+          }
           if (type === 'unsupported') {
             esType = 'integer_range';
           }


### PR DESCRIPTION
## Summary

- [x] [`SIGNUM`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-signum)
- [x] spatial functions
  - [x] [`ST_CENTROID_AGG`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-agg-st-centroid)
  - [x] [`ST_CONTAINS`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-st_contains)
  - [x] [`ST_DISJOINT`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-st_disjoint)
  - [x] [`ST_INTERSECTS`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-st_intersects)
  - [x] [`ST_WITHIN`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-st_within)
  - [x] [`ST_X`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-st_x)
  - [x] [`ST_Y`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-st_y)
- [x] [`MV_SLICE`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-mv_slice)
- [x] [`MV_ZIP`](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-mv_zip)

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
