### PR TITLE
[Security Solution][Alert details] - save state of left panel (collapsed/expanded) to local storage - memory approach

### DIFF
--- a/packages/kbn-expandable-flyout/src/hooks/use_expandable_flyout_api.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_expandable_flyout_api.ts
@@ -25,6 +25,9 @@ import { FlyoutPanelProps, type ExpandableFlyoutApi } from '../types';
 
 export type { ExpandableFlyoutApi };
 
+// we store all the functions that should be called when the flyout is closed
+let onCloseFunctions: Array<() => void> = [];
+
 /**
  * This hook allows you to interact with the flyout, open panels and previews etc.
  */
@@ -80,7 +83,17 @@ export const useExpandableFlyoutApi = () => {
     [dispatch, id]
   );
 
-  const closePanels = useCallback(() => dispatch(closePanelsAction({ id })), [dispatch, id]);
+  const closePanels = useCallback(() => {
+    dispatch(closePanelsAction({ id }));
+
+    // running all functions when the flyout closes then resets
+    onCloseFunctions.forEach((fc) => fc());
+    onCloseFunctions = [];
+  }, [dispatch, id]);
+
+  const onClose = useCallback((fc: () => void) => {
+    onCloseFunctions.push(fc);
+  }, []);
 
   const api: ExpandableFlyoutApi = useMemo(
     () => ({
@@ -93,6 +106,7 @@ export const useExpandableFlyoutApi = () => {
       closePreviewPanel,
       closeFlyout: closePanels,
       previousPreviewPanel,
+      onClose,
     }),
     [
       openPanels,
@@ -104,6 +118,7 @@ export const useExpandableFlyoutApi = () => {
       closePreviewPanel,
       closePanels,
       previousPreviewPanel,
+      onClose,
     ]
   );
 

--- a/packages/kbn-expandable-flyout/src/types.ts
+++ b/packages/kbn-expandable-flyout/src/types.ts
@@ -49,6 +49,10 @@ export interface ExpandableFlyoutApi {
    * Close all panels and closes flyout
    */
   closeFlyout: () => void;
+  /**
+   * Function called when the flyout is closed
+   */
+  onClose: (closeFct: () => void) => void;
 }
 
 export interface PanelPath {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_which_flyout.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_which_flyout.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Flyouts } from '../../shared/constants/flyouts';
+import { URL_PARAM_KEY } from '../../../../common/hooks/use_url_state';
+
+/**
+ * Hook that returns which flyout is the user currently interacting with.
+ * If the url contains timelineFlyout parameter and its value is not empty, we know the timeline flyout is rendered.
+ * As it is always on top of the normal flyout, we can deduce which flyout the user is interacting with.
+ */
+export const useWhichFlyout = (): string => {
+  const query = new URLSearchParams(window.location.search);
+  const flyout =
+    query.has(URL_PARAM_KEY.timelineFlyout) && query.get(URL_PARAM_KEY.timelineFlyout) !== '()'
+      ? Flyouts.timeline
+      : Flyouts.securitySolution;
+
+  return flyout;
+};

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/navigation.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/navigation.tsx
@@ -8,6 +8,8 @@
 import type { FC } from 'react';
 import React, { memo, useCallback } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useWhichFlyout } from './hooks/use_which_flyout';
+import { FLYOUT_STORAGE_KEYS } from '../shared/constants/local_storage';
 import { useKibana } from '../../../common/lib/kibana';
 import { HeaderActions } from './components/header_actions';
 import { FlyoutNavigation } from '../../shared/components/flyout_navigation';
@@ -22,9 +24,10 @@ interface PanelNavigationProps {
 }
 
 export const PanelNavigation: FC<PanelNavigationProps> = memo(({ flyoutIsExpandable }) => {
-  const { telemetry } = useKibana().services;
-  const { openLeftPanel } = useExpandableFlyoutApi();
+  const { storage, telemetry } = useKibana().services;
+  const { onClose, openLeftPanel } = useExpandableFlyoutApi();
   const { eventId, indexName, scopeId } = useRightPanelContext();
+  const flyout = useWhichFlyout();
 
   const expandDetails = useCallback(() => {
     openLeftPanel({
@@ -35,11 +38,36 @@ export const PanelNavigation: FC<PanelNavigationProps> = memo(({ flyoutIsExpanda
         scopeId,
       },
     });
+
+    const localStorageLeftPanelExpanded = storage.get(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED);
+
+    storage.set(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED, {
+      ...localStorageLeftPanelExpanded,
+      [flyout]: true,
+    });
+
+    // clearing local storage when flyout is closed
+    const clearingLocalStorage = () => {
+      storage.set(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED, {
+        ...localStorageLeftPanelExpanded,
+        [flyout]: false,
+      });
+    };
+    onClose(clearingLocalStorage);
+
     telemetry.reportDetailsFlyoutOpened({
       tableId: scopeId,
       panel: 'left',
     });
-  }, [eventId, openLeftPanel, indexName, scopeId, telemetry]);
+  }, [openLeftPanel, eventId, indexName, scopeId, storage, flyout, onClose, telemetry]);
+
+  // automatically open left panel if it was saved in local storage
+  if (
+    storage.get(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED) &&
+    storage.get(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED)[flyout]
+  ) {
+    expandDetails();
+  }
 
   return (
     <FlyoutNavigation

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/flyouts.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/flyouts.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum Flyouts {
+  securitySolution = 'SecuritySolution',
+  timeline = 'Timeline',
+}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -9,4 +9,5 @@ export const FLYOUT_STORAGE_KEYS = {
   OVERVIEW_TAB_EXPANDED_SECTIONS:
     'securitySolution.documentDetailsFlyout.overviewSectionExpanded.v8.14',
   RIGHT_PANEL_SELECTED_TABS: 'securitySolution.documentDetailsFlyout.rightPanel.selectedTabs.v8.14',
+  LEFT_PANEL_EXPANDED: 'securitySolution.documentDetailsFlyout.leftPanelExpanded.v8.14',
 };

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
@@ -18,6 +18,9 @@ import { css } from '@emotion/react';
 import { useExpandableFlyoutApi, useExpandableFlyoutState } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { useWhichFlyout } from '../../document_details/right/hooks/use_which_flyout';
+import { FLYOUT_STORAGE_KEYS } from '../../document_details/shared/constants/local_storage';
+import { useKibana } from '../../../common/lib/kibana';
 import {
   HEADER_ACTIONS_TEST_ID,
   COLLAPSE_DETAILS_BUTTON_TEST_ID,
@@ -45,12 +48,21 @@ export interface FlyoutNavigationProps {
  */
 export const FlyoutNavigation: FC<FlyoutNavigationProps> = memo(
   ({ flyoutIsExpandable = false, expandDetails, actions }) => {
+    const { storage } = useKibana().services;
     const { euiTheme } = useEuiTheme();
     const { closeLeftPanel } = useExpandableFlyoutApi();
     const panels = useExpandableFlyoutState();
+    const flyout = useWhichFlyout();
 
     const isExpanded: boolean = !!panels.left;
-    const collapseDetails = useCallback(() => closeLeftPanel(), [closeLeftPanel]);
+    const collapseDetails = useCallback(() => {
+      const localStorageLeftPanelExpanded = storage.get(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED);
+      storage.set(FLYOUT_STORAGE_KEYS.LEFT_PANEL_EXPANDED, {
+        ...localStorageLeftPanelExpanded,
+        [flyout]: false,
+      });
+      closeLeftPanel();
+    }, [closeLeftPanel, flyout, storage]);
 
     const collapseButton = useMemo(
       () => (


### PR DESCRIPTION
## Summary

This PR continues adding user behavior saved to local storage for the expandable flyout. After persisting [which section of the overview tab is expanded/collapses](https://github.com/elastic/kibana/pull/178746) and after persisting [which tab of the right section is selected](https://github.com/elastic/kibana/pull/179511), this PR adds the code to persist if the left section is expanded or not.

A small difference though, is contrary to the first 2 persistence, here we only persists the fact that the left section is expanded while the flyout is open. This allows users to navigate between alerts (by clicking in the open flyout icon button in the alerts table for example, or soon by using the pagination within the flyout) and not loose the current state of the flyout.
As soon as the user clicks on the close flyout button in the top-right corner, we clear the value from local storage. This means that the next time the user opens the flyout, the left section will not be expanded. This is by design.

Note that the _normal_ flyout (meaning the flyout open from NOT from timeline) and the _timeline_ flyout maintain their own state in local storage.

### Approach

This approach saves the functions to be run when the flyout closes within the `kbn-expandable-flyout` package. I'm not a fan of this approach, because we're storing information in the package that the package shouldn't really have to know about...
There is a [very similar PR](https://github.com/elastic/kibana/pull/180646) that uses a slightly different approach. It provides an observable that components can listen to and action upon when triggered to run the code they need. Please take a look and let me know which approach looks the best!

### TODO

- [ ] write unit tests for the hooks
- [ ] add documentation to the flyout package to explain how to use the `onClose` API

### Notes:

- when the user closes the browser tab or navigates to a different page without closing the flyout, the state is NOT reset (meaning a expanded section will automatically open up again next time the user opens a flyout

Saving state and clearing after closing flyout

https://github.com/elastic/kibana/assets/17276605/73e46b1b-9b2a-4f0d-bdc5-dab3843e5dd3

Security Solution and Timeline flyouts saving their state separately

https://github.com/elastic/kibana/assets/17276605/73983096-14d9-4df4-880b-a136d54f11e7

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

https://github.com/elastic/security-team/issues/7670
Will help https://github.com/elastic/kibana/issues/179520