### PR TITLE
[Fleet] Fix KQL/kuery for getting Fleet Server agent count

### DIFF
--- a/x-pack/plugins/fleet/public/hooks/use_fleet_server_agents.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_fleet_server_agents.ts
@@ -27,7 +27,10 @@ export async function sendGetAllFleetServerAgents(onlyCount: boolean = false) {
   if (agentPolicyIds.length === 0) {
     return { allFleetServerAgents: [] };
   }
-  const kuery = `${AGENTS_PREFIX}.policy_id:${agentPolicyIds.map((id) => `"${id}"`).join(' or ')}`;
+
+  const kuery = `${AGENTS_PREFIX}.policy_id:(${agentPolicyIds
+    .map((id) => `"${id}"`)
+    .join(' or ')})`;
 
   const response = await sendGetAgents({
     kuery,


### PR DESCRIPTION
## Summary

Resolves [#180427](https://github.com/elastic/kibana/issues/180427) - see issue for repro steps.

Code introduced in https://github.com/elastic/kibana/pull/179603 made the KQL to look up count of Fleet Server agents malformed. This is used to determine if the Add agent flyout should show "Add Fleet Server" instructions or show the normal instructions. When user has multiple Fleet Server policies on 8.13.2, the Add agent flyout will never show the normal instructions regardless of actual Fleet Server enrollment due to error response from the query.

Although the code was introduced in 8.13.2, the issue was "hidden" in 8.14.0 when strict KQL validation was turned off (https://github.com/elastic/kibana/pull/176806). Thus, this issue is only present in 8.13.2, 8.14 with the feature flag for strict validation turned on, or a future release if/when we turn strict validation back on.

This PR will be backported to 8.13 in case another patch release is cut. This fix adds parenthesis around the concatenation of multiple policy IDs:

<img width="763" alt="image" src="https://github.com/elastic/kibana/assets/1965714/99019ca2-e613-431f-8ff1-590116ba7511">


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->