### PR TITLE
[ES|QL] Fixes the problem with Discover and queries without the from command

### DIFF
--- a/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.test.ts
+++ b/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.test.ts
@@ -45,4 +45,19 @@ describe('getDataViewByTextBasedQueryLang', () => {
     expect(dataView.isPersisted()).toEqual(false);
     expect(dataView.timeFieldName).toBeUndefined();
   });
+
+  it('creates an adhoc ES|QL dataview if the query doesnt have from command', async () => {
+    discoverServiceMock.dataViews.create = jest.fn().mockReturnValue({
+      ...dataViewAdHoc,
+      isPersisted: () => false,
+      id: 'ad-hoc-id-1',
+      title: 'test-1',
+      timeFieldName: undefined,
+    });
+    const query = { esql: 'ROW x = "ES|QL is awesome"' };
+    const dataView = await getDataViewByTextBasedQueryLang(query, dataViewAdHoc, services);
+    expect(dataView.isPersisted()).toEqual(false);
+    expect(dataView.name).toEqual(dataViewAdHoc.name);
+    expect(dataView.timeFieldName).toBeUndefined();
+  });
 });

--- a/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.ts
+++ b/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.ts
@@ -27,7 +27,12 @@ export async function getDataViewByTextBasedQueryLang(
     indexPatternFromQuery = getIndexPatternFromESQLQuery(query.esql);
   }
   // we should find a better way to work with ESQL queries which dont need a dataview
-  if (!indexPatternFromQuery && currentDataView) return currentDataView;
+  if (!indexPatternFromQuery && currentDataView) {
+    // Here the user used either the ROW or SHOW META / SHOW INFO commands
+    // if we use the current dataview will create this error https://github.com/elastic/kibana/issues/163417
+    // so we are creating an adhoc dataview without an @timestamp timeFieldName
+    return await getESQLAdHocDataview(currentDataView.name, services.dataViews);
+  }
 
   if (
     currentDataView?.isPersisted() ||

--- a/test/functional/apps/discover/group4/_esql_view.ts
+++ b/test/functional/apps/discover/group4/_esql_view.ts
@@ -158,6 +158,19 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'machine.ram_range',
         ]);
       });
+
+      it('should work without a FROM statement', async function () {
+        await PageObjects.discover.selectTextBaseLang();
+        const testQuery = `ROW a = 1, b = "two", c = null`;
+
+        await monacoEditor.setCodeEditorValue(testQuery);
+        await testSubjects.click('querySubmitButton');
+        await PageObjects.header.waitUntilLoadingHasFinished();
+
+        await PageObjects.discover.dragFieldToTable('a');
+        const cell = await dataGrid.getCellElement(0, 2);
+        expect(await cell.getVisibleText()).to.be('1');
+      });
     });
 
     describe('errors', () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/163417

When there was no from command in the query we were using the current dataview. This might have the @timestamp field which is not returned by the `ROW ...` or `Show meta` commands. So the histogram was failing.

I am solving this issue by creating a dataview based on the current dataview but without the timeFieldName

<img width="1677" alt="image" src="https://github.com/elastic/kibana/assets/17003240/81b79634-8c2e-4346-bd34-48ae7580ab89">

I still think we should find another way to deal with these commands but for now this is a nice way forward

**Before:**

<img width="1679" alt="image" src="https://github.com/elastic/kibana/assets/17003240/68ec6f76-6721-472b-8b49-7c719ad04208">



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios