### PR TITLE
[Infra] Add NEW badge to the dashboards tab in the asset details view

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/common/asset_details_config/asset_details_tabs.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/common/asset_details_config/asset_details_tabs.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 
+import { EuiBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import React from 'react';
 import { ContentTabIds, type Tab } from '../../components/asset_details/types';
 
 export const commonFlyoutTabs: Tab[] = [
@@ -56,5 +58,12 @@ export const commonFlyoutTabs: Tab[] = [
     name: i18n.translate('xpack.infra.infra.nodeDetails.tabs.dashboards', {
       defaultMessage: 'Dashboards',
     }),
+    append: (
+      <EuiBadge color="accent">
+        {i18n.translate('xpack.infra.customDashboards.newLabel', {
+          defaultMessage: 'NEW',
+        })}
+      </EuiBadge>
+    ),
   },
 ];


### PR DESCRIPTION
## Summary

This PR adds `NEW` badge to the dashboards tab in the asset details view.

## Testing

- Enable dashboards feature flag from Stack Management > Advance Settings
<img width="1889" alt="image" src="https://github.com/elastic/kibana/assets/14139027/07a853c6-48b3-4922-8d04-38065edc36b6">

- To see the `NEW` badge next to the Dashboards tab title
   - Go to single Host flyout:
   
    ![image](https://github.com/elastic/kibana/assets/14139027/80493841-0039-4008-b6c4-cff14ad90318)

   - Go to asset details page:
   
    ![image](https://github.com/elastic/kibana/assets/14139027/5aa5bb67-a3e6-429f-9d43-675a38e1076d)
