### PR TITLE
[Fleet] Full width layout

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -30,6 +30,7 @@ export const allowedExperimentalValues = Object.freeze<Record<string, boolean>>(
   subfeaturePrivileges: false,
   enablePackagesStateMachine: true,
   advancedPolicySettings: true,
+  fullWidthLayout: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/public/components/header.tsx
+++ b/x-pack/plugins/fleet/public/components/header.tsx
@@ -23,7 +23,7 @@ const Container = styled.div`
 `;
 
 const Wrapper = styled.div<{ maxWidth?: number }>`
-  max-width: ${(props) => props.maxWidth || 1200}px;
+  ${(props) => (props.maxWidth === 0 ? '' : `max-width: ${props.maxWidth || 1200}px;`)}
   margin-left: auto;
   margin-right: auto;
   padding-top: ${(props) => props.theme.eui.euiSizeXL};

--- a/x-pack/plugins/fleet/public/layouts/with_header.tsx
+++ b/x-pack/plugins/fleet/public/layouts/with_header.tsx
@@ -11,6 +11,8 @@ import { EuiPageBody, EuiSpacer } from '@elastic/eui';
 import type { HeaderProps } from '../components';
 import { Header } from '../components';
 
+import { ExperimentalFeaturesService } from '../services';
+
 import { Page, ContentWrapper, Wrapper } from './without_header';
 
 export interface WithHeaderLayoutProps extends HeaderProps {
@@ -26,23 +28,27 @@ export const WithHeaderLayout: React.FC<WithHeaderLayoutProps> = ({
   children,
   'data-test-subj': dataTestSubj,
   ...rest
-}) => (
-  <Wrapper>
-    <Header
-      maxWidth={restrictHeaderWidth}
-      data-test-subj={dataTestSubj ? `${dataTestSubj}_header` : undefined}
-      {...rest}
-    />
-    <Page
-      restrictWidth={restrictWidth || 1200}
-      data-test-subj={dataTestSubj ? `${dataTestSubj}_page` : undefined}
-    >
-      <EuiPageBody>
-        <ContentWrapper>
-          <EuiSpacer size="m" />
-          {children}
-        </ContentWrapper>
-      </EuiPageBody>
-    </Page>
-  </Wrapper>
-);
+}) => {
+  const { fullWidthLayout } = ExperimentalFeaturesService.get();
+
+  return (
+    <Wrapper>
+      <Header
+        maxWidth={fullWidthLayout ? 0 : restrictHeaderWidth}
+        data-test-subj={dataTestSubj ? `${dataTestSubj}_header` : undefined}
+        {...rest}
+      />
+      <Page
+        restrictWidth={fullWidthLayout ? false : restrictWidth || 1200}
+        data-test-subj={dataTestSubj ? `${dataTestSubj}_page` : undefined}
+      >
+        <EuiPageBody>
+          <ContentWrapper>
+            <EuiSpacer size="m" />
+            {children}
+          </ContentWrapper>
+        </EuiPageBody>
+      </Page>
+    </Wrapper>
+  );
+};

--- a/x-pack/plugins/fleet/public/layouts/without_header.tsx
+++ b/x-pack/plugins/fleet/public/layouts/without_header.tsx
@@ -11,6 +11,8 @@ import { EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
 
 export const Wrapper = styled.div`
   background-color: ${(props) => props.theme.eui.euiColorEmptyShade};
+  margin-left: ${(props) => props.theme.eui.euiSizeXL};
+  margin-right: ${(props) => props.theme.eui.euiSizeXL};
 
   // Set the min height to the viewport size minus the height of any global Kibana headers
   min-height: calc(100vh - var(--euiFixedHeadersOffset, 0));


### PR DESCRIPTION
🚧 WIP - DO NOT MERGE

## Summary

Closes https://github.com/elastic/ingest-dev/issues/2602

This PR introduces the `fullWidthLayout` experimental flag: when `true`, Fleet UI is rendered full width.

## Screenshots

### Full width

#### Agents page

<img width="1727" alt="Screenshot 2024-04-12 at 15 32 51" src="https://github.com/elastic/kibana/assets/23701614/781f8064-b685-408b-8ed4-54b03215f82c">

<img width="1727" alt="Screenshot 2024-04-12 at 15 33 00" src="https://github.com/elastic/kibana/assets/23701614/e3cc9db5-b7c6-4079-b71b-68200e5ad350">

<img width="1727" alt="Screenshot 2024-04-12 at 15 33 08" src="https://github.com/elastic/kibana/assets/23701614/43f969af-5bd3-4acd-ad4a-4f31fd89116b">

<img width="1727" alt="Screenshot 2024-04-12 at 15 33 18" src="https://github.com/elastic/kibana/assets/23701614/63bbd9b8-0181-4972-bfd9-2db107ede093">

#### Agent details

<img width="1727" alt="Screenshot 2024-04-12 at 15 33 32" src="https://github.com/elastic/kibana/assets/23701614/5356ec5a-0cc4-4386-9a53-26ef1b36aa37">

<img width="1727" alt="Screenshot 2024-04-12 at 15 33 49" src="https://github.com/elastic/kibana/assets/23701614/7590d03e-c02d-445f-8c70-8d7a575c650d">

<img width="1727" alt="Screenshot 2024-04-12 at 15 34 07" src="https://github.com/elastic/kibana/assets/23701614/a5f85b65-58a4-4b4d-9385-f4185077971d">

#### Agent policies

<img width="1727" alt="Screenshot 2024-04-12 at 15 34 21" src="https://github.com/elastic/kibana/assets/23701614/ffbeb16a-58ff-470f-a957-9626a80d3b7e">

<img width="1727" alt="Screenshot 2024-04-12 at 15 46 47" src="https://github.com/elastic/kibana/assets/23701614/6adec1f7-e835-4d50-bd7a-7d532551ccc4">

⚠️ This doesn't look right:
<img width="1727" alt="Screenshot 2024-04-12 at 15 37 03" src="https://github.com/elastic/kibana/assets/23701614/550e8c90-6f1e-4f9c-a161-7c82b68c8bc8">

#### Integrations management

<img width="1727" alt="Screenshot 2024-04-12 at 15 35 28" src="https://github.com/elastic/kibana/assets/23701614/e1d25ba8-73bc-4392-8033-b73d77a2e1bf">

<img width="1727" alt="Screenshot 2024-04-12 at 15 35 41" src="https://github.com/elastic/kibana/assets/23701614/6fcb3c55-6585-4e2e-800e-55196a2dc9c6">

<img width="1727" alt="Screenshot 2024-04-12 at 15 35 47" src="https://github.com/elastic/kibana/assets/23701614/4398a1df-eb84-4e61-a659-0aaeef2800e1">

<img width="1727" alt="Screenshot 2024-04-12 at 15 35 55" src="https://github.com/elastic/kibana/assets/23701614/ec2c177b-b78d-4402-bf24-ccc2028fd1f0">

#### Fleet error page

<img width="1727" alt="Screenshot 2024-04-12 at 15 40 47" src="https://github.com/elastic/kibana/assets/23701614/e5c4f397-47e8-448a-8170-f2d4238ed0dc">

### Checklist

- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)