### PR TITLE
Add tooltips for connector counters

### DIFF
--- a/packages/kbn-search-connectors/components/sync_jobs/__snapshots__/documents_panel.test.tsx.snap
+++ b/packages/kbn-search-connectors/components/sync_jobs/__snapshots__/documents_panel.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`DocumentsPanel renders 1`] = `
           "name": <EuiToolTip
             content={
               <FormattedMessage
-                defaultMessage="The volume, in MB, of JSON data sent with {index} operations to the Elasticsearch _bulk API during this sync. The current Elasticsearch Index size may be larger, depending on index mappings and settings. It also may be smaller, if large data is substantially trimmed during any ingest processors."
+                defaultMessage="The volume, in MB, of JSON data sent with {index} operations to the Elasticsearch _bulk API during this sync. The current Elasticsearch Index size may be larger, depending on index mappings and settings. It also may be smaller, if large data is substantially trimmed by ingest processors."
                 id="searchConnectors.index.syncJobs.documents.volume.tooltip"
                 values={
                   Object {

--- a/packages/kbn-search-connectors/components/sync_jobs/__snapshots__/documents_panel.test.tsx.snap
+++ b/packages/kbn-search-connectors/components/sync_jobs/__snapshots__/documents_panel.test.tsx.snap
@@ -9,15 +9,96 @@ exports[`DocumentsPanel renders 1`] = `
       Array [
         Object {
           "field": "added",
-          "name": "Upserted",
+          "name": <EuiToolTip
+            content={
+              <FormattedMessage
+                defaultMessage="The number of {index} operations the connector sent to the Elasticsearch _bulk API during this sync. This includes net-new documents and updates to existing documents. This does not account for duplicate _ids, or any documents dropped by an ingest processor"
+                id="searchConnectors.index.syncJobs.documents.upserted.tooltip"
+                values={
+                  Object {
+                    "index": <EuiCode>
+                      index
+                    </EuiCode>,
+                  }
+                }
+              />
+            }
+            delay="regular"
+            display="inlineBlock"
+            position="top"
+          >
+            <React.Fragment>
+              Upserted
+              <EuiIcon
+                className="eui-alignTop"
+                color="subdued"
+                size="s"
+                type="questionInCircle"
+              />
+            </React.Fragment>
+          </EuiToolTip>,
         },
         Object {
           "field": "removed",
-          "name": "Deleted",
+          "name": <EuiToolTip
+            content={
+              <FormattedMessage
+                defaultMessage="The number of {delete} operations the connector sent to the Elasticsearch _bulk API at the conclusion of this sync. This may include documents dropped by Sync Rules. This does not include documents dropped by ingest processors. Documents are deleted from the index if the connector determines that they are no longer present in the data that should be fetched from the 3rd-party source."
+                id="searchConnectors.index.syncJobs.documents.deleted.tooltip"
+                values={
+                  Object {
+                    "delete": <EuiCode>
+                      delete
+                    </EuiCode>,
+                  }
+                }
+              />
+            }
+            delay="regular"
+            display="inlineBlock"
+            position="top"
+          >
+            <React.Fragment>
+              Deleted
+              <EuiIcon
+                className="eui-alignTop"
+                color="subdued"
+                size="s"
+                type="questionInCircle"
+              />
+            </React.Fragment>
+          </EuiToolTip>,
         },
         Object {
           "field": "volume",
-          "name": "Volume",
+          "name": <EuiToolTip
+            content={
+              <FormattedMessage
+                defaultMessage="The volume, in MB, of JSON data sent with {index} operations to the Elasticsearch _bulk API during this sync. The current Elasticsearch Index size may be larger, depending on index mappings and settings. It also may be smaller, if large data is substantially trimmed during any ingest processors."
+                id="searchConnectors.index.syncJobs.documents.volume.tooltip"
+                values={
+                  Object {
+                    "index": <EuiCode>
+                      index
+                    </EuiCode>,
+                  }
+                }
+              />
+            }
+            delay="regular"
+            display="inlineBlock"
+            position="top"
+          >
+            <React.Fragment>
+              Volume
+              <EuiIcon
+                className="eui-alignTop"
+                color="subdued"
+                size="s"
+                type="questionInCircle"
+              />
+            </React.Fragment>
+          </EuiToolTip>,
           "render": [Function],
         },
       ]

--- a/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
@@ -72,7 +72,7 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
           content={
             <FormattedMessage
               id="searchConnectors.index.syncJobs.documents.volume.tooltip"
-              defaultMessage="The volume, in MB, of JSON data sent with {index} operations to the Elasticsearch _bulk API during this sync. The current Elasticsearch Index size may be larger, depending on index mappings and settings. It also may be smaller, if large data is substantially trimmed during any ingest processors."
+              defaultMessage="The volume, in MB, of JSON data sent with {index} operations to the Elasticsearch _bulk API during this sync. The current Elasticsearch Index size may be larger, depending on index mappings and settings. It also may be smaller, if large data is substantially trimmed by ingest processors."
               values={{ index: <EuiCode>index</EuiCode> }}
             />
           }

--- a/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
@@ -12,8 +12,8 @@ import { EuiBasicTable, EuiBasicTableColumn, EuiIcon, EuiToolTip, EuiCode } from
 import { ByteSizeValue } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 
+import { FormattedMessage } from '@kbn/i18n-react';
 import { FlyoutPanel } from './flyout_panel';
-import {FormattedMessage} from "react-intl";
 
 interface SyncJobDocumentsPanelProps {
   added: number;

--- a/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
@@ -8,11 +8,12 @@
 
 import React from 'react';
 
-import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
+import { EuiBasicTable, EuiBasicTableColumn, EuiIcon, EuiToolTip, EuiCode } from '@elastic/eui';
 import { ByteSizeValue } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 
 import { FlyoutPanel } from './flyout_panel';
+import {FormattedMessage} from "react-intl";
 
 interface SyncJobDocumentsPanelProps {
   added: number;
@@ -24,21 +25,66 @@ export const SyncJobDocumentsPanel: React.FC<SyncJobDocumentsPanelProps> = (sync
   const columns: Array<EuiBasicTableColumn<SyncJobDocumentsPanelProps>> = [
     {
       field: 'added',
-      name: i18n.translate('searchConnectors.index.syncJobs.documents.added', {
-        defaultMessage: 'Upserted',
-      }),
+      name: (
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="searchConnectors.index.syncJobs.documents.upserted.tooltip"
+              defaultMessage="The number of {index} operations the connector sent to the Elasticsearch _bulk API during this sync. This includes net-new documents and updates to existing documents. This does not account for duplicate _ids, or any documents dropped by an ingest processor"
+              values={{ index: <EuiCode>index</EuiCode> }}
+            />
+          }
+        >
+          <>
+            {i18n.translate('searchConnectors.index.syncJobs.documents.added', {
+              defaultMessage: 'Upserted',
+            })}
+            <EuiIcon size="s" type="questionInCircle" color="subdued" className="eui-alignTop" />
+          </>
+        </EuiToolTip>
+      ),
     },
     {
       field: 'removed',
-      name: i18n.translate('searchConnectors.index.syncJobs.documents.removed', {
-        defaultMessage: 'Deleted',
-      }),
+      name: (
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="searchConnectors.index.syncJobs.documents.deleted.tooltip"
+              defaultMessage="The number of {delete} operations the connector sent to the Elasticsearch _bulk API at the conclusion of this sync. This may include documents dropped by Sync Rules. This does not include documents dropped by ingest processors. Documents are deleted from the index if the connector determines that they are no longer present in the data that should be fetched from the 3rd-party source."
+              values={{ delete: <EuiCode>delete</EuiCode> }}
+            />
+          }
+        >
+          <>
+            {i18n.translate('searchConnectors.index.syncJobs.documents.removed', {
+              defaultMessage: 'Deleted',
+            })}
+            <EuiIcon size="s" type="questionInCircle" color="subdued" className="eui-alignTop" />
+          </>
+        </EuiToolTip>
+      ),
     },
     {
       field: 'volume',
-      name: i18n.translate('searchConnectors.index.syncJobs.documents.volume', {
-        defaultMessage: 'Volume',
-      }),
+      name: (
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="searchConnectors.index.syncJobs.documents.volume.tooltip"
+              defaultMessage="The volume, in MB, of JSON data sent with {index} operations to the Elasticsearch _bulk API during this sync. The current Elasticsearch Index size may be larger, depending on index mappings and settings. It also may be smaller, if large data is substantially trimmed during any ingest processors."
+              values={{ index: <EuiCode>index</EuiCode> }}
+            />
+          }
+        >
+          <>
+            {i18n.translate('searchConnectors.index.syncJobs.documents.volume', {
+              defaultMessage: 'Volume',
+            })}
+            <EuiIcon size="s" type="questionInCircle" color="subdued" className="eui-alignTop" />
+          </>
+        </EuiToolTip>
+      ),
       render: (volume: number) =>
         volume < 1
           ? i18n.translate('searchConnectors.index.syncJobs.documents.volume.lessThanOneMBLabel', {

--- a/packages/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
@@ -111,17 +111,57 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
       ? [
           {
             field: 'indexed_document_count',
-            name: i18n.translate('searchConnectors.searchIndices.addedDocs.columnTitle', {
-              defaultMessage: 'Docs upserted',
-            }),
+            name: (
+              <EuiToolTip
+                content={
+                  <FormattedMessage
+                    id="searchConnectors.index.syncJobs.documents.upserted.tooltip"
+                    defaultMessage="The number of {index} operations the connector sent to the Elasticsearch _bulk API during this sync. This includes net-new documents and updates to existing documents. This does not account for duplicate _ids, or any documents dropped by an ingest processor"
+                    values={{ index: <EuiCode>index</EuiCode> }}
+                  />
+                }
+              >
+                <>
+                  {i18n.translate('searchConnectors.searchIndices.addedDocs.columnTitle', {
+                    defaultMessage: 'Docs upserted',
+                  })}
+                  <EuiIcon
+                    size="s"
+                    type="questionInCircle"
+                    color="subdued"
+                    className="eui-alignTop"
+                  />
+                </>
+              </EuiToolTip>
+            ),
             sortable: true,
             truncateText: true,
           },
           {
             field: 'deleted_document_count',
-            name: i18n.translate('searchConnectors.searchIndices.deletedDocs.columnTitle', {
-              defaultMessage: 'Docs deleted',
-            }),
+            name: (
+              <EuiToolTip
+                content={
+                  <FormattedMessage
+                    id="searchConnectors.index.syncJobs.documents.deleted.tooltip"
+                    defaultMessage="The number of {delete} operations the connector sent to the Elasticsearch _bulk API at the conclusion of this sync. This may include documents dropped by Sync Rules. This does not include documents dropped by ingest processors. Documents are deleted from the index if the connector determines that they are no longer present in the data that should be fetched from the 3rd-party source."
+                    values={{ delete: <EuiCode>delete</EuiCode> }}
+                  />
+                }
+              >
+                <>
+                  {i18n.translate('searchConnectors.searchIndices.deletedDocs.columnTitle', {
+                    defaultMessage: 'Docs deleted',
+                  })}
+                  <EuiIcon
+                    size="s"
+                    type="questionInCircle"
+                    color="subdued"
+                    className="eui-alignTop"
+                  />
+                </>
+              </EuiToolTip>
+            ),
             sortable: true,
             truncateText: true,
           },

--- a/packages/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
@@ -91,7 +91,7 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
               defaultMessage="The time between when a sync started ({started_at}) and when it terminated ({completed_at}) (whether successfully, in error, or canceled). Note that this does not include the time the job may have spent in a “pending” stage, waiting for a worker to pick it up."
               values={{
                 completed_at: <EuiCode>completed_at</EuiCode>,
-                started_at: <EuiCode>completed_at</EuiCode>,
+                started_at: <EuiCode>started_at</EuiCode>,
               }}
             />
           }

--- a/packages/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/sync_jobs_table.tsx
@@ -14,10 +14,14 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiButtonIcon,
+  EuiCode,
+  EuiIcon,
+  EuiToolTip,
   Pagination,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { ConnectorSyncJob, isSyncCancellable, SyncJobType, SyncStatus } from '../..';
 
 import { syncJobTypeToText, syncStatusToColor, syncStatusToText } from '../..';
@@ -55,18 +59,51 @@ export const SyncJobsTable: React.FC<SyncJobHistoryTableProps> = ({
   const columns: Array<EuiBasicTableColumn<ConnectorSyncJob>> = [
     {
       field: 'completed_at',
-      name: i18n.translate('searchConnectors.syncJobs.lastSync.columnTitle', {
-        defaultMessage: 'Last sync',
-      }),
+      name: (
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="searchConnectors.syncJobs.lastSync.columnTitle.tooltip"
+              defaultMessage="The timestamp of a given job's {completed_at}. This is when syncs finish, either successfully, in error, or by being canceled."
+              values={{ completed_at: <EuiCode>completed_at</EuiCode> }}
+            />
+          }
+        >
+          <>
+            {i18n.translate('searchConnectors.syncJobs.lastSync.columnTitle', {
+              defaultMessage: 'Last sync',
+            })}
+            <EuiIcon size="s" type="questionInCircle" color="subdued" className="eui-alignTop" />
+          </>
+        </EuiToolTip>
+      ),
       render: (lastSync: string) =>
         lastSync ? <FormattedDateTime date={new Date(lastSync)} /> : '--',
       sortable: true,
       truncateText: false,
     },
     {
-      name: i18n.translate('searchConnectors.syncJobs.syncDuration.columnTitle', {
-        defaultMessage: 'Sync duration',
-      }),
+      name: (
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="searchConnectors.syncJobs.syncDuration.columnTitle.tooltip"
+              defaultMessage="The time between when a sync started ({started_at}) and when it terminated ({completed_at}) (whether successfully, in error, or canceled). Note that this does not include the time the job may have spent in a “pending” stage, waiting for a worker to pick it up."
+              values={{
+                completed_at: <EuiCode>completed_at</EuiCode>,
+                started_at: <EuiCode>completed_at</EuiCode>,
+              }}
+            />
+          }
+        >
+          <>
+            {i18n.translate('searchConnectors.syncJobs.syncDuration.columnTitle', {
+              defaultMessage: 'Sync duration',
+            })}
+            <EuiIcon size="s" type="questionInCircle" color="subdued" className="eui-alignTop" />
+          </>
+        </EuiToolTip>
+      ),
       render: (syncJob: ConnectorSyncJob) => durationToText(getSyncJobDuration(syncJob)),
       truncateText: false,
     },


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/connectors/issues/2316

The connectors UI has some tables that display counters and timestamps, and we aren't very clear about what those values mean. This adds tooltips to help add clarity.


### Checklist


- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
