### PR TITLE
[Security Solution] Skips trained models test on MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/ml/trained_models_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ml/trained_models_list.ts
@@ -11,7 +11,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const svlMl = getService('svlMl');
   const PageObjects = getPageObjects(['svlCommonPage']);
 
+  // failsOnMKI, see https://github.com/elastic/kibana/issues/180481
   describe('Trained models list', function () {
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await PageObjects.svlCommonPage.login();
       await ml.api.syncSavedObjects();


### PR DESCRIPTION
## Summary

~See https://github.com/elastic/kibana/issues/180481 for details, but looks like this failure on MKI was not actually resolved. See build: https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/1429~

~Skipping for now and I will look to rework this test so that it will be happy both running locally and in MKI.~


I had mis-read the failure. Security trained models test is 👍, failure was another suite. Closing PR.

<img width="508" alt="image" src="https://github.com/elastic/kibana/assets/2946766/7cbfde1a-3b50-4103-a2bf-11b404287a50">
 

