### PR TITLE
[ML] Fixing groups dropdown in AD job wizards

### DIFF
--- a/x-pack/plugins/ml/public/application/routing/routes/new_job/recognize.tsx
+++ b/x-pack/plugins/ml/public/application/routing/routes/new_job/recognize.tsx
@@ -17,7 +17,7 @@ import { useMlKibana, useNavigateToPath } from '../../../contexts/kibana';
 import type { MlRoute, PageProps } from '../../router';
 import { createPath, PageLoader } from '../../router';
 import { useRouteResolver } from '../../use_resolver';
-import { mlJobService } from '../../../services/job_service';
+import { mlJobServiceFactory } from '../../../services/job_service';
 import { getBreadcrumbWithUrlForApp } from '../../breadcrumbs';
 import { useCreateADLinks } from '../../../components/custom_hooks/use_create_ad_links';
 import { DataSourceContextProvider } from '../../../contexts/ml';
@@ -54,10 +54,15 @@ export const checkViewOrCreateRouteFactory = (): MlRoute => ({
 
 const PageWrapper: FC<PageProps> = ({ location }) => {
   const { id } = parse(location.search, { sort: false });
+  const {
+    services: {
+      mlServices: { mlApiServices },
+    },
+  } = useMlKibana();
 
   const { context, results } = useRouteResolver('full', ['canGetJobs'], {
     ...basicResolvers(),
-    existingJobsAndGroups: mlJobService.getJobAndGroupIds,
+    existingJobsAndGroups: () => mlJobServiceFactory(undefined, mlApiServices).getJobAndGroupIds(),
   });
 
   return (

--- a/x-pack/plugins/ml/public/application/routing/routes/new_job/wizard.tsx
+++ b/x-pack/plugins/ml/public/application/routing/routes/new_job/wizard.tsx
@@ -19,7 +19,7 @@ import type { MlRoute, PageProps } from '../../router';
 import { createPath, PageLoader } from '../../router';
 import { useRouteResolver } from '../../use_resolver';
 import { JOB_TYPE } from '../../../../../common/constants/new_job';
-import { mlJobService } from '../../../services/job_service';
+import { mlJobServiceFactory } from '../../../services/job_service';
 import {
   loadNewJobCapabilities,
   ANOMALY_DETECTOR,
@@ -206,6 +206,7 @@ const PageWrapper: FC<WizardPageProps> = ({ location, jobType }) => {
     services: {
       data: { dataViews: dataViewsService },
       savedSearch: savedSearchService,
+      mlServices: { mlApiServices },
     },
   } = useMlKibana();
 
@@ -221,7 +222,7 @@ const PageWrapper: FC<WizardPageProps> = ({ location, jobType }) => {
         savedSearchService,
         ANOMALY_DETECTOR
       ),
-    existingJobsAndGroups: mlJobService.getJobAndGroupIds,
+    existingJobsAndGroups: () => mlJobServiceFactory(undefined, mlApiServices).getJobAndGroupIds(),
   });
 
   return (


### PR DESCRIPTION
Fixing bug introduced in https://github.com/elastic/kibana/pull/176788
The `jobService` hasn't been initialised when being used to load the groups.