### PR TITLE
[Security Solution][Detection Engine] fixes disabled preview for ML rule

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/helpers.test.ts
@@ -268,6 +268,24 @@ describe('query_preview/helpers', () => {
       });
       expect(isDisabled).toEqual(false);
     });
+
+    // ML rule does not have index or data view id properties, so preview should not depend on these fields
+    test('enabled for ML rule when index patterns and data view id are empty', () => {
+      const isDisabled = getIsRulePreviewDisabled({
+        ruleType: 'machine_learning',
+        isQueryBarValid: true,
+        isThreatQueryBarValid: true,
+        index: [],
+        dataViewId: undefined,
+        dataSourceType: DataSourceType.IndexPatterns,
+        threatIndex: [],
+        threatMapping: [],
+        machineLearningJobId: ['test-ml-job-id'],
+        queryBar: { filters: [], query: { query: '', language: '' }, saved_id: null },
+        newTermsFields: [],
+      });
+      expect(isDisabled).toEqual(false);
+    });
   });
 
   describe('getTimeframeOptions', () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/helpers.ts
@@ -124,6 +124,9 @@ export const getIsRulePreviewDisabled = ({
   if (ruleType === 'esql') {
     return isEsqlPreviewDisabled({ isQueryBarValid, queryBar });
   }
+  if (ruleType === 'machine_learning') {
+    return machineLearningJobId.length === 0;
+  }
   if (
     !isQueryBarValid ||
     (dataSourceType === DataSourceType.DataView && !dataViewId) ||
@@ -137,9 +140,6 @@ export const getIsRulePreviewDisabled = ({
       threatMapping,
       isThreatQueryBarValid,
     });
-  }
-  if (ruleType === 'machine_learning') {
-    return machineLearningJobId.length === 0;
   }
   if (ruleType === 'eql' || ruleType === 'query' || ruleType === 'threshold') {
     return isEmpty(queryBar.query.query) && isEmpty(queryBar.filters);


### PR DESCRIPTION
## Summary

- addresses https://github.com/elastic/kibana/issues/180069
- ML rule  does not have index or data view id properties, so preview should not depend on these fields. Added also unit test to verify this

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
