### PR TITLE
[SecuritySolution] Migrate bulk enable/diable rules to Alerting methods

### DIFF
--- a/x-pack/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.mock.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.mock.ts
@@ -8,7 +8,7 @@
 import type { PerformBulkActionRequestBody } from './bulk_actions_route.gen';
 import { BulkActionEditTypeEnum, BulkActionTypeEnum } from './bulk_actions_route.gen';
 
-export const getPerformBulkActionSchemaMock = (): PerformBulkActionRequestBody => ({
+export const getBulkDisableRuleActionSchemaMock = (): PerformBulkActionRequestBody => ({
   query: '',
   ids: undefined,
   action: BulkActionTypeEnum.disable,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_responses.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_responses.ts
@@ -31,7 +31,7 @@ import {
   PREBUILT_RULES_URL,
 } from '../../../../../common/api/detection_engine/prebuilt_rules';
 import {
-  getPerformBulkActionSchemaMock,
+  getBulkDisableRuleActionSchemaMock,
   getPerformBulkActionEditSchemaMock,
 } from '../../../../../common/api/detection_engine/rule_management/mocks';
 
@@ -131,11 +131,11 @@ export const getPatchBulkRequest = () =>
     body: [getCreateRulesSchemaMock()],
   });
 
-export const getBulkActionRequest = () =>
+export const getBulkDisableRuleActionRequest = () =>
   requestMock.create({
     method: 'patch',
     path: DETECTION_ENGINE_RULES_BULK_ACTION,
-    body: getPerformBulkActionSchemaMock(),
+    body: getBulkDisableRuleActionSchemaMock(),
   });
 
 export const getBulkActionEditRequest = () =>

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_actions_response.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_actions_response.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { BulkActionSkipResult } from '@kbn/alerting-plugin/common';
+import type { BulkOperationError } from '@kbn/alerting-plugin/server';
+import type { IKibanaResponse, KibanaResponseFactory } from '@kbn/core/server';
+import { transformError } from '@kbn/securitysolution-es-utils';
+import { truncate } from 'lodash';
+import type {
+  BulkEditActionResults,
+  BulkEditActionSummary,
+  NormalizedRuleError,
+  RuleDetailsInError,
+} from '../../../../../../../common/api/detection_engine';
+import type { BulkEditActionResponse } from '../../../../../../../common/api/detection_engine/rule_management';
+import type { BulkActionsDryRunErrCode } from '../../../../../../../common/constants';
+import type { PromisePoolError } from '../../../../../../utils/promise_pool';
+import type { RuleAlertType } from '../../../../rule_schema';
+import type { DryRunError } from '../../../logic/bulk_actions/dry_run';
+import { internalRuleToAPIResponse } from '../../../normalization/rule_converters';
+
+const MAX_ERROR_MESSAGE_LENGTH = 1000;
+
+export type BulkActionError =
+  | PromisePoolError<string>
+  | PromisePoolError<RuleAlertType>
+  | BulkOperationError;
+
+export const buildBulkResponse = (
+  response: KibanaResponseFactory,
+  {
+    isDryRun = false,
+    errors = [],
+    updated = [],
+    created = [],
+    deleted = [],
+    skipped = [],
+  }: {
+    isDryRun?: boolean;
+    errors?: BulkActionError[];
+    updated?: RuleAlertType[];
+    created?: RuleAlertType[];
+    deleted?: RuleAlertType[];
+    skipped?: BulkActionSkipResult[];
+  }
+): IKibanaResponse<BulkEditActionResponse> => {
+  const numSucceeded = updated.length + created.length + deleted.length;
+  const numSkipped = skipped.length;
+  const numFailed = errors.length;
+
+  const summary: BulkEditActionSummary = {
+    failed: numFailed,
+    succeeded: numSucceeded,
+    skipped: numSkipped,
+    total: numSucceeded + numFailed + numSkipped,
+  };
+
+  // if response is for dry_run, empty lists of rules returned, as rules are not actually updated and stored within ES
+  // thus, it's impossible to return reliably updated/duplicated/deleted rules
+  const results: BulkEditActionResults = isDryRun
+    ? {
+        updated: [],
+        created: [],
+        deleted: [],
+        skipped: [],
+      }
+    : {
+        updated: updated.map((rule) => internalRuleToAPIResponse(rule)),
+        created: created.map((rule) => internalRuleToAPIResponse(rule)),
+        deleted: deleted.map((rule) => internalRuleToAPIResponse(rule)),
+        skipped,
+      };
+
+  if (numFailed > 0) {
+    return response.custom<BulkEditActionResponse>({
+      headers: { 'content-type': 'application/json' },
+      body: {
+        message: summary.succeeded > 0 ? 'Bulk edit partially failed' : 'Bulk edit failed',
+        status_code: 500,
+        attributes: {
+          errors: normalizeErrorResponse(errors),
+          results,
+          summary,
+        },
+      },
+      statusCode: 500,
+    });
+  }
+
+  const responseBody: BulkEditActionResponse = {
+    success: true,
+    rules_count: summary.total,
+    attributes: { results, summary },
+  };
+
+  return response.ok({ body: responseBody });
+};
+
+export const normalizeErrorResponse = (errors: BulkActionError[]): NormalizedRuleError[] => {
+  const errorsMap = new Map<string, NormalizedRuleError>();
+
+  errors.forEach((errorObj) => {
+    let message: string;
+    let statusCode: number = 500;
+    let errorCode: BulkActionsDryRunErrCode | undefined;
+    let rule: RuleDetailsInError;
+    // transform different error types (PromisePoolError<string> | PromisePoolError<RuleAlertType> | BulkOperationError)
+    // to one common used in NormalizedRuleError
+    if ('rule' in errorObj) {
+      rule = errorObj.rule;
+      message = errorObj.message;
+    } else {
+      const { error, item } = errorObj;
+      const transformedError =
+        error instanceof Error
+          ? transformError(error)
+          : { message: String(error), statusCode: 500 };
+
+      errorCode = (error as DryRunError)?.errorCode;
+      message = transformedError.message;
+      statusCode = transformedError.statusCode;
+      // The promise pool item is either a rule ID string or a rule object. We have
+      // string IDs when we fail to fetch rules. Rule objects come from other
+      // situations when we found a rule but failed somewhere else.
+      rule = typeof item === 'string' ? { id: item } : { id: item.id, name: item.name };
+    }
+
+    if (errorsMap.has(message)) {
+      errorsMap.get(message)?.rules.push(rule);
+    } else {
+      errorsMap.set(message, {
+        message: truncate(message, { length: MAX_ERROR_MESSAGE_LENGTH }),
+        status_code: statusCode,
+        err_code: errorCode,
+        rules: [rule],
+      });
+    }
+  });
+
+  return Array.from(errorsMap, ([_, normalizedError]) => normalizedError);
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_enable_disable_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/bulk_enable_disable_rules.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import { invariant } from '../../../../../../../common/utils/invariant';
+import type { PromisePoolError } from '../../../../../../utils/promise_pool';
+import type { MlAuthz } from '../../../../../machine_learning/authz';
+import type { RuleAlertType } from '../../../../rule_schema';
+import { validateBulkEnableRule } from '../../../logic/bulk_actions/validations';
+
+interface BulkEnableDisableRulesArgs {
+  rules: RuleAlertType[];
+  action: 'enable' | 'disable';
+  isDryRun?: boolean;
+  rulesClient: RulesClient;
+  mlAuthz: MlAuthz;
+}
+
+interface BulkEnableDisableRulesOutcome {
+  updatedRules: RuleAlertType[];
+  errors: Array<PromisePoolError<RuleAlertType, Error>>;
+}
+
+export const bulkEnableDisableRules = async ({
+  rules,
+  isDryRun,
+  rulesClient,
+  action: operation,
+  mlAuthz,
+}: BulkEnableDisableRulesArgs): Promise<BulkEnableDisableRulesOutcome> => {
+  const errors: Array<PromisePoolError<RuleAlertType, Error>> = [];
+  const updatedRules: RuleAlertType[] = [];
+
+  // In the first step, we validate if the rules can be enabled
+  const validatedRules: RuleAlertType[] = [];
+  await Promise.all(
+    rules.map(async (rule) => {
+      try {
+        await validateBulkEnableRule({ mlAuthz, rule });
+        validatedRules.push(rule);
+      } catch (error) {
+        errors.push({ item: rule, error });
+      }
+    })
+  );
+
+  if (isDryRun || validatedRules.length === 0) {
+    return {
+      updatedRules: validatedRules,
+      errors,
+    };
+  }
+
+  // Then if it's not a dry run, we enable the rules that passed the validation
+  const ruleIds = validatedRules.map(({ id }) => id);
+
+  // Perform actual update using the rulesClient
+  const results =
+    operation === 'enable'
+      ? await rulesClient.bulkEnableRules({ ids: ruleIds })
+      : await rulesClient.bulkDisableRules({ ids: ruleIds });
+
+  const failedRuleIds = results.errors.map(({ rule: { id } }) => id);
+
+  // We need to go through the original rules array and update rules that were
+  // not returned as failed from the bulkEnableRules. We cannot rely on the
+  // results from the bulkEnableRules because the response is not consistent.
+  // Some rules might be missing in the response if they were skipped by
+  // Alerting Framework. See this issue for more details:
+  // https://github.com/elastic/kibana/issues/181050
+  updatedRules.push(
+    ...rules.flatMap((rule) => {
+      if (failedRuleIds.includes(rule.id)) {
+        return [];
+      }
+      return {
+        ...rule,
+        enabled: operation === 'enable',
+      };
+    })
+  );
+
+  // Rule objects returned from the bulkEnableRules are not
+  // compatible with the response type. So we need to map them to
+  // the original rules and update the enabled field
+  errors.push(
+    ...results.errors.map(({ rule: { id }, message }) => {
+      const rule = rules.find((r) => r.id === id);
+      invariant(rule != null, 'Unexpected rule id');
+      return {
+        item: rule,
+        error: new Error(message),
+      };
+    })
+  );
+
+  return {
+    updatedRules,
+    errors,
+  };
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/fetch_rules_by_query_or_ids.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/fetch_rules_by_query_or_ids.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import { BadRequestError } from '@kbn/securitysolution-es-utils';
+import { MAX_RULES_TO_UPDATE_IN_PARALLEL } from '../../../../../../../common/constants';
+import type { PromisePoolOutcome } from '../../../../../../utils/promise_pool';
+import { initPromisePool } from '../../../../../../utils/promise_pool';
+import type { RuleAlertType } from '../../../../rule_schema';
+import { readRules } from '../../../logic/crud/read_rules';
+import { findRules } from '../../../logic/search/find_rules';
+import { MAX_RULES_TO_PROCESS_TOTAL } from './route';
+
+export const fetchRulesByQueryOrIds = async ({
+  query,
+  ids,
+  rulesClient,
+  abortSignal,
+}: {
+  query: string | undefined;
+  ids: string[] | undefined;
+  rulesClient: RulesClient;
+  abortSignal: AbortSignal;
+}): Promise<PromisePoolOutcome<string, RuleAlertType>> => {
+  if (ids) {
+    return initPromisePool({
+      concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
+      items: ids,
+      executor: async (id: string) => {
+        const rule = await readRules({ id, rulesClient, ruleId: undefined });
+        if (rule == null) {
+          throw Error('Rule not found');
+        }
+        return rule;
+      },
+      abortSignal,
+    });
+  }
+
+  const { data, total } = await findRules({
+    rulesClient,
+    perPage: MAX_RULES_TO_PROCESS_TOTAL,
+    filter: query,
+    page: undefined,
+    sortField: undefined,
+    sortOrder: undefined,
+    fields: undefined,
+  });
+
+  if (total > MAX_RULES_TO_PROCESS_TOTAL) {
+    throw new BadRequestError(
+      `More than ${MAX_RULES_TO_PROCESS_TOTAL} rules matched the filter query. Try to narrow it down.`
+    );
+  }
+
+  return {
+    results: data.map((rule) => ({ item: rule.id, result: rule })),
+    errors: [],
+  };
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -5,230 +5,45 @@
  * 2.0.
  */
 
-import { truncate } from 'lodash';
-import { BadRequestError, transformError } from '@kbn/securitysolution-es-utils';
-import type { IKibanaResponse, KibanaResponseFactory, Logger } from '@kbn/core/server';
-
-import type { RulesClient, BulkOperationError } from '@kbn/alerting-plugin/server';
-import type { BulkActionSkipResult } from '@kbn/alerting-plugin/common';
+import type { IKibanaResponse, Logger } from '@kbn/core/server';
 import { AbortError } from '@kbn/kibana-utils-plugin/common';
-import type { RuleAlertType } from '../../../../rule_schema';
-import type { BulkActionsDryRunErrCode } from '../../../../../../../common/constants';
-import {
-  DETECTION_ENGINE_RULES_BULK_ACTION,
-  MAX_RULES_TO_UPDATE_IN_PARALLEL,
-  RULES_TABLE_MAX_PAGE_SIZE,
-} from '../../../../../../../common/constants';
-import type {
-  BulkEditActionResponse,
-  PerformBulkActionResponse,
-} from '../../../../../../../common/api/detection_engine/rule_management';
+import { transformError } from '@kbn/securitysolution-es-utils';
+import type { PerformBulkActionResponse } from '../../../../../../../common/api/detection_engine/rule_management';
 import {
   BulkActionTypeEnum,
   PerformBulkActionRequestBody,
   PerformBulkActionRequestQuery,
 } from '../../../../../../../common/api/detection_engine/rule_management';
-import type {
-  NormalizedRuleError,
-  RuleDetailsInError,
-  BulkEditActionResults,
-  BulkEditActionSummary,
-} from '../../../../../../../common/api/detection_engine';
+import {
+  DETECTION_ENGINE_RULES_BULK_ACTION,
+  MAX_RULES_TO_UPDATE_IN_PARALLEL,
+  RULES_TABLE_MAX_PAGE_SIZE,
+} from '../../../../../../../common/constants';
 import type { SetupPlugins } from '../../../../../../plugin';
 import type { SecuritySolutionPluginRouter } from '../../../../../../types';
 import { buildRouteValidationWithZod } from '../../../../../../utils/build_validation/route_validation';
-import { routeLimitedConcurrencyTag } from '../../../../../../utils/route_limited_concurrency_tag';
-import type { PromisePoolError, PromisePoolOutcome } from '../../../../../../utils/promise_pool';
 import { initPromisePool } from '../../../../../../utils/promise_pool';
+import { routeLimitedConcurrencyTag } from '../../../../../../utils/route_limited_concurrency_tag';
 import { buildMlAuthz } from '../../../../../machine_learning/authz';
-import { deleteRules } from '../../../logic/crud/delete_rules';
-import { duplicateRule } from '../../../logic/actions/duplicate_rule';
-import { duplicateExceptions } from '../../../logic/actions/duplicate_exceptions';
-import { findRules } from '../../../logic/search/find_rules';
-import { readRules } from '../../../logic/crud/read_rules';
-import { getExportByObjectIds } from '../../../logic/export/get_export_by_object_ids';
 import { buildSiemResponse } from '../../../../routes/utils';
-import { internalRuleToAPIResponse } from '../../../normalization/rule_converters';
+import type { RuleAlertType } from '../../../../rule_schema';
+import { duplicateExceptions } from '../../../logic/actions/duplicate_exceptions';
+import { duplicateRule } from '../../../logic/actions/duplicate_rule';
 import { bulkEditRules } from '../../../logic/bulk_actions/bulk_edit_rules';
-import type { DryRunError } from '../../../logic/bulk_actions/dry_run';
 import {
-  validateBulkEnableRule,
-  validateBulkDisableRule,
-  validateBulkDuplicateRule,
   dryRunValidateBulkEditRule,
+  validateBulkDuplicateRule,
 } from '../../../logic/bulk_actions/validations';
+import { deleteRules } from '../../../logic/crud/delete_rules';
+import { getExportByObjectIds } from '../../../logic/export/get_export_by_object_ids';
 import { RULE_MANAGEMENT_BULK_ACTION_SOCKET_TIMEOUT_MS } from '../../timeouts';
+import type { BulkActionError } from './bulk_actions_response';
+import { buildBulkResponse } from './bulk_actions_response';
+import { bulkEnableDisableRules } from './bulk_enable_disable_rules';
+import { fetchRulesByQueryOrIds } from './fetch_rules_by_query_or_ids';
 
-const MAX_RULES_TO_PROCESS_TOTAL = 10000;
-const MAX_ERROR_MESSAGE_LENGTH = 1000;
+export const MAX_RULES_TO_PROCESS_TOTAL = 10000;
 const MAX_ROUTE_CONCURRENCY = 5;
-
-export type BulkActionError =
-  | PromisePoolError<string>
-  | PromisePoolError<RuleAlertType>
-  | BulkOperationError;
-
-const normalizeErrorResponse = (errors: BulkActionError[]): NormalizedRuleError[] => {
-  const errorsMap = new Map<string, NormalizedRuleError>();
-
-  errors.forEach((errorObj) => {
-    let message: string;
-    let statusCode: number = 500;
-    let errorCode: BulkActionsDryRunErrCode | undefined;
-    let rule: RuleDetailsInError;
-    // transform different error types (PromisePoolError<string> | PromisePoolError<RuleAlertType> | BulkOperationError)
-    // to one common used in NormalizedRuleError
-    if ('rule' in errorObj) {
-      rule = errorObj.rule;
-      message = errorObj.message;
-    } else {
-      const { error, item } = errorObj;
-      const transformedError =
-        error instanceof Error
-          ? transformError(error)
-          : { message: String(error), statusCode: 500 };
-
-      errorCode = (error as DryRunError)?.errorCode;
-      message = transformedError.message;
-      statusCode = transformedError.statusCode;
-      // The promise pool item is either a rule ID string or a rule object. We have
-      // string IDs when we fail to fetch rules. Rule objects come from other
-      // situations when we found a rule but failed somewhere else.
-      rule = typeof item === 'string' ? { id: item } : { id: item.id, name: item.name };
-    }
-
-    if (errorsMap.has(message)) {
-      errorsMap.get(message)?.rules.push(rule);
-    } else {
-      errorsMap.set(message, {
-        message: truncate(message, { length: MAX_ERROR_MESSAGE_LENGTH }),
-        status_code: statusCode,
-        err_code: errorCode,
-        rules: [rule],
-      });
-    }
-  });
-
-  return Array.from(errorsMap, ([_, normalizedError]) => normalizedError);
-};
-
-const buildBulkResponse = (
-  response: KibanaResponseFactory,
-  {
-    isDryRun = false,
-    errors = [],
-    updated = [],
-    created = [],
-    deleted = [],
-    skipped = [],
-  }: {
-    isDryRun?: boolean;
-    errors?: BulkActionError[];
-    updated?: RuleAlertType[];
-    created?: RuleAlertType[];
-    deleted?: RuleAlertType[];
-    skipped?: BulkActionSkipResult[];
-  }
-): IKibanaResponse<BulkEditActionResponse> => {
-  const numSucceeded = updated.length + created.length + deleted.length;
-  const numSkipped = skipped.length;
-  const numFailed = errors.length;
-
-  const summary: BulkEditActionSummary = {
-    failed: numFailed,
-    succeeded: numSucceeded,
-    skipped: numSkipped,
-    total: numSucceeded + numFailed + numSkipped,
-  };
-
-  // if response is for dry_run, empty lists of rules returned, as rules are not actually updated and stored within ES
-  // thus, it's impossible to return reliably updated/duplicated/deleted rules
-  const results: BulkEditActionResults = isDryRun
-    ? {
-        updated: [],
-        created: [],
-        deleted: [],
-        skipped: [],
-      }
-    : {
-        updated: updated.map((rule) => internalRuleToAPIResponse(rule)),
-        created: created.map((rule) => internalRuleToAPIResponse(rule)),
-        deleted: deleted.map((rule) => internalRuleToAPIResponse(rule)),
-        skipped,
-      };
-
-  if (numFailed > 0) {
-    return response.custom<BulkEditActionResponse>({
-      headers: { 'content-type': 'application/json' },
-      body: {
-        message: summary.succeeded > 0 ? 'Bulk edit partially failed' : 'Bulk edit failed',
-        status_code: 500,
-        attributes: {
-          errors: normalizeErrorResponse(errors),
-          results,
-          summary,
-        },
-      },
-      statusCode: 500,
-    });
-  }
-
-  const responseBody: BulkEditActionResponse = {
-    success: true,
-    rules_count: summary.total,
-    attributes: { results, summary },
-  };
-
-  return response.ok({ body: responseBody });
-};
-
-const fetchRulesByQueryOrIds = async ({
-  query,
-  ids,
-  rulesClient,
-  abortSignal,
-}: {
-  query: string | undefined;
-  ids: string[] | undefined;
-  rulesClient: RulesClient;
-  abortSignal: AbortSignal;
-}): Promise<PromisePoolOutcome<string, RuleAlertType>> => {
-  if (ids) {
-    return initPromisePool({
-      concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-      items: ids,
-      executor: async (id: string) => {
-        const rule = await readRules({ id, rulesClient, ruleId: undefined });
-        if (rule == null) {
-          throw Error('Rule not found');
-        }
-        return rule;
-      },
-      abortSignal,
-    });
-  }
-
-  const { data, total } = await findRules({
-    rulesClient,
-    perPage: MAX_RULES_TO_PROCESS_TOTAL,
-    filter: query,
-    page: undefined,
-    sortField: undefined,
-    sortOrder: undefined,
-    fields: undefined,
-  });
-
-  if (total > MAX_RULES_TO_PROCESS_TOTAL) {
-    throw new BadRequestError(
-      `More than ${MAX_RULES_TO_PROCESS_TOTAL} rules matched the filter query. Try to narrow it down.`
-    );
-  }
-
-  return {
-    results: data.map((rule) => ({ item: rule.id, result: rule })),
-    errors: [],
-  };
-};
 
 export const performBulkActionRoute = (
   router: SecuritySolutionPluginRouter,
@@ -256,6 +71,7 @@ export const performBulkActionRoute = (
           },
         },
       },
+
       async (context, request, response): Promise<IKibanaResponse<PerformBulkActionResponse>> => {
         const { body } = request;
         const siemResponse = buildSiemResponse(response);
@@ -302,9 +118,9 @@ export const performBulkActionRoute = (
           const rulesClient = ctx.alerting.getRulesClient();
           const exceptionsClient = ctx.lists?.getExceptionListClient();
           const savedObjectsClient = ctx.core.savedObjects.client;
-          const actionsClient = (await ctx.actions)?.getActionsClient();
+          const actionsClient = ctx.actions.getActionsClient();
 
-          const { getExporter, getClient } = (await ctx.core).savedObjects;
+          const { getExporter, getClient } = ctx.core.savedObjects;
           const client = getClient({ includedHiddenTypes: ['action'] });
 
           const exporter = getExporter(client);
@@ -344,69 +160,38 @@ export const performBulkActionRoute = (
           });
 
           const rules = fetchRulesOutcome.results.map(({ result }) => result);
-          let bulkActionOutcome: PromisePoolOutcome<RuleAlertType, RuleAlertType | null>;
+          const errors: BulkActionError[] = [...fetchRulesOutcome.errors];
           let updated: RuleAlertType[] = [];
           let created: RuleAlertType[] = [];
           let deleted: RuleAlertType[] = [];
 
           switch (body.action) {
-            case BulkActionTypeEnum.enable:
-              bulkActionOutcome = await initPromisePool({
-                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-                items: rules,
-                executor: async (rule) => {
-                  await validateBulkEnableRule({ mlAuthz, rule });
-
-                  // during dry run only validation is getting performed and rule is not saved in ES, thus return early
-                  if (isDryRun) {
-                    return rule;
-                  }
-
-                  if (!rule.enabled) {
-                    await rulesClient.enable({ id: rule.id });
-                  }
-
-                  return {
-                    ...rule,
-                    enabled: true,
-                  };
-                },
-                abortSignal: abortController.signal,
+            case BulkActionTypeEnum.enable: {
+              const { updatedRules, errors: bulkActionErrors } = await bulkEnableDisableRules({
+                rules,
+                isDryRun,
+                rulesClient,
+                action: 'enable',
+                mlAuthz,
               });
-              updated = bulkActionOutcome.results
-                .map(({ result }) => result)
-                .filter((rule): rule is RuleAlertType => rule !== null);
+              errors.push(...bulkActionErrors);
+              updated = updatedRules;
               break;
-            case BulkActionTypeEnum.disable:
-              bulkActionOutcome = await initPromisePool({
-                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-                items: rules,
-                executor: async (rule) => {
-                  await validateBulkDisableRule({ mlAuthz, rule });
-
-                  // during dry run only validation is getting performed and rule is not saved in ES, thus return early
-                  if (isDryRun) {
-                    return rule;
-                  }
-
-                  if (rule.enabled) {
-                    await rulesClient.disable({ id: rule.id });
-                  }
-
-                  return {
-                    ...rule,
-                    enabled: false,
-                  };
-                },
-                abortSignal: abortController.signal,
+            }
+            case BulkActionTypeEnum.disable: {
+              const { updatedRules, errors: bulkActionErrors } = await bulkEnableDisableRules({
+                rules,
+                isDryRun,
+                rulesClient,
+                action: 'disable',
+                mlAuthz,
               });
-              updated = bulkActionOutcome.results
-                .map(({ result }) => result)
-                .filter((rule): rule is RuleAlertType => rule !== null);
+              errors.push(...bulkActionErrors);
+              updated = updatedRules;
               break;
-
-            case BulkActionTypeEnum.delete:
-              bulkActionOutcome = await initPromisePool({
+            }
+            case BulkActionTypeEnum.delete: {
+              const bulkActionOutcome = await initPromisePool({
                 concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
                 items: rules,
                 executor: async (rule) => {
@@ -424,13 +209,14 @@ export const performBulkActionRoute = (
                 },
                 abortSignal: abortController.signal,
               });
+              errors.push(...bulkActionOutcome.errors);
               deleted = bulkActionOutcome.results
                 .map(({ item }) => item)
                 .filter((rule): rule is RuleAlertType => rule !== null);
               break;
-
-            case BulkActionTypeEnum.duplicate:
-              bulkActionOutcome = await initPromisePool({
+            }
+            case BulkActionTypeEnum.duplicate: {
+              const bulkActionOutcome = await initPromisePool({
                 concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
                 items: rules,
                 executor: async (rule) => {
@@ -483,12 +269,13 @@ export const performBulkActionRoute = (
                 },
                 abortSignal: abortController.signal,
               });
+              errors.push(...bulkActionOutcome.errors);
               created = bulkActionOutcome.results
                 .map(({ result }) => result)
                 .filter((rule): rule is RuleAlertType => rule !== null);
               break;
-
-            case BulkActionTypeEnum.export:
+            }
+            case BulkActionTypeEnum.export: {
               const exported = await getExportByObjectIds(
                 rulesClient,
                 exceptionsClient,
@@ -507,11 +294,12 @@ export const performBulkActionRoute = (
                 },
                 body: responseBody,
               });
+            }
 
             // will be processed only when isDryRun === true
             // during dry run only validation is getting performed and rule is not saved in ES
-            case BulkActionTypeEnum.edit:
-              bulkActionOutcome = await initPromisePool({
+            case BulkActionTypeEnum.edit: {
+              const bulkActionOutcome = await initPromisePool({
                 concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
                 items: rules,
                 executor: async (rule) => {
@@ -521,9 +309,12 @@ export const performBulkActionRoute = (
                 },
                 abortSignal: abortController.signal,
               });
+              errors.push(...bulkActionOutcome.errors);
               updated = bulkActionOutcome.results
                 .map(({ result }) => result)
                 .filter((rule): rule is RuleAlertType => rule !== null);
+              break;
+            }
           }
 
           if (abortController.signal.aborted === true) {
@@ -534,7 +325,7 @@ export const performBulkActionRoute = (
             updated,
             deleted,
             created,
-            errors: [...fetchRulesOutcome.errors, ...bulkActionOutcome.errors],
+            errors,
             isDryRun,
           });
         } catch (err) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/validations.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/bulk_actions/validations.ts
@@ -55,9 +55,7 @@ const throwMlAuthError = (mlAuthz: MlAuthz, ruleType: RuleType) =>
  * @param params - {@link BulkActionsValidationArgs}
  */
 export const validateBulkEnableRule = async ({ rule, mlAuthz }: BulkActionsValidationArgs) => {
-  if (!rule.enabled) {
-    await throwMlAuthError(mlAuthz, rule.params.type);
-  }
+  await throwMlAuthError(mlAuthz, rule.params.type);
 };
 
 /**
@@ -65,9 +63,7 @@ export const validateBulkEnableRule = async ({ rule, mlAuthz }: BulkActionsValid
  * @param params - {@link BulkActionsValidationArgs}
  */
 export const validateBulkDisableRule = async ({ rule, mlAuthz }: BulkActionsValidationArgs) => {
-  if (rule.enabled) {
-    await throwMlAuthError(mlAuthz, rule.params.type);
-  }
+  await throwMlAuthError(mlAuthz, rule.params.type);
 };
 
 /**

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
@@ -6,57 +6,38 @@
  */
 
 import { Rule } from '@kbn/alerting-plugin/common';
-import { BaseRuleParams } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_schema';
 import expect from '@kbn/expect';
+import type { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import { getCreateEsqlRulesSchemaMock } from '@kbn/security-solution-plugin/common/api/detection_engine/model/rule_schema/mocks';
 import {
-  DETECTION_ENGINE_RULES_BULK_ACTION,
-  DETECTION_ENGINE_RULES_URL,
-} from '@kbn/security-solution-plugin/common/constants';
-import type { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
-import {
-  BulkActionTypeEnum,
   BulkActionEditTypeEnum,
+  BulkActionTypeEnum,
 } from '@kbn/security-solution-plugin/common/api/detection_engine/rule_management';
-import {
-  binaryToString,
-  createLegacyRuleAction,
-  getLegacyActionSO,
-  getSimpleRule,
-  getWebHookAction,
-  createRuleThroughAlertingEndpoint,
-  getRuleSavedObjectWithLegacyInvestigationFields,
-  getRuleSavedObjectWithLegacyInvestigationFieldsEmptyArray,
-  checkInvestigationFieldSoValue,
-  getRuleSOById,
-} from '../../../utils';
+import { BaseRuleParams } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_schema';
 import {
   createRule,
-  createAlertsIndex,
   deleteAllRules,
-  deleteAllAlerts,
   waitForRuleSuccess,
 } from '../../../../../../common/utils/security_solution';
-
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
+import {
+  binaryToString,
+  checkInvestigationFieldSoValue,
+  createLegacyRuleAction,
+  createRuleThroughAlertingEndpoint,
+  getLegacyActionSO,
+  getRuleSavedObjectWithLegacyInvestigationFields,
+  getRuleSavedObjectWithLegacyInvestigationFieldsEmptyArray,
+  getRuleSOById,
+  getSimpleRule,
+  getWebHookAction,
+} from '../../../utils';
 
 export default ({ getService }: FtrProviderContext): void => {
   const supertest = getService('supertest');
+  const securitySolutionApi = getService('securitySolutionApi');
   const es = getService('es');
   const log = getService('log');
-  const esArchiver = getService('esArchiver');
-
-  const postBulkAction = () =>
-    supertest
-      .post(DETECTION_ENGINE_RULES_BULK_ACTION)
-      .set('kbn-xsrf', 'true')
-      .set('elastic-api-version', '2023-10-31');
-
-  const fetchRule = (ruleId: string) =>
-    supertest
-      .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
-      .set('kbn-xsrf', 'true')
-      .set('elastic-api-version', '2023-10-31');
 
   const createConnector = async (payload: Record<string, unknown>) =>
     (await supertest.post('/api/actions/action').set('kbn-xsrf', 'true').send(payload).expect(200))
@@ -67,14 +48,7 @@ export default ({ getService }: FtrProviderContext): void => {
   // Failing: See https://github.com/elastic/kibana/issues/173804
   describe('@ess perform_bulk_action - ESS specific logic', () => {
     beforeEach(async () => {
-      await createAlertsIndex(supertest, log);
-      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
-    });
-
-    afterEach(async () => {
-      await deleteAllAlerts(supertest, log, es);
       await deleteAllRules(supertest, log);
-      await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
     });
 
     it('should delete rules and any associated legacy actions', async () => {
@@ -99,8 +73,11 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(sidecarActionsResults.hits.hits.length).to.eql(1);
       expect(sidecarActionsResults.hits.hits[0]?._source?.references[0].id).to.eql(rule1.id);
 
-      const { body } = await postBulkAction()
-        .send({ query: '', action: BulkActionTypeEnum.delete })
+      const { body } = await securitySolutionApi
+        .performBulkAction({
+          body: { query: '', action: BulkActionTypeEnum.delete },
+          query: {},
+        })
         .expect(200);
 
       expect(body.attributes.summary).to.eql({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
@@ -113,7 +90,7 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(sidecarActionsPostResults.hits.hits.length).to.eql(0);
 
       // Check that the updates have been persisted
-      await fetchRule(ruleId).expect(404);
+      await securitySolutionApi.readRule({ query: { rule_id: ruleId } }).expect(404);
     });
 
     it('should enable rules and migrate actions', async () => {
@@ -138,8 +115,11 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(sidecarActionsResults.hits.hits.length).to.eql(1);
       expect(sidecarActionsResults.hits.hits[0]?._source?.references[0].id).to.eql(rule1.id);
 
-      const { body } = await postBulkAction()
-        .send({ query: '', action: BulkActionTypeEnum.enable })
+      const { body } = await securitySolutionApi
+        .performBulkAction({
+          body: { query: '', action: BulkActionTypeEnum.enable },
+          query: {},
+        })
         .expect(200);
 
       expect(body.attributes.summary).to.eql({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
@@ -148,7 +128,9 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(body.attributes.results.updated[0].enabled).to.eql(true);
 
       // Check that the updates have been persisted
-      const { body: ruleBody } = await fetchRule(ruleId).expect(200);
+      const { body: ruleBody } = await securitySolutionApi
+        .readRule({ query: { rule_id: ruleId } })
+        .expect(200);
 
       // legacy sidecar action should be gone
       const sidecarActionsPostResults = await getLegacyActionSO(es);
@@ -193,8 +175,11 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(sidecarActionsResults.hits.hits.length).to.eql(1);
       expect(sidecarActionsResults.hits.hits[0]?._source?.references[0].id).to.eql(rule1.id);
 
-      const { body } = await postBulkAction()
-        .send({ query: '', action: BulkActionTypeEnum.disable })
+      const { body } = await securitySolutionApi
+        .performBulkAction({
+          body: { query: '', action: BulkActionTypeEnum.disable },
+          query: {},
+        })
         .expect(200);
 
       expect(body.attributes.summary).to.eql({ failed: 0, skipped: 0, succeeded: 1, total: 1 });
@@ -203,7 +188,9 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(body.attributes.results.updated[0].enabled).to.eql(false);
 
       // Check that the updates have been persisted
-      const { body: ruleBody } = await fetchRule(ruleId).expect(200);
+      const { body: ruleBody } = await securitySolutionApi
+        .readRule({ query: { rule_id: ruleId } })
+        .expect(200);
 
       // legacy sidecar action should be gone
       const sidecarActionsPostResults = await getLegacyActionSO(es);
@@ -248,11 +235,14 @@ export default ({ getService }: FtrProviderContext): void => {
         ruleToDuplicate.id
       );
 
-      const { body } = await postBulkAction()
-        .send({
-          query: '',
-          action: BulkActionTypeEnum.duplicate,
-          duplicate: { include_exceptions: false, include_expired_exceptions: false },
+      const { body } = await securitySolutionApi
+        .performBulkAction({
+          body: {
+            query: '',
+            action: BulkActionTypeEnum.duplicate,
+            duplicate: { include_exceptions: false, include_expired_exceptions: false },
+          },
+          query: {},
         })
         .expect(200);
 
@@ -262,10 +252,8 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(body.attributes.results.created[0].name).to.eql(`${ruleToDuplicate.name} [Duplicate]`);
 
       // Check that the updates have been persisted
-      const { body: rulesResponse } = await supertest
-        .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
-        .set('kbn-xsrf', 'true')
-        .set('elastic-api-version', '2023-10-31')
+      const { body: rulesResponse } = await securitySolutionApi
+        .findRules({ query: {} })
         .expect(200);
 
       expect(rulesResponse.total).to.eql(2);
@@ -293,16 +281,19 @@ export default ({ getService }: FtrProviderContext): void => {
         it('should return error if index patterns action is applied to ES|QL rule', async () => {
           const esqlRule = await createRule(supertest, log, getCreateEsqlRulesSchemaMock());
 
-          const { body } = await postBulkAction()
-            .send({
-              ids: [esqlRule.id],
-              action: BulkActionTypeEnum.edit,
-              [BulkActionTypeEnum.edit]: [
-                {
-                  type: BulkActionEditTypeEnum.add_index_patterns,
-                  value: ['index-*'],
-                },
-              ],
+          const { body } = await securitySolutionApi
+            .performBulkAction({
+              body: {
+                ids: [esqlRule.id],
+                action: BulkActionTypeEnum.edit,
+                [BulkActionTypeEnum.edit]: [
+                  {
+                    type: BulkActionEditTypeEnum.add_index_patterns,
+                    value: ['index-*'],
+                  },
+                ],
+              },
+              query: {},
             })
             .expect(500);
 
@@ -345,15 +336,18 @@ export default ({ getService }: FtrProviderContext): void => {
           ruleToDuplicate.id
         );
 
-        const { body: setTagsBody } = await postBulkAction().send({
-          query: '',
-          action: BulkActionTypeEnum.edit,
-          [BulkActionTypeEnum.edit]: [
-            {
-              type: BulkActionEditTypeEnum.set_tags,
-              value: ['reset-tag'],
-            },
-          ],
+        const { body: setTagsBody } = await securitySolutionApi.performBulkAction({
+          body: {
+            query: '',
+            action: BulkActionTypeEnum.edit,
+            [BulkActionTypeEnum.edit]: [
+              {
+                type: BulkActionEditTypeEnum.set_tags,
+                value: ['reset-tag'],
+              },
+            ],
+          },
+          query: {},
         });
         expect(setTagsBody.attributes.summary).to.eql({
           failed: 0,
@@ -363,7 +357,9 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         // Check that the updates have been persisted
-        const { body: setTagsRule } = await fetchRule(ruleId).expect(200);
+        const { body: setTagsRule } = await securitySolutionApi
+          .readRule({ query: { rule_id: ruleId } })
+          .expect(200);
 
         // Sidecar should be removed
         const sidecarActionsPostResults = await getLegacyActionSO(es);
@@ -422,24 +418,27 @@ export default ({ getService }: FtrProviderContext): void => {
               createdRule.id
             );
 
-            const { body } = await postBulkAction()
-              .send({
-                ids: [createdRule.id],
-                action: BulkActionTypeEnum.edit,
-                [BulkActionTypeEnum.edit]: [
-                  {
-                    type: BulkActionEditTypeEnum.set_rule_actions,
-                    value: {
-                      throttle: '1h',
-                      actions: [
-                        {
-                          ...webHookActionMock,
-                          id: webHookConnector.id,
-                        },
-                      ],
+            const { body } = await securitySolutionApi
+              .performBulkAction({
+                body: {
+                  ids: [createdRule.id],
+                  action: BulkActionTypeEnum.edit,
+                  [BulkActionTypeEnum.edit]: [
+                    {
+                      type: BulkActionEditTypeEnum.set_rule_actions,
+                      value: {
+                        throttle: '1h',
+                        actions: [
+                          {
+                            ...webHookActionMock,
+                            id: webHookConnector.id,
+                          },
+                        ],
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
+                query: {},
               })
               .expect(200);
 
@@ -457,7 +456,9 @@ export default ({ getService }: FtrProviderContext): void => {
             expect(body.attributes.results.updated[0].actions).to.eql(expectedRuleActions);
 
             // Check that the updates have been persisted
-            const { body: readRule } = await fetchRule(ruleId).expect(200);
+            const { body: readRule } = await securitySolutionApi
+              .readRule({ query: { rule_id: ruleId } })
+              .expect(200);
 
             expect(readRule.actions).to.eql(expectedRuleActions);
 
@@ -475,9 +476,6 @@ export default ({ getService }: FtrProviderContext): void => {
       let ruleWithIntendedInvestigationField: RuleResponse;
 
       beforeEach(async () => {
-        await deleteAllAlerts(supertest, log, es);
-        await deleteAllRules(supertest, log);
-        await createAlertsIndex(supertest, log);
         ruleWithLegacyInvestigationField = await createRuleThroughAlertingEndpoint(
           supertest,
           getRuleSavedObjectWithLegacyInvestigationFields()
@@ -495,13 +493,12 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
-      afterEach(async () => {
-        await deleteAllRules(supertest, log);
-      });
-
       it('should export rules with legacy investigation_fields and transform legacy field in response', async () => {
-        const { body } = await postBulkAction()
-          .send({ query: '', action: BulkActionTypeEnum.export })
+        const { body } = await securitySolutionApi
+          .performBulkAction({
+            body: { query: '', action: BulkActionTypeEnum.export },
+            query: {},
+          })
           .expect(200)
           .expect('Content-Type', 'application/ndjson')
           .expect('Content-Disposition', 'attachment; filename="rules_export.ndjson"')
@@ -566,8 +563,11 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('should delete rules with investigation fields and transform legacy field in response', async () => {
-        const { body } = await postBulkAction()
-          .send({ query: '', action: BulkActionTypeEnum.delete })
+        const { body } = await securitySolutionApi
+          .performBulkAction({
+            body: { query: '', action: BulkActionTypeEnum.delete },
+            query: {},
+          })
           .expect(200);
 
         expect(body.attributes.summary).to.eql({ failed: 0, skipped: 0, succeeded: 3, total: 3 });
@@ -590,14 +590,25 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         // Check that the updates have been persisted
-        await fetchRule(ruleWithLegacyInvestigationField.params.ruleId).expect(404);
-        await fetchRule(ruleWithLegacyInvestigationFieldEmptyArray.params.ruleId).expect(404);
-        await fetchRule('rule-with-investigation-field').expect(404);
+        await securitySolutionApi
+          .readRule({ query: { rule_id: ruleWithLegacyInvestigationField.params.ruleId } })
+          .expect(404);
+        await securitySolutionApi
+          .readRule({
+            query: { rule_id: ruleWithLegacyInvestigationFieldEmptyArray.params.ruleId },
+          })
+          .expect(404);
+        await securitySolutionApi
+          .readRule({ query: { rule_id: 'rule-with-investigation-field' } })
+          .expect(404);
       });
 
       it('should enable rules with legacy investigation fields and transform legacy field in response', async () => {
-        const { body } = await postBulkAction()
-          .send({ query: '', action: BulkActionTypeEnum.enable })
+        const { body } = await securitySolutionApi
+          .performBulkAction({
+            body: { query: '', action: BulkActionTypeEnum.enable },
+            query: {},
+          })
           .expect(200);
 
         expect(body.attributes.summary).to.eql({ failed: 0, skipped: 0, succeeded: 3, total: 3 });
@@ -664,8 +675,8 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('should disable rules with legacy investigation fields and transform legacy field in response', async () => {
-        const { body } = await postBulkAction()
-          .send({ query: '', action: BulkActionTypeEnum.disable })
+        const { body } = await securitySolutionApi
+          .performBulkAction({ body: { query: '', action: BulkActionTypeEnum.disable }, query: {} })
           .expect(200);
 
         expect(body.attributes.summary).to.eql({ failed: 0, skipped: 0, succeeded: 3, total: 3 });
@@ -735,11 +746,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('should duplicate rules with legacy investigation fields and transform field in response', async () => {
-        const { body } = await postBulkAction()
-          .send({
-            query: '',
-            action: BulkActionTypeEnum.duplicate,
-            duplicate: { include_exceptions: false, include_expired_exceptions: false },
+        const { body } = await securitySolutionApi
+          .performBulkAction({
+            body: {
+              query: '',
+              action: BulkActionTypeEnum.duplicate,
+              duplicate: { include_exceptions: false, include_expired_exceptions: false },
+            },
+            query: {},
           })
           .expect(200);
 
@@ -754,10 +768,8 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(names.includes('Test investigation fields object [Duplicate]')).to.eql(true);
 
         // Check that the updates have been persisted
-        const { body: rulesResponse } = await supertest
-          .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
-          .set('kbn-xsrf', 'true')
-          .set('elastic-api-version', '2023-10-31')
+        const { body: rulesResponse } = await await securitySolutionApi
+          .findRules({ query: {} })
           .expect(200);
 
         expect(rulesResponse.total).to.eql(6);
@@ -854,15 +866,18 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('should edit rules with legacy investigation fields', async () => {
-        const { body } = await postBulkAction().send({
-          query: '',
-          action: BulkActionTypeEnum.edit,
-          [BulkActionTypeEnum.edit]: [
-            {
-              type: BulkActionEditTypeEnum.set_tags,
-              value: ['reset-tag'],
-            },
-          ],
+        const { body } = await securitySolutionApi.performBulkAction({
+          body: {
+            query: '',
+            action: BulkActionTypeEnum.edit,
+            [BulkActionTypeEnum.edit]: [
+              {
+                type: BulkActionEditTypeEnum.set_tags,
+                value: ['reset-tag'],
+              },
+            ],
+          },
+          query: {},
         });
         expect(body.attributes.summary).to.eql({
           failed: 0,


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/171350**
**Resolves partially: https://github.com/elastic/kibana/issues/177634**

## Summary

This PR migrates the `/api/detection_engine/rules/_bulk_action` API endpoint to use the `rulesClient.bulkEnableRules` and `rulesClient.bulkDisableRules` methods under the hood. This change helps mitigate Task Manager flooding when users enable many detection rules at once. The alerting framework's bulk methods implement task staggering to ensure that multiple tasks are not scheduled for execution simultaneously. For more details, refer to [the ticket](https://github.com/elastic/kibana/issues/171350).

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->