### PR TITLE
[Search] Add sync rules callout when advanced rules are used

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -217,6 +217,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       start: `${ENTERPRISE_SEARCH_DOCS}start.html`,
       supportedNlpModels: `${MACHINE_LEARNING_DOCS}ml-nlp-model-ref.html`,
       syncRules: `${ENTERPRISE_SEARCH_DOCS}sync-rules.html`,
+      syncRulesAdvanced: `${ENTERPRISE_SEARCH_DOCS}sync-rules.html#sync-rules-advanced`,
       trainedModels: `${MACHINE_LEARNING_DOCS}ml-trained-models.html`,
       textEmbedding: `${MACHINE_LEARNING_DOCS}ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding`,
       troubleshootSetup: `${ENTERPRISE_SEARCH_DOCS}troubleshoot-setup.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -182,6 +182,7 @@ export interface DocLinks {
     readonly start: string;
     readonly supportedNlpModels: string;
     readonly syncRules: string;
+    readonly syncRulesAdvanced: string;
     readonly trainedModels: string;
     readonly textEmbedding: string;
     readonly troubleshootSetup: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -269,7 +269,7 @@ export const ConnectorConfiguration: React.FC = () => {
                         >
                           <FormattedMessage
                             id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout.description"
-                            defaultMessage="Configuration fields might be overridden when {advancedSyncRulesDocs} are used"
+                            defaultMessage="{advancedSyncRulesDocs} can override some configuration fields."
                             values={{
                               advancedSyncRulesDocs: (
                                 <EuiLink href={docLinks.syncRules} target="_blank">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -44,6 +44,8 @@ import { ApiKeyConfig } from '../search_index/connector/api_key_configuration';
 
 import { getConnectorTemplate } from '../search_index/connector/constants';
 
+import { ConnectorFilteringLogic } from '../search_index/connector/sync_rules/connector_filtering_logic';
+
 import { AttachIndexBox } from './attach_index_box';
 import { ConnectorDetailTabId } from './connector_detail';
 import { ConnectorViewLogic } from './connector_view_logic';
@@ -51,11 +53,17 @@ import { NativeConnectorConfiguration } from './native_connector_configuration';
 
 export const ConnectorConfiguration: React.FC = () => {
   const { data: apiKeyData } = useValues(GenerateConnectorApiKeyApiLogic);
-  const { index, isLoading, connector, updateConnectorConfigurationStatus } =
-    useValues(ConnectorViewLogic);
+  const {
+    index,
+    isLoading,
+    connector,
+    updateConnectorConfigurationStatus,
+    hasAdvancedFilteringFeature,
+  } = useValues(ConnectorViewLogic);
   const cloudContext = useCloudDetails();
   const { hasPlatinumLicense } = useValues(LicensingLogic);
   const { errorConnectingMessage, http } = useValues(HttpLogic);
+  const { advancedSnippet } = useValues(ConnectorFilteringLogic);
 
   const { connectorTypes } = useValues(KibanaLogic);
   const BETA_CONNECTORS = useMemo(
@@ -248,6 +256,32 @@ export const ConnectorConfiguration: React.FC = () => {
                             }
                           )}
                         />
+                      )}
+                      <EuiSpacer size="s" />
+                      {connector.status && hasAdvancedFilteringFeature && !!advancedSnippet && (
+                        <EuiCallOut
+                          title={i18n.translate(
+                            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout',
+                            { defaultMessage: 'Configuration warning' }
+                          )}
+                          iconType="iInCircle"
+                          color="warning"
+                        >
+                          <FormattedMessage
+                            id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout.description"
+                            defaultMessage="Configuration fields might be overridden when {advancedSyncRulesDocs} are used"
+                            values={{
+                              advancedSyncRulesDocs: (
+                                <EuiLink href={docLinks.syncRules} target="_blank">
+                                  {i18n.translate(
+                                    'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedSyncRulesDocs',
+                                    { defaultMessage: 'Advanced Sync Rules' }
+                                  )}
+                                </EuiLink>
+                              ),
+                            }}
+                          />
+                        </EuiCallOut>
                       )}
                     </ConnectorConfigurationComponent>
                   ),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -127,7 +127,7 @@ export const NativeConnectorConfigurationConfig: React.FC<
           >
             <FormattedMessage
               id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout.description"
-              defaultMessage="Configuration fields might be overridden when {advancedSyncRulesDocs} are used"
+              defaultMessage="{advancedSyncRulesDocs} can override some configuration fields."
               values={{
                 advancedSyncRulesDocs: (
                   <EuiLink href={docLinks.syncRules} target="_blank">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -13,6 +13,7 @@ import { EuiSpacer, EuiLink, EuiText, EuiFlexGroup, EuiFlexItem, EuiCallOut } fr
 
 import { i18n } from '@kbn/i18n';
 
+import { FormattedMessage } from '@kbn/i18n-react';
 import { Connector, ConnectorStatus } from '@kbn/search-connectors';
 
 import { ConnectorConfigurationComponent } from '@kbn/search-connectors/components/configuration/connector_configuration';
@@ -26,6 +27,8 @@ import { HttpLogic } from '../../../../../shared/http';
 import { LicensingLogic } from '../../../../../shared/licensing';
 
 import { ConnectorConfigurationApiLogic } from '../../../../api/connector/update_connector_configuration_api_logic';
+import { ConnectorViewLogic } from '../../../connector_detail/connector_view_logic';
+import { ConnectorFilteringLogic } from '../sync_rules/connector_filtering_logic';
 
 interface NativeConnectorConfigurationConfigProps {
   connector: Connector;
@@ -39,6 +42,8 @@ export const NativeConnectorConfigurationConfig: React.FC<
   const { hasPlatinumLicense } = useValues(LicensingLogic);
   const { status: updateStatus } = useValues(ConnectorConfigurationApiLogic);
   const { makeRequest } = useActions(ConnectorConfigurationApiLogic);
+  const { hasAdvancedFilteringFeature } = useValues(ConnectorViewLogic);
+  const { advancedSnippet } = useValues(ConnectorFilteringLogic);
   const { http } = useValues(HttpLogic);
   return (
     <ConnectorConfigurationComponent
@@ -106,6 +111,35 @@ export const NativeConnectorConfigurationConfig: React.FC<
               }
             )}
           />
+        </>
+      )}
+
+      {connector.status && hasAdvancedFilteringFeature && !!advancedSnippet && (
+        <>
+          <EuiSpacer size="l" />
+          <EuiCallOut
+            title={i18n.translate(
+              'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout',
+              { defaultMessage: 'Configuration warning' }
+            )}
+            iconType="iInCircle"
+            color="warning"
+          >
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout.description"
+              defaultMessage="Configuration fields might be overridden when {advancedSyncRulesDocs} are used"
+              values={{
+                advancedSyncRulesDocs: (
+                  <EuiLink href={docLinks.syncRules} target="_blank">
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedSyncRulesDocs',
+                      { defaultMessage: 'Advanced Sync Rules' }
+                    )}
+                  </EuiLink>
+                ),
+              }}
+            />
+          </EuiCallOut>
         </>
       )}
     </ConnectorConfigurationComponent>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/advanced_sync_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/advanced_sync_rules.tsx
@@ -9,52 +9,76 @@ import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import { EuiFormRow } from '@elastic/eui';
+import { EuiCallOut, EuiFormRow } from '@elastic/eui';
 import { CodeEditor } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
+
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { ConnectorFilteringLogic } from './connector_filtering_logic';
 
 export const AdvancedSyncRules: React.FC = () => {
-  const { hasJsonValidationError: hasError, localAdvancedSnippet } =
-    useValues(ConnectorFilteringLogic);
+  const {
+    hasJsonValidationError: hasError,
+    localAdvancedSnippet,
+    advancedSnippet,
+  } = useValues(ConnectorFilteringLogic);
   const { setLocalAdvancedSnippet } = useActions(ConnectorFilteringLogic);
   return (
-    <EuiFormRow
-      label={i18n.translate(
-        'xpack.enterpriseSearch.content.indices.connector.syncRules.advancedRules.title',
-        {
-          defaultMessage: 'Advanced rules',
+    <>
+      <EuiFormRow
+        label={i18n.translate(
+          'xpack.enterpriseSearch.content.indices.connector.syncRules.advancedRules.title',
+          {
+            defaultMessage: 'Advanced rules',
+          }
+        )}
+        isInvalid={hasError}
+        error={
+          hasError
+            ? i18n.translate(
+                'xpack.enterpriseSearch.content.indices.connector.syncRules.advancedRules.error',
+                {
+                  defaultMessage: 'JSON format is invalid',
+                }
+              )
+            : undefined
         }
+        fullWidth
+      >
+        <CodeEditor
+          isCopyable
+          languageId="json"
+          options={{
+            detectIndentation: true,
+            lineNumbers: 'on',
+            tabSize: 2,
+          }}
+          value={localAdvancedSnippet}
+          onChange={(value) => {
+            setLocalAdvancedSnippet(value);
+          }}
+          height="250px"
+          width="100%"
+        />
+      </EuiFormRow>
+
+      {(!!advancedSnippet || !!localAdvancedSnippet) && (
+        <EuiCallOut
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.index.connector.syncRules.advancedTabCallout.title',
+            { defaultMessage: 'Configuration warning' }
+          )}
+          color="warning"
+        >
+          <p>
+            <FormattedMessage
+              id="xpack.enterpriseSearch.editSyncRulesFlyout.advancedTablCallout.description"
+              defaultMessage="This advanced sync rule might override some configuration fields."
+            />
+          </p>
+        </EuiCallOut>
       )}
-      isInvalid={hasError}
-      error={
-        hasError
-          ? i18n.translate(
-              'xpack.enterpriseSearch.content.indices.connector.syncRules.advancedRules.error',
-              {
-                defaultMessage: 'JSON format is invalid',
-              }
-            )
-          : undefined
-      }
-      fullWidth
-    >
-      <CodeEditor
-        isCopyable
-        languageId="json"
-        options={{
-          detectIndentation: true,
-          lineNumbers: 'on',
-          tabSize: 2,
-        }}
-        value={localAdvancedSnippet}
-        onChange={(value) => {
-          setLocalAdvancedSnippet(value);
-        }}
-        height="250px"
-        width="100%"
-      />
-    </EuiFormRow>
+    </>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
@@ -11,6 +11,7 @@ import { useActions, useValues } from 'kea';
 
 import {
   EuiButton,
+  EuiCallOut,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -190,7 +191,7 @@ export const ConnectorSyncRules: React.FC = () => {
                       )}
                     </p>
                     <p>
-                      <EuiLink external href={docLinks.syncRules}>
+                      <EuiLink external href={docLinks.syncRulesAdvanced}>
                         {i18n.translate(
                           'xpack.enterpriseSearch.content.index.connector.syncRules.advancedFiltersLinkTitle',
                           {
@@ -204,6 +205,28 @@ export const ConnectorSyncRules: React.FC = () => {
                 <EuiCodeBlock isCopyable language="json">
                   {advancedSnippet}
                 </EuiCodeBlock>
+                <EuiFlexItem>
+                  <EuiCallOut
+                    title={i18n.translate(
+                      'xpack.enterpriseSearch.content.index.connector.syncRules.advancedRulesCalloutTitle',
+                      { defaultMessage: 'Configuration' }
+                    )}
+                    color="warning"
+                    iconType="iInCircle"
+                  >
+                    <EuiText size="s">
+                      <p>
+                        {i18n.translate(
+                          'xpack.enterpriseSearch.content.index.connector.syncRules.advancedRulesCalloutDescription',
+                          {
+                            defaultMessage:
+                              'This advanced sync rule might override some configuration fields.',
+                          }
+                        )}
+                      </p>
+                    </EuiText>
+                  </EuiCallOut>
+                </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPanel>
           </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -141,6 +141,7 @@ class DocLinks {
   public start: string;
   public supportedNlpModels: string;
   public syncRules: string;
+  public syncRulesAdvanced: string;
   public trainedModels: string;
   public textEmbedding: string;
   public workplaceSearchApiKeys: string;
@@ -317,6 +318,7 @@ class DocLinks {
     this.start = '';
     this.supportedNlpModels = '';
     this.syncRules = '';
+    this.syncRulesAdvanced = '';
     this.trainedModels = '';
     this.textEmbedding = '';
     this.workplaceSearchApiKeys = '';
@@ -495,6 +497,7 @@ class DocLinks {
     this.start = docLinks.links.enterpriseSearch.start;
     this.supportedNlpModels = docLinks.links.enterpriseSearch.supportedNlpModels;
     this.syncRules = docLinks.links.enterpriseSearch.syncRules;
+    this.syncRulesAdvanced = docLinks.links.enterpriseSearch.syncRulesAdvanced;
     this.trainedModels = docLinks.links.enterpriseSearch.trainedModels;
     this.textEmbedding = docLinks.links.enterpriseSearch.textEmbedding;
     this.workplaceSearchGatedFormBlog = docLinks.links.workplaceSearch.gatedFormBlog;


### PR DESCRIPTION
## Summary

Adds callouts for advanced rules when they are used. 
<img width="740" alt="Screenshot 2024-04-15 at 15 12 37" src="https://github.com/elastic/kibana/assets/1410658/d6980020-3996-49dd-9c67-97083d9426e9">
<img width="1233" alt="Screenshot 2024-04-15 at 15 12 44" src="https://github.com/elastic/kibana/assets/1410658/caf9647c-f59e-44d1-8207-442fb01c6c91">
<img width="1118" alt="Screenshot 2024-04-15 at 15 12 50" src="https://github.com/elastic/kibana/assets/1410658/2df35c49-afc7-4b0e-b369-e8227ddfbf82">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


