### PR TITLE
[8.13] [SecuritySolution] Display full name in greetings (#180670)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/onboarding.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/onboarding.test.tsx
@@ -22,6 +22,7 @@ jest.mock('../../../lib/kibana', () => {
   const original = jest.requireActual('../../../lib/kibana');
   return {
     ...original,
+    useCurrentUser: jest.fn().mockReturnValue({ fullName: 'UserFullName' }),
     useAppUrl: jest.fn().mockReturnValue({ getAppUrl: jest.fn().mockReturnValue('mock url') }),
   };
 });
@@ -63,10 +64,14 @@ describe('OnboardingComponent', () => {
       ViewAlertsSteps.viewAlerts,
     ],
   };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render page title, subtitle, and description', () => {
     const { getByText } = render(<OnboardingComponent {...props} />);
 
-    const pageTitle = getByText('Hi Unknown!');
+    const pageTitle = getByText('Hi UserFullName!');
     const subtitle = getByText(`Get started with Security`);
     const description = getByText(
       `This area shows you everything you need to know. Feel free to explore all content. You can always come back here at any time.`

--- a/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/welcome_header/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/welcome_header/index.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { WelcomeHeader } from '.';
+import { useCurrentUser } from '../../../../lib/kibana';
+import { CurrentPlan } from './current_plan';
+import { ProductTier } from '../configs';
+import { useProjectFeaturesUrl } from '../hooks/use_project_features_url';
+
+jest.mock('../../../../lib/kibana', () => ({
+  useCurrentUser: jest.fn(),
+}));
+
+jest.mock('../hooks/use_project_features_url', () => ({
+  useProjectFeaturesUrl: jest.fn(),
+}));
+
+jest.mock('./current_plan', () => ({
+  CurrentPlan: jest.fn().mockReturnValue(<div data-test-subj="current-plan" />),
+}));
+
+const mockUseCurrentUser = useCurrentUser as jest.Mock;
+const mockCurrentPlan = CurrentPlan as unknown as jest.Mock;
+const mockUseProjectFeaturesUrl = useProjectFeaturesUrl as jest.Mock;
+const mockProjectFeaturesUrl = '/features';
+
+describe('WelcomeHeaderComponent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render fullName when fullName is provided', () => {
+    const fullName = 'John Doe';
+    mockUseCurrentUser.mockReturnValue({ fullName });
+    const { getByText } = render(<WelcomeHeader />);
+    const titleElement = getByText(`Hi ${fullName}!`);
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  it('should render username when fullName is not provided', () => {
+    const username = 'jd';
+    mockUseCurrentUser.mockReturnValue({ username });
+
+    const { getByText } = render(<WelcomeHeader />);
+    const titleElement = getByText(`Hi ${username}!`);
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  it('should not render the greeting message if both fullName and username are not available', () => {
+    mockUseCurrentUser.mockReturnValue({});
+
+    const { queryByTestId } = render(<WelcomeHeader />);
+    const greetings = queryByTestId(`welcome-header-greetings`);
+    expect(greetings).not.toBeInTheDocument();
+  });
+
+  it('should render subtitle', () => {
+    const { getByText } = render(<WelcomeHeader />);
+    const subtitleElement = getByText('Get started with Security');
+    expect(subtitleElement).toBeInTheDocument();
+  });
+
+  it('should render description', () => {
+    const { getByText } = render(<WelcomeHeader />);
+    const descriptionElement = getByText(
+      'This area shows you everything you need to know. Feel free to explore all content. You can always come back here at any time.'
+    );
+    expect(descriptionElement).toBeInTheDocument();
+  });
+
+  it('should render current plan', () => {
+    mockUseProjectFeaturesUrl.mockReturnValue(mockProjectFeaturesUrl);
+    const { getByTestId } = render(<WelcomeHeader productTier={ProductTier.complete} />);
+    const currentPlanElement = getByTestId('current-plan');
+    expect(currentPlanElement).toBeInTheDocument();
+    expect(mockCurrentPlan.mock.calls[0][0]).toEqual({
+      productTier: 'complete',
+      projectFeaturesUrl: mockProjectFeaturesUrl,
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/welcome_header/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/welcome_header/index.tsx
@@ -22,6 +22,10 @@ import { CurrentPlan } from './current_plan';
 
 const WelcomeHeaderComponent: React.FC<{ productTier?: ProductTier }> = ({ productTier }) => {
   const userName = useCurrentUser();
+
+  // Full name could be null, user name should always exist
+  const name = userName?.fullName ?? userName?.username;
+
   const projectFeaturesUrl = useProjectFeaturesUrl();
 
   const {
@@ -38,9 +42,13 @@ const WelcomeHeaderComponent: React.FC<{ productTier?: ProductTier }> = ({ produ
   return (
     <EuiFlexGroup className={headerStyles} data-test-subj="welcome-header">
       <EuiFlexItem grow={false} className={headerContentStyles}>
-        {userName?.username && (
-          <EuiTitle size="l" className={headerTitleStyles}>
-            <span>{GET_STARTED_PAGE_TITLE(userName.username)}</span>
+        {name && (
+          <EuiTitle
+            size="l"
+            className={headerTitleStyles}
+            data-test-subj="welcome-header-greetings"
+          >
+            <span>{GET_STARTED_PAGE_TITLE(name)}</span>
           </EuiTitle>
         )}
         <EuiSpacer size="s" />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[SecuritySolution] Display full name in greetings (#180670)](https://github.com/elastic/kibana/pull/180670)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Angela Chuang","email":"6295984+angorayc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-15T13:15:48Z","message":"[SecuritySolution] Display full name in greetings (#180670)\n\n## Summary\r\n\r\nWe could find the user's full name might not always be available from\r\nthe 1st image below, but username should always exist.\r\nPreviously, we displayed username straight away and it didn't look good.\r\n[bug](https://github.com/elastic/kibana/issues/177204)\r\nIn this PR, we change the logic and display user's full name if it\r\nexists, otherwise fallback to the username.\r\n\r\n\r\n**No Full Name scenario - It displays username**\r\n\r\n<img width=\"2293\" alt=\"Screenshot 2024-04-12 at 09 58 52\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/355e5a3d-e8f8-4204-8234-8eddd14691e1\">\r\n\r\n\r\n<img width=\"2559\" alt=\"Screenshot 2024-04-12 at 09 59 18\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/14ba8250-57cf-4fc1-9bdf-a3ac021b91c8\">\r\n\r\n**Full Name available scenario - It displays the full name**\r\n\r\n<img width=\"2291\" alt=\"Screenshot 2024-04-12 at 10 07 28\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/57cb5aa2-ae23-4e0b-bd13-7b6d72edce40\">\r\n<img width=\"2557\" alt=\"Screenshot 2024-04-12 at 10 08 24\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/a4cbd64f-7eef-454b-a5fc-e12f25a82ea5\">\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"01e2379929f2fe8cfda3e8d95bb8f4e252f8ae9d","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:skip","v8.14.0"],"number":180670,"url":"https://github.com/elastic/kibana/pull/180670","mergeCommit":{"message":"[SecuritySolution] Display full name in greetings (#180670)\n\n## Summary\r\n\r\nWe could find the user's full name might not always be available from\r\nthe 1st image below, but username should always exist.\r\nPreviously, we displayed username straight away and it didn't look good.\r\n[bug](https://github.com/elastic/kibana/issues/177204)\r\nIn this PR, we change the logic and display user's full name if it\r\nexists, otherwise fallback to the username.\r\n\r\n\r\n**No Full Name scenario - It displays username**\r\n\r\n<img width=\"2293\" alt=\"Screenshot 2024-04-12 at 09 58 52\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/355e5a3d-e8f8-4204-8234-8eddd14691e1\">\r\n\r\n\r\n<img width=\"2559\" alt=\"Screenshot 2024-04-12 at 09 59 18\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/14ba8250-57cf-4fc1-9bdf-a3ac021b91c8\">\r\n\r\n**Full Name available scenario - It displays the full name**\r\n\r\n<img width=\"2291\" alt=\"Screenshot 2024-04-12 at 10 07 28\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/57cb5aa2-ae23-4e0b-bd13-7b6d72edce40\">\r\n<img width=\"2557\" alt=\"Screenshot 2024-04-12 at 10 08 24\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/a4cbd64f-7eef-454b-a5fc-e12f25a82ea5\">\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"01e2379929f2fe8cfda3e8d95bb8f4e252f8ae9d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/180670","number":180670,"mergeCommit":{"message":"[SecuritySolution] Display full name in greetings (#180670)\n\n## Summary\r\n\r\nWe could find the user's full name might not always be available from\r\nthe 1st image below, but username should always exist.\r\nPreviously, we displayed username straight away and it didn't look good.\r\n[bug](https://github.com/elastic/kibana/issues/177204)\r\nIn this PR, we change the logic and display user's full name if it\r\nexists, otherwise fallback to the username.\r\n\r\n\r\n**No Full Name scenario - It displays username**\r\n\r\n<img width=\"2293\" alt=\"Screenshot 2024-04-12 at 09 58 52\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/355e5a3d-e8f8-4204-8234-8eddd14691e1\">\r\n\r\n\r\n<img width=\"2559\" alt=\"Screenshot 2024-04-12 at 09 59 18\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/14ba8250-57cf-4fc1-9bdf-a3ac021b91c8\">\r\n\r\n**Full Name available scenario - It displays the full name**\r\n\r\n<img width=\"2291\" alt=\"Screenshot 2024-04-12 at 10 07 28\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/57cb5aa2-ae23-4e0b-bd13-7b6d72edce40\">\r\n<img width=\"2557\" alt=\"Screenshot 2024-04-12 at 10 08 24\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6295984/a4cbd64f-7eef-454b-a5fc-e12f25a82ea5\">\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"01e2379929f2fe8cfda3e8d95bb8f4e252f8ae9d"}}]}] BACKPORT-->