### PR TITLE
fix(slo): set short window duration as 1/12th of long duration for low priority

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/components/burn_rate_rule_editor/constants.ts
+++ b/x-pack/plugins/observability_solution/slo/public/components/burn_rate_rule_editor/constants.ts
@@ -38,7 +38,7 @@ const WEEKLY: PartialWindowSchema[] = [
   {
     burnRateThreshold: 0.234,
     longWindow: { value: 72, unit: 'h' },
-    shortWindow: { value: 260, unit: 'm' },
+    shortWindow: { value: 360, unit: 'm' },
     actionGroup: LOW_PRIORITY_ACTION.id,
   },
 ];
@@ -65,7 +65,7 @@ const MONTHLY: PartialWindowSchema[] = [
   {
     burnRateThreshold: 1,
     longWindow: { value: 72, unit: 'h' },
-    shortWindow: { value: 260, unit: 'm' },
+    shortWindow: { value: 360, unit: 'm' },
     actionGroup: LOW_PRIORITY_ACTION.id,
   },
 ];
@@ -92,7 +92,7 @@ const QUARTERLY: PartialWindowSchema[] = [
   {
     burnRateThreshold: 3,
     longWindow: { value: 72, unit: 'h' },
-    shortWindow: { value: 260, unit: 'm' },
+    shortWindow: { value: 360, unit: 'm' },
     actionGroup: LOW_PRIORITY_ACTION.id,
   },
 ];


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/180801

## 🌮  Summary

This PR fixes the duration of the low priority burn rate short window, to set it as 1/12th of the long window: 72h long window to 6 hours (360 minutes) short window.

## Release note

The duration of the short window of the low criticality burn rate rule was set to 4 hours instead of 6 hours.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->