### PR TITLE
Fetch Snapshot telemetry on UI nodes only

### DIFF
--- a/src/plugins/telemetry/server/plugin.ts
+++ b/src/plugins/telemetry/server/plugin.ts
@@ -103,6 +103,7 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
   private isOptedIn?: boolean;
   private readonly isDev: boolean;
   private readonly fetcherTask: FetcherTask;
+  private readonly shouldStartSnapshotTelemetryFetcher: boolean;
   /**
    * @private Used to mark the completion of the old UI Settings migration
    */
@@ -132,6 +133,10 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
       ...initializerContext,
       logger: this.logger,
     });
+
+    // Only generate and report the snapshot telemetry in the UI node.
+    // This allows better cache optimizations and allowing background tasks to focus on alerts and similar.
+    this.shouldStartSnapshotTelemetryFetcher = initializerContext.node.roles.ui;
 
     // If the opt-in selection cannot be changed, set it as early as possible.
     const { optIn, allowChangingOptInStatus } = this.initialConfig;
@@ -240,7 +245,10 @@ export class TelemetryPlugin implements Plugin<TelemetryPluginSetup, TelemetryPl
 
     this.security = security;
 
-    this.startFetcher(core, telemetryCollectionManager);
+    if (this.shouldStartSnapshotTelemetryFetcher) {
+      // Only generate and report the snapshot telemetry if we are on the appropriate node role
+      this.startFetcher(core, telemetryCollectionManager);
+    }
 
     return {
       getIsOptedIn: async () => this.isOptedIn === true,

--- a/src/plugins/telemetry/tsconfig.json
+++ b/src/plugins/telemetry/tsconfig.json
@@ -36,6 +36,7 @@
     "@kbn/core-http-browser",
     "@kbn/core-http-server",
     "@kbn/analytics-collection-utils",
+    "@kbn/core-node-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

We want to prioritize background tasks stability, including alerts and detections over telemetry.

In the future, we may add more stability improvements to the UI (like reporting snapshot telemetry only during idling periods).


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Since the background nodes may report today, some UI nodes might be relieved from performing that duty. Taking background-tasks nodes out, might increase the load on UI nodes. | Low | Low | We can apply other backpressure mechanisms or circuit-breakers in the UI nodes based on HTTP traffic. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
