### PR TITLE
Wrap Snapshot Telemetry generation in an APM transaction

### DIFF
--- a/src/plugins/telemetry_collection_manager/server/plugin.ts
+++ b/src/plugins/telemetry_collection_manager/server/plugin.ts
@@ -21,6 +21,7 @@ import type {
 } from '@kbn/core/server';
 
 import { firstValueFrom, ReplaySubject } from 'rxjs';
+import apm from 'elastic-apm-node';
 import type {
   TelemetryCollectionManagerPluginSetup,
   TelemetryCollectionManagerPluginStart,
@@ -259,7 +260,16 @@ export class TelemetryCollectionManagerPlugin
     config: EncryptedStatsGetterConfig
   ): Promise<Array<{ clusterUuid: string; stats: string }>>;
   private async getStats(config: StatsGetterConfig) {
+    const retrieveSnapshotTelemetryTransaction = apm.startTransaction(
+      'Retrieve Snapshot Telemetry',
+      'telemetry'
+    );
+    retrieveSnapshotTelemetryTransaction.addLabels({
+      unencrypted: config.unencrypted,
+      refresh: config.refreshCache,
+    });
     if (!this.usageCollection) {
+      retrieveSnapshotTelemetryTransaction.end('skipped');
       return [];
     }
     const collection = this.collectionStrategy;
@@ -268,10 +278,12 @@ export class TelemetryCollectionManagerPlugin
       const statsCollectionConfig = this.getStatsCollectionConfig(config, this.usageCollection);
       if (statsCollectionConfig) {
         try {
+          retrieveSnapshotTelemetryTransaction.startSpan('Fetch usage');
           const usageData = await this.getUsageForCollection(collection, statsCollectionConfig);
           this.logger.debug(`Received Usage using ${collection.title} collection.`);
 
-          return await Promise.all(
+          retrieveSnapshotTelemetryTransaction.startSpan('Prepare response');
+          const results = await Promise.all(
             usageData.map(async (clusterStats) => {
               const { cluster_uuid: clusterUuid } = clusterStats.cluster_stats as Record<
                 string,
@@ -288,13 +300,19 @@ export class TelemetryCollectionManagerPlugin
               };
             })
           );
+          retrieveSnapshotTelemetryTransaction.end('success');
+          return results;
         } catch (err) {
           this.logger.debug(
             `Failed to collect any usage with registered collection ${collection.title}.`
           );
+          retrieveSnapshotTelemetryTransaction.end('error');
+          return [];
         }
       }
     }
+
+    retrieveSnapshotTelemetryTransaction.end('skipped');
 
     return [];
   }


### PR DESCRIPTION
## Summary

We want to know more about our Snapshot Telemetry generation to identify potential places where we can optimize it.

This PR wraps the generation of the Snapshot Telemetry in an APM transaction that we'll analyze and improve upon.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
