### PR TITLE
Fix multi kibana integration test's tearDown

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
@@ -162,7 +162,11 @@ describe('migration v2', () => {
   });
 
   afterEach(async () => {
-    await Promise.all([rootA.shutdown(), rootB.shutdown(), rootC.shutdown()]);
+    try {
+      await Promise.all([rootA.shutdown(), rootB.shutdown(), rootC.shutdown()]);
+    } catch (e) {
+      /* trap */
+    }
 
     if (esServer) {
       await esServer.stop();


### PR DESCRIPTION
## Summary

(supposedly) Fix https://github.com/elastic/kibana/issues/180651

Add a `try/catch` block around the termination of the Kibana roots in `afterEach` to properly reach the ES termination statement in case of error. 