### PR TITLE
[Cypress] Hardcode fleet server 8.13.0 version in tests

### DIFF
--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -343,6 +343,7 @@ ${JSON.stringify(
 
                 fleetServer = await startFleetServer({
                   kbnClient,
+                  version: '8.13.0-SNAPSHOT',
                   logger: log,
                   port:
                     fleetServerPort ?? config.has('servers.fleetserver.port')

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -343,6 +343,7 @@ ${JSON.stringify(
 
                 fleetServer = await startFleetServer({
                   kbnClient,
+                  // TODO TC: https://github.com/elastic/kibana/pull/180879 - there was an issue with 8.14.0, this should be removed when it's fixed
                   version: '8.13.0-SNAPSHOT',
                   logger: log,
                   port:

--- a/x-pack/test/osquery_cypress/fleet_server.ts
+++ b/x-pack/test/osquery_cypress/fleet_server.ts
@@ -12,7 +12,6 @@ import {
   startFleetServer,
 } from '@kbn/security-solution-plugin/scripts/endpoint/common/fleet_server/fleet_server_services';
 import { Manager } from './resource_manager';
-// import { getLatestAvailableAgentVersion } from './utils';
 
 export class FleetManager extends Manager {
   private fleetServer: StartedFleetServer | undefined = undefined;
@@ -26,8 +25,8 @@ export class FleetManager extends Manager {
   }
 
   public async setup(): Promise<void> {
+    // TODO TC: https://github.com/elastic/kibana/pull/180879 - there was an issue with 8.14.0, this should be removed when it's fixed
     const version = '8.13.0-SNAPSHOT';
-    // const version = await getLatestAvailableAgentVersion(this.kbnClient);
     this.fleetServer = await startFleetServer({
       kbnClient: this.kbnClient,
       logger: this.log,

--- a/x-pack/test/osquery_cypress/fleet_server.ts
+++ b/x-pack/test/osquery_cypress/fleet_server.ts
@@ -12,7 +12,7 @@ import {
   startFleetServer,
 } from '@kbn/security-solution-plugin/scripts/endpoint/common/fleet_server/fleet_server_services';
 import { Manager } from './resource_manager';
-import { getLatestAvailableAgentVersion } from './utils';
+// import { getLatestAvailableAgentVersion } from './utils';
 
 export class FleetManager extends Manager {
   private fleetServer: StartedFleetServer | undefined = undefined;
@@ -26,7 +26,8 @@ export class FleetManager extends Manager {
   }
 
   public async setup(): Promise<void> {
-    const version = await getLatestAvailableAgentVersion(this.kbnClient);
+    const version = '8.13.0-SNAPSHOT';
+    // const version = await getLatestAvailableAgentVersion(this.kbnClient);
     this.fleetServer = await startFleetServer({
       kbnClient: this.kbnClient,
       logger: this.log,


### PR DESCRIPTION
We've identified all Cypress tests using `fleet-server` in `8.14.0` version have [started to fail recently](https://buildkite.com/elastic/kibana-on-merge/builds/43732#_) therefore blocking other PRs from merging. 

Together with @szwarckonrad  we came up with this PR as a quick fix that hardcodes our tests to use FS 8.13.0 in order to unblock other PRs. 

@elastic/fleet I believe this should be investigated on your side too as to understand what changed in 8.14.0 that FS is unable to register within ES. I am wondering if this is just our tests not being aligned with new changes, or is it a **real bug in production?** 

cc: @dasansol92 
<img width="1017" alt="Zrzut ekranu 2024-04-16 o 11 31 43" src="https://github.com/elastic/kibana/assets/16632552/c0d27c30-83cd-4c6a-905d-6584e89c86a4">

``` 
   │ERROR Error: Timed out waiting for host [dev-fleet-server.8212.1n5b] to show up in Fleet. Waited 120 seconds
2024-04-16 05:56:03	       │          at waitForHostToEnroll (fleet_services.ts:221:7)
2024-04-16 05:56:03	       │          at fleet_server_services.ts:330:11
2024-04-16 05:56:03	       │          at tooling_log.ts:84:18
2024-04-16 05:56:03	       │          at startFleetServerWithDocker (fleet_server_services.ts:395:35)
2024-04-16 05:56:03	       │          at fleet_server_services.ts:142:32
2024-04-16 05:56:03	       │          at tooling_log.ts:84:18
2024-04-16 05:56:03	       │          at parallel.ts:344:31
2024-04-16 05:56:03	       │          at withProcRunner (with_proc_runner.ts:29:5)
2024-04-16 05:56:03	       │          at concurrency (parallel.ts:217:13)
2024-04-16 05:56:03	       │          at /opt/local-ssd/buildkite/builds/kb-n2-4-virt-c91969ffbad5cc2b/elastic/kibana-on-merge/kibana/node_modules/p-map/index.js:57:22 {
2024-04-16 05:56:03	       │        agentId: '732018e1-53f1-4d41-84a8-bf92127abb57',
2024-04-16 05:56:03	       │        hostname: 'dev-fleet-server.8212.1n5b'
2024-04-16 05:56:03	       │      }
2024-04-16 05:56:03	 info [kibana] exited with null after 189.0 seconds
2024-04-16 05:56:03	ERROR UNHANDLED ERROR
```