### PR TITLE
[Discover] Prevent red overlays on Dashboard

### DIFF
--- a/src/plugins/discover/public/components/doc_table/_doc_table.scss
+++ b/src/plugins/discover/public/components/doc_table/_doc_table.scss
@@ -29,6 +29,11 @@
     font-family: $euiCodeFontFamily;
     font-size: $euiFontSizeXS;
   }
+
+  .embPanel & {
+    // Bug fix for dashboard panels https://github.com/elastic/kibana/issues/180828
+    mask-image: none;
+  }
 }
 
 .kbnDocTable__footer {


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/180828

## Summary

`mask-image` was not working correctly in Google Chrome after [changes to border-radius](https://github.com/elastic/kibana/pull/178544/files#diff-d4f343c3886df5fe9a99f56aeaf035c5e7d8723062fc689f6b889398b3c41d6eR22) of dashboard panels. 
This PR applies a quick fix before FF to prevent red overlays.

`kbnDocTableWrapper` is used only for Field Statistics embeddable and Saved search embeddable with legacy table. 

Before:
<img width="500" alt="Screenshot 2024-04-16 at 10 59 42" src="https://github.com/elastic/kibana/assets/1415710/edd9c5a4-8b66-4d0e-9d6e-34faedd53dfd">

After:
<img width="500" alt="Screenshot 2024-04-16 at 10 59 14" src="https://github.com/elastic/kibana/assets/1415710/5dcfba69-b41f-4e06-abe0-7736a08650e4">
