### PR TITLE
[Cases] Fix failing test: `useActionTypes should show a toast error message if failed to fetch`.

### DIFF
--- a/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
@@ -15,35 +15,36 @@ import { useToasts } from '../../common/lib/kibana';
 jest.mock('./api');
 jest.mock('../../common/lib/kibana');
 
-// FLAKY: https://github.com/elastic/kibana/issues/178760
-describe.skip('useActionTypes', () => {
-  let appMockRenderer: AppMockRenderer;
-  beforeEach(() => {
-    jest.clearAllMocks();
-    appMockRenderer = createAppMockRenderer();
-  });
-
-  it('should fetch action types', async () => {
-    const spy = jest.spyOn(api, 'fetchActionTypes');
-    const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
-      wrapper: appMockRenderer.AppWrapper,
+for (let i = 0; i <= 250; i = i + 1) {
+  describe('useActionTypes', () => {
+    let appMockRenderer: AppMockRenderer;
+    beforeEach(() => {
+      jest.clearAllMocks();
+      appMockRenderer = createAppMockRenderer();
     });
 
-    await waitForNextUpdate();
-    expect(spy).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
-  });
+    it('should fetch action types', async () => {
+      const spy = jest.spyOn(api, 'fetchActionTypes');
+      const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
+        wrapper: appMockRenderer.AppWrapper,
+      });
 
-  it('should show a toast eror message if failed to fetch', async () => {
-    const spy = jest.spyOn(api, 'fetchActionTypes');
-    spy.mockImplementation(() => {
-      throw new Error('Something went wrong');
+      await waitForNextUpdate();
+      expect(spy).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
     });
-    const addErrorMock = jest.fn();
-    (useToasts as jest.Mock).mockReturnValue({ addError: addErrorMock });
-    const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
-      wrapper: appMockRenderer.AppWrapper,
+
+    it('should show a toast eror message if failed to fetch', async () => {
+      const spy = jest.spyOn(api, 'fetchActionTypes');
+      spy.mockImplementation(() => {
+        throw new Error('Something went wrong');
+      });
+      const addErrorMock = jest.fn();
+      (useToasts as jest.Mock).mockReturnValue({ addError: addErrorMock });
+      const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
+        wrapper: appMockRenderer.AppWrapper,
+      });
+      await waitForNextUpdate();
+      expect(addErrorMock).toHaveBeenCalled();
     });
-    await waitForNextUpdate();
-    expect(addErrorMock).toHaveBeenCalled();
   });
-});
+}

--- a/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
@@ -15,40 +15,38 @@ import { useToasts } from '../../common/lib/kibana';
 jest.mock('./api');
 jest.mock('../../common/lib/kibana');
 
-for (let i = 0; i <= 250; i = i + 1) {
-  describe('useActionTypes', () => {
-    let appMockRenderer: AppMockRenderer;
-    beforeEach(() => {
-      jest.clearAllMocks();
-      appMockRenderer = createAppMockRenderer();
-    });
-
-    it('should fetch action types', async () => {
-      const spy = jest.spyOn(api, 'fetchActionTypes');
-
-      renderHook(() => useGetActionTypes(), {
-        wrapper: appMockRenderer.AppWrapper,
-      });
-
-      expect(spy).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
-    });
-
-    it('should show a toast error message if failed to fetch', async () => {
-      const spyOnFetchActionTypes = jest.spyOn(api, 'fetchActionTypes');
-
-      spyOnFetchActionTypes.mockRejectedValue(() => {
-        throw new Error('Something went wrong');
-      });
-
-      const addErrorMock = jest.fn();
-
-      (useToasts as jest.Mock).mockReturnValue({ addError: addErrorMock });
-
-      const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
-        wrapper: appMockRenderer.AppWrapper,
-      });
-      await waitForNextUpdate({ timeout: 2000 });
-      expect(addErrorMock).toHaveBeenCalled();
-    });
+describe('useActionTypes', () => {
+  let appMockRenderer: AppMockRenderer;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appMockRenderer = createAppMockRenderer();
   });
-}
+
+  it('should fetch action types', async () => {
+    const spy = jest.spyOn(api, 'fetchActionTypes');
+
+    renderHook(() => useGetActionTypes(), {
+      wrapper: appMockRenderer.AppWrapper,
+    });
+
+    expect(spy).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
+  });
+
+  it('should show a toast error message if failed to fetch', async () => {
+    const spyOnFetchActionTypes = jest.spyOn(api, 'fetchActionTypes');
+
+    spyOnFetchActionTypes.mockRejectedValue(() => {
+      throw new Error('Something went wrong');
+    });
+
+    const addErrorMock = jest.fn();
+
+    (useToasts as jest.Mock).mockReturnValue({ addError: addErrorMock });
+
+    const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
+      wrapper: appMockRenderer.AppWrapper,
+    });
+    await waitForNextUpdate({ timeout: 2000 });
+    expect(addErrorMock).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
@@ -25,21 +25,25 @@ for (let i = 0; i <= 250; i = i + 1) {
 
     it('should fetch action types', async () => {
       const spy = jest.spyOn(api, 'fetchActionTypes');
-      const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
+
+      renderHook(() => useGetActionTypes(), {
         wrapper: appMockRenderer.AppWrapper,
       });
 
-      await waitForNextUpdate();
       expect(spy).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
     });
 
-    it('should show a toast eror message if failed to fetch', async () => {
-      const spy = jest.spyOn(api, 'fetchActionTypes');
-      spy.mockImplementation(() => {
+    it('should show a toast error message if failed to fetch', async () => {
+      const spyOnFetchActionTypes = jest.spyOn(api, 'fetchActionTypes');
+
+      spyOnFetchActionTypes.mockRejectedValue(() => {
         throw new Error('Something went wrong');
       });
+
       const addErrorMock = jest.fn();
+
       (useToasts as jest.Mock).mockReturnValue({ addError: addErrorMock });
+
       const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
         wrapper: appMockRenderer.AppWrapper,
       });

--- a/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_action_types.test.tsx
@@ -47,7 +47,7 @@ for (let i = 0; i <= 250; i = i + 1) {
       const { waitForNextUpdate } = renderHook(() => useGetActionTypes(), {
         wrapper: appMockRenderer.AppWrapper,
       });
-      await waitForNextUpdate();
+      await waitForNextUpdate({ timeout: 2000 });
       expect(addErrorMock).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Fixes #178760

## Summary

- `useQuery` expects `fetchActionTypes` to return a promise so I changed an instance of `mockImplementation` in the tests to `mockRejectedValue`.
- Increased the `waitForNextUpdate` timeout value.