### PR TITLE
[Cases] Fix failing test: `Severity form field renders`

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
@@ -10,50 +10,64 @@ import React from 'react';
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
 import userEvent from '@testing-library/user-event';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import { SeverityFilter } from './severity_filter';
 
-// FLAKY: https://github.com/elastic/kibana/issues/176336
-describe.skip('Severity form field', () => {
-  const onChange = jest.fn();
-  let appMockRender: AppMockRenderer;
-  const props = {
-    selectedOptionKeys: [],
-    onChange,
-  };
+for (let i = 0; i <= 300; i = i + 1) {
+  describe('Severity form field', () => {
+    const onChange = jest.fn();
+    let appMockRender: AppMockRenderer;
+    const props = {
+      selectedOptionKeys: [],
+      onChange,
+    };
 
-  beforeEach(() => {
-    appMockRender = createAppMockRenderer();
-  });
+    beforeEach(() => {
+      appMockRender = createAppMockRenderer();
+    });
 
-  it('renders', async () => {
-    appMockRender.render(<SeverityFilter {...props} />);
-    expect(await screen.findByTestId('options-filter-popover-button-severity')).toBeInTheDocument();
-    expect(await screen.findByTestId('options-filter-popover-button-severity')).not.toBeDisabled();
+    it('renders', async () => {
+      appMockRender.render(<SeverityFilter {...props} />);
 
-    userEvent.click(await screen.findByRole('button', { name: 'Severity' }));
-    await waitForEuiPopoverOpen();
+      const popoverButton = await screen.findByTestId('options-filter-popover-button-severity');
+      expect(popoverButton).toBeInTheDocument();
+      expect(popoverButton).not.toBeDisabled();
 
-    expect(await screen.findByRole('option', { name: CaseSeverity.LOW })).toBeInTheDocument();
-    expect(await screen.findByRole('option', { name: CaseSeverity.MEDIUM })).toBeInTheDocument();
-    expect(await screen.findByRole('option', { name: CaseSeverity.HIGH })).toBeInTheDocument();
-    expect(await screen.findByRole('option', { name: CaseSeverity.CRITICAL })).toBeInTheDocument();
-    expect((await screen.findAllByRole('option')).length).toBe(4);
-  });
+      userEvent.click(popoverButton);
 
-  it('selects the correct value when changed', async () => {
-    appMockRender.render(<SeverityFilter {...props} />);
+      await waitForEuiPopoverOpen();
 
-    userEvent.click(await screen.findByRole('button', { name: 'Severity' }));
-    await waitForEuiPopoverOpen();
-    userEvent.click(await screen.findByRole('option', { name: 'high' }));
+      const allOptions = await within(await screen.findByTestId('euiSelectableList')).findAllByRole(
+        'option'
+      );
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        filterId: 'severity',
-        selectedOptionKeys: ['high'],
+      expect(allOptions.length).toBe(4);
+      expect(allOptions[0]).toHaveAttribute('title', CaseSeverity.LOW);
+      expect(allOptions[1]).toHaveAttribute('title', CaseSeverity.MEDIUM);
+      expect(allOptions[2]).toHaveAttribute('title', CaseSeverity.HIGH);
+      expect(allOptions[3]).toHaveAttribute('title', CaseSeverity.CRITICAL);
+    });
+
+    it('selects the correct value when changed', async () => {
+      appMockRender.render(<SeverityFilter {...props} />);
+
+      userEvent.click(await screen.findByRole('button', { name: 'Severity' }));
+
+      await waitForEuiPopoverOpen();
+
+      userEvent.click(
+        await within(await screen.findByTestId('euiSelectableList')).findByRole('option', {
+          name: 'high',
+        })
+      );
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith({
+          filterId: 'severity',
+          selectedOptionKeys: ['high'],
+        });
       });
     });
   });
-});
+}

--- a/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
@@ -14,60 +14,58 @@ import { screen, waitFor, within } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import { SeverityFilter } from './severity_filter';
 
-for (let i = 0; i <= 300; i = i + 1) {
-  describe('Severity form field', () => {
-    const onChange = jest.fn();
-    let appMockRender: AppMockRenderer;
-    const props = {
-      selectedOptionKeys: [],
-      onChange,
-    };
+describe('Severity form field', () => {
+  const onChange = jest.fn();
+  let appMockRender: AppMockRenderer;
+  const props = {
+    selectedOptionKeys: [],
+    onChange,
+  };
 
-    beforeEach(() => {
-      appMockRender = createAppMockRenderer();
-    });
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+  });
 
-    it('renders', async () => {
-      appMockRender.render(<SeverityFilter {...props} />);
+  it('renders', async () => {
+    appMockRender.render(<SeverityFilter {...props} />);
 
-      const popoverButton = await screen.findByTestId('options-filter-popover-button-severity');
-      expect(popoverButton).toBeInTheDocument();
-      expect(popoverButton).not.toBeDisabled();
+    const popoverButton = await screen.findByTestId('options-filter-popover-button-severity');
+    expect(popoverButton).toBeInTheDocument();
+    expect(popoverButton).not.toBeDisabled();
 
-      userEvent.click(popoverButton);
+    userEvent.click(popoverButton);
 
-      await waitForEuiPopoverOpen();
+    await waitForEuiPopoverOpen();
 
-      const allOptions = await within(await screen.findByTestId('euiSelectableList')).findAllByRole(
-        'option'
-      );
+    const allOptions = await within(await screen.findByTestId('euiSelectableList')).findAllByRole(
+      'option'
+    );
 
-      expect(allOptions.length).toBe(4);
-      expect(allOptions[0]).toHaveAttribute('title', CaseSeverity.LOW);
-      expect(allOptions[1]).toHaveAttribute('title', CaseSeverity.MEDIUM);
-      expect(allOptions[2]).toHaveAttribute('title', CaseSeverity.HIGH);
-      expect(allOptions[3]).toHaveAttribute('title', CaseSeverity.CRITICAL);
-    });
+    expect(allOptions.length).toBe(4);
+    expect(allOptions[0]).toHaveAttribute('title', CaseSeverity.LOW);
+    expect(allOptions[1]).toHaveAttribute('title', CaseSeverity.MEDIUM);
+    expect(allOptions[2]).toHaveAttribute('title', CaseSeverity.HIGH);
+    expect(allOptions[3]).toHaveAttribute('title', CaseSeverity.CRITICAL);
+  });
 
-    it('selects the correct value when changed', async () => {
-      appMockRender.render(<SeverityFilter {...props} />);
+  it('selects the correct value when changed', async () => {
+    appMockRender.render(<SeverityFilter {...props} />);
 
-      userEvent.click(await screen.findByRole('button', { name: 'Severity' }));
+    userEvent.click(await screen.findByRole('button', { name: 'Severity' }));
 
-      await waitForEuiPopoverOpen();
+    await waitForEuiPopoverOpen();
 
-      userEvent.click(
-        await within(await screen.findByTestId('euiSelectableList')).findByRole('option', {
-          name: 'high',
-        })
-      );
+    userEvent.click(
+      await within(await screen.findByTestId('euiSelectableList')).findByRole('option', {
+        name: 'high',
+      })
+    );
 
-      await waitFor(() => {
-        expect(onChange).toHaveBeenCalledWith({
-          filterId: 'severity',
-          selectedOptionKeys: ['high'],
-        });
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        filterId: 'severity',
+        selectedOptionKeys: ['high'],
       });
     });
   });
-}
+});


### PR DESCRIPTION
Fixes #176336

## Summary

The only thing I could find in the test was a bunch of unnecessary DOM searches. This is one of the most expensive operations in tests so I:
1. Converted the 3 redundant `findByTestId('options-filter-popover-button-severity')` into just 1.
2. Did a single `findAllByRole('option')` instead of a search for every single value + a search for all to guarantee length was 4.

Locally the test duration was reduced from 300ms to 150+-. Let's see how it behaves in the pipeline.