### PR TITLE
[Lens] support `legendStats` along with `valuesInLegend` in preparation for legend statistics

### DIFF
--- a/packages/kbn-lens-embeddable-utils/attribute_builder/visualization_types/xy_chart.ts
+++ b/packages/kbn-lens-embeddable-utils/attribute_builder/visualization_types/xy_chart.ts
@@ -16,7 +16,7 @@ import type {
 } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SavedObjectReference } from '@kbn/core/server';
-import { AxesSettingsConfig } from '@kbn/visualizations-plugin/common';
+import { AxesSettingsConfig, LegendStats } from '@kbn/visualizations-plugin/common';
 import type { Chart, ChartConfig, ChartLayer } from '../types';
 import { DEFAULT_LAYER_ID } from '../utils';
 import { XY_ID } from './constants';
@@ -130,6 +130,7 @@ export const getXYVisualizationState = (
     isVisible: false,
     position: 'right',
     showSingleSeries: false,
+    legendStats: [LegendStats.values],
   },
   valueLabels: 'show',
   yLeftScale: 'linear',
@@ -149,7 +150,6 @@ export const getXYVisualizationState = (
     yRight: true,
   },
   preferredSeriesType: 'line',
-  valuesInLegend: false,
   hideEndzones: true,
   ...custom,
 });

--- a/packages/kbn-lens-embeddable-utils/attribute_builder/visualization_types/xy_chart.ts
+++ b/packages/kbn-lens-embeddable-utils/attribute_builder/visualization_types/xy_chart.ts
@@ -16,7 +16,8 @@ import type {
 } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SavedObjectReference } from '@kbn/core/server';
-import { AxesSettingsConfig, LegendStats } from '@kbn/visualizations-plugin/common';
+import { AxesSettingsConfig } from '@kbn/visualizations-plugin/common';
+import type { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import type { Chart, ChartConfig, ChartLayer } from '../types';
 import { DEFAULT_LAYER_ID } from '../utils';
 import { XY_ID } from './constants';
@@ -130,7 +131,7 @@ export const getXYVisualizationState = (
     isVisible: false,
     position: 'right',
     showSingleSeries: false,
-    legendStats: [LegendStats.values],
+    legendStats: ['values' as LegendStats.values],
   },
   valueLabels: 'show',
   yLeftScale: 'linear',

--- a/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/__snapshots__/waffle_vis_function.test.ts.snap
+++ b/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/__snapshots__/waffle_vis_function.test.ts.snap
@@ -92,6 +92,9 @@ Object {
       "legendDisplay": "show",
       "legendPosition": "right",
       "legendSize": "medium",
+      "legendStats": Array [
+        "values",
+      ],
       "maxLegendLines": 2,
       "metrics": Array [
         Object {
@@ -108,7 +111,6 @@ Object {
         "name": "kibana_palette",
         "type": "system_palette",
       },
-      "showValuesInLegend": true,
       "splitColumn": undefined,
       "splitRow": undefined,
       "truncateLegend": true,

--- a/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/i18n.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/i18n.ts
@@ -61,6 +61,10 @@ export const strings = {
     i18n.translate('expressionPartitionVis.reusable.function.args.truncateLegendHelpText', {
       defaultMessage: 'Defines if the legend items will be truncated or not',
     }),
+  getLegendStatsArgHelp: () =>
+    i18n.translate('expressionPartitionVis.reusable.function.args.legendStatsArgHelp', {
+      defaultMessage: 'Defines the legend stats',
+    }),
   getMaxLegendLinesArgHelp: () =>
     i18n.translate('expressionPartitionVis.reusable.function.args.maxLegendLinesHelpText', {
       defaultMessage: 'Defines the number of lines per legend item',
@@ -96,10 +100,6 @@ export const strings = {
   getLabelsArgHelp: () =>
     i18n.translate('expressionPartitionVis.reusable.function.args.labelsHelpText', {
       defaultMessage: 'Pie labels config',
-    }),
-  getShowValuesInLegendArgHelp: () =>
-    i18n.translate('expressionPartitionVis.waffle.function.args.showValuesInLegendHelpText', {
-      defaultMessage: 'Show values in legend',
     }),
   getAriaLabelHelp: () =>
     i18n.translate('expressionPartitionVis.reusable.functions.args.ariaLabelHelpText', {

--- a/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/waffle_vis_function.test.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/waffle_vis_function.test.ts
@@ -13,7 +13,7 @@ import {
   ValueFormats,
   LegendDisplay,
 } from '../types/expression_renderers';
-import { ExpressionValueVisDimension } from '@kbn/visualizations-plugin/common';
+import { ExpressionValueVisDimension, LegendStats } from '@kbn/visualizations-plugin/common';
 import { Datatable } from '@kbn/expressions-plugin/common/expression_types/specs';
 import { waffleVisFunction } from './waffle_vis_function';
 import { PARTITION_LABELS_VALUE, PARTITION_VIS_RENDERER_NAME } from '../constants';
@@ -34,7 +34,7 @@ describe('interpreter/functions#waffleVis', () => {
 
   const visConfig: WaffleVisConfig = {
     addTooltip: true,
-    showValuesInLegend: true,
+    legendStats: [LegendStats.values],
     metricsToLabels: JSON.stringify({}),
     legendDisplay: LegendDisplay.SHOW,
     legendPosition: 'right',

--- a/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/waffle_vis_function.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/common/expression_functions/waffle_vis_function.ts
@@ -85,6 +85,11 @@ export const waffleVisFunction = (): WaffleVisExpressionFunctionDefinition => ({
       ],
       strict: true,
     },
+    legendStats: {
+      types: ['string'],
+      multi: true,
+      help: strings.getLegendStatsArgHelp(),
+    },
     truncateLegend: {
       types: ['boolean'],
       help: strings.getTruncateLegendArgHelp(),
@@ -103,11 +108,6 @@ export const waffleVisFunction = (): WaffleVisExpressionFunctionDefinition => ({
       types: [PARTITION_LABELS_VALUE],
       help: strings.getLabelsArgHelp(),
       default: `{${PARTITION_LABELS_FUNCTION}}`,
-    },
-    showValuesInLegend: {
-      types: ['boolean'],
-      help: strings.getShowValuesInLegendArgHelp(),
-      default: false,
     },
     ariaLabel: {
       types: ['string'],

--- a/src/plugins/chart_expressions/expression_partition_vis/common/types/expression_renderers.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/common/types/expression_renderers.ts
@@ -11,7 +11,7 @@ import type { AllowedChartOverrides, AllowedSettingsOverrides } from '@kbn/chart
 import type { PaletteOutput } from '@kbn/coloring';
 import type { Datatable, DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { SerializedFieldFormat } from '@kbn/field-formats-plugin/common';
-import type { ExpressionValueVisDimension } from '@kbn/visualizations-plugin/common';
+import type { ExpressionValueVisDimension, LegendStats } from '@kbn/visualizations-plugin/common';
 import type { LegendSize } from '@kbn/visualizations-plugin/public';
 import {
   type AllowedPartitionOverrides,
@@ -80,7 +80,7 @@ export interface PartitionVisParams extends VisCommonParams {
   labels: LabelsParams;
   palette: PaletteOutput;
   isDonut?: boolean;
-  showValuesInLegend?: boolean;
+  legendStats?: LegendStats[];
   respectSourceOrder?: boolean;
   emptySizeRatio?: EmptySizeRatios;
   startFromSecondLargestSlice?: boolean;
@@ -110,7 +110,7 @@ export interface MosaicVisConfig
 
 export interface WaffleVisConfig extends Omit<VisCommonConfig, 'buckets'> {
   bucket?: ExpressionValueVisDimension | string;
-  showValuesInLegend: boolean;
+  legendStats?: LegendStats[];
 }
 
 export interface PartitionChartProps {

--- a/src/plugins/chart_expressions/expression_partition_vis/public/__stories__/shared/arg_types.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/__stories__/shared/arg_types.ts
@@ -8,6 +8,7 @@
 
 import { Position } from '@elastic/charts';
 import { ArgTypes } from '@storybook/addons';
+import { LegendStats } from '@kbn/visualizations-plugin/common';
 import { EmptySizeRatios, LegendDisplay } from '../../../common';
 import { ChartTypes } from '../../../common/types';
 
@@ -206,11 +207,12 @@ export const waffleArgTypes: ArgTypes = {
     control: { type: 'text', disable: true },
   },
   ...argTypes,
-  showValuesInLegend: {
-    name: `${visConfigName}.nestedLegend`,
-    description: 'Enable displaying values in the legend',
-    type: { name: 'boolean', required: false },
-    table: { type: { summary: 'boolean' }, defaultValue: { summary: false } },
-    control: { type: 'boolean' },
+  legendStats: {
+    name: `${visConfigName}.legendStats`,
+    description: 'Legend stats',
+    type: { name: 'string', required: false },
+    table: { type: { summary: 'string' }, defaultValue: { summary: undefined } },
+    options: [LegendStats.values],
+    control: { type: 'select' },
   },
 };

--- a/src/plugins/chart_expressions/expression_partition_vis/public/__stories__/shared/arg_types.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/__stories__/shared/arg_types.ts
@@ -8,7 +8,7 @@
 
 import { Position } from '@elastic/charts';
 import { ArgTypes } from '@storybook/addons';
-import { LegendStats } from '@kbn/visualizations-plugin/common';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { EmptySizeRatios, LegendDisplay } from '../../../common';
 import { ChartTypes } from '../../../common/types';
 

--- a/src/plugins/chart_expressions/expression_partition_vis/public/__stories__/shared/config.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/__stories__/shared/config.ts
@@ -129,5 +129,4 @@ export const waffleConfig: PartitionVisParams = {
       },
     ],
   },
-  showValuesInLegend: false,
 };

--- a/src/plugins/chart_expressions/expression_partition_vis/public/components/__snapshots__/partition_vis_component.test.tsx.snap
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/components/__snapshots__/partition_vis_component.test.tsx.snap
@@ -775,6 +775,7 @@ exports[`PartitionVisComponent should render correct structure for donut 1`] = `
           onElementClick={[Function]}
           onRenderChange={[Function]}
           showLegend={true}
+          showLegendExtra={false}
           theme={
             Array [
               Object {
@@ -1689,6 +1690,7 @@ exports[`PartitionVisComponent should render correct structure for mosaic 1`] = 
           onElementClick={[Function]}
           onRenderChange={[Function]}
           showLegend={true}
+          showLegendExtra={false}
           theme={
             Array [
               Object {
@@ -2667,6 +2669,7 @@ exports[`PartitionVisComponent should render correct structure for multi-metric 
           onElementClick={[Function]}
           onRenderChange={[Function]}
           showLegend={true}
+          showLegendExtra={false}
           theme={
             Array [
               Object {
@@ -3645,6 +3648,7 @@ exports[`PartitionVisComponent should render correct structure for pie 1`] = `
           onElementClick={[Function]}
           onRenderChange={[Function]}
           showLegend={true}
+          showLegendExtra={false}
           theme={
             Array [
               Object {
@@ -4559,6 +4563,7 @@ exports[`PartitionVisComponent should render correct structure for treemap 1`] =
           onElementClick={[Function]}
           onRenderChange={[Function]}
           showLegend={true}
+          showLegendExtra={false}
           theme={
             Array [
               Object {

--- a/src/plugins/chart_expressions/expression_partition_vis/public/components/partition_vis_component.tsx
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/components/partition_vis_component.tsx
@@ -39,6 +39,7 @@ import {
 } from '@kbn/expressions-plugin/public';
 import type { FieldFormat } from '@kbn/field-formats-plugin/common';
 import { getOverridesFor } from '@kbn/chart-expressions-common';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { consolidateMetricColumns } from '../../common/utils';
 import { DEFAULT_PERCENT_DECIMALS } from '../../common/constants';
 import {
@@ -563,7 +564,7 @@ const PartitionVisComponent = (props: PartitionVisComponentProps) => {
                 legendColorPicker={props.uiState ? LegendColorPickerWrapper : undefined}
                 flatLegend={flatLegend}
                 legendSort={customLegendSort}
-                showLegendExtra={visParams.showValuesInLegend}
+                showLegendExtra={visParams.legendStats?.[0] === LegendStats.values}
                 onElementClick={([elementEvent]) => {
                   // this cast is safe because we are rendering a partition chart
                   const [layerValues] = elementEvent as PartitionElementEvent;

--- a/src/plugins/chart_expressions/expression_partition_vis/public/mocks.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/mocks.ts
@@ -7,6 +7,7 @@
  */
 
 import { Datatable } from '@kbn/expressions-plugin/public';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import {
   BucketColumns,
   PartitionVisParams,
@@ -381,6 +382,6 @@ export const createMockWaffleParams = (): PartitionVisParams => {
         },
       ],
     },
-    showValuesInLegend: true,
+    legendStats: [LegendStats.values],
   };
 };

--- a/src/plugins/chart_expressions/expression_xy/common/__mocks__/index.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/__mocks__/index.ts
@@ -94,7 +94,6 @@ export const createArgsWithLayers = (
     position: Position.Top,
   },
   valueLabels: 'hide',
-  valuesInLegend: false,
   xAxisConfig: {
     type: 'xAxisConfig',
     position: 'bottom',

--- a/src/plugins/chart_expressions/expression_xy/common/constants.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/constants.ts
@@ -134,7 +134,3 @@ export const AxisModes = {
   WIGGLE: 'wiggle',
   SILHOUETTE: 'silhouette',
 } as const;
-
-export enum LegendStats {
-  values = 'values',
-}

--- a/src/plugins/chart_expressions/expression_xy/common/constants.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/constants.ts
@@ -134,3 +134,7 @@ export const AxisModes = {
   WIGGLE: 'wiggle',
   SILHOUETTE: 'silhouette',
 } as const;
+
+export enum LegendStats {
+  values = 'values',
+}

--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/common_xy_args.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/common_xy_args.ts
@@ -58,11 +58,6 @@ export const commonXYArgs: CommonXYFn['args'] = {
     default: false,
     help: strings.getHideEndzonesHelp(),
   },
-  valuesInLegend: {
-    types: ['boolean'],
-    default: false,
-    help: strings.getValuesInLegendHelp(),
-  },
   ariaLabel: {
     types: ['string'],
     help: strings.getAriaLabelHelp(),

--- a/src/plugins/chart_expressions/expression_xy/common/expression_functions/legend_config.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/expression_functions/legend_config.ts
@@ -99,6 +99,13 @@ export const legendConfigFunction: LegendConfigFn = {
       ],
       strict: true,
     },
+    legendStats: {
+      types: ['string'],
+      multi: true,
+      help: i18n.translate('expressionXY.legendConfig.legendStats.help', {
+        defaultMessage: 'Specifies the legend stats.',
+      }),
+    },
   },
   async fn(input, args, handlers) {
     const { legendConfigFn } = await import('./legend_config_fn');

--- a/src/plugins/chart_expressions/expression_xy/common/i18n/index.tsx
+++ b/src/plugins/chart_expressions/expression_xy/common/i18n/index.tsx
@@ -81,9 +81,9 @@ export const strings = {
     i18n.translate('expressionXY.xyVis.hideEndzones.help', {
       defaultMessage: 'Hide endzone markers for partial data',
     }),
-  getValuesInLegendHelp: () =>
-    i18n.translate('expressionXY.xyVis.valuesInLegend.help', {
-      defaultMessage: 'Show values in legend',
+  getLegendStatsArgHelp: () =>
+    i18n.translate('expressionXY.xyVis.legendStats.help', {
+      defaultMessage: 'Define the stats to show in the legend',
     }),
   getAriaLabelHelp: () =>
     i18n.translate('expressionXY.xyVis.ariaLabel.help', {

--- a/src/plugins/chart_expressions/expression_xy/common/types/expression_functions.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/types/expression_functions.ts
@@ -49,6 +49,7 @@ import {
   LAYERED_XY_VIS,
   EXTENDED_ANNOTATION_LAYER,
   EXTENDED_REFERENCE_LINE_DECORATION_CONFIG,
+  LegendStats,
 } from '../constants';
 import { XYRender } from './expression_renderers';
 
@@ -214,6 +215,10 @@ export interface LegendConfig {
    * Limited to max of 70% of the chart container dimension Vertical legends limited to min of 30% of computed width
    */
   legendSize?: LegendSize;
+  /**
+   * metrics to display in the legend
+   */
+  legendStats?: LegendStats[];
 }
 
 // Arguments to XY chart expression, with computed properties
@@ -226,7 +231,6 @@ export interface XYArgs extends DataLayerArgs {
   fittingFunction?: FittingFunction;
   fillOpacity?: number;
   hideEndzones?: boolean;
-  valuesInLegend?: boolean;
   ariaLabel?: string;
   yAxisConfigs?: YAxisConfigResult[];
   xAxisConfig?: XAxisConfigResult;
@@ -277,7 +281,6 @@ export interface LayeredXYArgs {
   fittingFunction?: FittingFunction;
   fillOpacity?: number;
   hideEndzones?: boolean;
-  valuesInLegend?: boolean;
   ariaLabel?: string;
   yAxisConfigs?: YAxisConfigResult[];
   xAxisConfig?: XAxisConfigResult;
@@ -302,7 +305,6 @@ export interface XYProps {
   fittingFunction?: FittingFunction;
   fillOpacity?: number;
   hideEndzones?: boolean;
-  valuesInLegend?: boolean;
   ariaLabel?: string;
   yAxisConfigs?: YAxisConfigResult[];
   xAxisConfig?: XAxisConfigResult;

--- a/src/plugins/chart_expressions/expression_xy/common/types/expression_functions.ts
+++ b/src/plugins/chart_expressions/expression_xy/common/types/expression_functions.ts
@@ -14,7 +14,7 @@ import type {
   DatatableColumnMeta,
   ExpressionFunctionDefinition,
 } from '@kbn/expressions-plugin/common';
-import { LegendSize } from '@kbn/visualizations-plugin/common';
+import { LegendSize, LegendStats } from '@kbn/visualizations-plugin/common';
 import { EventAnnotationOutput } from '@kbn/event-annotation-plugin/common';
 import { ExpressionValueVisDimension } from '@kbn/visualizations-plugin/common';
 
@@ -49,7 +49,6 @@ import {
   LAYERED_XY_VIS,
   EXTENDED_ANNOTATION_LAYER,
   EXTENDED_REFERENCE_LINE_DECORATION_CONFIG,
-  LegendStats,
 } from '../constants';
 import { XYRender } from './expression_renderers';
 

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
@@ -37,7 +37,7 @@ import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { eventAnnotationServiceMock } from '@kbn/event-annotation-plugin/public/mocks';
 import { EventAnnotationOutput } from '@kbn/event-annotation-plugin/common';
 import { DataLayerConfig } from '../../common';
-import { LayerTypes } from '../../common/constants';
+import { LayerTypes, LegendStats } from '../../common/constants';
 import { XyEndzones } from './x_domain';
 import {
   chartsActiveCursorService,
@@ -740,7 +740,10 @@ describe('XYChart component', () => {
   test('ignores legend extra for ordinal chart', () => {
     const { args } = sampleArgs();
     const component = shallow(
-      <XYChart {...defaultProps} args={{ ...args, valuesInLegend: true }} />
+      <XYChart
+        {...defaultProps}
+        args={{ ...args, legend: { ...args.legend, legendStats: [LegendStats.values] } }}
+      />
     );
     expect(component.find(Settings).at(0).prop('showLegendExtra')).toEqual(false);
   });
@@ -752,8 +755,11 @@ describe('XYChart component', () => {
         {...defaultProps}
         args={{
           ...args,
+          legend: {
+            ...args.legend,
+            legendStats: [LegendStats.values],
+          },
           layers: [dateHistogramLayer],
-          valuesInLegend: true,
         }}
       />
     );

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
@@ -37,7 +37,7 @@ import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { eventAnnotationServiceMock } from '@kbn/event-annotation-plugin/public/mocks';
 import { EventAnnotationOutput } from '@kbn/event-annotation-plugin/common';
 import { DataLayerConfig } from '../../common';
-import { LayerTypes, LegendStats } from '../../common/constants';
+import { LayerTypes } from '../../common/constants';
 import { XyEndzones } from './x_domain';
 import {
   chartsActiveCursorService,
@@ -58,7 +58,7 @@ import { XYChart, XYChartRenderProps } from './xy_chart';
 import { ExtendedDataLayerConfig, XYProps, AnnotationLayerConfigResult } from '../../common/types';
 import { DataLayers } from './data_layers';
 import { SplitChart } from './split_chart';
-import { LegendSize } from '@kbn/visualizations-plugin/common';
+import { LegendSize, LegendStats } from '@kbn/visualizations-plugin/common';
 import type { LayerCellValueActions } from '../types';
 
 const onClickValue = jest.fn();

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -869,7 +869,7 @@ export function XYChart({
                   )
                 : undefined
             }
-            showLegendExtra={isHistogramViz && !!(legend.legendStats?.[0] === LegendStats.values)}
+            showLegendExtra={isHistogramViz && legend.legendStats?.[0] === LegendStats.values}
             ariaLabel={args.ariaLabel}
             ariaUseDefaultSummary={!args.ariaLabel}
             orderOrdinalBinsBy={

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -105,7 +105,13 @@ import {
   OUTSIDE_RECT_ANNOTATION_WIDTH,
   OUTSIDE_RECT_ANNOTATION_WIDTH_SUGGESTION,
 } from './annotations';
-import { AxisExtentModes, SeriesTypes, ValueLabelModes, XScaleTypes } from '../../common/constants';
+import {
+  AxisExtentModes,
+  LegendStats,
+  SeriesTypes,
+  ValueLabelModes,
+  XScaleTypes,
+} from '../../common/constants';
 import { DataLayers } from './data_layers';
 import { Tooltip as CustomTooltip } from './tooltip';
 import { XYCurrentTime } from './xy_current_time';
@@ -220,7 +226,6 @@ export function XYChart({
     emphasizeFitting,
     valueLabels,
     hideEndzones,
-    valuesInLegend,
     yAxisConfigs,
     xAxisConfig,
     splitColumnAccessor,
@@ -869,7 +874,7 @@ export function XYChart({
                   )
                 : undefined
             }
-            showLegendExtra={isHistogramViz && valuesInLegend}
+            showLegendExtra={isHistogramViz && !!(legend.legendStats?.[0] === LegendStats.values)}
             ariaLabel={args.ariaLabel}
             ariaUseDefaultSummary={!args.ariaLabel}
             orderOrdinalBinsBy={

--- a/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -50,6 +50,7 @@ import {
 import {
   DEFAULT_LEGEND_SIZE,
   LegendSizeToPixels,
+  LegendStats,
 } from '@kbn/visualizations-plugin/common/constants';
 import { PersistedState } from '@kbn/visualizations-plugin/public';
 import { getOverridesFor, ChartSizeSpec } from '@kbn/chart-expressions-common';
@@ -105,13 +106,7 @@ import {
   OUTSIDE_RECT_ANNOTATION_WIDTH,
   OUTSIDE_RECT_ANNOTATION_WIDTH_SUGGESTION,
 } from './annotations';
-import {
-  AxisExtentModes,
-  LegendStats,
-  SeriesTypes,
-  ValueLabelModes,
-  XScaleTypes,
-} from '../../common/constants';
+import { AxisExtentModes, SeriesTypes, ValueLabelModes, XScaleTypes } from '../../common/constants';
 import { DataLayers } from './data_layers';
 import { Tooltip as CustomTooltip } from './tooltip';
 import { XYCurrentTime } from './xy_current_time';

--- a/src/plugins/event_annotation_listing/public/components/group_editor_flyout/lens_attributes.ts
+++ b/src/plugins/event_annotation_listing/public/components/group_editor_flyout/lens_attributes.ts
@@ -8,7 +8,6 @@
 
 import { EventAnnotationGroupConfig } from '@kbn/event-annotation-common';
 import { FieldBasedIndexPatternColumn, TypedLensByValueInput } from '@kbn/lens-plugin/public';
-import { XYPersistedByValueAnnotationLayerConfig } from '@kbn/lens-plugin/public/async_services';
 
 export const DATA_LAYER_ID = 'data-layer-id';
 export const DATE_HISTOGRAM_COLUMN_ID = 'date-histogram-column-id';
@@ -64,7 +63,7 @@ export const getLensAttributes = (group: EventAnnotationGroupConfig, timeField: 
             layerType: 'annotations',
             persistanceType: 'byValue',
             ...group,
-          } as XYPersistedByValueAnnotationLayerConfig,
+          },
         ],
       },
       query: {

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.test.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { getConfiguration } from '.';
 import { samplePieVis } from '../../sample_vis.test.mocks';
 
@@ -38,7 +39,7 @@ describe('getConfiguration', () => {
           percentDecimals: 2,
           primaryGroups: ['bucket-1'],
           secondaryGroups: [],
-          showValuesInLegend: true,
+          legendStats: [LegendStats.values],
           truncateLegend: true,
         },
       ],

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.test.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.test.ts
@@ -15,7 +15,7 @@ describe('getConfiguration', () => {
     jest.clearAllMocks();
   });
 
-  test.only('should return correct configuration', () => {
+  test('should return correct configuration', () => {
     samplePieVis.uiState.get.mockReturnValueOnce(undefined);
     expect(
       getConfiguration('test1', samplePieVis as any, {

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.test.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.test.ts
@@ -15,7 +15,7 @@ describe('getConfiguration', () => {
     jest.clearAllMocks();
   });
 
-  test('should return correct configuration', () => {
+  test.only('should return correct configuration', () => {
     samplePieVis.uiState.get.mockReturnValueOnce(undefined);
     expect(
       getConfiguration('test1', samplePieVis as any, {

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
@@ -26,9 +26,10 @@ const getLayers = (
     legendOpen !== undefined ? (legendOpen ? LegendDisplay.SHOW : LegendDisplay.HIDE) : undefined;
 
   const showValuesInLegend =
-    vis.params.labels.values ?? vis.params.legendStats
+    vis.params.labels.values ??
+    (vis.params.legendStats
       ? vis.params.legendStats?.[0] === LegendStats.values
-      : vis.type.visConfig.defaults.showValuesInLegend;
+      : vis.type.visConfig.defaults.showValuesInLegend);
 
   return [
     {

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
@@ -26,9 +26,9 @@ const getLayers = (
     legendOpen !== undefined ? (legendOpen ? LegendDisplay.SHOW : LegendDisplay.HIDE) : undefined;
 
   const showValuesInLegend =
-    vis.params.labels.values ??
-    vis.params.legendStats?.[0] === LegendStats.values ??
-    vis.type.visConfig.defaults.showValuesInLegend;
+    vis.params.labels.values ?? vis.params.legendStats
+      ? vis.params.legendStats?.[0] === LegendStats.values
+      : vis.type.visConfig.defaults.showValuesInLegend;
 
   return [
     {

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
@@ -7,9 +7,9 @@
  */
 
 import { LegendDisplay, PartitionVisParams } from '@kbn/expression-partition-vis-plugin/common';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import {
   CategoryDisplayTypes,
-  LegendStats,
   NumberDisplayTypes,
   PartitionVisConfiguration,
 } from '@kbn/visualizations-plugin/common/convert_to_lens';

--- a/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/pie/public/convert_to_lens/configurations/index.ts
@@ -9,6 +9,7 @@
 import { LegendDisplay, PartitionVisParams } from '@kbn/expression-partition-vis-plugin/common';
 import {
   CategoryDisplayTypes,
+  LegendStats,
   NumberDisplayTypes,
   PartitionVisConfiguration,
 } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -26,7 +27,7 @@ const getLayers = (
 
   const showValuesInLegend =
     vis.params.labels.values ??
-    vis.params.showValuesInLegend ??
+    vis.params.legendStats?.[0] === LegendStats.values ??
     vis.type.visConfig.defaults.showValuesInLegend;
 
   return [
@@ -48,7 +49,7 @@ const getLayers = (
         vis.params.legendDisplay ??
         vis.type.visConfig.defaults.legendDisplay,
       legendPosition: vis.params.legendPosition ?? vis.type.visConfig.defaults.legendPosition,
-      showValuesInLegend,
+      legendStats: showValuesInLegend ? [LegendStats.values] : undefined,
       nestedLegend: vis.params.nestedLegend ?? vis.type.visConfig.defaults.nestedLegend,
       percentDecimals:
         vis.params.labels.percentDecimals ?? vis.type.visConfig.defaults.labels.percentDecimals,

--- a/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.test.ts
+++ b/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.test.ts
@@ -149,7 +149,6 @@ describe('getConfiguration', () => {
       },
       tickLabelsVisibilitySettings: { x: true, yLeft: true, yRight: true },
       valueLabels: 'hide',
-      valuesInLegend: false,
       xTitle: undefined,
       yLeftExtent: { enforce: true, lowerBound: undefined, mode: 'full', upperBound: undefined },
       yLeftScale: 'linear',

--- a/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.ts
@@ -15,6 +15,7 @@ import {
   XYReferenceLineLayerConfig,
 } from '@kbn/visualizations-plugin/common/convert_to_lens';
 import { Vis } from '@kbn/visualizations-plugin/public';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { Layer } from '..';
 import { ChartType } from '../../../common';
 import {
@@ -29,7 +30,6 @@ import {
   VisParams,
 } from '../../types';
 import { getCurveType, getMode, getYAxisPosition } from '../../utils/common';
-import { LegendStats } from '../../to_ast';
 
 function getYScaleType(scale?: Scale): XYConfiguration['yLeftScale'] | undefined {
   const type = scale?.type;

--- a/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.ts
+++ b/src/plugins/vis_types/xy/public/convert_to_lens/configurations/index.ts
@@ -29,6 +29,7 @@ import {
   VisParams,
 } from '../../types';
 import { getCurveType, getMode, getYAxisPosition } from '../../utils/common';
+import { LegendStats } from '../../to_ast';
 
 function getYScaleType(scale?: Scale): XYConfiguration['yLeftScale'] | undefined {
   const type = scale?.type;
@@ -235,6 +236,9 @@ export const getConfiguration = (
       shouldTruncate: vis.params.truncateLegend ?? vis.type.visConfig.defaults.truncateLegend,
       maxLines: vis.params.maxLegendLines ?? vis.type.visConfig.defaults.maxLegendLines,
       showSingleSeries: true,
+      legendStats: Boolean(vis.params.labels.show ?? vis.type.visConfig.defaults.labels?.show)
+        ? [LegendStats.values]
+        : undefined,
     },
     fittingFunction: fittingFunction
       ? fittingFunction[0].toUpperCase() + fittingFunction.slice(1)
@@ -269,7 +273,6 @@ export const getConfiguration = (
     xTitle: xAxis.title.text,
     valueLabels:
       vis.params.labels.show ?? vis.type.visConfig.defaults.labels?.show ? 'show' : 'hide',
-    valuesInLegend: Boolean(vis.params.labels.show ?? vis.type.visConfig.defaults.labels?.show),
     showCurrentTimeMarker: isTimeChart
       ? Boolean(vis.params.addTimeMarker ?? vis.type.visConfig.defaults.addTimeMarker)
       : undefined,

--- a/src/plugins/vis_types/xy/public/to_ast.ts
+++ b/src/plugins/vis_types/xy/public/to_ast.ts
@@ -20,6 +20,7 @@ import { buildExpression, buildExpressionFunction } from '@kbn/expressions-plugi
 import { BUCKET_TYPES } from '@kbn/data-plugin/public';
 import type { TimeRangeBounds } from '@kbn/data-plugin/common';
 import type { PaletteOutput } from '@kbn/charts-plugin/common/expressions/palette/types';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import {
   Dimensions,
   Dimension,
@@ -187,10 +188,6 @@ function getScaleType(
   }
 
   return type;
-}
-
-export enum LegendStats {
-  values = 'values',
 }
 
 function getXAxisPosition(position: Position) {

--- a/src/plugins/vis_types/xy/public/to_ast.ts
+++ b/src/plugins/vis_types/xy/public/to_ast.ts
@@ -47,6 +47,7 @@ const prepareLengend = (params: VisParams, legendSize?: LegendSize) => {
     shouldTruncate: params.truncateLegend,
     showSingleSeries: true,
     legendSize,
+    legendStats: params.labels.show ? [LegendStats.values] : undefined,
   });
 
   return buildExpression([legend]);
@@ -186,6 +187,10 @@ function getScaleType(
   }
 
   return type;
+}
+
+export enum LegendStats {
+  values = 'values',
 }
 
 function getXAxisPosition(position: Position) {
@@ -434,7 +439,6 @@ export const toExpressionAst: VisToExpressionAst<VisParams> = async (vis, params
     splitColumnAccessor: dimensions.splitColumn?.map(prepareVisDimension),
     splitRowAccessor: dimensions.splitRow?.map(prepareVisDimension),
     valueLabels: vis.params.labels.show ? 'show' : 'hide',
-    valuesInLegend: vis.params.labels.show,
     singleTable: true,
   });
 

--- a/src/plugins/visualizations/common/constants.ts
+++ b/src/plugins/visualizations/common/constants.ts
@@ -51,3 +51,7 @@ export const SUPPORTED_AGGREGATIONS = [
   ...Object.values(METRIC_TYPES),
   ...Object.values(BUCKET_TYPES),
 ] as const;
+
+export enum LegendStats {
+  values = 'values',
+}

--- a/src/plugins/visualizations/common/convert_to_lens/constants.ts
+++ b/src/plugins/visualizations/common/convert_to_lens/constants.ts
@@ -137,3 +137,7 @@ export const GaugeColorModes = {
 } as const;
 
 export const CollapseFunctions = ['sum', 'avg', 'min', 'max'] as const;
+
+export enum LegendStats {
+  values = 'values',
+}

--- a/src/plugins/visualizations/common/convert_to_lens/constants.ts
+++ b/src/plugins/visualizations/common/convert_to_lens/constants.ts
@@ -137,7 +137,3 @@ export const GaugeColorModes = {
 } as const;
 
 export const CollapseFunctions = ['sum', 'avg', 'min', 'max'] as const;
-
-export enum LegendStats {
-  values = 'values',
-}

--- a/src/plugins/visualizations/common/convert_to_lens/types/configurations.ts
+++ b/src/plugins/visualizations/common/convert_to_lens/types/configurations.ts
@@ -27,6 +27,7 @@ import {
   GaugeColorModes,
   GaugeCentralMajorModes,
   CollapseFunctions,
+  LegendStats,
 } from '../constants';
 import { ExpressionValueVisDimension } from '../../expression_functions';
 
@@ -142,6 +143,7 @@ export interface LegendConfig {
   maxLines?: number;
   shouldTruncate?: boolean;
   legendSize?: LegendSize;
+  legendStats?: LegendStats[];
 }
 
 export interface XYConfiguration {
@@ -168,7 +170,6 @@ export interface XYConfiguration {
   fillOpacity?: number;
   minBarHeight?: number;
   hideEndzones?: boolean;
-  valuesInLegend?: boolean;
   showCurrentTimeMarker?: boolean;
 }
 
@@ -238,7 +239,7 @@ export interface PartitionLayerState {
   categoryDisplay: CategoryDisplayType;
   legendDisplay: LegendDisplayType;
   legendPosition?: Position;
-  showValuesInLegend?: boolean;
+  legendStats?: LegendStats[];
   nestedLegend?: boolean;
   percentDecimals?: number;
   emptySizeRatio?: number;

--- a/src/plugins/visualizations/common/convert_to_lens/types/configurations.ts
+++ b/src/plugins/visualizations/common/convert_to_lens/types/configurations.ts
@@ -10,7 +10,7 @@ import { HorizontalAlignment, LayoutDirection, Position, VerticalAlignment } fro
 import { $Values } from '@kbn/utility-types';
 import type { CustomPaletteParams, PaletteOutput } from '@kbn/coloring';
 import { KibanaQueryOutput } from '@kbn/data-plugin/common';
-import { LegendSize } from '../../constants';
+import { LegendSize, LegendStats } from '../../constants';
 import {
   CategoryDisplayTypes,
   PartitionChartTypes,
@@ -27,7 +27,6 @@ import {
   GaugeColorModes,
   GaugeCentralMajorModes,
   CollapseFunctions,
-  LegendStats,
 } from '../constants';
 import { ExpressionValueVisDimension } from '../../expression_functions';
 

--- a/src/plugins/visualizations/common/index.ts
+++ b/src/plugins/visualizations/common/index.ts
@@ -16,4 +16,4 @@ export * from './expression_functions';
 export * from './convert_to_lens';
 export { convertToSchemaConfig } from './vis_schemas';
 
-export { LegendSize, LegendSizeToPixels, DEFAULT_LEGEND_SIZE } from './constants';
+export { LegendSize, LegendSizeToPixels, DEFAULT_LEGEND_SIZE, LegendStats } from './constants';

--- a/x-pack/plugins/lens/common/types.ts
+++ b/x-pack/plugins/lens/common/types.ts
@@ -64,7 +64,7 @@ export interface SharedPieLayerState {
   categoryDisplay: CategoryDisplayType;
   legendDisplay: LegendDisplayType;
   legendPosition?: Position;
-  showValuesInLegend?: boolean;
+  legendStats?: LegendStats[];
   nestedLegend?: boolean;
   percentDecimals?: number;
   emptySizeRatio?: number;
@@ -79,11 +79,16 @@ export type PieLayerState = SharedPieLayerState & {
   layerType: LayerType;
 };
 
+export enum LegendStats {
+  values = 'values',
+}
+
 export interface PieVisualizationState {
   shape: $Values<typeof PieChartTypes>;
   layers: PieLayerState[];
   palette?: PaletteOutput;
 }
+
 export interface LegacyMetricState {
   autoScaleMetricAlignment?: 'left' | 'right' | 'center';
   layerId: string;

--- a/x-pack/plugins/lens/common/types.ts
+++ b/x-pack/plugins/lens/common/types.ts
@@ -10,7 +10,7 @@ import type { Position } from '@elastic/charts';
 import type { $Values } from '@kbn/utility-types';
 import { CustomPaletteParams, PaletteOutput, ColorMapping } from '@kbn/coloring';
 import type { ColorMode } from '@kbn/charts-plugin/common';
-import type { LegendSize } from '@kbn/visualizations-plugin/common';
+import type { LegendSize, LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { CategoryDisplay, LegendDisplay, NumberDisplay, PieChartTypes } from './constants';
 import { layerTypes } from './layer_types';
 import { CollapseFunction } from './expressions';
@@ -78,10 +78,6 @@ export type PieLayerState = SharedPieLayerState & {
   layerId: string;
   layerType: LayerType;
 };
-
-export enum LegendStats {
-  values = 'values',
-}
 
 export interface PieVisualizationState {
   shape: $Values<typeof PieChartTypes>;

--- a/x-pack/plugins/lens/public/index.ts
+++ b/x-pack/plugins/lens/public/index.ts
@@ -38,6 +38,7 @@ export type {
   LegacyMetricState as MetricState,
   ValueLabelConfig,
   PieVisualizationState,
+  LegendStats,
   PieLayerState,
   SharedPieLayerState,
   LayerType,

--- a/x-pack/plugins/lens/public/index.ts
+++ b/x-pack/plugins/lens/public/index.ts
@@ -38,7 +38,6 @@ export type {
   LegacyMetricState as MetricState,
   ValueLabelConfig,
   PieVisualizationState,
-  LegendStats,
   PieLayerState,
   SharedPieLayerState,
   LayerType,

--- a/x-pack/plugins/lens/public/shared_components/legend/legend_settings_popover.tsx
+++ b/x-pack/plugins/lens/public/shared_components/legend/legend_settings_popover.tsx
@@ -24,6 +24,10 @@ import { LegendLocationSettings } from './location/legend_location_settings';
 import { ColumnsNumberSetting } from './layout/columns_number_setting';
 import { LegendSizeSettings } from './size/legend_size_settings';
 
+export enum LegendStats {
+  values = 'values',
+}
+
 export interface LegendSettingsPopoverProps {
   /**
    * Determines the legend display options
@@ -108,15 +112,15 @@ export interface LegendSettingsPopoverProps {
   /**
    * value in legend status
    */
-  valueInLegend?: boolean;
+  legendStats?: LegendStats[];
   /**
    * Callback on value in legend status change
    */
-  onValueInLegendChange?: (event: EuiSwitchEvent) => void;
+  onLegendStatsChange?: (legendStats?: LegendStats[]) => void;
   /**
    * If true, value in legend switch is rendered
    */
-  renderValueInLegendSwitch?: boolean;
+  allowLegendStats?: boolean;
   /**
    * Button group position
    */
@@ -197,9 +201,9 @@ export const LegendSettingsPopover: React.FunctionComponent<LegendSettingsPopove
   renderNestedLegendSwitch,
   nestedLegend,
   onNestedLegendChange = noop,
-  valueInLegend,
-  onValueInLegendChange = noop,
-  renderValueInLegendSwitch,
+  legendStats,
+  onLegendStatsChange = noop,
+  allowLegendStats,
   groupPosition = 'right',
   maxLines,
   onMaxLinesChange = noop,
@@ -317,7 +321,7 @@ export const LegendSettingsPopover: React.FunctionComponent<LegendSettingsPopove
               />
             </EuiFormRow>
           )}
-          {renderValueInLegendSwitch && (
+          {allowLegendStats && (
             <EuiFormRow
               display="columnCompressedSwitch"
               label={i18n.translate('xpack.lens.shared.valueInLegendLabel', {
@@ -332,8 +336,14 @@ export const LegendSettingsPopover: React.FunctionComponent<LegendSettingsPopove
                 })}
                 data-test-subj="lens-legend-show-value"
                 showLabel={false}
-                checked={!!valueInLegend}
-                onChange={onValueInLegendChange}
+                checked={legendStats?.[0] === LegendStats.values}
+                onChange={(ev) => {
+                  if (ev.target.checked) {
+                    onLegendStatsChange([LegendStats.values]);
+                  } else {
+                    onLegendStatsChange([]);
+                  }
+                }}
               />
             </EuiFormRow>
           )}

--- a/x-pack/plugins/lens/public/shared_components/legend/legend_settings_popover.tsx
+++ b/x-pack/plugins/lens/public/shared_components/legend/legend_settings_popover.tsx
@@ -19,14 +19,11 @@ import {
 import { Position, VerticalAlignment, HorizontalAlignment } from '@elastic/charts';
 import { LegendSize } from '@kbn/visualizations-plugin/public';
 import { useDebouncedValue } from '@kbn/visualization-ui-components';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { ToolbarPopover, type ToolbarPopoverProps } from '../toolbar_popover';
 import { LegendLocationSettings } from './location/legend_location_settings';
 import { ColumnsNumberSetting } from './layout/columns_number_setting';
 import { LegendSizeSettings } from './size/legend_size_settings';
-
-export enum LegendStats {
-  values = 'values',
-}
 
 export interface LegendSettingsPopoverProps {
   /**

--- a/x-pack/plugins/lens/public/visualizations/partition/partition_charts_meta.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/partition_charts_meta.ts
@@ -16,6 +16,7 @@ import {
   IconChartMosaic,
   IconChartWaffle,
 } from '@kbn/chart-icons';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { SharedPieLayerState, EmptySizeRatios } from '../../../common/types';
 import { CategoryDisplay, NumberDisplay } from '../../../common/constants';
 import type { PieChartType } from '../../../common/types';
@@ -44,7 +45,7 @@ interface PartitionChartMeta {
   };
   legend: {
     flat?: boolean;
-    showValues?: boolean;
+    defaultLegendStats?: LegendStats[];
     hideNestedLegendSwitch?: boolean;
     getShowLegendDefault?: (bucketColumns: DatatableColumn[]) => boolean;
   };
@@ -211,7 +212,7 @@ export const PartitionChartsMeta: Record<PieChartType, PartitionChartMeta> = {
     },
     legend: {
       flat: true,
-      showValues: true,
+      defaultLegendStats: [LegendStats.values],
       hideNestedLegendSwitch: true,
       getShowLegendDefault: () => true,
     },

--- a/x-pack/plugins/lens/public/visualizations/partition/persistence.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/persistence.tsx
@@ -6,7 +6,8 @@
  */
 
 import { cloneDeep } from 'lodash';
-import { LegendStats, PieLayerState, PieVisualizationState } from '../../../common/types';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
+import { PieLayerState, PieVisualizationState } from '../../../common/types';
 
 type PersistedPieLayerState = Omit<PieLayerState, 'legendStats'> & {
   showValuesInLegend?: boolean;

--- a/x-pack/plugins/lens/public/visualizations/partition/persistence.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/persistence.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cloneDeep } from 'lodash';
+import { LegendStats, PieLayerState, PieVisualizationState } from '../../../common/types';
+
+type PersistedPieLayerState = Omit<PieLayerState, 'legendStats'> & {
+  showValuesInLegend?: boolean;
+};
+
+export type PersistedPieVisualizationState = Omit<PieVisualizationState, 'layers'> & {
+  layers: PersistedPieLayerState[];
+};
+
+export function convertToRuntime(state: PersistedPieVisualizationState) {
+  if (state.layers.some((l) => 'showValuesInLegend' in l)) {
+    return convertToLegendStats(state);
+  }
+  return state;
+}
+
+function convertToLegendStats(state: PieVisualizationState) {
+  const newState = cloneDeep(state) as unknown as PieVisualizationState;
+
+  newState.layers.forEach((l) => {
+    if ('showValuesInLegend' in l) {
+      l.legendStats = [
+        ...new Set([
+          ...(l.showValuesInLegend ? [LegendStats.values] : []),
+          ...(l.legendStats || []),
+        ]),
+      ];
+    }
+    delete (l as PersistedPieLayerState).showValuesInLegend;
+  });
+
+  return newState;
+}
+
+export function convertToPersistable(state: PieVisualizationState) {
+  const newState = cloneDeep(state) as unknown as PersistedPieVisualizationState;
+
+  newState.layers.forEach((l) => {
+    if ('legendStats' in l && Array.isArray(l.legendStats)) {
+      l.showValuesInLegend = l.legendStats.includes(LegendStats.values);
+      delete l.legendStats;
+    }
+  });
+
+  return newState;
+}

--- a/x-pack/plugins/lens/public/visualizations/partition/persistence.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/persistence.tsx
@@ -18,16 +18,13 @@ export type PersistedPieVisualizationState = Omit<PieVisualizationState, 'layers
 };
 
 export function convertToRuntime(state: PersistedPieVisualizationState) {
-  if (state.layers.some((l) => 'showValuesInLegend' in l)) {
-    return convertToLegendStats(state);
-  }
-  return state;
+  let newState = cloneDeep(state) as unknown as PieVisualizationState;
+  newState = convertToLegendStats(newState);
+  return newState;
 }
 
 function convertToLegendStats(state: PieVisualizationState) {
-  const newState = cloneDeep(state) as unknown as PieVisualizationState;
-
-  newState.layers.forEach((l) => {
+  state.layers.forEach((l) => {
     if ('showValuesInLegend' in l) {
       l.legendStats = [
         ...new Set([
@@ -39,7 +36,7 @@ function convertToLegendStats(state: PieVisualizationState) {
     delete (l as PersistedPieLayerState).showValuesInLegend;
   });
 
-  return newState;
+  return state;
 }
 
 export function convertToPersistable(state: PieVisualizationState) {

--- a/x-pack/plugins/lens/public/visualizations/partition/render_helpers.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/render_helpers.test.ts
@@ -7,9 +7,10 @@
 
 import type { Datatable } from '@kbn/expressions-plugin/public';
 
-import { checkTableForContainsSmallValues, shouldShowValuesInLegend } from './render_helpers';
+import { checkTableForContainsSmallValues, getLegendStats } from './render_helpers';
 import { PieLayerState } from '../../../common/types';
 import { PieChartTypes } from '../../../common/constants';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 
 describe('render helpers', () => {
   describe('#checkTableForContainsSmallValues', () => {
@@ -68,39 +69,27 @@ describe('render helpers', () => {
     });
   });
 
-  describe('#shouldShowValuesInLegend', () => {
+  describe('#getLegendStats', () => {
     it('should firstly read the state value', () => {
       expect(
-        shouldShowValuesInLegend(
-          { showValuesInLegend: true } as PieLayerState,
-          PieChartTypes.WAFFLE
-        )
-      ).toBeTruthy();
+        getLegendStats({ legendStats: [LegendStats.values] } as PieLayerState, PieChartTypes.WAFFLE)
+      ).toEqual([LegendStats.values]);
 
       expect(
-        shouldShowValuesInLegend(
-          { showValuesInLegend: false } as PieLayerState,
-          PieChartTypes.WAFFLE
-        )
-      ).toBeFalsy();
+        getLegendStats({ legendStats: [] as LegendStats[] } as PieLayerState, PieChartTypes.WAFFLE)
+      ).toEqual([]);
     });
 
     it('should read value from meta in case of value in state is undefined', () => {
-      expect(
-        shouldShowValuesInLegend(
-          { showValuesInLegend: undefined } as PieLayerState,
-          PieChartTypes.WAFFLE
-        )
-      ).toBeTruthy();
-
-      expect(shouldShowValuesInLegend({} as PieLayerState, PieChartTypes.WAFFLE)).toBeTruthy();
+      expect(getLegendStats({} as PieLayerState, PieChartTypes.WAFFLE)).toEqual([
+        LegendStats.values,
+      ]);
 
       expect(
-        shouldShowValuesInLegend(
-          { showValuesInLegend: undefined } as PieLayerState,
-          PieChartTypes.PIE
-        )
-      ).toBeFalsy();
+        getLegendStats({ legendStats: undefined } as PieLayerState, PieChartTypes.WAFFLE)
+      ).toEqual([LegendStats.values]);
+
+      expect(getLegendStats({} as PieLayerState, PieChartTypes.PIE)).toEqual(undefined);
     });
   });
 });

--- a/x-pack/plugins/lens/public/visualizations/partition/render_helpers.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/render_helpers.ts
@@ -14,7 +14,7 @@ export const getLegendStats = (layer: PieLayerState, shape: PieChartType) => {
   if ('defaultLegendStats' in PartitionChartsMeta[shape]?.legend) {
     return (
       layer.legendStats ??
-      PartitionChartsMeta[shape]?.legend?.defaultLegendStats ?? [LegendStats.values]
+      PartitionChartsMeta[shape].legend.defaultLegendStats ?? [LegendStats.values]
     );
   }
 };

--- a/x-pack/plugins/lens/public/visualizations/partition/render_helpers.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/render_helpers.ts
@@ -6,15 +6,17 @@
  */
 
 import type { Datatable } from '@kbn/expressions-plugin/public';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import type { PieChartType, PieLayerState } from '../../../common/types';
 import { PartitionChartsMeta } from './partition_charts_meta';
 
-export const shouldShowValuesInLegend = (layer: PieLayerState, shape: PieChartType) => {
-  if ('showValues' in PartitionChartsMeta[shape]?.legend) {
-    return layer.showValuesInLegend ?? PartitionChartsMeta[shape]?.legend?.showValues ?? true;
+export const getLegendStats = (layer: PieLayerState, shape: PieChartType) => {
+  if ('defaultLegendStats' in PartitionChartsMeta[shape]?.legend) {
+    return (
+      layer.legendStats ??
+      PartitionChartsMeta[shape]?.legend?.defaultLegendStats ?? [LegendStats.values]
+    );
   }
-
-  return false;
 };
 
 export const checkTableForContainsSmallValues = (

--- a/x-pack/plugins/lens/public/visualizations/partition/to_expression.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/to_expression.ts
@@ -25,7 +25,7 @@ import { ExpressionFunctionVisDimension } from '@kbn/visualizations-plugin/commo
 import type { CollapseExpressionFunction } from '../../../common/expressions';
 import type { Operation, DatasourcePublicAPI, DatasourceLayers } from '../../types';
 import { DEFAULT_PERCENT_DECIMALS } from './constants';
-import { shouldShowValuesInLegend } from './render_helpers';
+import { getLegendStats } from './render_helpers';
 import { PieLayerState, PieVisualizationState, EmptySizeRatios } from '../../../common/types';
 import {
   CategoryDisplay,
@@ -269,7 +269,7 @@ const generateWaffleVisAst: GenerateExpressionAstFunction = (...rest) => {
         layer,
         getColumnToLabelMap(layer.metrics, datasourceLayers[layer.layerId])
       ),
-      showValuesInLegend: shouldShowValuesInLegend(layer, state.shape),
+      legendStats: getLegendStats(layer, state.shape),
     }),
   ]).toAst();
 };

--- a/x-pack/plugins/lens/public/visualizations/partition/toolbar.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/toolbar.tsx
@@ -249,7 +249,7 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
         mode={layer.legendDisplay}
         onDisplayChange={onLegendDisplayChange}
         legendStats={getLegendStats(layer, state.shape)}
-        allowLegendStats={'defaultLegendStats' in PartitionChartsMeta[state.shape]?.legend ?? false}
+        allowLegendStats={!!PartitionChartsMeta[state.shape]?.legend.defaultLegendStats}
         onLegendStatsChange={onLegendStatsChange}
         position={layer.legendPosition}
         onPositionChange={onLegendPositionChange}

--- a/x-pack/plugins/lens/public/visualizations/partition/toolbar.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/toolbar.tsx
@@ -26,7 +26,7 @@ import { LegendDisplay } from '../../../common/constants';
 import { VisualizationToolbarProps } from '../../types';
 import { ToolbarPopover, LegendSettingsPopover } from '../../shared_components';
 import { getDefaultVisualValuesForLayer } from '../../shared_components/datasource_default_values';
-import { shouldShowValuesInLegend } from './render_helpers';
+import { getLegendStats } from './render_helpers';
 
 const legendOptions: Array<{
   value: SharedPieLayerState['legendDisplay'];
@@ -133,11 +133,14 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
     [onStateChange]
   );
 
-  const onValueInLegendChange = useCallback(() => {
-    onStateChange({
-      showValuesInLegend: !shouldShowValuesInLegend(layer, state.shape),
-    });
-  }, [layer, state.shape, onStateChange]);
+  const onLegendStatsChange = useCallback(
+    (legendStats) => {
+      onStateChange({
+        legendStats,
+      });
+    },
+    [onStateChange]
+  );
 
   const onEmptySizeRatioChange = useCallback(
     (sizeId) => {
@@ -245,11 +248,9 @@ export function PieToolbar(props: VisualizationToolbarProps<PieVisualizationStat
         legendOptions={legendOptions}
         mode={layer.legendDisplay}
         onDisplayChange={onLegendDisplayChange}
-        valueInLegend={shouldShowValuesInLegend(layer, state.shape)}
-        renderValueInLegendSwitch={
-          'showValues' in PartitionChartsMeta[state.shape]?.legend ?? false
-        }
-        onValueInLegendChange={onValueInLegendChange}
+        legendStats={getLegendStats(layer, state.shape)}
+        allowLegendStats={'defaultLegendStats' in PartitionChartsMeta[state.shape]?.legend ?? false}
+        onLegendStatsChange={onLegendStatsChange}
         position={layer.legendPosition}
         onPositionChange={onLegendPositionChange}
         renderNestedLegendSwitch={

--- a/x-pack/plugins/lens/public/visualizations/partition/visualization.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/partition/visualization.test.ts
@@ -22,7 +22,7 @@ import { cloneDeep } from 'lodash';
 import { PartitionChartsMeta } from './partition_charts_meta';
 import { CollapseFunction } from '../../../common/expressions';
 import { PaletteOutput } from '@kbn/coloring';
-import { LegendStats } from '@kbn/visualizations-plugin/common';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 import { PersistedPieVisualizationState } from './persistence';
 
 jest.mock('../../id_generator');

--- a/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
@@ -168,18 +168,19 @@ export const getPieVisualization = ({
   triggers: [VIS_EVENT_TO_TRIGGER.filter],
 
   initialize(addNewLayer, state, mainPalette) {
-    return state
-      ? convertToRuntime(state)
-      : {
-          shape: PieChartTypes.DONUT,
-          layers: [
-            newLayerState(
-              addNewLayer(),
-              mainPalette?.type === 'colorMapping' ? mainPalette.value : getColorMappingDefaults()
-            ),
-          ],
-          palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
-        };
+    if (state) {
+      return convertToRuntime(state);
+    }
+    return {
+      shape: PieChartTypes.DONUT,
+      layers: [
+        newLayerState(
+          addNewLayer(),
+          mainPalette?.type === 'colorMapping' ? mainPalette.value : getColorMappingDefaults()
+        ),
+      ],
+      palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
+    };
   },
 
   getPersistableState(state) {

--- a/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
@@ -53,6 +53,11 @@ import { checkTableForContainsSmallValues } from './render_helpers';
 import { DatasourcePublicAPI } from '../..';
 import { nonNullable, getColorMappingDefaults } from '../../utils';
 import { getColorMappingTelemetryEvents } from '../../lens_ui_telemetry/color_telemetry_helpers';
+import {
+  PersistedPieVisualizationState,
+  convertToPersistable,
+  convertToRuntime,
+} from './persistence';
 
 const metricLabel = i18n.translate('xpack.lens.pie.groupMetricLabelSingular', {
   defaultMessage: 'Metric',
@@ -123,7 +128,7 @@ export const getPieVisualization = ({
 }: {
   paletteService: PaletteRegistry;
   kibanaTheme: ThemeServiceStart;
-}): Visualization<PieVisualizationState> => ({
+}): Visualization<PieVisualizationState, PersistedPieVisualizationState> => ({
   id: 'lnsPie',
 
   visualizationTypes: Object.entries(PartitionChartsMeta).map(([key, meta]) => ({
@@ -163,18 +168,22 @@ export const getPieVisualization = ({
   triggers: [VIS_EVENT_TO_TRIGGER.filter],
 
   initialize(addNewLayer, state, mainPalette) {
-    return (
-      state || {
-        shape: PieChartTypes.DONUT,
-        layers: [
-          newLayerState(
-            addNewLayer(),
-            mainPalette?.type === 'colorMapping' ? mainPalette.value : getColorMappingDefaults()
-          ),
-        ],
-        palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
-      }
-    );
+    return state
+      ? convertToRuntime(state)
+      : {
+          shape: PieChartTypes.DONUT,
+          layers: [
+            newLayerState(
+              addNewLayer(),
+              mainPalette?.type === 'colorMapping' ? mainPalette.value : getColorMappingDefaults()
+            ),
+          ],
+          palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
+        };
+  },
+
+  getPersistableState(state) {
+    return { savedObjectReferences: [], state: convertToPersistable(state) };
   },
 
   getMainPalette: (state) => {

--- a/x-pack/plugins/lens/public/visualizations/xy/__snapshots__/to_expression.test.ts.snap
+++ b/x-pack/plugins/lens/public/visualizations/xy/__snapshots__/to_expression.test.ts.snap
@@ -131,9 +131,6 @@ Object {
         "valueLabels": Array [
           "hide",
         ],
-        "valuesInLegend": Array [
-          false,
-        ],
         "xAxisConfig": Array [
           Object {
             "chain": Array [

--- a/x-pack/plugins/lens/public/visualizations/xy/persistence.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/persistence.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LegendConfig } from '@kbn/visualizations-plugin/common';
+import { v4 as uuidv4 } from 'uuid';
+import type { SavedObjectReference } from '@kbn/core/public';
+import { EVENT_ANNOTATION_GROUP_TYPE } from '@kbn/event-annotation-common';
+import { cloneDeep } from 'lodash';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
+
+import { layerTypes } from '../../../common/layer_types';
+import { AnnotationGroups } from '../../types';
+import {
+  XYLayerConfig,
+  XYDataLayerConfig,
+  XYReferenceLineLayerConfig,
+  XYState,
+  XYAnnotationLayerConfig,
+  XYByReferenceAnnotationLayerConfig,
+  XYByValueAnnotationLayerConfig,
+} from './types';
+import { isAnnotationsLayer, isByReferenceAnnotationsLayer } from './visualization_helpers';
+import { nonNullable } from '../../utils';
+import { annotationLayerHasUnsavedChanges } from './state_helpers';
+
+export const isPersistedByReferenceAnnotationsLayer = (
+  layer: XYPersistedAnnotationLayerConfig
+): layer is XYPersistedByReferenceAnnotationLayerConfig =>
+  isPersistedAnnotationsLayer(layer) && layer.persistanceType === 'byReference';
+
+export const isPersistedLinkedByValueAnnotationsLayer = (
+  layer: XYPersistedAnnotationLayerConfig
+): layer is XYPersistedLinkedByValueAnnotationLayerConfig =>
+  isPersistedAnnotationsLayer(layer) && layer.persistanceType === 'linked';
+
+/**
+ * This is the type of hybrid layer we get after the user has made a change to
+ * a by-reference annotation layer and saved the visualization without
+ * first saving the changes to the library annotation layer.
+ *
+ * We maintain the link to the library annotation group, but allow the users
+ * changes (persisted in the visualization state) to override the attributes in
+ * the library version until the user
+ * - saves the changes to the library annotation group
+ * - reverts the changes
+ * - unlinks the layer from the library annotation group
+ */
+export type XYPersistedLinkedByValueAnnotationLayerConfig = Omit<
+  XYPersistedByValueAnnotationLayerConfig,
+  'persistanceType'
+> &
+  Omit<XYPersistedByReferenceAnnotationLayerConfig, 'persistanceType'> & {
+    persistanceType: 'linked';
+  };
+
+export type XYPersistedByValueAnnotationLayerConfig = Omit<
+  XYByValueAnnotationLayerConfig,
+  'indexPatternId' | 'hide' | 'simpleView'
+> & { persistanceType?: 'byValue'; hide?: boolean; simpleView?: boolean }; // props made optional for backwards compatibility since this is how the existing saved objects are
+
+export type XYPersistedByReferenceAnnotationLayerConfig = Pick<
+  XYByValueAnnotationLayerConfig,
+  'layerId' | 'layerType'
+> & {
+  persistanceType: 'byReference';
+  annotationGroupRef: string;
+};
+
+export type XYPersistedAnnotationLayerConfig =
+  | XYPersistedByReferenceAnnotationLayerConfig
+  | XYPersistedByValueAnnotationLayerConfig
+  | XYPersistedLinkedByValueAnnotationLayerConfig;
+
+export type XYPersistedLayerConfig =
+  | XYDataLayerConfig
+  | XYReferenceLineLayerConfig
+  | XYPersistedAnnotationLayerConfig;
+
+export type XYPersistedState = Omit<XYState, 'layers'> & {
+  layers: XYPersistedLayerConfig[];
+  valuesInLegend?: boolean;
+  legend: Omit<LegendConfig, 'legendStats'>;
+};
+
+export function convertToRuntime(
+  state: XYPersistedState,
+  annotationGroups?: AnnotationGroups,
+  references?: SavedObjectReference[]
+) {
+  const outputState = needsInjectReferences(state)
+    ? injectReferences(state, annotationGroups, references)
+    : state;
+  if ('valuesInLegend' in outputState) {
+    return convertToLegendStats(outputState);
+  }
+  return outputState;
+}
+
+export function convertToPersistable(state: XYState) {
+  const persistableState: XYPersistedState = convertToValuesInLegend(state);
+  const savedObjectReferences: SavedObjectReference[] = [];
+  const persistableLayers: XYPersistedLayerConfig[] = [];
+
+  persistableState.layers.forEach((layer) => {
+    if (!isAnnotationsLayer(layer)) {
+      persistableLayers.push(layer);
+    } else {
+      if (isByReferenceAnnotationsLayer(layer)) {
+        const referenceName = `ref-${uuidv4()}`;
+        savedObjectReferences.push({
+          type: EVENT_ANNOTATION_GROUP_TYPE,
+          id: layer.annotationGroupId,
+          name: referenceName,
+        });
+
+        if (!annotationLayerHasUnsavedChanges(layer)) {
+          const persistableLayer: XYPersistedByReferenceAnnotationLayerConfig = {
+            persistanceType: 'byReference',
+            layerId: layer.layerId,
+            layerType: layer.layerType,
+            annotationGroupRef: referenceName,
+          };
+
+          persistableLayers.push(persistableLayer);
+        } else {
+          const persistableLayer: XYPersistedLinkedByValueAnnotationLayerConfig = {
+            persistanceType: 'linked',
+            cachedMetadata: layer.cachedMetadata || {
+              title: layer.__lastSaved.title,
+              description: layer.__lastSaved.description,
+              tags: layer.__lastSaved.tags,
+            },
+            layerId: layer.layerId,
+            layerType: layer.layerType,
+            annotationGroupRef: referenceName,
+            annotations: layer.annotations,
+            ignoreGlobalFilters: layer.ignoreGlobalFilters,
+          };
+          persistableLayers.push(persistableLayer);
+
+          savedObjectReferences.push({
+            type: 'index-pattern',
+            id: layer.indexPatternId,
+            name: getLayerReferenceName(layer.layerId),
+          });
+        }
+      } else {
+        const { indexPatternId, ...persistableLayer } = layer;
+        savedObjectReferences.push({
+          type: 'index-pattern',
+          id: indexPatternId,
+          name: getLayerReferenceName(layer.layerId),
+        });
+        persistableLayers.push({ ...persistableLayer, persistanceType: 'byValue' });
+      }
+    }
+  });
+  return { savedObjectReferences, state: { ...persistableState, layers: persistableLayers } };
+}
+
+export const isPersistedAnnotationsLayer = (
+  layer: XYPersistedLayerConfig
+): layer is XYPersistedAnnotationLayerConfig =>
+  layer.layerType === layerTypes.ANNOTATIONS && !('indexPatternId' in layer);
+
+export const isPersistedByValueAnnotationsLayer = (
+  layer: XYPersistedLayerConfig
+): layer is XYPersistedByValueAnnotationLayerConfig =>
+  isPersistedAnnotationsLayer(layer) &&
+  (layer.persistanceType === 'byValue' || !layer.persistanceType);
+
+function getLayerReferenceName(layerId: string) {
+  return `xy-visualization-layer-${layerId}`;
+}
+
+function needsInjectReferences(state: XYPersistedState | XYState): state is XYPersistedState {
+  return state.layers.some(isPersistedAnnotationsLayer);
+}
+
+function injectReferences(
+  state: XYPersistedState,
+  annotationGroups?: AnnotationGroups,
+  references?: SavedObjectReference[]
+): XYState {
+  if (!references || !references.length) {
+    return state as XYState;
+  }
+
+  if (!annotationGroups) {
+    throw new Error(
+      'xy visualization: injecting references relies on annotation groups but they were not provided'
+    );
+  }
+
+  // called on-demand since indexPattern reference won't be here on the vis if its a by-reference group
+  const getIndexPatternIdFromReferences = (annotationLayerId: string) => {
+    const fallbackIndexPatternId = references.find(({ type }) => type === 'index-pattern')!.id;
+    return (
+      references.find(({ name }) => name === getLayerReferenceName(annotationLayerId))?.id ||
+      fallbackIndexPatternId
+    );
+  };
+
+  return {
+    ...state,
+    layers: state.layers
+      .map((persistedLayer) => {
+        if (!isPersistedAnnotationsLayer(persistedLayer)) {
+          return persistedLayer as XYLayerConfig;
+        }
+
+        let injectedLayer: XYAnnotationLayerConfig;
+
+        if (isPersistedByValueAnnotationsLayer(persistedLayer)) {
+          injectedLayer = {
+            ...persistedLayer,
+            indexPatternId: getIndexPatternIdFromReferences(persistedLayer.layerId),
+          };
+        } else {
+          const annotationGroupId = references?.find(
+            ({ name }) => name === persistedLayer.annotationGroupRef
+          )?.id;
+
+          const annotationGroup = annotationGroupId
+            ? annotationGroups[annotationGroupId]
+            : undefined;
+
+          if (!annotationGroupId || !annotationGroup) {
+            return undefined; // the annotation group this layer was referencing is gone, so remove the layer
+          }
+
+          // declared as a separate variable for type checking
+          const commonProps: Pick<
+            XYByReferenceAnnotationLayerConfig,
+            'layerId' | 'layerType' | 'annotationGroupId' | '__lastSaved'
+          > = {
+            layerId: persistedLayer.layerId,
+            layerType: persistedLayer.layerType,
+            annotationGroupId,
+            __lastSaved: annotationGroup,
+          };
+
+          if (isPersistedByReferenceAnnotationsLayer(persistedLayer)) {
+            // a clean by-reference layer inherits everything from the library annotation group
+            injectedLayer = {
+              ...commonProps,
+              ignoreGlobalFilters: annotationGroup.ignoreGlobalFilters,
+              indexPatternId: annotationGroup.indexPatternId,
+              annotations: cloneDeep(annotationGroup.annotations),
+            };
+          } else {
+            // a linked by-value layer gets settings from visualization state while
+            // still maintaining the reference to the library annotation group
+            injectedLayer = {
+              ...commonProps,
+              ignoreGlobalFilters: persistedLayer.ignoreGlobalFilters,
+              indexPatternId: getIndexPatternIdFromReferences(persistedLayer.layerId),
+              annotations: cloneDeep(persistedLayer.annotations),
+              cachedMetadata: persistedLayer.cachedMetadata,
+            };
+          }
+        }
+
+        return injectedLayer;
+      })
+      .filter(nonNullable),
+  };
+}
+
+function convertToLegendStats(state: XYState & { valuesInLegend?: unknown }) {
+  const newState = cloneDeep(state);
+  delete newState.valuesInLegend;
+  const result: XYState = {
+    ...newState,
+    legend: {
+      ...newState.legend,
+      legendStats: [
+        ...new Set([
+          ...(state.valuesInLegend ? [LegendStats.values] : []),
+          ...(state.legend.legendStats || []),
+        ]),
+      ],
+    },
+  };
+
+  return result;
+}
+
+function convertToValuesInLegend(state: XYState) {
+  const newState: XYPersistedState = cloneDeep(state);
+
+  if ('legendStats' in newState.legend && Array.isArray(newState.legend.legendStats)) {
+    newState.valuesInLegend = newState.legend.legendStats.includes(LegendStats.values);
+    delete newState.legend.legendStats;
+  }
+  return newState;
+}

--- a/x-pack/plugins/lens/public/visualizations/xy/persistence.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/persistence.ts
@@ -271,24 +271,25 @@ function injectReferences(
 }
 
 function convertToLegendStats(state: XYState & { valuesInLegend?: unknown }) {
-  if (!('valuesInLegend' in state)) {
-    return state;
-  }
-  delete state.valuesInLegend;
-  const result: XYState = {
-    ...state,
-    legend: {
-      ...state.legend,
-      legendStats: [
-        ...new Set([
-          ...(state.valuesInLegend ? [LegendStats.values] : []),
-          ...(state.legend.legendStats || []),
-        ]),
-      ],
-    },
-  };
+  if ('valuesInLegend' in state) {
+    const valuesInLegend = state.valuesInLegend;
+    delete state.valuesInLegend;
+    const result: XYState = {
+      ...state,
+      legend: {
+        ...state.legend,
+        legendStats: [
+          ...new Set([
+            ...(valuesInLegend ? [LegendStats.values] : []),
+            ...(state.legend.legendStats || []),
+          ]),
+        ],
+      },
+    };
 
-  return result;
+    return result;
+  }
+  return state;
 }
 
 function convertToValuesInLegend(state: XYState) {

--- a/x-pack/plugins/lens/public/visualizations/xy/to_expression.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/to_expression.ts
@@ -308,6 +308,7 @@ export const buildXYExpression = (
         ? Math.min(5, state.legend.floatingColumns)
         : [],
     maxLines: state.legend.maxLines,
+    legendStats: state.legend.legendStats,
     shouldTruncate:
       state.legend.shouldTruncate ??
       getDefaultVisualValuesForLayer(state, datasourceLayers).truncateText,
@@ -341,7 +342,6 @@ export const buildXYExpression = (
     hideEndzones: state.hideEndzones ?? false,
     addTimeMarker:
       (isTimeChart(validDataLayers, { datasourceLayers }) && state.showCurrentTimeMarker) ?? false,
-    valuesInLegend: state.valuesInLegend ?? false,
     yAxisConfigs: [...yAxisConfigsToExpression(yAxisConfigs)],
     xAxisConfig: buildExpression([xAxisConfigFn]).toAst(),
     showTooltip: [],

--- a/x-pack/plugins/lens/public/visualizations/xy/types.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/types.ts
@@ -128,57 +128,14 @@ export interface XYByValueAnnotationLayerConfig {
   };
 }
 
-export type XYPersistedByValueAnnotationLayerConfig = Omit<
-  XYByValueAnnotationLayerConfig,
-  'indexPatternId' | 'hide' | 'simpleView'
-> & { persistanceType?: 'byValue'; hide?: boolean; simpleView?: boolean }; // props made optional for backwards compatibility since this is how the existing saved objects are
-
 export type XYByReferenceAnnotationLayerConfig = XYByValueAnnotationLayerConfig & {
   annotationGroupId: string;
   __lastSaved: EventAnnotationGroupConfig;
 };
 
-export type XYPersistedByReferenceAnnotationLayerConfig = Pick<
-  XYByValueAnnotationLayerConfig,
-  'layerId' | 'layerType'
-> & {
-  persistanceType: 'byReference';
-  annotationGroupRef: string;
-};
-
-/**
- * This is the type of hybrid layer we get after the user has made a change to
- * a by-reference annotation layer and saved the visualization without
- * first saving the changes to the library annotation layer.
- *
- * We maintain the link to the library annotation group, but allow the users
- * changes (persisted in the visualization state) to override the attributes in
- * the library version until the user
- * - saves the changes to the library annotation group
- * - reverts the changes
- * - unlinks the layer from the library annotation group
- */
-export type XYPersistedLinkedByValueAnnotationLayerConfig = Omit<
-  XYPersistedByValueAnnotationLayerConfig,
-  'persistanceType'
-> &
-  Omit<XYPersistedByReferenceAnnotationLayerConfig, 'persistanceType'> & {
-    persistanceType: 'linked';
-  };
-
 export type XYAnnotationLayerConfig =
   | XYByReferenceAnnotationLayerConfig
   | XYByValueAnnotationLayerConfig;
-
-export type XYPersistedAnnotationLayerConfig =
-  | XYPersistedByReferenceAnnotationLayerConfig
-  | XYPersistedByValueAnnotationLayerConfig
-  | XYPersistedLinkedByValueAnnotationLayerConfig;
-
-export type XYPersistedLayerConfig =
-  | XYDataLayerConfig
-  | XYReferenceLineLayerConfig
-  | XYPersistedAnnotationLayerConfig;
 
 export type XYLayerConfig =
   | XYDataLayerConfig
@@ -218,16 +175,9 @@ export interface XYState {
   minBarHeight?: number;
   hideEndzones?: boolean;
   showCurrentTimeMarker?: boolean;
-  valuesInLegend?: boolean;
 }
 
 export type State = XYState;
-
-export type XYPersistedState = Omit<XYState, 'layers'> & {
-  layers: XYPersistedLayerConfig[];
-};
-
-export type PersistedState = XYPersistedState;
 
 const groupLabelForBar = i18n.translate('xpack.lens.xyVisualization.barGroupLabel', {
   defaultMessage: 'Bar',

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.test.tsx
@@ -44,7 +44,7 @@ import { DataViewsState } from '../../state_management';
 import { createMockedIndexPattern } from '../../datasources/form_based/mocks';
 import { createMockDataViewsState } from '../../data_views_service/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
-import { layerTypes, LegendStats, Visualization } from '../..';
+import { layerTypes, Visualization } from '../..';
 import { set } from '@kbn/safer-lodash-set';
 import { SavedObjectReference } from '@kbn/core-saved-objects-api-server';
 import {
@@ -60,6 +60,7 @@ import {
   XYPersistedLinkedByValueAnnotationLayerConfig,
   XYPersistedState,
 } from './persistence';
+import { LegendStats } from '@kbn/visualizations-plugin/common/constants';
 
 const DATE_HISTORGRAM_COLUMN_ID = 'date_histogram_column';
 const exampleAnnotation: EventAnnotationConfig = {

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -270,29 +270,28 @@ export const getXyVisualization = ({
     annotationGroups?: AnnotationGroups,
     references?: SavedObjectReference[]
   ) {
-    return state
-      ? convertToRuntime(state, annotationGroups!, references)
-      : {
-          title: 'Empty XY chart',
-          legend: { isVisible: true, position: Position.Right },
-          valueLabels: 'hide',
-          preferredSeriesType: defaultSeriesType,
-          layers: [
-            {
-              layerId: addNewLayer(),
-              accessors: [],
-              position: Position.Top,
-              seriesType: defaultSeriesType,
-              showGridlines: false,
-              layerType: LayerTypes.DATA,
-              palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
-              colorMapping:
-                mainPalette?.type === 'colorMapping'
-                  ? mainPalette.value
-                  : getColorMappingDefaults(),
-            },
-          ],
-        };
+    if (state) {
+      return convertToRuntime(state, annotationGroups!, references);
+    }
+    return {
+      title: 'Empty XY chart',
+      legend: { isVisible: true, position: Position.Right },
+      valueLabels: 'hide',
+      preferredSeriesType: defaultSeriesType,
+      layers: [
+        {
+          layerId: addNewLayer(),
+          accessors: [],
+          position: Position.Top,
+          seriesType: defaultSeriesType,
+          showGridlines: false,
+          layerType: LayerTypes.DATA,
+          palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
+          colorMapping:
+            mainPalette?.type === 'colorMapping' ? mainPalette.value : getColorMappingDefaults(),
+        },
+      ],
+    };
   },
 
   getLayerType(layerId, state) {

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -60,15 +60,11 @@ import {
   type XYLayerConfig,
   type XYDataLayerConfig,
   type SeriesType,
-  type PersistedState,
   visualizationTypes,
 } from './types';
 import {
-  getPersistableState,
   getAnnotationLayerErrors,
-  injectReferences,
   isHorizontalChart,
-  isPersistedState,
   annotationLayerHasUnsavedChanges,
   isHorizontalSeries,
 } from './state_helpers';
@@ -122,6 +118,7 @@ import { AddLayerButton } from './add_layer';
 import { LayerSettings } from './layer_settings';
 import { IgnoredGlobalFiltersEntries } from '../../shared_components/ignore_global_filter';
 import { getColorMappingTelemetryEvents } from '../../lens_ui_telemetry/color_telemetry_helpers';
+import { XYPersistedState, convertToPersistable, convertToRuntime } from './persistence';
 
 const XY_ID = 'lnsXY';
 
@@ -151,7 +148,7 @@ export const getXyVisualization = ({
   unifiedSearch: UnifiedSearchPublicPluginStart;
   dataViewsService: DataViewsPublicPluginStart;
   savedObjectsTagging?: SavedObjectTaggingPluginStart;
-}): Visualization<State, PersistedState, ExtraAppendLayerArg> => ({
+}): Visualization<State, XYPersistedState, ExtraAppendLayerArg> => ({
   id: XY_ID,
   visualizationTypes,
   getVisualizationTypeId(state) {
@@ -245,7 +242,7 @@ export const getXyVisualization = ({
   },
 
   getPersistableState(state) {
-    return getPersistableState(state);
+    return convertToPersistable(state);
   },
 
   getDescription,
@@ -273,31 +270,29 @@ export const getXyVisualization = ({
     annotationGroups?: AnnotationGroups,
     references?: SavedObjectReference[]
   ) {
-    const finalState =
-      state && isPersistedState(state)
-        ? injectReferences(state, annotationGroups!, references)
-        : state;
-    return (
-      finalState || {
-        title: 'Empty XY chart',
-        legend: { isVisible: true, position: Position.Right },
-        valueLabels: 'hide',
-        preferredSeriesType: defaultSeriesType,
-        layers: [
-          {
-            layerId: addNewLayer(),
-            accessors: [],
-            position: Position.Top,
-            seriesType: defaultSeriesType,
-            showGridlines: false,
-            layerType: LayerTypes.DATA,
-            palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
-            colorMapping:
-              mainPalette?.type === 'colorMapping' ? mainPalette.value : getColorMappingDefaults(),
-          },
-        ],
-      }
-    );
+    return state
+      ? convertToRuntime(state, annotationGroups!, references)
+      : {
+          title: 'Empty XY chart',
+          legend: { isVisible: true, position: Position.Right },
+          valueLabels: 'hide',
+          preferredSeriesType: defaultSeriesType,
+          layers: [
+            {
+              layerId: addNewLayer(),
+              accessors: [],
+              position: Position.Top,
+              seriesType: defaultSeriesType,
+              showGridlines: false,
+              layerType: LayerTypes.DATA,
+              palette: mainPalette?.type === 'legacyPalette' ? mainPalette.value : undefined,
+              colorMapping:
+                mainPalette?.type === 'colorMapping'
+                  ? mainPalette.value
+                  : getColorMappingDefaults(),
+            },
+          ],
+        };
   },
 
   getLayerType(layerId, state) {
@@ -984,8 +979,8 @@ export const getXyVisualization = ({
   },
 
   isEqual(state1, references1, state2, references2, annotationGroups) {
-    const injected1 = injectReferences(state1, annotationGroups, references1);
-    const injected2 = injectReferences(state2, annotationGroups, references2);
+    const injected1 = convertToRuntime(state1, annotationGroups, references1);
+    const injected2 = convertToRuntime(state2, annotationGroups, references2);
     return isEqual(injected1, injected2);
   },
 

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization_helpers.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization_helpers.tsx
@@ -25,11 +25,6 @@ import {
   XYReferenceLineLayerConfig,
   SeriesType,
   XYByReferenceAnnotationLayerConfig,
-  XYPersistedAnnotationLayerConfig,
-  XYPersistedByReferenceAnnotationLayerConfig,
-  XYPersistedLinkedByValueAnnotationLayerConfig,
-  XYPersistedLayerConfig,
-  XYPersistedByValueAnnotationLayerConfig,
   XYByValueAnnotationLayerConfig,
 } from './types';
 import { isHorizontalChart } from './state_helpers';
@@ -154,31 +149,10 @@ export const isAnnotationsLayer = (
 ): layer is XYAnnotationLayerConfig =>
   layer.layerType === layerTypes.ANNOTATIONS && 'indexPatternId' in layer;
 
-export const isPersistedAnnotationsLayer = (
-  layer: XYPersistedLayerConfig
-): layer is XYPersistedAnnotationLayerConfig =>
-  layer.layerType === layerTypes.ANNOTATIONS && !('indexPatternId' in layer);
-
-export const isPersistedByValueAnnotationsLayer = (
-  layer: XYPersistedLayerConfig
-): layer is XYPersistedByValueAnnotationLayerConfig =>
-  isPersistedAnnotationsLayer(layer) &&
-  (layer.persistanceType === 'byValue' || !layer.persistanceType);
-
 export const isByReferenceAnnotationsLayer = (
   layer: XYLayerConfig
 ): layer is XYByReferenceAnnotationLayerConfig =>
   'annotationGroupId' in layer && '__lastSaved' in layer;
-
-export const isPersistedByReferenceAnnotationsLayer = (
-  layer: XYPersistedAnnotationLayerConfig
-): layer is XYPersistedByReferenceAnnotationLayerConfig =>
-  isPersistedAnnotationsLayer(layer) && layer.persistanceType === 'byReference';
-
-export const isPersistedLinkedByValueAnnotationsLayer = (
-  layer: XYPersistedAnnotationLayerConfig
-): layer is XYPersistedLinkedByValueAnnotationLayerConfig =>
-  isPersistedAnnotationsLayer(layer) && layer.persistanceType === 'linked';
 
 export const getAnnotationsLayers = (layers: Array<Pick<XYLayerConfig, 'layerType'>>) =>
   (layers || []).filter((layer): layer is XYAnnotationLayerConfig => isAnnotationsLayer(layer));

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/index.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/index.tsx
@@ -428,12 +428,15 @@ export const XyToolbar = memo(function XyToolbar(
                 legend: { ...state.legend, verticalAlignment, horizontalAlignment },
               });
             }}
-            renderValueInLegendSwitch={nonOrdinalXAxis}
-            valueInLegend={state?.valuesInLegend}
-            onValueInLegendChange={() => {
+            allowLegendStats={nonOrdinalXAxis}
+            legendStats={state?.legend.legendStats}
+            onLegendStatsChange={(newLegendStats) => {
               setState({
                 ...state,
-                valuesInLegend: !state.valuesInLegend,
+                legend: {
+                  ...state.legend,
+                  legendStats: newLegendStats,
+                },
               });
             }}
             legendSize={legendSize}

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_suggestions.ts
@@ -598,7 +598,6 @@ function buildSuggestion({
     yRightTitle: currentState?.yRightTitle,
     hideEndzones: currentState?.hideEndzones,
     showCurrentTimeMarker: currentState?.showCurrentTimeMarker,
-    valuesInLegend: currentState?.valuesInLegend,
     yLeftExtent: currentState?.yLeftExtent,
     yRightExtent: currentState?.yRightExtent,
     yLeftScale: currentState?.yLeftScale,

--- a/x-pack/plugins/observability_solution/ux/public/components/app/rum_dashboard/charts/visitor_breakdown_chart.tsx
+++ b/x-pack/plugins/observability_solution/ux/public/components/app/rum_dashboard/charts/visitor_breakdown_chart.tsx
@@ -6,11 +6,11 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import { ViewMode } from '@kbn/embeddable-plugin/public';
 import {
   CountIndexPatternColumn,
   PersistedIndexPatternLayer,
-  PieVisualizationState,
   TermsIndexPatternColumn,
   TypedLensByValueInput,
 } from '@kbn/lens-plugin/public';
@@ -77,7 +77,13 @@ export function VisitorBreakdownChart({
   );
 
   if (!LensEmbeddableComponent) {
-    return <EuiText>No lens component</EuiText>;
+    return (
+      <EuiText>
+        {i18n.translate('xpack.ux.visitorBreakdownChart.noLensComponentTextLabel', {
+          defaultMessage: 'No lens component',
+        })}
+      </EuiText>
+    );
   }
 
   return (
@@ -97,7 +103,7 @@ export function VisitorBreakdownChart({
   );
 }
 
-const visConfig: PieVisualizationState = {
+const visConfig = {
   layers: [
     {
       layerId: 'layer1',

--- a/x-pack/test/functional/apps/lens/group6/index.ts
+++ b/x-pack/test/functional/apps/lens/group6/index.ts
@@ -23,11 +23,15 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
     const remoteIndexPatternString = 'ftr-remote:logstash-*';
     const localFixtures = {
       lensBasic: 'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json',
+      lensLegendStatistics:
+        'x-pack/test/functional/fixtures/kbn_archiver/lens/legend_statistics.json',
       lensDefault: 'x-pack/test/functional/fixtures/kbn_archiver/lens/default',
     };
 
     const remoteFixtures = {
       lensBasic: 'x-pack/test/functional/fixtures/kbn_archiver/lens/ccs/lens_basic.json',
+      lensLegendStatistics:
+        'x-pack/test/functional/fixtures/kbn_archiver/lens/legend_statistics.json',
       lensDefault: 'x-pack/test/functional/fixtures/kbn_archiver/lens/ccs/default',
     };
     let esNode: EsArchiver;
@@ -81,6 +85,7 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
     loadTestFile(require.resolve('./error_handling')); // 1m 8s
     loadTestFile(require.resolve('./lens_tagging')); // 1m 9s
     loadTestFile(require.resolve('./workspace_size'));
+    loadTestFile(require.resolve('./legend_statistics'));
     // keep these last in the group in this order because they are messing with the default saved objects
     loadTestFile(require.resolve('./lens_reporting')); // 3m
     loadTestFile(require.resolve('./rollup')); // 1m 30s

--- a/x-pack/test/functional/apps/lens/group6/legend_statistics.ts
+++ b/x-pack/test/functional/apps/lens/group6/legend_statistics.ts
@@ -27,43 +27,43 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     expect(text).to.eql(expectedText);
   }
 
-  async function goToTimeRangeForXyChart() {
-    await PageObjects.lens.goToTimeRange(undefined, 'Sep 22, 2015 @ 23:30:00.000');
-  }
-
   describe('lens persisted and runtime state differences properties', () => {
     before(async () => {
       await kibanaServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/lens/legend_statistics'
       );
+      await kibanaServer.uiSettings.update({
+        'timepicker:timeDefaults':
+          '{  "from": "2015-09-18T19:37:13.000Z",  "to": "2015-09-22T23:30:30.000Z"}',
+      });
+    });
+
+    after(async () => {
+      await kibanaServer.uiSettings.unset('timepicker:timeDefaults');
     });
     describe('xy chart', () => {
       it('shows values in legend for legacy valuesInLegend===true property and saves it correctly', async () => {
         const title = 'xyValuesInLegendTrue';
         await loadSavedLens(title);
-        await goToTimeRangeForXyChart();
         await expectLegendOneItem('Count of records', '2');
         await PageObjects.lens.save(title);
         await loadSavedLens(title);
-        await goToTimeRangeForXyChart();
         await expectLegendOneItem('Count of records', '2');
       });
 
       it('does not show values in legend for legacy valuesInLegend===false prop', async () => {
         await loadSavedLens('xyValuesInLegendFalse');
-        await goToTimeRangeForXyChart();
         await expectLegendOneItem('Count of records');
       });
       it('shows values in legend for legendStats===["values"] prop', async () => {
         await loadSavedLens('xyLegendStats');
-        await goToTimeRangeForXyChart();
         await expectLegendOneItem('Count of records', '2');
       });
     });
     describe('waffle chart', () => {
       it('waffleshows values in legend for legacy valuesInLegend===true property', async () => {
         await loadSavedLens('waffleValuesInLegendTrue');
-        await expectLegendOneItem('Count of records', '14,005');
+        await expectLegendOneItem('Count of records', '14,003');
       });
       it('shows values in legend for legacy showValuesInLegend===false prop', async () => {
         await loadSavedLens('waffleValuesInLegendFalse');
@@ -71,7 +71,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       it('shows values in legend for legendStats===["values"] prop', async () => {
         await loadSavedLens('waffleLegendStats');
-        await expectLegendOneItem('Count of records', '14,005');
+        await expectLegendOneItem('Count of records', '14,003');
       });
     });
   });

--- a/x-pack/test/functional/apps/lens/group6/legend_statistics.ts
+++ b/x-pack/test/functional/apps/lens/group6/legend_statistics.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['visualize', 'lens', 'common', 'header']);
+  const find = getService('find');
+  const listingTable = getService('listingTable');
+  const kibanaServer = getService('kibanaServer');
+
+  async function loadSavedLens(title: string) {
+    await PageObjects.visualize.gotoVisualizationLandingPage();
+    await listingTable.searchForItemWithName(title);
+    await PageObjects.lens.clickVisualizeListItemTitle(title);
+  }
+
+  async function expectLegendOneItem(name: string, value?: string) {
+    const expectedText = value ? `${name}\n${value}` : name;
+    const legendElement = await find.byCssSelector('.echLegendItem');
+    const text = await legendElement.getVisibleText();
+    expect(text).to.eql(expectedText);
+  }
+
+  async function goToTimeRangeForXyChart() {
+    await PageObjects.lens.goToTimeRange(undefined, 'Sep 22, 2015 @ 23:30:00.000');
+  }
+
+  describe('lens persisted and runtime state differences properties', () => {
+    before(async () => {
+      await kibanaServer.importExport.load(
+        'x-pack/test/functional/fixtures/kbn_archiver/lens/legend_statistics'
+      );
+    });
+    describe('xy chart', () => {
+      it('shows values in legend for legacy valuesInLegend===true property and saves it correctly', async () => {
+        const title = 'xyValuesInLegendTrue';
+        await loadSavedLens(title);
+        await goToTimeRangeForXyChart();
+        await expectLegendOneItem('Count of records', '2');
+        await PageObjects.lens.save(title);
+        await loadSavedLens(title);
+        await goToTimeRangeForXyChart();
+        await expectLegendOneItem('Count of records', '2');
+      });
+
+      it('does not show values in legend for legacy valuesInLegend===false prop', async () => {
+        await loadSavedLens('xyValuesInLegendFalse');
+        await goToTimeRangeForXyChart();
+        await expectLegendOneItem('Count of records');
+      });
+      it('shows values in legend for legendStats===["values"] prop', async () => {
+        await loadSavedLens('xyLegendStats');
+        await goToTimeRangeForXyChart();
+        await expectLegendOneItem('Count of records', '2');
+      });
+    });
+    describe('waffle chart', () => {
+      it('waffleshows values in legend for legacy valuesInLegend===true property', async () => {
+        await loadSavedLens('waffleValuesInLegendTrue');
+        await expectLegendOneItem('Count of records', '14,005');
+      });
+      it('shows values in legend for legacy showValuesInLegend===false prop', async () => {
+        await loadSavedLens('waffleValuesInLegendFalse');
+        await expectLegendOneItem('Count of records', undefined);
+      });
+      it('shows values in legend for legendStats===["values"] prop', async () => {
+        await loadSavedLens('waffleLegendStats');
+        await expectLegendOneItem('Count of records', '14,005');
+      });
+    });
+  });
+}

--- a/x-pack/test/functional/fixtures/kbn_archiver/lens/legend_statistics.json
+++ b/x-pack/test/functional/fixtures/kbn_archiver/lens/legend_statistics.json
@@ -1,0 +1,763 @@
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "adHocDataViews": {},
+      "datasourceStates": {
+        "formBased": {
+          "layers": {
+            "c61a8afb-a185-4fae-a064-fb3846f6c451": {
+              "columnOrder": [
+                "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea",
+                "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8"
+              ],
+              "columns": {
+                "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8": {
+                  "dataType": "number",
+                  "isBucketed": false,
+                  "label": "Count of records",
+                  "operationType": "count",
+                  "params": {
+                    "emptyAsNull": true
+                  },
+                  "scale": "ratio",
+                  "sourceField": "___records___"
+                },
+                "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea": {
+                  "dataType": "date",
+                  "isBucketed": true,
+                  "label": "@timestamp",
+                  "operationType": "date_histogram",
+                  "params": {
+                    "dropPartials": false,
+                    "includeEmptyRows": true,
+                    "interval": "auto"
+                  },
+                  "scale": "interval",
+                  "sourceField": "@timestamp"
+                }
+              },
+              "incompleteColumns": {},
+              "sampling": 1
+            }
+          }
+        },
+        "indexpattern": {
+          "layers": {}
+        },
+        "textBased": {
+          "layers": {}
+        }
+      },
+      "filters": [],
+      "internalReferences": [],
+      "query": {
+        "language": "kuery",
+        "query": ""
+      },
+      "visualization": {
+        "axisTitlesVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "fittingFunction": "None",
+        "gridlinesVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "labelsOrientation": {
+          "x": 0,
+          "yLeft": 0,
+          "yRight": 0
+        },
+        "layers": [
+          {
+            "accessors": [
+              "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8"
+            ],
+            "colorMapping": {
+              "assignments": [],
+              "colorMode": {
+                "type": "categorical"
+              },
+              "paletteId": "eui_amsterdam_color_blind",
+              "specialAssignments": [
+                {
+                  "color": {
+                    "type": "loop"
+                  },
+                  "rule": {
+                    "type": "other"
+                  },
+                  "touched": false
+                }
+              ]
+            },
+            "layerId": "c61a8afb-a185-4fae-a064-fb3846f6c451",
+            "layerType": "data",
+            "position": "top",
+            "seriesType": "bar_stacked",
+            "showGridlines": false,
+            "xAccessor": "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea"
+          }
+        ],
+        "legend": {
+          "isVisible": true,
+          "position": "right",
+          "showSingleSeries": true
+        },
+        "valuesInLegend": true,
+        "preferredSeriesType": "bar_stacked",
+        "tickLabelsVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "valueLabels": "hide"
+      }
+    },
+    "title": "xyValuesInLegendTrue",
+    "visualizationType": "lnsXY"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-04-18T13:53:59.791Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "506bcb94-71cc-4acf-8c63-cc2d486af3fb",
+  "managed": false,
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-c61a8afb-a185-4fae-a064-fb3846f6c451",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2024-04-18T13:53:59.791Z",
+  "version": "WzEzMywxXQ=="
+}
+
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "adHocDataViews": {},
+      "datasourceStates": {
+        "formBased": {
+          "layers": {
+            "c61a8afb-a185-4fae-a064-fb3846f6c451": {
+              "columnOrder": [
+                "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea",
+                "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8"
+              ],
+              "columns": {
+                "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8": {
+                  "dataType": "number",
+                  "isBucketed": false,
+                  "label": "Count of records",
+                  "operationType": "count",
+                  "params": {
+                    "emptyAsNull": true
+                  },
+                  "scale": "ratio",
+                  "sourceField": "___records___"
+                },
+                "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea": {
+                  "dataType": "date",
+                  "isBucketed": true,
+                  "label": "@timestamp",
+                  "operationType": "date_histogram",
+                  "params": {
+                    "dropPartials": false,
+                    "includeEmptyRows": true,
+                    "interval": "auto"
+                  },
+                  "scale": "interval",
+                  "sourceField": "@timestamp"
+                }
+              },
+              "incompleteColumns": {},
+              "sampling": 1
+            }
+          }
+        },
+        "indexpattern": {
+          "layers": {}
+        },
+        "textBased": {
+          "layers": {}
+        }
+      },
+      "filters": [],
+      "internalReferences": [],
+      "query": {
+        "language": "kuery",
+        "query": ""
+      },
+      "visualization": {
+        "axisTitlesVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "fittingFunction": "None",
+        "gridlinesVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "labelsOrientation": {
+          "x": 0,
+          "yLeft": 0,
+          "yRight": 0
+        },
+        "layers": [
+          {
+            "accessors": [
+              "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8"
+            ],
+            "colorMapping": {
+              "assignments": [],
+              "colorMode": {
+                "type": "categorical"
+              },
+              "paletteId": "eui_amsterdam_color_blind",
+              "specialAssignments": [
+                {
+                  "color": {
+                    "type": "loop"
+                  },
+                  "rule": {
+                    "type": "other"
+                  },
+                  "touched": false
+                }
+              ]
+            },
+            "layerId": "c61a8afb-a185-4fae-a064-fb3846f6c451",
+            "layerType": "data",
+            "position": "top",
+            "seriesType": "bar_stacked",
+            "showGridlines": false,
+            "xAccessor": "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea"
+          }
+        ],
+        "legend": {
+          "isVisible": true,
+          "position": "right",
+          "showSingleSeries": true
+        },
+        "valuesInLegend": false,
+        "preferredSeriesType": "bar_stacked",
+        "tickLabelsVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "valueLabels": "hide"
+      }
+    },
+    "title": "xyValuesInLegendFalse",
+    "visualizationType": "lnsXY"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-04-18T13:53:59.791Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "506bcb94-71cc-4acf-8c63-cc2d486s96dc",
+  "managed": false,
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-c61a8afb-a185-4fae-a064-fb3846f6c451",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2024-04-18T13:53:59.791Z",
+  "version": "WzEzMywxXQ=="
+}
+
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "adHocDataViews": {},
+      "datasourceStates": {
+        "formBased": {
+          "layers": {
+            "c61a8afb-a185-4fae-a064-fb3846f6c451": {
+              "columnOrder": [
+                "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea",
+                "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8"
+              ],
+              "columns": {
+                "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8": {
+                  "dataType": "number",
+                  "isBucketed": false,
+                  "label": "Count of records",
+                  "operationType": "count",
+                  "params": {
+                    "emptyAsNull": true
+                  },
+                  "scale": "ratio",
+                  "sourceField": "___records___"
+                },
+                "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea": {
+                  "dataType": "date",
+                  "isBucketed": true,
+                  "label": "@timestamp",
+                  "operationType": "date_histogram",
+                  "params": {
+                    "dropPartials": false,
+                    "includeEmptyRows": true,
+                    "interval": "auto"
+                  },
+                  "scale": "interval",
+                  "sourceField": "@timestamp"
+                }
+              },
+              "incompleteColumns": {},
+              "sampling": 1
+            }
+          }
+        },
+        "indexpattern": {
+          "layers": {}
+        },
+        "textBased": {
+          "layers": {}
+        }
+      },
+      "filters": [],
+      "internalReferences": [],
+      "query": {
+        "language": "kuery",
+        "query": ""
+      },
+      "visualization": {
+        "axisTitlesVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "fittingFunction": "None",
+        "gridlinesVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "labelsOrientation": {
+          "x": 0,
+          "yLeft": 0,
+          "yRight": 0
+        },
+        "layers": [
+          {
+            "accessors": [
+              "2bc6ebe0-16cc-44a2-b888-9c9932fb89b8"
+            ],
+            "colorMapping": {
+              "assignments": [],
+              "colorMode": {
+                "type": "categorical"
+              },
+              "paletteId": "eui_amsterdam_color_blind",
+              "specialAssignments": [
+                {
+                  "color": {
+                    "type": "loop"
+                  },
+                  "rule": {
+                    "type": "other"
+                  },
+                  "touched": false
+                }
+              ]
+            },
+            "layerId": "c61a8afb-a185-4fae-a064-fb3846f6c451",
+            "layerType": "data",
+            "position": "top",
+            "seriesType": "bar_stacked",
+            "showGridlines": false,
+            "xAccessor": "c3d9cb9f-e96f-44dd-b3a5-8441f986b6ea"
+          }
+        ],
+        "legend": {
+          "isVisible": true,
+          "position": "right",
+          "showSingleSeries": true,
+          "legendStats": [
+            "values"
+          ]
+        },
+        "preferredSeriesType": "bar_stacked",
+        "tickLabelsVisibilitySettings": {
+          "x": true,
+          "yLeft": true,
+          "yRight": true
+        },
+        "valueLabels": "hide"
+      }
+    },
+    "title": "xyLegendStats",
+    "visualizationType": "lnsXY"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-04-18T13:53:59.791Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "506bcb94-71cc-4acf-8c63-ee6c486s96dc",
+  "managed": false,
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-c61a8afb-a185-4fae-a064-fb3846f6c451",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2024-04-18T13:53:59.791Z",
+  "version": "WzEzMywxXQ=="
+}
+
+
+
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "adHocDataViews": {},
+      "datasourceStates": {
+        "formBased": {
+          "layers": {
+            "c61a8afb-a185-4fae-a064-fb3846f6c451": {
+              "columnOrder": [
+                "b997b7b4-14e1-49bf-a289-345fff2f8a54"
+              ],
+              "columns": {
+                "b997b7b4-14e1-49bf-a289-345fff2f8a54": {
+                  "dataType": "number",
+                  "isBucketed": false,
+                  "label": "Count of records",
+                  "operationType": "count",
+                  "params": {
+                    "emptyAsNull": true
+                  },
+                  "scale": "ratio",
+                  "sourceField": "___records___"
+                }
+              },
+              "incompleteColumns": {},
+              "sampling": 1
+            }
+          }
+        },
+        "indexpattern": {
+          "layers": {}
+        },
+        "textBased": {
+          "layers": {}
+        }
+      },
+      "filters": [],
+      "internalReferences": [],
+      "query": {
+        "language": "kuery",
+        "query": ""
+      },
+      "visualization": {
+        "layers": [
+          {
+            "categoryDisplay": "default",
+            "colorMapping": {
+              "assignments": [],
+              "colorMode": {
+                "type": "categorical"
+              },
+              "paletteId": "eui_amsterdam_color_blind",
+              "specialAssignments": [
+                {
+                  "color": {
+                    "type": "loop"
+                  },
+                  "rule": {
+                    "type": "other"
+                  },
+                  "touched": false
+                }
+              ]
+            },
+            "layerId": "c61a8afb-a185-4fae-a064-fb3846f6c451",
+            "layerType": "data",
+            "legendDisplay": "default",
+            "metrics": [
+              "b997b7b4-14e1-49bf-a289-345fff2f8a54"
+            ],
+            "nestedLegend": false,
+            "numberDisplay": "percent",
+            "primaryGroups": [],
+            "showValuesInLegend": true
+          }
+        ],
+        "shape": "waffle"
+      }
+    },
+    "title": "waffleValuesInLegendTrue",
+    "visualizationType": "lnsPie"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-04-18T14:13:02.458Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "7d70df7d-f73f-42eb-9970-df1473e7eedc",
+  "managed": false,
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-c61a8afb-a185-4fae-a064-fb3846f6c451",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2024-04-18T14:13:02.458Z",
+  "version": "WzEzNiwxXQ=="
+}
+
+
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "adHocDataViews": {},
+      "datasourceStates": {
+        "formBased": {
+          "layers": {
+            "c61a8afb-a185-4fae-a064-fb3846f6c451": {
+              "columnOrder": [
+                "b997b7b4-14e1-49bf-a289-345fff2f8a54"
+              ],
+              "columns": {
+                "b997b7b4-14e1-49bf-a289-345fff2f8a54": {
+                  "dataType": "number",
+                  "isBucketed": false,
+                  "label": "Count of records",
+                  "operationType": "count",
+                  "params": {
+                    "emptyAsNull": true
+                  },
+                  "scale": "ratio",
+                  "sourceField": "___records___"
+                }
+              },
+              "incompleteColumns": {},
+              "sampling": 1
+            }
+          }
+        },
+        "indexpattern": {
+          "layers": {}
+        },
+        "textBased": {
+          "layers": {}
+        }
+      },
+      "filters": [],
+      "internalReferences": [],
+      "query": {
+        "language": "kuery",
+        "query": ""
+      },
+      "visualization": {
+        "layers": [
+          {
+            "categoryDisplay": "default",
+            "colorMapping": {
+              "assignments": [],
+              "colorMode": {
+                "type": "categorical"
+              },
+              "paletteId": "eui_amsterdam_color_blind",
+              "specialAssignments": [
+                {
+                  "color": {
+                    "type": "loop"
+                  },
+                  "rule": {
+                    "type": "other"
+                  },
+                  "touched": false
+                }
+              ]
+            },
+            "layerId": "c61a8afb-a185-4fae-a064-fb3846f6c451",
+            "layerType": "data",
+            "legendDisplay": "default",
+            "metrics": [
+              "b997b7b4-14e1-49bf-a289-345fff2f8a54"
+            ],
+            "nestedLegend": false,
+            "numberDisplay": "percent",
+            "primaryGroups": [],
+            "showValuesInLegend": false
+          }
+        ],
+        "shape": "waffle"
+      }
+    },
+    "title": "waffleValuesInLegendFalse",
+    "visualizationType": "lnsPie"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-04-18T14:13:02.458Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "7d70df7d-f73f-42eb-9970-df1473e7aaf4",
+  "managed": false,
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-c61a8afb-a185-4fae-a064-fb3846f6c451",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2024-04-18T14:13:02.458Z",
+  "version": "WzEzNiwxXQ=="
+}
+
+
+{
+  "attributes": {
+    "description": "",
+    "state": {
+      "adHocDataViews": {},
+      "datasourceStates": {
+        "formBased": {
+          "layers": {
+            "c61a8afb-a185-4fae-a064-fb3846f6c451": {
+              "columnOrder": [
+                "b997b7b4-14e1-49bf-a289-345fff2f8a54"
+              ],
+              "columns": {
+                "b997b7b4-14e1-49bf-a289-345fff2f8a54": {
+                  "dataType": "number",
+                  "isBucketed": false,
+                  "label": "Count of records",
+                  "operationType": "count",
+                  "params": {
+                    "emptyAsNull": true
+                  },
+                  "scale": "ratio",
+                  "sourceField": "___records___"
+                }
+              },
+              "incompleteColumns": {},
+              "sampling": 1
+            }
+          }
+        },
+        "indexpattern": {
+          "layers": {}
+        },
+        "textBased": {
+          "layers": {}
+        }
+      },
+      "filters": [],
+      "internalReferences": [],
+      "query": {
+        "language": "kuery",
+        "query": ""
+      },
+      "visualization": {
+        "layers": [
+          {
+            "categoryDisplay": "default",
+            "colorMapping": {
+              "assignments": [],
+              "colorMode": {
+                "type": "categorical"
+              },
+              "paletteId": "eui_amsterdam_color_blind",
+              "specialAssignments": [
+                {
+                  "color": {
+                    "type": "loop"
+                  },
+                  "rule": {
+                    "type": "other"
+                  },
+                  "touched": false
+                }
+              ]
+            },
+            "layerId": "c61a8afb-a185-4fae-a064-fb3846f6c451",
+            "layerType": "data",
+            "legendDisplay": "default",
+            "metrics": [
+              "b997b7b4-14e1-49bf-a289-345fff2f8a54"
+            ],
+            "nestedLegend": false,
+            "numberDisplay": "percent",
+            "primaryGroups": [],
+            "legendStats": [
+              "values"
+            ]
+          }
+        ],
+        "shape": "waffle"
+      }
+    },
+    "title": "waffleLegendStats",
+    "visualizationType": "lnsPie"
+  },
+  "coreMigrationVersion": "8.8.0",
+  "created_at": "2024-04-18T14:13:02.458Z",
+  "created_by": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0",
+  "id": "7d70df7d-f73f-42eb-9970-df1590e1aaf4",
+  "managed": false,
+  "references": [
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-current-indexpattern",
+      "type": "index-pattern"
+    },
+    {
+      "id": "logstash-*",
+      "name": "indexpattern-datasource-layer-c61a8afb-a185-4fae-a064-fb3846f6c451",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "lens",
+  "typeMigrationVersion": "8.9.0",
+  "updated_at": "2024-04-18T14:13:02.458Z",
+  "version": "WzEzNiwxXQ=="
+}


### PR DESCRIPTION
## Summary

This PR addresses phase one of https://github.com/elastic/kibana/issues/181035. 

Doesn't introduce any user facing changes. 
It starts supporting a new saved object property `legendStats` while supporting a old `valuesInLegend` property. In this PR, `legendStats: ['values']` and `valuesInLegend:true` are  treated as equal. When loading the saved object, `valuesInLegend:true` is transformed to `legendStats:['values']`. After loading the document, the Lens app logic is built around the new `legendStats` property. 
When user saves the saved object, we do a reverse operation- we save the runtime state `legendStats:['values']` as `valuesInLegend: true` to ensure backwards compatibility.

![image](https://github.com/elastic/kibana/assets/4283304/5e09b062-b4d3-424d-b8a8-79a08f4d6260)


Changes for runtime state:

- For xyCharts, the `valuesInLegend?: boolean ` property is replaced with a more extensible `legend.legendStats?: LegendStats[]` interface

- For partition charts, the `showValuesInLegend?: boolean` property is replaced with `legendStats?: LegendStats[]`.

after loading - in initialize function:

```ts
export function convertToRuntime(
  state: XYPersistedState,
  annotationGroups?: AnnotationGroups,
  references?: SavedObjectReference[]
) {
  const outputState = needsInjectReferences(state)
    ? injectReferences(state, annotationGroups, references)
    : state;
  if ('valuesInLegend' in outputState) {
    return convertToLegendStats(outputState);
  }
  return outputState;
}
```

before saving :

```ts
export function convertToPersistable(state: XYState) {
  const persistableState: XYPersistedState = convertToValuesInLegend(state);
  /.../
}
```

In the future the `legendStats` prop would contain also other types of stats -see the [issue](https://github.com/elastic/kibana/issues/176583). 

