### PR TITLE
[SecuritySolution] Fix global timerange test on serverless

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/legacy_risk_score.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/legacy_risk_score.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import moment from 'moment';
+import { updateDashboardTimeRange } from '../../../../tasks/entity_analytics';
 import { login } from '../../../../tasks/login';
 import { visitWithTimeRange } from '../../../../tasks/navigation';
 
@@ -37,7 +38,7 @@ import { getNewRule } from '../../../../objects/rule';
 import { clickOnFirstHostsAlerts, clickOnFirstUsersAlerts } from '../../../../tasks/risk_scores';
 import { OPTION_LIST_LABELS, OPTION_LIST_VALUES } from '../../../../screens/common/filter_group';
 import { kqlSearch } from '../../../../tasks/security_header';
-import { setEndDate, updateDates } from '../../../../tasks/date_picker';
+import { setEndDate } from '../../../../tasks/date_picker';
 
 const TEST_USER_ALERTS = 1;
 const TEST_USER_NAME = 'test';
@@ -47,255 +48,250 @@ const DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
 const DATE_BEFORE_ALERT_CREATION = moment().format(DATE_FORMAT);
 
 // https://github.com/elastic/kibana/issues/179686
-describe(
-  'Entity Analytics Dashboard',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
-  () => {
-    before(() => {
-      cy.task('esArchiverLoad', { archiveName: 'auditbeat_multiple' });
+describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => {
+  before(() => {
+    cy.task('esArchiverLoad', { archiveName: 'auditbeat_multiple' });
+  });
+
+  after(() => {
+    cy.task('esArchiverUnload', { archiveName: 'auditbeat_multiple' });
+  });
+
+  describe('legacy risk score', () => {
+    describe('Without data', () => {
+      beforeEach(() => {
+        login();
+        visitWithTimeRange(ENTITY_ANALYTICS_URL);
+      });
+
+      it('shows enable host risk button', () => {
+        cy.get(ENABLE_HOST_RISK_SCORE_BUTTON).should('be.visible');
+      });
+
+      it('shows enable user risk button', () => {
+        cy.get(ENABLE_USER_RISK_SCORE_BUTTON).should('be.visible');
+      });
     });
 
-    after(() => {
-      cy.task('esArchiverUnload', { archiveName: 'auditbeat_multiple' });
+    describe('Risk Score enabled but still no data', () => {
+      before(() => {
+        cy.task('esArchiverLoad', { archiveName: 'risk_hosts_no_data' });
+        cy.task('esArchiverLoad', { archiveName: 'risk_users_no_data' });
+      });
+
+      beforeEach(() => {
+        login();
+        visitWithTimeRange(ENTITY_ANALYTICS_URL);
+      });
+
+      after(() => {
+        cy.task('esArchiverUnload', { archiveName: 'risk_hosts_no_data' });
+        cy.task('esArchiverUnload', { archiveName: 'risk_users_no_data' });
+      });
+
+      it('shows no data detected prompt for host risk score module', () => {
+        cy.get(HOST_RISK_SCORE_NO_DATA_DETECTED).should('be.visible');
+      });
+
+      it('shows no data detected prompt for user risk score module', () => {
+        cy.get(USER_RISK_SCORE_NO_DATA_DETECTED).should('be.visible');
+      });
     });
 
-    describe('legacy risk score', () => {
-      describe('Without data', () => {
-        beforeEach(() => {
-          login();
-          visitWithTimeRange(ENTITY_ANALYTICS_URL);
-        });
-
-        it('shows enable host risk button', () => {
-          cy.get(ENABLE_HOST_RISK_SCORE_BUTTON).should('be.visible');
-        });
-
-        it('shows enable user risk button', () => {
-          cy.get(ENABLE_USER_RISK_SCORE_BUTTON).should('be.visible');
-        });
+    describe('With Legacy data', () => {
+      before(() => {
+        cy.task('esArchiverLoad', { archiveName: 'risk_hosts_legacy_data' });
+        cy.task('esArchiverLoad', { archiveName: 'risk_users_legacy_data' });
       });
 
-      describe('Risk Score enabled but still no data', () => {
+      beforeEach(() => {
+        login();
+        visitWithTimeRange(ENTITY_ANALYTICS_URL);
+      });
+
+      after(() => {
+        cy.task('esArchiverUnload', { archiveName: 'risk_hosts_legacy_data' });
+        cy.task('esArchiverUnload', { archiveName: 'risk_users_legacy_data' });
+      });
+
+      it('shows enable host risk button', () => {
+        cy.get(ENABLE_HOST_RISK_SCORE_BUTTON).should('be.visible');
+      });
+
+      it('shows enable user risk button', () => {
+        cy.get(ENABLE_USER_RISK_SCORE_BUTTON).should('be.visible');
+      });
+    });
+
+    describe('With host risk data', () => {
+      before(() => {
+        cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
+      });
+
+      beforeEach(() => {
+        login();
+        visitWithTimeRange(ENTITY_ANALYTICS_URL);
+      });
+
+      after(() => {
+        cy.task('esArchiverUnload', { archiveName: 'risk_hosts' });
+      });
+
+      it('renders donut chart', () => {
+        cy.get(HOSTS_DONUT_CHART).should('include.text', '6Total');
+      });
+
+      it('renders table', () => {
+        cy.get(HOSTS_TABLE).should('be.visible');
+        cy.get(HOSTS_TABLE_ROWS).should('have.length', 5);
+      });
+
+      it('renders alerts column', () => {
+        cy.get(HOSTS_TABLE_ALERT_CELL).should('have.length', 5);
+      });
+      it('filters by risk level', () => {
+        cy.get(HOSTS_TABLE).should('be.visible');
+        cy.get(HOSTS_TABLE_ROWS).should('have.length', 5);
+
+        openRiskTableFilterAndSelectTheLowOption();
+
+        cy.get(HOSTS_DONUT_CHART).should('include.text', '1Total');
+        cy.get(HOSTS_TABLE_ROWS).should('have.length', 1);
+
+        removeLowFilterAndCloseRiskTableFilter();
+      });
+
+      it('filters the host risk table with KQL search bar query', () => {
+        kqlSearch(`host.name : ${SIEM_KIBANA_HOST_NAME}{enter}`);
+
+        cy.get(HOSTS_DONUT_CHART).should('include.text', '1Total');
+        cy.get(HOSTS_TABLE_ROWS).should('have.length', 1);
+      });
+
+      describe('With alerts data', () => {
         before(() => {
-          cy.task('esArchiverLoad', { archiveName: 'risk_hosts_no_data' });
-          cy.task('esArchiverLoad', { archiveName: 'risk_users_no_data' });
+          createRule(getNewRule());
         });
 
         beforeEach(() => {
           login();
+          visitWithTimeRange(ALERTS_URL);
+          waitForAlertsToPopulate();
           visitWithTimeRange(ENTITY_ANALYTICS_URL);
         });
 
         after(() => {
-          cy.task('esArchiverUnload', { archiveName: 'risk_hosts_no_data' });
-          cy.task('esArchiverUnload', { archiveName: 'risk_users_no_data' });
+          deleteAlertsAndRules();
         });
 
-        it('shows no data detected prompt for host risk score module', () => {
-          cy.get(HOST_RISK_SCORE_NO_DATA_DETECTED).should('be.visible');
+        it('populates alerts column', () => {
+          cy.get(HOSTS_TABLE_ALERT_CELL).first().should('include.text', SIEM_KIBANA_HOST_ALERTS);
         });
 
-        it('shows no data detected prompt for user risk score module', () => {
-          cy.get(USER_RISK_SCORE_NO_DATA_DETECTED).should('be.visible');
-        });
-      });
+        it('filters the alerts count with time range', () => {
+          setEndDate(DATE_BEFORE_ALERT_CREATION);
 
-      describe('With Legacy data', () => {
-        before(() => {
-          cy.task('esArchiverLoad', { archiveName: 'risk_hosts_legacy_data' });
-          cy.task('esArchiverLoad', { archiveName: 'risk_users_legacy_data' });
+          updateDashboardTimeRange();
+
+          cy.get(HOSTS_TABLE_ALERT_CELL).first().should('include.text', 0);
         });
 
-        beforeEach(() => {
-          login();
-          visitWithTimeRange(ENTITY_ANALYTICS_URL);
-        });
+        it('opens alerts page when alerts count is clicked', () => {
+          clickOnFirstHostsAlerts();
+          cy.url().should('include', ALERTS_URL);
 
-        after(() => {
-          cy.task('esArchiverUnload', { archiveName: 'risk_hosts_legacy_data' });
-          cy.task('esArchiverUnload', { archiveName: 'risk_users_legacy_data' });
-        });
-
-        it('shows enable host risk button', () => {
-          cy.get(ENABLE_HOST_RISK_SCORE_BUTTON).should('be.visible');
-        });
-
-        it('shows enable user risk button', () => {
-          cy.get(ENABLE_USER_RISK_SCORE_BUTTON).should('be.visible');
-        });
-      });
-
-      describe('With host risk data', () => {
-        before(() => {
-          cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
-        });
-
-        beforeEach(() => {
-          login();
-          visitWithTimeRange(ENTITY_ANALYTICS_URL);
-        });
-
-        after(() => {
-          cy.task('esArchiverUnload', { archiveName: 'risk_hosts' });
-        });
-
-        it('renders donut chart', () => {
-          cy.get(HOSTS_DONUT_CHART).should('include.text', '6Total');
-        });
-
-        it('renders table', () => {
-          cy.get(HOSTS_TABLE).should('be.visible');
-          cy.get(HOSTS_TABLE_ROWS).should('have.length', 5);
-        });
-
-        it('renders alerts column', () => {
-          cy.get(HOSTS_TABLE_ALERT_CELL).should('have.length', 5);
-        });
-        it('filters by risk level', () => {
-          cy.get(HOSTS_TABLE).should('be.visible');
-          cy.get(HOSTS_TABLE_ROWS).should('have.length', 5);
-
-          openRiskTableFilterAndSelectTheLowOption();
-
-          cy.get(HOSTS_DONUT_CHART).should('include.text', '1Total');
-          cy.get(HOSTS_TABLE_ROWS).should('have.length', 1);
-
-          removeLowFilterAndCloseRiskTableFilter();
-        });
-
-        it('filters the host risk table with KQL search bar query', () => {
-          kqlSearch(`host.name : ${SIEM_KIBANA_HOST_NAME}{enter}`);
-
-          cy.get(HOSTS_DONUT_CHART).should('include.text', '1Total');
-          cy.get(HOSTS_TABLE_ROWS).should('have.length', 1);
-        });
-
-        // FLAKY: https://github.com/elastic/kibana/issues/178914
-        describe.skip('With alerts data', () => {
-          before(() => {
-            createRule(getNewRule());
-          });
-
-          beforeEach(() => {
-            login();
-            visitWithTimeRange(ALERTS_URL);
-            waitForAlertsToPopulate();
-            visitWithTimeRange(ENTITY_ANALYTICS_URL);
-          });
-
-          after(() => {
-            deleteAlertsAndRules();
-          });
-
-          it('populates alerts column', () => {
-            cy.get(HOSTS_TABLE_ALERT_CELL).first().should('include.text', SIEM_KIBANA_HOST_ALERTS);
-          });
-
-          it('filters the alerts count with time range', () => {
-            setEndDate(DATE_BEFORE_ALERT_CREATION);
-
-            updateDates();
-
-            cy.get(HOSTS_TABLE_ALERT_CELL).first().should('include.text', 0);
-          });
-
-          it('opens alerts page when alerts count is clicked', () => {
-            clickOnFirstHostsAlerts();
-            cy.url().should('include', ALERTS_URL);
-
-            cy.get(OPTION_LIST_LABELS).eq(0).should('include.text', 'Status');
-            cy.get(OPTION_LIST_VALUES(0)).should('include.text', 'open');
-            cy.get(OPTION_LIST_LABELS).eq(1).should('include.text', 'Host');
-            cy.get(OPTION_LIST_VALUES(1)).should('include.text', SIEM_KIBANA_HOST_NAME);
-          });
-        });
-      });
-
-      describe('With user risk data', () => {
-        before(() => {
-          cy.task('esArchiverLoad', { archiveName: 'risk_users' });
-        });
-
-        beforeEach(() => {
-          login();
-          visitWithTimeRange(ENTITY_ANALYTICS_URL);
-        });
-
-        after(() => {
-          cy.task('esArchiverUnload', { archiveName: 'risk_users' });
-        });
-
-        it('renders donut chart', () => {
-          cy.get(USERS_DONUT_CHART).should('include.text', '7Total');
-        });
-
-        it('renders table', () => {
-          cy.get(USERS_TABLE).should('be.visible');
-          cy.get(USERS_TABLE_ROWS).should('have.length', 5);
-        });
-
-        it('renders alerts column', () => {
-          cy.get(USERS_TABLE_ALERT_CELL).should('have.length', 5);
-        });
-
-        it('filters by risk level', () => {
-          cy.get(USERS_TABLE).should('be.visible');
-          cy.get(USERS_TABLE_ROWS).should('have.length', 5);
-
-          openRiskTableFilterAndSelectTheLowOption();
-
-          cy.get(USERS_DONUT_CHART).should('include.text', '2Total');
-          cy.get(USERS_TABLE_ROWS).should('have.length', 2);
-
-          removeLowFilterAndCloseRiskTableFilter();
-        });
-
-        it('filters the host risk table with KQL search bar query', () => {
-          kqlSearch(`user.name : ${TEST_USER_NAME}{enter}`);
-
-          cy.get(USERS_DONUT_CHART).should('include.text', '1Total');
-          cy.get(USERS_TABLE_ROWS).should('have.length', 1);
-        });
-
-        describe('With alerts data', () => {
-          before(() => {
-            createRule(getNewRule());
-          });
-
-          beforeEach(() => {
-            login();
-            visitWithTimeRange(ALERTS_URL);
-            waitForAlertsToPopulate();
-            visitWithTimeRange(ENTITY_ANALYTICS_URL);
-          });
-
-          after(() => {
-            deleteAlertsAndRules();
-          });
-
-          it('populates alerts column', () => {
-            cy.get(USERS_TABLE_ALERT_CELL).first().should('include.text', TEST_USER_ALERTS);
-          });
-
-          it('filters the alerts count with time range', () => {
-            setEndDate(DATE_BEFORE_ALERT_CREATION);
-            updateDates();
-
-            cy.get(USERS_TABLE_ALERT_CELL).first().should('include.text', 0);
-          });
-
-          it('opens alerts page when alerts count is clicked', () => {
-            clickOnFirstUsersAlerts();
-
-            cy.url().should('include', ALERTS_URL);
-
-            cy.get(OPTION_LIST_LABELS).eq(0).should('include.text', 'Status');
-            cy.get(OPTION_LIST_VALUES(0)).should('include.text', 'open');
-            cy.get(OPTION_LIST_LABELS).eq(1).should('include.text', 'User');
-            cy.get(OPTION_LIST_VALUES(1)).should('include.text', TEST_USER_NAME);
-          });
+          cy.get(OPTION_LIST_LABELS).eq(0).should('include.text', 'Status');
+          cy.get(OPTION_LIST_VALUES(0)).should('include.text', 'open');
+          cy.get(OPTION_LIST_LABELS).eq(1).should('include.text', 'Host');
+          cy.get(OPTION_LIST_VALUES(1)).should('include.text', SIEM_KIBANA_HOST_NAME);
         });
       });
     });
-  }
-);
+
+    describe('With user risk data', () => {
+      before(() => {
+        cy.task('esArchiverLoad', { archiveName: 'risk_users' });
+      });
+
+      beforeEach(() => {
+        login();
+        visitWithTimeRange(ENTITY_ANALYTICS_URL);
+      });
+
+      after(() => {
+        cy.task('esArchiverUnload', { archiveName: 'risk_users' });
+      });
+
+      it('renders donut chart', () => {
+        cy.get(USERS_DONUT_CHART).should('include.text', '7Total');
+      });
+
+      it('renders table', () => {
+        cy.get(USERS_TABLE).should('be.visible');
+        cy.get(USERS_TABLE_ROWS).should('have.length', 5);
+      });
+
+      it('renders alerts column', () => {
+        cy.get(USERS_TABLE_ALERT_CELL).should('have.length', 5);
+      });
+
+      it('filters by risk level', () => {
+        cy.get(USERS_TABLE).should('be.visible');
+        cy.get(USERS_TABLE_ROWS).should('have.length', 5);
+
+        openRiskTableFilterAndSelectTheLowOption();
+
+        cy.get(USERS_DONUT_CHART).should('include.text', '2Total');
+        cy.get(USERS_TABLE_ROWS).should('have.length', 2);
+
+        removeLowFilterAndCloseRiskTableFilter();
+      });
+
+      it('filters the host risk table with KQL search bar query', () => {
+        kqlSearch(`user.name : ${TEST_USER_NAME}{enter}`);
+
+        cy.get(USERS_DONUT_CHART).should('include.text', '1Total');
+        cy.get(USERS_TABLE_ROWS).should('have.length', 1);
+      });
+
+      describe('With alerts data', () => {
+        before(() => {
+          createRule(getNewRule());
+        });
+
+        beforeEach(() => {
+          login();
+          visitWithTimeRange(ALERTS_URL);
+          waitForAlertsToPopulate();
+          visitWithTimeRange(ENTITY_ANALYTICS_URL);
+        });
+
+        after(() => {
+          deleteAlertsAndRules();
+        });
+
+        it('populates alerts column', () => {
+          cy.get(USERS_TABLE_ALERT_CELL).first().should('include.text', TEST_USER_ALERTS);
+        });
+
+        it('filters the alerts count with time range', () => {
+          setEndDate(DATE_BEFORE_ALERT_CREATION);
+          updateDashboardTimeRange();
+
+          cy.get(USERS_TABLE_ALERT_CELL).first().should('include.text', 0);
+        });
+
+        it('opens alerts page when alerts count is clicked', () => {
+          clickOnFirstUsersAlerts();
+
+          cy.url().should('include', ALERTS_URL);
+
+          cy.get(OPTION_LIST_LABELS).eq(0).should('include.text', 'Status');
+          cy.get(OPTION_LIST_VALUES(0)).should('include.text', 'open');
+          cy.get(OPTION_LIST_LABELS).eq(1).should('include.text', 'User');
+          cy.get(OPTION_LIST_VALUES(1)).should('include.text', TEST_USER_NAME);
+        });
+      });
+    });
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/new_risk_score.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/new_risk_score.cy.ts
@@ -41,8 +41,11 @@ import { getNewRule } from '../../../../objects/rule';
 import { clickOnFirstHostsAlerts, clickOnFirstUsersAlerts } from '../../../../tasks/risk_scores';
 import { OPTION_LIST_LABELS, OPTION_LIST_VALUES } from '../../../../screens/common/filter_group';
 import { kqlSearch } from '../../../../tasks/security_header';
-import { setEndDate, setStartDate, updateDates } from '../../../../tasks/date_picker';
-import { mockRiskEngineEnabled } from '../../../../tasks/entity_analytics';
+import { setEndDate, setStartDate } from '../../../../tasks/date_picker';
+import {
+  mockRiskEngineEnabled,
+  updateDashboardTimeRange,
+} from '../../../../tasks/entity_analytics';
 
 const TEST_USER_ALERTS = 1;
 const TEST_USER_NAME = 'test';
@@ -76,7 +79,7 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
     });
 
     // https://github.com/elastic/kibana/issues/179687
-    describe('When risk engine is enabled', { tags: ['@skipInServerless'] }, () => {
+    describe('When risk engine is enabled', () => {
       beforeEach(() => {
         login();
         mockRiskEngineEnabled();
@@ -140,8 +143,7 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
           cy.get(HOSTS_TABLE_ROWS).should('have.length', 1);
         });
 
-        // FLAKY: https://github.com/elastic/kibana/issues/178838
-        describe.skip('With alerts data', () => {
+        describe('With alerts data', () => {
           before(() => {
             createRule(getNewRule());
           });
@@ -163,7 +165,7 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
 
           it('filters the alerts count with time range', () => {
             setEndDate(DATE_BEFORE_ALERT_CREATION);
-            updateDates();
+            updateDashboardTimeRange();
 
             cy.get(HOSTS_TABLE_ALERT_CELL).first().should('include.text', 0);
           });
@@ -171,13 +173,13 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
           it('filters risk scores with time range', () => {
             const now = moment().format(DATE_FORMAT);
             setStartDate(now);
-            updateDates();
+            updateDashboardTimeRange();
 
             cy.get(HOST_RISK_SCORE_NO_DATA_DETECTED).should('be.visible');
 
             // CLEAR DATES
             setStartDate(OLDEST_DATE);
-            updateDates();
+            updateDashboardTimeRange();
           });
 
           it('opens alerts page when alerts count is clicked', () => {
@@ -256,7 +258,7 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
 
           it('filters the alerts count with time range', () => {
             setEndDate(DATE_BEFORE_ALERT_CREATION);
-            updateDates();
+            updateDashboardTimeRange();
 
             cy.get(USERS_TABLE_ALERT_CELL).first().should('include.text', 0);
           });
@@ -264,13 +266,13 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
           it('filters risk scores with time range', () => {
             const now = moment().format(DATE_FORMAT);
             setStartDate(now);
-            updateDates();
+            updateDashboardTimeRange();
 
             cy.get(USER_RISK_SCORE_NO_DATA_DETECTED).should('be.visible');
 
             // CLEAR DATES
             setStartDate(OLDEST_DATE);
-            updateDates();
+            updateDashboardTimeRange();
           });
 
           it('opens alerts page when alerts count is clicked', () => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/entity_analytics.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/entity_analytics.ts
@@ -29,7 +29,8 @@ import { GET_DATE_PICKER_APPLY_BUTTON, GLOBAL_FILTERS_CONTAINER } from '../scree
 import { LOADING_SPINNER } from '../screens/loading';
 
 export const updateDashboardTimeRange = () => {
-  cy.get(GET_DATE_PICKER_APPLY_BUTTON(GLOBAL_FILTERS_CONTAINER)).click();
+  // eslint-disable-next-line cypress/no-force
+  cy.get(GET_DATE_PICKER_APPLY_BUTTON(GLOBAL_FILTERS_CONTAINER)).click({ force: true }); // Force to fix global timerange flakiness
   cy.get(LOADING_SPINNER).should('exist');
   cy.get(LOADING_SPINNER).should('not.exist');
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/entity_analytics.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/entity_analytics.ts
@@ -25,6 +25,14 @@ import {
   RISK_PREVIEW_ERROR_BUTTON,
 } from '../screens/entity_analytics_management';
 import { visitWithTimeRange } from './navigation';
+import { GET_DATE_PICKER_APPLY_BUTTON, GLOBAL_FILTERS_CONTAINER } from '../screens/date_picker';
+import { LOADING_SPINNER } from '../screens/loading';
+
+export const updateDashboardTimeRange = () => {
+  cy.get(GET_DATE_PICKER_APPLY_BUTTON(GLOBAL_FILTERS_CONTAINER)).click();
+  cy.get(LOADING_SPINNER).should('exist');
+  cy.get(LOADING_SPINNER).should('not.exist');
+};
 
 export const waitForAnomaliesToBeLoaded = () => {
   cy.waitUntil(() => {


### PR DESCRIPTION
## Summary

Fix and enable entity analytic cypress tests.

Previously, we were using [updateDates](https://github.com/elastic/kibana/blob/4f52bd50371044246d1bd24ccdefb15723275c46/x-pack/test/security_solution_cypress/cypress/tasks/date_picker.ts#L57)  to update the global time range. This clicks on the data picker update button (with force) and waits for the button loading state. 

Sometimes (bug?), the button loads forever on serverless, and the test fails. As a workaround, I removed the button loading check and added a check for the page panels' loading state.  The new check is inside `updateDashboardTimeRange`.



flaky test run https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5694 🟢 

