### PR TITLE
[Uptime alerts] Add monitor config id to context

### DIFF
--- a/x-pack/plugins/observability_solution/uptime/server/legacy_uptime/lib/alerts/status_check.test.ts
+++ b/x-pack/plugins/observability_solution/uptime/server/legacy_uptime/lib/alerts/status_check.test.ts
@@ -279,6 +279,7 @@ describe('status check alert', () => {
         Array [
           Object {
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "currentTriggerStarted": "foo date string",
             "firstCheckedAt": "foo date string",
             "firstTriggeredAt": "foo date string",
@@ -305,6 +306,7 @@ describe('status check alert', () => {
           Object {
             "alertDetailsUrl": "mockedAlertsLocator > getLocation",
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "latestErrorMessage": "error message 1",
             "monitorId": "first",
             "monitorName": "First",
@@ -361,6 +363,7 @@ describe('status check alert', () => {
         Array [
           Object {
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "currentTriggerStarted": "foo date string",
             "firstCheckedAt": "foo date string",
             "firstTriggeredAt": "foo date string",
@@ -387,6 +390,7 @@ describe('status check alert', () => {
           Object {
             "alertDetailsUrl": "mockedAlertsLocator > getLocation",
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "latestErrorMessage": "error message 1",
             "monitorId": "first",
             "monitorName": "First",
@@ -434,6 +438,7 @@ describe('status check alert', () => {
         Array [
           Object {
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "currentTriggerStarted": "7.7 date",
             "firstCheckedAt": "7.7 date",
             "firstTriggeredAt": "7.7 date",
@@ -651,6 +656,7 @@ describe('status check alert', () => {
         Array [
           Object {
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "currentTriggerStarted": "foo date string",
             "firstCheckedAt": "foo date string",
             "firstTriggeredAt": "foo date string",
@@ -845,6 +851,7 @@ describe('status check alert', () => {
         Array [
           Object {
             "checkedAt": "July 6, 2020 9:14 PM",
+            "configId": undefined,
             "currentTriggerStarted": "availability test",
             "firstCheckedAt": "availability test",
             "firstTriggeredAt": "availability test",
@@ -872,6 +879,7 @@ describe('status check alert', () => {
             Object {
               "alertDetailsUrl": "mockedAlertsLocator > getLocation",
               "checkedAt": "July 6, 2020 9:14 PM",
+              "configId": undefined,
               "latestErrorMessage": undefined,
               "monitorId": "foo",
               "monitorName": "Foo",
@@ -889,6 +897,7 @@ describe('status check alert', () => {
             Object {
               "alertDetailsUrl": "mockedAlertsLocator > getLocation",
               "checkedAt": "July 6, 2020 9:14 PM",
+              "configId": undefined,
               "latestErrorMessage": undefined,
               "monitorId": "foo",
               "monitorName": "Foo",
@@ -906,6 +915,7 @@ describe('status check alert', () => {
             Object {
               "alertDetailsUrl": "mockedAlertsLocator > getLocation",
               "checkedAt": "July 6, 2020 9:14 PM",
+              "configId": undefined,
               "latestErrorMessage": undefined,
               "monitorId": "unreliable",
               "monitorName": "Unreliable",
@@ -923,6 +933,7 @@ describe('status check alert', () => {
             Object {
               "alertDetailsUrl": "mockedAlertsLocator > getLocation",
               "checkedAt": "July 6, 2020 9:14 PM",
+              "configId": undefined,
               "latestErrorMessage": undefined,
               "monitorId": "no-name",
               "monitorName": "no-name",

--- a/x-pack/plugins/observability_solution/uptime/server/legacy_uptime/lib/alerts/status_check.ts
+++ b/x-pack/plugins/observability_solution/uptime/server/legacy_uptime/lib/alerts/status_check.ts
@@ -160,6 +160,7 @@ export const getMonitorSummary = (
     checkedAt,
     monitorUrl: monitorInfo.url?.full,
     monitorId: monitorInfo.monitor?.id,
+    configId: monitorInfo.config_id,
     monitorName: monitorInfo.monitor?.name ?? monitorInfo.monitor?.id,
     monitorType: monitorInfo.monitor?.type,
     latestErrorMessage: monitorInfo.error?.message,
@@ -204,6 +205,7 @@ export const getReasonMessage = ({
 
 export const getMonitorAlertDocument = (monitorSummary: Record<string, string | undefined>) => ({
   'monitor.id': monitorSummary.monitorId,
+  configId: monitorSummary.configId,
   'monitor.type': monitorSummary.monitorType,
   'monitor.name': monitorSummary.monitorName,
   'url.full': monitorSummary.monitorUrl,

--- a/x-pack/plugins/observability_solution/uptime/server/legacy_uptime/lib/alerts/translations.ts
+++ b/x-pack/plugins/observability_solution/uptime/server/legacy_uptime/lib/alerts/translations.ts
@@ -24,6 +24,15 @@ export const commonMonitorStateI18 = [
     ),
   },
   {
+    name: 'configId',
+    description: i18n.translate(
+      'xpack.uptime.alerts.monitorStatus.actionVariables.state.configId',
+      {
+        defaultMessage: 'Config ID of the monitor.',
+      }
+    ),
+  },
+  {
     name: 'monitorUrl',
     description: i18n.translate(
       'xpack.uptime.alerts.monitorStatus.actionVariables.state.monitorUrl',


### PR DESCRIPTION
## Summary

This is needed where users want to generate links to synthetics monitors using uptime alerts !!

### Example usage 

<img width="625" alt="image" src="https://github.com/elastic/kibana/assets/3505601/4f2f7833-9313-4c3a-8ea0-a383cb2ec857">


<img width="956" alt="image" src="https://github.com/elastic/kibana/assets/3505601/10541a9c-987b-427c-a55e-4e0ba01891cf">


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->