### PR TITLE
[Search] Add description tooltips to stats

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect } from 'react';
 
+import { css } from '@emotion/react';
 import { useActions, useValues } from 'kea';
 
 import {
@@ -16,21 +17,56 @@ import {
   EuiSplitPanel,
   EuiText,
   EuiTitle,
+  EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
 import { FetchSyncJobsStatsApiLogic } from '../../api/stats/fetch_sync_jobs_stats_api_logic';
 
+import {
+  getConnectedConnectorsBadgeLabel,
+  getConnectedConnectorsTooltipContent,
+  getConnectedBadgeAriaLabel,
+  getIncompleteConnectorsBadgeLabel,
+  getIncompleteConnectorBadgeAriaLabel,
+  getIncompleteConnectorsTooltip,
+  getIdleJobsLabel,
+  getIdleJobsTooltip,
+  getOrphanedJobsLabel,
+  getOrphanedJobsTooltip,
+  getRunningJobsBadgeAriaLabel,
+  getRunningJobsBadgeLabel,
+  getRunningJobsLabel,
+  getRunningJobsTooltip,
+  getSyncJobErrorsLabel,
+  getSyncJobErrorsTooltip,
+} from './utils';
+
 export interface ConnectorStatsProps {
   isCrawler: boolean;
 }
 
 export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => {
+  const { euiTheme } = useEuiTheme();
+
+  const tooltipAncherProps = {
+    css: css`
+      margin: ${euiTheme.size.xs};
+    `,
+  };
   const { makeRequest } = useActions(FetchSyncJobsStatsApiLogic);
   const { data } = useValues(FetchSyncJobsStatsApiLogic);
+
   const connectorCount = (data?.connected || 0) + (data?.incomplete || 0);
   const hasMultipleConnectors = connectorCount > 1;
+  const connectedCount = data?.connected || 0;
+  const incompleteCount = data?.incomplete || 0;
+  const inProgressCount = data?.in_progress || 0;
+  const idleCount = data?.idle || 0;
+  const orphanedCount = data?.orphaned_jobs || 0;
+  const errorCount = data?.errors || 0;
 
   useEffect(() => {
     makeRequest({ isCrawler });
@@ -90,23 +126,31 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
           </EuiSplitPanel.Inner>
 
           <EuiSplitPanel.Inner grow={false} color="subdued">
-            <EuiBadge color="success">
-              {i18n.translate('xpack.enterpriseSearch.connectorStats.connectedBadgeLabel', {
-                defaultMessage: '{number} connected',
-                values: {
-                  number: data?.connected || 0,
-                },
-              })}
-            </EuiBadge>
-            <EuiBadge color="warning">
-              {i18n.translate('xpack.enterpriseSearch.connectorStats.incompleteBadgeLabel', {
-                defaultMessage: '{number} incomplete',
+            <EuiToolTip
+              anchorProps={tooltipAncherProps}
+              content={getConnectedConnectorsTooltipContent(connectedCount)}
+            >
+              <EuiBadge
+                color="success"
+                onClick={() => {}}
+                onClickAriaLabel={getConnectedBadgeAriaLabel(connectedCount)}
+              >
+                {getConnectedConnectorsBadgeLabel(connectedCount)}
+              </EuiBadge>
+            </EuiToolTip>
 
-                values: {
-                  number: data?.incomplete || 0,
-                },
-              })}
-            </EuiBadge>
+            <EuiToolTip
+              anchorProps={tooltipAncherProps}
+              content={getIncompleteConnectorsTooltip(incompleteCount)}
+            >
+              <EuiBadge
+                color="warning"
+                onClick={() => {}}
+                onClickAriaLabel={getIncompleteConnectorBadgeAriaLabel(incompleteCount)}
+              >
+                {getIncompleteConnectorsBadgeLabel(incompleteCount)}
+              </EuiBadge>
+            </EuiToolTip>
           </EuiSplitPanel.Inner>
         </EuiSplitPanel.Outer>
       </EuiFlexItem>
@@ -124,42 +168,55 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiText>
-                  {i18n.translate('xpack.enterpriseSearch.connectorStats.runningSyncsTextLabel', {
-                    defaultMessage: '{syncs} running syncs',
-                    values: {
-                      syncs: data?.in_progress,
-                    },
-                  })}
-                </EuiText>
+                <EuiText>{getRunningJobsLabel(inProgressCount, isCrawler)}</EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiSplitPanel.Inner>
 
           <EuiSplitPanel.Inner grow={false} color="subdued">
-            {isCrawler
-              ? i18n.translate(
-                  'xpack.enterpriseSearch.connectorStats.crawlerSyncsOrphanedSyncsLabel',
-                  {
-                    defaultMessage: '{orphanedCount} Orphaned syncs / {errorCount} Sync errors',
-                    values: {
-                      errorCount: data?.errors || 0,
-                      orphanedCount: data?.orphaned_jobs,
-                    },
-                  }
-                )
-              : i18n.translate(
-                  'xpack.enterpriseSearch.connectorStats.connectorSyncsOrphanedSyncsLabel',
-                  {
-                    defaultMessage:
-                      '{idleCount} Idle syncs  / {orphanedCount} Orphaned syncs / {errorCount} Sync errors',
-                    values: {
-                      errorCount: data?.errors || 0,
-                      idleCount: data?.idle,
-                      orphanedCount: data?.orphaned_jobs,
-                    },
-                  }
-                )}
+            <EuiToolTip
+              anchorProps={tooltipAncherProps}
+              content={getRunningJobsTooltip(inProgressCount, isCrawler)}
+            >
+              <EuiBadge
+                onClick={() => {}}
+                onClickAriaLabel={getRunningJobsBadgeAriaLabel(inProgressCount, isCrawler)}
+              >
+                {getRunningJobsBadgeLabel(inProgressCount, isCrawler)}
+              </EuiBadge>
+            </EuiToolTip>
+
+            {!isCrawler && (
+              <EuiToolTip anchorProps={tooltipAncherProps} content={getIdleJobsTooltip(idleCount)}>
+                <EuiBadge onClick={() => {}} onClickAriaLabel={getIdleJobsLabel(idleCount)}>
+                  {getIdleJobsLabel(idleCount)}
+                </EuiBadge>
+              </EuiToolTip>
+            )}
+
+            <EuiToolTip
+              anchorProps={tooltipAncherProps}
+              content={getOrphanedJobsTooltip(orphanedCount, isCrawler)}
+            >
+              <EuiBadge
+                onClick={() => {}}
+                onClickAriaLabel={getOrphanedJobsLabel(orphanedCount, isCrawler)}
+              >
+                {getOrphanedJobsLabel(orphanedCount, isCrawler)}
+              </EuiBadge>
+            </EuiToolTip>
+
+            <EuiToolTip
+              anchorProps={tooltipAncherProps}
+              content={getSyncJobErrorsTooltip(errorCount, isCrawler)}
+            >
+              <EuiBadge
+                onClick={() => {}}
+                onClickAriaLabel={getSyncJobErrorsLabel(errorCount, isCrawler)}
+              >
+                {getSyncJobErrorsLabel(errorCount, isCrawler)}
+              </EuiBadge>
+            </EuiToolTip>
           </EuiSplitPanel.Inner>
         </EuiSplitPanel.Outer>
       </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -128,7 +128,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
           <EuiSplitPanel.Inner grow={false} color="subdued">
             <EuiToolTip
               anchorProps={tooltipAncherProps}
-              content={getConnectedConnectorsTooltipContent(connectedCount)}
+              content={getConnectedConnectorsTooltipContent(connectedCount, isCrawler)}
             >
               <EuiBadge
                 color="success"
@@ -141,7 +141,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
 
             <EuiToolTip
               anchorProps={tooltipAncherProps}
-              content={getIncompleteConnectorsTooltip(incompleteCount)}
+              content={getIncompleteConnectorsTooltip(incompleteCount, isCrawler)}
             >
               <EuiBadge
                 color="warning"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -27,40 +27,77 @@ export const getConnectedConnectorsBadgeLabel = (connectedCount: number) => (
     }}
   />
 );
-export const getConnectedConnectorsTooltipContent = (connectedCount: number) => (
+export const getConnectedConnectorsTooltipContent = (
+  connectedCount: number,
+  isCrawler: boolean
+) => (
   <EuiText size="xs">
-    <FormattedMessage
-      id="xpack.enterpriseSearch.connectorStats.connectedTooltip"
-      defaultMessage="{connectedCount} {completeConnectorsText} - Number of connectors which are complete in the last 30 minutes"
-      values={{
-        completeConnectorsText: (
-          <b>
-            {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipConnected', {
-              defaultMessage: `Connected connectors`,
-            })}
-          </b>
-        ),
-        connectedCount: <b>{connectedCount}</b>,
-      }}
-    />
+    {!isCrawler ? (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.connectedTooltip"
+        defaultMessage="{connectedCount} {completeConnectorsText} - Number of connectors which are complete in the last 30 minutes"
+        values={{
+          completeConnectorsText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipConnected', {
+                defaultMessage: `Connected connectors`,
+              })}
+            </b>
+          ),
+          connectedCount: <b>{connectedCount}</b>,
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.connectedCrawlerTooltip"
+        defaultMessage="{connectedCount} {completeConnectorsText} - Number of crawlers that are configured and connected."
+        values={{
+          completeConnectorsText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.crawlerTooltipConnected', {
+                defaultMessage: `Connected crawlers`,
+              })}
+            </b>
+          ),
+          connectedCount: <b>{connectedCount}</b>,
+        }}
+      />
+    )}
   </EuiText>
 );
-export const getIncompleteConnectorsTooltip = (incompleteCount: number) => (
+export const getIncompleteConnectorsTooltip = (incompleteCount: number, isCrawler: boolean) => (
   <EuiText size="xs">
-    <FormattedMessage
-      id="xpack.enterpriseSearch.connectorStats.incompleteTooltip"
-      defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of connectors which are not ready to sync (i.e. the connector is not completely configured), or there’s no backend connector running which knows how to sync it."
-      values={{
-        incompleteConnectorsText: (
-          <b>
-            {i18n.translate('xpack.enterpriseSearch.connectorStats.incompleteTooltipConnected', {
-              defaultMessage: `Incomplete connectors`,
-            })}
-          </b>
-        ),
-        incompleteCount: <b>{incompleteCount}</b>,
-      }}
-    />
+    {!isCrawler ? (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.incompleteTooltip"
+        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of connectors which are not ready to sync (i.e. the connector is not completely configured), or there’s no backend connector running which knows how to sync it."
+        values={{
+          incompleteConnectorsText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.incompleteTooltipConnected', {
+                defaultMessage: `Incomplete connectors`,
+              })}
+            </b>
+          ),
+          incompleteCount: <b>{incompleteCount}</b>,
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.incompleteCrawlerTooltip"
+        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of crawlers that are not ready to crawl (i.e. the crawler is not completely configured)."
+        values={{
+          incompleteConnectorsText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.incompleteTooltipCrawler', {
+                defaultMessage: `Incomplete crawlers`,
+              })}
+            </b>
+          ),
+          incompleteCount: <b>{incompleteCount}</b>,
+        }}
+      />
+    )}
   </EuiText>
 );
 export const getIncompleteConnectorsBadgeLabel = (incompleteCount: number) => (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -70,7 +70,7 @@ export const getIncompleteConnectorsTooltip = (incompleteCount: number, isCrawle
     {!isCrawler ? (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.incompleteTooltip"
-        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of connectors which are not ready to sync (i.e. the connector is not completely configured), or there’s no backend connector running which knows how to sync it."
+        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of connectors whose configuration is incomplete. Syncs won't be possible until the connector is fully configured and running."
         values={{
           incompleteConnectorsText: (
             <b>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -223,7 +223,7 @@ export const getOrphanedJobsTooltip = (orphanedCount: number, isCrawler: boolean
     {!isCrawler ? (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.orphanedTooltip"
-        defaultMessage="{orphanedCount} {orphanedCountText} - Number of sync jobs whose associated connector is not found"
+        defaultMessage="{orphanedCount} {orphanedCountText} - Number of sync jobs whose associated connector can't be found. The connector might have been deleted."
         values={{
           orphanedCount: <b>{orphanedCount}</b>,
           orphanedCountText: (
@@ -238,7 +238,7 @@ export const getOrphanedJobsTooltip = (orphanedCount: number, isCrawler: boolean
     ) : (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.orphanedCrawlerTooltip"
-        defaultMessage="{orphanedCount} {orphanedCountText} - Number of crawls whose associated crawler is not found"
+        defaultMessage="{orphanedCount} {orphanedCountText} - Number of crawl jobs whose associated crawler can't be found. The crawler might have been deleted."
         values={{
           orphanedCount: <b>{orphanedCount}</b>,
           orphanedCountText: (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -35,7 +35,7 @@ export const getConnectedConnectorsTooltipContent = (
     {!isCrawler ? (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.connectedTooltip"
-        defaultMessage="{connectedCount} {completeConnectorsText} - Number of connectors which are complete in the last 30 minutes"
+        defaultMessage="{connectedCount} {completeConnectorsText} - Number of connectors successfully configured and connected in the last 30 minutes."
         values={{
           completeConnectorsText: (
             <b>
@@ -85,7 +85,7 @@ export const getIncompleteConnectorsTooltip = (incompleteCount: number, isCrawle
     ) : (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.incompleteCrawlerTooltip"
-        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of crawlers whose configuration is incomplete. These crawlers are not ready to crawl.
+        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of crawlers whose configuration is incomplete. These crawlers are not ready to crawl."
         values={{
           incompleteConnectorsText: (
             <b>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -135,7 +135,7 @@ export const getRunningJobsTooltip = (inProgressCount: number, isCrawler: boolea
     {!isCrawler ? (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.runningTooltip"
-        defaultMessage="{inProgressCount} {runningCountText} - Number of running sync jobs (This includes Idle Syncs)"
+        defaultMessage="{inProgressCount} {runningCountText} - Number of running sync jobs. This includes idle syncs."
         values={{
           inProgressCount: <b>{inProgressCount}</b>,
           runningCountText: (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -1,0 +1,281 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const getConnectedBadgeAriaLabel = (connectedCount: number) =>
+  i18n.translate('xpack.enterpriseSearch.connectorStats.connectedBadgeAriaLabel', {
+    defaultMessage: '{number} Connected connectors',
+    values: {
+      number: connectedCount,
+    },
+  });
+export const getConnectedConnectorsBadgeLabel = (connectedCount: number) => (
+  <FormattedMessage
+    id="xpack.enterpriseSearch.connectorStats.connectedBadgeLabel"
+    defaultMessage="{number} Connected"
+    values={{
+      number: connectedCount,
+    }}
+  />
+);
+export const getConnectedConnectorsTooltipContent = (connectedCount: number) => (
+  <EuiText size="xs">
+    <FormattedMessage
+      id="xpack.enterpriseSearch.connectorStats.connectedTooltip"
+      defaultMessage="{connectedCount} {completeConnectorsText} - Number of connectors which are complete in the last 30 minutes"
+      values={{
+        completeConnectorsText: (
+          <b>
+            {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipConnected', {
+              defaultMessage: `Connected connectors`,
+            })}
+          </b>
+        ),
+        connectedCount: <b>{connectedCount}</b>,
+      }}
+    />
+  </EuiText>
+);
+export const getIncompleteConnectorsTooltip = (incompleteCount: number) => (
+  <EuiText size="xs">
+    <FormattedMessage
+      id="xpack.enterpriseSearch.connectorStats.incompleteTooltip"
+      defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of connectors which are not ready to sync (i.e. the connector is not completely configured), or there’s no backend connector running which knows how to sync it."
+      values={{
+        incompleteConnectorsText: (
+          <b>
+            {i18n.translate('xpack.enterpriseSearch.connectorStats.incompleteTooltipConnected', {
+              defaultMessage: `Incomplete connectors`,
+            })}
+          </b>
+        ),
+        incompleteCount: <b>{incompleteCount}</b>,
+      }}
+    />
+  </EuiText>
+);
+export const getIncompleteConnectorsBadgeLabel = (incompleteCount: number) => (
+  <FormattedMessage
+    id="xpack.enterpriseSearch.connectorStats.incompleteBadgeLabel"
+    defaultMessage="{incompleteCount} Incomplete"
+    values={{
+      incompleteCount,
+    }}
+  />
+);
+export const getIncompleteConnectorBadgeAriaLabel = (incompleteCount: number) =>
+  i18n.translate('xpack.enterpriseSearch.connectorStats.incompleteBadgeAriaLabel', {
+    defaultMessage: '{incompleteCount} Incomplete connectors',
+    values: {
+      incompleteCount,
+    },
+  });
+export const getRunningJobsLabel = (inProgressCount: number, isCrawler: boolean) =>
+  !isCrawler
+    ? i18n.translate('xpack.enterpriseSearch.connectorStats.runningSyncsTextLabel', {
+        defaultMessage: '{syncs} running syncs',
+        values: {
+          syncs: inProgressCount,
+        },
+      })
+    : i18n.translate('xpack.enterpriseSearch.connectorStats.runningCrawlsTextLabel', {
+        defaultMessage: '{syncs} running crawls',
+        values: {
+          syncs: inProgressCount,
+        },
+      });
+export const getRunningJobsTooltip = (inProgressCount: number, isCrawler: boolean) => (
+  <EuiText size="xs">
+    {!isCrawler ? (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.runningTooltip"
+        defaultMessage="{inProgressCount} {runningCountText} - Number of running sync jobs (This includes Idle Syncs)"
+        values={{
+          inProgressCount: <b>{inProgressCount}</b>,
+          runningCountText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipRunning', {
+                defaultMessage: `Running syncs`,
+              })}
+            </b>
+          ),
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.runningCrawlerTooltip"
+        defaultMessage="{inProgressCount} {runningCountText} - Number of running crawls"
+        values={{
+          inProgressCount: <b>{inProgressCount}</b>,
+          runningCountText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.crawlerTooltipRunning', {
+                defaultMessage: `Running crawls`,
+              })}
+            </b>
+          ),
+        }}
+      />
+    )}
+  </EuiText>
+);
+export const getRunningJobsBadgeAriaLabel = (inProgressCount: number, isCrawler: boolean) =>
+  !isCrawler
+    ? i18n.translate('xpack.enterpriseSearch.connectorStats.runningBadgeAriaLabel', {
+        defaultMessage: '{number} Running syncs.',
+        values: {
+          number: inProgressCount,
+        },
+      })
+    : i18n.translate('xpack.enterpriseSearch.connectorStats.runningCrawlerBadgeAriaLabel', {
+        defaultMessage: '{number} Running crawls.',
+        values: {
+          number: inProgressCount,
+        },
+      });
+export const getRunningJobsBadgeLabel = (inProgressCount: number, isCrawler: boolean) =>
+  !isCrawler
+    ? i18n.translate('xpack.enterpriseSearch.connectorStats.runningBadgeLabel', {
+        defaultMessage: '{number} Running syncs',
+        values: {
+          number: inProgressCount,
+        },
+      })
+    : i18n.translate('xpack.enterpriseSearch.connectorStats.runningCrawlerBadgeLabel', {
+        defaultMessage: '{number} Running crawls',
+        values: {
+          number: inProgressCount,
+        },
+      });
+export const getIdleJobsLabel = (idleCount: number) =>
+  i18n.translate('xpack.enterpriseSearch.connectorStats.idleJobsText', {
+    defaultMessage: '{idleCount} Idle syncs',
+    values: {
+      idleCount,
+    },
+  });
+export const getIdleJobsTooltip = (idleCount: number) => (
+  <EuiText size="xs">
+    <FormattedMessage
+      id="xpack.enterpriseSearch.connectorStats.idleTooltip"
+      defaultMessage="{idleCount} {idleCountText} - Number of sync jobs which are still running but have not seen any update from the backend connector for more than 1 minute"
+      values={{
+        idleCount: <b>{idleCount}</b>,
+        idleCountText: (
+          <b>
+            {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipIdle', {
+              defaultMessage: `Idle syncs`,
+            })}
+          </b>
+        ),
+      }}
+    />
+  </EuiText>
+);
+export const getOrphanedJobsTooltip = (orphanedCount: number, isCrawler: boolean) => (
+  <EuiText size="xs">
+    {!isCrawler ? (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.orphanedTooltip"
+        defaultMessage="{orphanedCount} {orphanedCountText} - Number of sync jobs whose associated connector is not found"
+        values={{
+          orphanedCount: <b>{orphanedCount}</b>,
+          orphanedCountText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipOrphaned', {
+                defaultMessage: `Orphaned syncs`,
+              })}
+            </b>
+          ),
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.orphanedCrawlerTooltip"
+        defaultMessage="{orphanedCount} {orphanedCountText} - Number of crawls whose associated crawler is not found"
+        values={{
+          orphanedCount: <b>{orphanedCount}</b>,
+          orphanedCountText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.crawlerTooltipOrphaned', {
+                defaultMessage: `Orphaned crawls`,
+              })}
+            </b>
+          ),
+        }}
+      />
+    )}
+  </EuiText>
+);
+export const getOrphanedJobsLabel = (orphanedCount: number, isCrawler: boolean) =>
+  !isCrawler
+    ? i18n.translate('xpack.enterpriseSearch.connectorStats.orphanedBadgeAriaLabel', {
+        defaultMessage: '{number} Orphaned syncs.',
+        values: {
+          number: orphanedCount,
+        },
+      })
+    : i18n.translate('xpack.enterpriseSearch.connectorStats.orphanedCrawlerBadgeAriaLabel', {
+        defaultMessage: '{number} Orphaned crawls.',
+        values: {
+          number: orphanedCount,
+        },
+      });
+export const getSyncJobErrorsTooltip = (errorCount: number, isCrawler: boolean) => (
+  <EuiText size="xs">
+    {!isCrawler ? (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.errorTooltip"
+        defaultMessage="{errorCount} {errorCountText} - Number of connectors whose last full sync failed"
+        values={{
+          errorCount: <b>{errorCount}</b>,
+          errorCountText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.connectorTooltipError', {
+                defaultMessage: `Sync errors`,
+              })}
+            </b>
+          ),
+        }}
+      />
+    ) : (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.connectorStats.errorCrawlerTooltip"
+        defaultMessage="{errorCount} {errorCountText} - Number of crawlers whose last crawl failed"
+        values={{
+          errorCount: <b>{errorCount}</b>,
+          errorCountText: (
+            <b>
+              {i18n.translate('xpack.enterpriseSearch.connectorStats.crawlerTooltipError', {
+                defaultMessage: `Crawl errors`,
+              })}
+            </b>
+          ),
+        }}
+      />
+    )}
+  </EuiText>
+);
+export const getSyncJobErrorsLabel = (errorCount: number, isCrawler: boolean) =>
+  !isCrawler
+    ? i18n.translate('xpack.enterpriseSearch.connectorStats.errorBadgeLabel', {
+        defaultMessage: '{number} Sync errors',
+        values: {
+          number: errorCount,
+        },
+      })
+    : i18n.translate('xpack.enterpriseSearch.connectorStats.errorCrawlerBadgeLabel', {
+        defaultMessage: '{number} Crawl errors',
+        values: {
+          number: errorCount,
+        },
+      });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/utils.tsx
@@ -85,7 +85,7 @@ export const getIncompleteConnectorsTooltip = (incompleteCount: number, isCrawle
     ) : (
       <FormattedMessage
         id="xpack.enterpriseSearch.connectorStats.incompleteCrawlerTooltip"
-        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of crawlers that are not ready to crawl (i.e. the crawler is not completely configured)."
+        defaultMessage="{incompleteCount} {incompleteConnectorsText} - Number of crawlers whose configuration is incomplete. These crawlers are not ready to crawl.
         values={{
           incompleteConnectorsText: (
             <b>


### PR DESCRIPTION
## Summary

Adds a bunch of descriptive tooltips to the stats.
<img width="324" alt="Screenshot 2024-04-16 at 15 02 57" src="https://github.com/elastic/kibana/assets/1410658/c0df028f-ad1d-45c3-b16e-abaa496b55ad">
<img width="283" alt="Screenshot 2024-04-16 at 15 03 11" src="https://github.com/elastic/kibana/assets/1410658/8569e289-4a21-4df2-9f5c-7d75205a03f2">
<img width="281" alt="Screenshot 2024-04-16 at 15 03 13" src="https://github.com/elastic/kibana/assets/1410658/f17b6023-0468-46c7-b5b0-c7c62af5c353">



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
