### PR TITLE
Use a single instance of the `coreUsageStatsClient`

### DIFF
--- a/packages/core/usage-data/core-usage-data-server-internal/src/core_usage_data_service.ts
+++ b/packages/core/usage-data/core-usage-data-server-internal/src/core_usage_data_service.ts
@@ -493,22 +493,16 @@ export class CoreUsageDataService
       typeRegistry.registerType(coreUsageStatsType);
     };
 
-    const getClient = () => {
-      const debugLogger = (message: string) => this.logger.debug(message);
-
-      return new CoreUsageStatsClient(
-        debugLogger,
-        http.basePath,
-        internalRepositoryPromise,
-        this.stop$
-      );
-    };
-
-    this.coreUsageStatsClient = getClient();
+    this.coreUsageStatsClient = new CoreUsageStatsClient(
+      (message: string) => this.logger.debug(message),
+      http.basePath,
+      internalRepositoryPromise,
+      this.stop$
+    );
 
     const contract: InternalCoreUsageDataSetup = {
       registerType,
-      getClient,
+      getClient: () => this.coreUsageStatsClient!,
       registerUsageCounter: (usageCounter) => {
         this.incrementUsageCounter = (params) => usageCounter.incrementCounter(params);
       },


### PR DESCRIPTION
## Summary

Fixes #180405

The PR above introduces an RxJS pipeline to buffer Core SO usage stats operations, aiming at writing in batches, instead of for each API call. However, a small implementation detail makes the enhancement unsuccessful.

This PR aims at fixing this, so that #180405 works as intended.