### PR TITLE
Reference for markdown implementation in kibana

### DIFF
--- a/package.json
+++ b/package.json
@@ -1615,6 +1615,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.1",
+    "commonmark-spec": "^0.31.2",
     "content-security-policy-parser": "^0.6.0",
     "cpy": "^8.1.1",
     "css-loader": "^3.4.2",

--- a/packages/shared-ux/markdown/impl/__snapshots__/markdown.test.tsx.snap
+++ b/packages/shared-ux/markdown/impl/__snapshots__/markdown.test.tsx.snap
@@ -1,0 +1,11471 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`shared ux markdown component EuiMarkdownFormat renders consistently matches to spec 1`] = `
+<div
+  aria-label="markdown component"
+  class="euiText euiMarkdownFormat emotion-euiText-relative-euiMarkdownFormat-relative"
+  data-test-subj="spec-validation"
+>
+  <hr
+    class="euiHorizontalRule emotion-euiHorizontalRule-full-l"
+  />
+  
+
+  <p>
+    title: CommonMark Spec
+    <br />
+    
+
+    author: John MacFarlane
+    <br />
+    
+
+    version: '0.31.2'
+    <br />
+    
+
+    date: '2024-01-28'
+    <br />
+    
+
+    license: '
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="https://creativecommons.org/licenses/by-sa/4.0/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      CC-BY-SA 4.0
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+    '
+    <br />
+    
+
+    ...
+  </p>
+  
+
+  <h1>
+    Introduction
+  </h1>
+  
+
+  <h2>
+    What is Markdown?
+  </h2>
+  
+
+  <p>
+    Markdown is a plain text format for writing structured documents,
+    <br />
+    
+
+    based on conventions for indicating formatting in email
+    <br />
+    
+
+    and usenet posts.  It was developed by John Gruber (with
+    <br />
+    
+
+    help from Aaron Swartz) and released in 2004 in the form of a
+    <br />
+    
+
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="https://daringfireball.net/projects/markdown/syntax"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      syntax description
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+    <br />
+    
+
+    and a Perl script (
+    <code>
+      Markdown.pl
+    </code>
+    ) for converting Markdown to
+    <br />
+    
+
+    HTML.  In the next decade, dozens of implementations were
+    <br />
+    
+
+    developed in many languages.  Some extended the original
+    <br />
+    
+
+    Markdown syntax with conventions for footnotes, tables, and
+    <br />
+    
+
+    other document elements.  Some allowed Markdown documents to be
+    <br />
+    
+
+    rendered in formats other than HTML.  Websites like Reddit,
+    <br />
+    
+
+    StackOverflow, and GitHub had millions of people using Markdown.
+    <br />
+    
+
+    And Markdown started to be used beyond the web, to author books,
+    <br />
+    
+
+    articles, slide shows, letters, and lecture notes.
+  </p>
+  
+
+  <p>
+    What distinguishes Markdown from many other lightweight markup
+    <br />
+    
+
+    syntaxes, which are often easier to write, is its readability.
+    <br />
+    
+
+    As Gruber writes:
+  </p>
+  
+
+  <blockquote
+    class="euiMarkdownFormat__blockquote"
+  >
+    
+
+    <p>
+      The overriding design goal for Markdown's formatting syntax is
+      <br />
+      
+
+      to make it as readable as possible. The idea is that a
+      <br />
+      
+
+      Markdown-formatted document should be publishable as-is, as
+      <br />
+      
+
+      plain text, without looking like it's been marked up with tags
+      <br />
+      
+
+      or formatting instructions.
+      <br />
+      
+
+      (
+      <a
+        class="euiLink emotion-euiLink-primary"
+        href="https://daringfireball.net/projects/markdown/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        https://daringfireball.net/projects/markdown/
+        <span
+          class="emotion-EuiExternalLinkIcon"
+          data-euiicon-type="popout"
+        >
+          External link
+        </span>
+        <span
+          class="emotion-euiScreenReaderOnly"
+        >
+          (opens in a new tab or window)
+        </span>
+      </a>
+      )
+    </p>
+    
+
+  </blockquote>
+  
+
+  <p>
+    The point can be illustrated by comparing a sample of
+    <br />
+    
+
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="https://asciidoc.org/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      AsciiDoc
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     with
+    <br />
+    
+
+    an equivalent sample of Markdown.  Here is a sample of
+    <br />
+    
+
+    AsciiDoc from the AsciiDoc manual:
+  </p>
+  
+
+  <div
+    class="euiMarkdownFormat__codeblockWrapper"
+  >
+    <div>
+      <pre>
+        <code>
+          1. List item one.
++
+List item one continued with a second paragraph followed by an
+Indented block.
++
+.................
+$ ls *.sh
+$ mv *.sh ~/tmp
+.................
++
+List item continued with a third paragraph.
+
+2. List item two continued with an open block.
++
+--
+This paragraph is part of the preceding list item.
+
+a. This list is nested and does not require explicit item
+continuation.
++
+This paragraph is part of the preceding list item.
+
+b. List item b.
+
+This paragraph belongs to item two of the outer list.
+--
+
+        </code>
+      </pre>
+    </div>
+  </div>
+  
+
+  <p>
+    And here is the equivalent in Markdown:
+  </p>
+  
+
+  <div
+    class="euiMarkdownFormat__codeblockWrapper"
+  >
+    <div>
+      <pre>
+        <code>
+          1.  List item one.
+
+    List item one continued with a second paragraph followed by an
+    Indented block.
+
+        $ ls *.sh
+        $ mv *.sh ~/tmp
+
+    List item continued with a third paragraph.
+
+2.  List item two continued with an open block.
+
+    This paragraph is part of the preceding list item.
+
+    1. This list is nested and does not require explicit item continuation.
+
+       This paragraph is part of the preceding list item.
+
+    2. List item b.
+
+    This paragraph belongs to item two of the outer list.
+
+        </code>
+      </pre>
+    </div>
+  </div>
+  
+
+  <p>
+    The AsciiDoc version is, arguably, easier to write. You don't need
+    <br />
+    
+
+    to worry about indentation.  But the Markdown version is much easier
+    <br />
+    
+
+    to read.  The nesting of list items is apparent to the eye in the
+    <br />
+    
+
+    source, not just in the processed document.
+  </p>
+  
+
+  <h2>
+    Why is a spec needed?
+  </h2>
+  
+
+  <p>
+    John Gruber's 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="https://daringfireball.net/projects/markdown/syntax"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      canonical description of Markdown's
+      <br />
+      
+
+      syntax
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+    <br />
+    
+
+    does not specify the syntax unambiguously.  Here are some examples of
+    <br />
+    
+
+    questions it does not answer:
+  </p>
+  
+
+  <ol>
+    
+
+    <li>
+      
+
+      <p>
+        How much indentation is needed for a sublist?  The spec says that
+        <br />
+        
+
+        continuation paragraphs need to be indented four spaces, but is
+        <br />
+        
+
+        not fully explicit about sublists.  It is natural to think that
+        <br />
+        
+
+        they, too, must be indented four spaces, but 
+        <code>
+          Markdown.pl
+        </code>
+         does
+        <br />
+        
+
+        not require that.  This is hardly a "corner case," and divergences
+        <br />
+        
+
+        between implementations on this issue often lead to surprises for
+        <br />
+        
+
+        users in real documents. (See 
+        <a
+          class="euiLink emotion-euiLink-primary"
+          href="https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/1997"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          this comment by John
+          <br />
+          
+
+          Gruber
+          <span
+            class="emotion-EuiExternalLinkIcon"
+            data-euiicon-type="popout"
+          >
+            External link
+          </span>
+          <span
+            class="emotion-euiScreenReaderOnly"
+          >
+            (opens in a new tab or window)
+          </span>
+        </a>
+        .)
+      </p>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Is a blank line needed before a block quote or heading?
+        <br />
+        
+
+        Most implementations do not require the blank line.  However,
+        <br />
+        
+
+        this can lead to unexpected results in hard-wrapped text, and
+        <br />
+        
+
+        also to ambiguities in parsing (note that some implementations
+        <br />
+        
+
+        put the heading inside the blockquote, while others do not).
+        <br />
+        
+
+        (John Gruber has also spoken 
+        <a
+          class="euiLink emotion-euiLink-primary"
+          href="https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/2146"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          in favor of requiring the blank
+          <br />
+          
+
+          lines
+          <span
+            class="emotion-EuiExternalLinkIcon"
+            data-euiicon-type="popout"
+          >
+            External link
+          </span>
+          <span
+            class="emotion-euiScreenReaderOnly"
+          >
+            (opens in a new tab or window)
+          </span>
+        </a>
+        .)
+      </p>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Is a blank line needed before an indented code block?
+        <br />
+        
+
+        (
+        <code>
+          Markdown.pl
+        </code>
+         requires it, but this is not mentioned in the
+        <br />
+        
+
+        documentation, and some implementations do not require it.)
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              paragraph
+    code?
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        What is the exact rule for determining when list items get
+        <br />
+        
+
+        wrapped in 
+        <code>
+          &lt;p&gt;
+        </code>
+         tags?  Can a list be partially "loose" and partially
+        <br />
+        
+
+        "tight"?  What should we do with a list like this?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                1.
+              </span>
+               one
+
+
+              <span
+                class="token list punctuation"
+              >
+                2.
+              </span>
+               two
+
+              <span
+                class="token list punctuation"
+              >
+                3.
+              </span>
+               three
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+      <p>
+        Or this?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                1.
+              </span>
+                one
+    
+              <span
+                class="token list punctuation"
+              >
+                -
+              </span>
+               a
+
+
+              <span
+                class="token code keyword"
+              >
+                    - b
+              </span>
+              
+
+              <span
+                class="token list punctuation"
+              >
+                2.
+              </span>
+                two
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+      <p>
+        (There are some relevant comments by John Gruber
+        <br />
+        
+
+        <a
+          class="euiLink emotion-euiLink-primary"
+          href="https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/2554"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          here
+          <span
+            class="emotion-EuiExternalLinkIcon"
+            data-euiicon-type="popout"
+          >
+            External link
+          </span>
+          <span
+            class="emotion-euiScreenReaderOnly"
+          >
+            (opens in a new tab or window)
+          </span>
+        </a>
+        .)
+      </p>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Can list markers be indented?  Can ordered list markers be right-aligned?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+               
+              <span
+                class="token list punctuation"
+              >
+                8.
+              </span>
+               item 1
+ 
+              <span
+                class="token list punctuation"
+              >
+                9.
+              </span>
+               item 2
+
+              <span
+                class="token list punctuation"
+              >
+                10.
+              </span>
+               item 2a
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Is this one list with a thematic break in its second item,
+        <br />
+        
+
+        or two lists separated by a thematic break?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                *
+              </span>
+               a
+
+              <span
+                class="token hr punctuation"
+              >
+                * * * * *
+              </span>
+              
+
+              <span
+                class="token list punctuation"
+              >
+                *
+              </span>
+               b
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        When list markers change from numbers to bullets, do we have
+        <br />
+        
+
+        two lists or one?  (The Markdown syntax description suggests two,
+        <br />
+        
+
+        but the perl scripts and many other implementations produce one.)
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                1.
+              </span>
+               fee
+
+              <span
+                class="token list punctuation"
+              >
+                2.
+              </span>
+               fie
+
+              <span
+                class="token list punctuation"
+              >
+                -
+              </span>
+                foe
+
+              <span
+                class="token list punctuation"
+              >
+                -
+              </span>
+                fum
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        What are the precedence rules for the markers of inline structure?
+        <br />
+        
+
+        For\`text, is the following a valid link, or does the code span
+        <br />
+        
+
+        take precedence ?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token url"
+              >
+                [
+                <span
+                  class="token content"
+                >
+                  a backtick (\`)
+                </span>
+                ](
+                <span
+                  class="token url"
+                >
+                  /url
+                </span>
+                )
+              </span>
+               and 
+              <span
+                class="token url"
+              >
+                [
+                <span
+                  class="token content"
+                >
+                  another backtick (\`)
+                </span>
+                ](
+                <span
+                  class="token url"
+                >
+                  /url
+                </span>
+                )
+              </span>
+              .
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        What are the precedence rules for markers of emphasis and strong
+        <br />
+        
+
+        emphasis?  For\`text, how should the following be parsed?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token italic"
+              >
+                <span
+                  class="token punctuation"
+                >
+                  *
+                </span>
+                <span
+                  class="token content"
+                >
+                  foo 
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  *
+                </span>
+              </span>
+              bar
+              <span
+                class="token italic"
+              >
+                <span
+                  class="token punctuation"
+                >
+                  *
+                </span>
+                <span
+                  class="token content"
+                >
+                   baz
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  *
+                </span>
+              </span>
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        What are the precedence rules between block-level and inline-level
+        <br />
+        
+
+        structure?  For\`text, how should the following be parsed?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                -
+              </span>
+               \`a long code span can contain a hyphen like this
+  
+              <span
+                class="token list punctuation"
+              >
+                -
+              </span>
+               and it can screw things up\`
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Can list items include section headings?  (
+        <code>
+          Markdown.pl
+        </code>
+         does not
+        <br />
+        
+
+        allow this, but does allow blockquotes to include headings.)
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                -
+              </span>
+               # Heading
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Can list items be empty?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token list punctuation"
+              >
+                *
+              </span>
+               a
+
+              <span
+                class="token italic"
+              >
+                <span
+                  class="token punctuation"
+                >
+                  *
+                </span>
+                <span
+                  class="token content"
+                >
+                  
+
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  *
+                </span>
+              </span>
+               b
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        Can link references be defined inside block quotes or list items?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token blockquote punctuation"
+              >
+                &gt;
+              </span>
+               Blockquote [foo].
+
+              <span
+                class="token blockquote punctuation"
+              >
+                &gt;
+              </span>
+              
+
+              <span
+                class="token blockquote punctuation"
+              >
+                &gt;
+              </span>
+               
+              <span
+                class="token url-reference url"
+              >
+                <span
+                  class="token punctuation"
+                >
+                  [
+                </span>
+                <span
+                  class="token variable"
+                >
+                  foo
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  ]
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  :
+                </span>
+                 /url
+              </span>
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+    <li>
+      
+
+      <p>
+        If there are multiple definitions for the same reference, which takes
+        <br />
+        
+
+        precedence?
+      </p>
+      
+
+      <div
+        class="euiMarkdownFormat__codeblockWrapper"
+      >
+        <div>
+          <pre>
+            <code
+              data-code-language="markdown"
+            >
+              <span
+                class="token url-reference url"
+              >
+                <span
+                  class="token punctuation"
+                >
+                  [
+                </span>
+                <span
+                  class="token variable"
+                >
+                  foo
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  ]
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  :
+                </span>
+                 /url1
+              </span>
+              
+
+              <span
+                class="token url-reference url"
+              >
+                <span
+                  class="token punctuation"
+                >
+                  [
+                </span>
+                <span
+                  class="token variable"
+                >
+                  foo
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  ]
+                </span>
+                <span
+                  class="token punctuation"
+                >
+                  :
+                </span>
+                 /url2
+              </span>
+              
+
+[foo][]
+            </code>
+          </pre>
+        </div>
+      </div>
+      
+
+    </li>
+    
+
+  </ol>
+  
+
+  <p>
+    In the absence of a spec, early implementers consulted 
+    <code>
+      Markdown.pl
+    </code>
+    <br />
+    
+
+    to resolve these ambiguities.  But 
+    <code>
+      Markdown.pl
+    </code>
+     was quite buggy, and
+    <br />
+    
+
+    gave manifestly bad results in many cases, so it was not a
+    <br />
+    
+
+    satisfactory replacement for a spec.
+  </p>
+  
+
+  <p>
+    Because there is no unambiguous spec, implementations have diverged
+    <br />
+    
+
+    considerably.  As a result, users are often surprised to find that
+    <br />
+    
+
+    a document that renders one way on one system (say, a GitHub wiki)
+    <br />
+    
+
+    renders differently on another (say, converting to docbook using
+    <br />
+    
+
+    pandoc).  To make matters worse, because nothing in Markdown counts
+    <br />
+    
+
+    as a "syntax error," the divergence often isn't discovered right away.
+  </p>
+  
+
+  <h2>
+    About this document
+  </h2>
+  
+
+  <p>
+    This document attempts to specify Markdown syntax unambiguously.
+    <br />
+    
+
+    It contains many examples with side-by-side Markdown and
+    <br />
+    
+
+    HTML.  These are intended to double as conformance tests.  An
+    <br />
+    
+
+    accompanying script 
+    <code>
+      spec_tests.py
+    </code>
+     can be used to run the tests
+    <br />
+    
+
+    against any Markdown program:
+  </p>
+  
+
+  <div
+    class="euiMarkdownFormat__codeblockWrapper"
+  >
+    <div>
+      <pre>
+        <code>
+          python test/spec_tests.py --spec spec.txt --program PROGRAM
+
+        </code>
+      </pre>
+    </div>
+  </div>
+  
+
+  <p>
+    Since this document describes how Markdown is to be parsed into
+    <br />
+    
+
+    an abstract syntax tree, it would have made sense to use an abstract
+    <br />
+    
+
+    representation of the syntax tree instead of HTML.  But HTML is capable
+    <br />
+    
+
+    of representing the structural distinctions we need to make, and the
+    <br />
+    
+
+    choice of HTML for the tests makes it possible to run the tests against
+    <br />
+    
+
+    an implementation without writing an abstract syntax tree renderer.
+  </p>
+  
+
+  <p>
+    Note that not every feature of the HTML samples is mandated by
+    <br />
+    
+
+    the spec.  For\`text, the spec says what counts as a link
+    <br />
+    
+
+    destination, but it doesn't mandate that non-ASCII characters in
+    <br />
+    
+
+    the URL be percent-encoded.  To use the automatic tests,
+    <br />
+    
+
+    implementers will need to provide a renderer that conforms to
+    <br />
+    
+
+    the expectations of the spec examples (percent-encoding
+    <br />
+    
+
+    non-ASCII characters in URLs).  But a conforming implementation
+    <br />
+    
+
+    can use a different renderer and may choose not to
+    <br />
+    
+
+    percent-encode non-ASCII characters in URLs.
+  </p>
+  
+
+  <p>
+    This document is generated from a text file, 
+    <code>
+      spec.txt
+    </code>
+    , written
+    <br />
+    
+
+    in Markdown with a small extension for the side-by-side tests.
+    <br />
+    
+
+    The script 
+    <code>
+      tools/makespec.py
+    </code>
+     can be used to convert 
+    <code>
+      spec.txt
+    </code>
+     into
+    <br />
+    
+
+    HTML or CommonMark (which can then be converted into other formats).
+  </p>
+  
+
+  <p>
+    In the examples, the 
+    <code>
+      →
+    </code>
+     character is used to represent tabs.
+  </p>
+  
+
+  <h1>
+    Preliminaries
+  </h1>
+  
+
+  <h2>
+    Characters and lines
+  </h2>
+  
+
+  <p>
+    Any sequence of 
+    [characters]
+     is a valid CommonMark
+    <br />
+    
+
+    document.
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      character
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a Unicode code point.  Although some
+    <br />
+    
+
+    code points (for\`text, combining accents) do not correspond to
+    <br />
+    
+
+    characters in an intuitive sense, all code points count as characters
+    <br />
+    
+
+    for purposes of this spec.
+  </p>
+  
+
+  <p>
+    This spec does not specify an encoding; it thinks of lines as composed
+    <br />
+    
+
+    of 
+    [characters]
+     rather than bytes.  A conforming parser may be limited
+    <br />
+    
+
+    to a certain encoding.
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      line
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a sequence of zero or more 
+    [characters]
+    <br />
+    
+
+    other than line feed (
+    <code>
+      U+000A
+    </code>
+    ) or carriage return (
+    <code>
+      U+000D
+    </code>
+    ),
+    <br />
+    
+
+    followed by a 
+    [line ending]
+     or by the end of file.
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      line ending
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a line feed (
+    <code>
+      U+000A
+    </code>
+    ), a carriage return
+    <br />
+    
+
+    (
+    <code>
+      U+000D
+    </code>
+    ) not followed by a line feed, or a carriage return and a
+    <br />
+    
+
+    following line feed.
+  </p>
+  
+
+  <p>
+    A line containing no characters, or a line containing only spaces
+    <br />
+    
+
+    (
+    <code>
+      U+0020
+    </code>
+    ) or tabs (
+    <code>
+      U+0009
+    </code>
+    ), is called a 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      blank line
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+    .
+  </p>
+  
+
+  <p>
+    The following definitions of character classes will be used in this spec:
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Unicode whitespace character
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a character in the Unicode 
+    <code>
+      Zs
+    </code>
+     general
+    <br />
+    
+
+    category, or a tab (
+    <code>
+      U+0009
+    </code>
+    ), line feed (
+    <code>
+      U+000A
+    </code>
+    ), form feed (
+    <code>
+      U+000C
+    </code>
+    ), or
+    <br />
+    
+
+    carriage return (
+    <code>
+      U+000D
+    </code>
+    ).
+  </p>
+  
+
+  <p>
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Unicode whitespace
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a sequence of one or more
+    <br />
+    
+
+    [Unicode whitespace characters]
+    .
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      tab
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is 
+    <code>
+      U+0009
+    </code>
+    .
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      space
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is 
+    <code>
+      U+0020
+    </code>
+    .
+  </p>
+  
+
+  <p>
+    An 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      ASCII control character
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a character between 
+    <code>
+      U+0000–1F
+    </code>
+     (both
+    <br />
+    
+
+    including) or 
+    <code>
+      U+007F
+    </code>
+    .
+  </p>
+  
+
+  <p>
+    An 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      ASCII punctuation character
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+    <br />
+    
+
+    is 
+    <code>
+      !
+    </code>
+    , 
+    <code>
+      "
+    </code>
+    , 
+    <code>
+      #
+    </code>
+    , 
+    <code>
+      $
+    </code>
+    , 
+    <code>
+      %
+    </code>
+    , 
+    <code>
+      &
+    </code>
+    , 
+    <code>
+      '
+    </code>
+    , 
+    <code>
+      (
+    </code>
+    , 
+    <code>
+      )
+    </code>
+    ,
+    <br />
+    
+
+    <code>
+      *
+    </code>
+    , 
+    <code>
+      +
+    </code>
+    , 
+    <code>
+      ,
+    </code>
+    , 
+    <code>
+      -
+    </code>
+    , 
+    <code>
+      .
+    </code>
+    , 
+    <code>
+      /
+    </code>
+     (U+0021–2F),
+    <br />
+    
+
+    <code>
+      :
+    </code>
+    , 
+    <code>
+      ;
+    </code>
+    , 
+    <code>
+      &lt;
+    </code>
+    , 
+    <code>
+      =
+    </code>
+    , 
+    <code>
+      &gt;
+    </code>
+    , 
+    <code>
+      ?
+    </code>
+    , 
+    <code>
+      @
+    </code>
+     (U+003A–0040),
+    <br />
+    
+
+    <code>
+      [
+    </code>
+    , 
+    <code>
+      , \`]\`, \`^\`, \`_\`, 
+    </code>
+     
+    <code>
+      \`\` (U+005B–0060), 
+    </code>
+    {
+    <code>
+      , 
+    </code>
+    |
+    <code>
+      , 
+    </code>
+    }
+    <code>
+      , or 
+    </code>
+    ~\` (U+007B–007E).
+  </p>
+  
+
+  <p>
+    A 
+    <a
+      class="euiLink emotion-euiLink-primary"
+      href="@"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Unicode punctuation character
+      <span
+        class="emotion-EuiExternalLinkIcon"
+        data-euiicon-type="popout"
+      >
+        External link
+      </span>
+      <span
+        class="emotion-euiScreenReaderOnly"
+      >
+        (opens in a new tab or window)
+      </span>
+    </a>
+     is a character in the Unicode 
+    <code>
+      P
+    </code>
+    <br />
+    
+
+    (puncuation) or 
+    <code>
+      S
+    </code>
+     (symbol) general categories.
+  </p>
+  
+
+  <h2>
+    Tabs
+  </h2>
+  
+
+  <p>
+    Tabs in lines are not expanded to 
+    [spaces]
+    .  However,
+    <br />
+    
+
+    in contexts where spaces help to define block structure,
+    <br />
+    
+
+    tabs behave as if they were replaced by spaces with a tab stop
+    <br />
+    
+
+    of 4 characters.
+  </p>
+  
+
+  <p>
+    Thus, for\`text, a tab can be used instead of four spaces
+    <br />
+    
+
+    in an indented code block.  (Note, however, that internal
+    <br />
+    
+
+    tabs are passed through as literal tabs, not expanded to
+    <br />
+    
+
+    spaces.)
+  </p>
+  
+
+  <div
+    class="euiMarkdownFormat__codeblockWrapper"
+  >
+    <div>
+      <pre>
+        <code
+          data-code-language="text"
+        >
+          →foo→baz→→bim
+.
+&lt;pre&gt;&lt;code&gt;foo→baz→→bim
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  →foo→baz→→bim
+.
+&lt;pre&gt;&lt;code&gt;foo→baz→→bim
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    a→a
+    ὐ→a
+.
+&lt;pre&gt;&lt;code&gt;a→a
+ὐ→a
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+In the following\`text, a continuation paragraph of a list
+item is indented with a tab; this has exactly the same effect
+as indentation with four spaces would:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  - foo
+
+→bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+
+→→bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;  bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Normally the \`&gt;\` that begins a block quote may be followed
+optionally by a space, which is not considered part of the
+content.  In the following case \`&gt;\` is followed by a tab,
+which is treated as if it were expanded into three spaces.
+Since one of these spaces is considered part of the
+delimiter, \`foo\` is considered to be indented six spaces
+inside the block quote context, so we get an indented
+code block starting with two spaces.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;→→foo
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;  foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-→→foo
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;  foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    foo
+→bar
+.
+&lt;pre&gt;&lt;code&gt;foo
+bar
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ - foo
+   - bar
+→ - baz
+.
+&lt;ul&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+#→Foo
+.
+&lt;h1&gt;Foo&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*→*→*→
+.
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Insecure characters
+
+For security reasons, the Unicode character \`U+0000\` must be replaced
+with the REPLACEMENT CHARACTER (\`U+FFFD\`).
+
+
+## Backslash escapes
+
+Any ASCII punctuation character may be backslash-escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\!\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\&lt;\\=\\&gt;\\?\\@\\[\\\\\\]\\^\\_\\\`\\{\\|\\}\\~
+.
+&lt;p&gt;!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_\`{|}~&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslashes before other characters are treated as literal
+backslashes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\→\\A\\a\\ \\3\\φ\\«
+.
+&lt;p&gt;\\→\\A\\a\\ \\3\\φ\\«&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Escaped characters are treated as regular characters and do
+not have their usual Markdown meanings:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\*not emphasized*
+\\&lt;br/&gt; not a tag
+\\[not a link](/foo)
+\\\`not code\`
+1\\. not a list
+\\* not a list
+\\# not a heading
+\\[foo]: /url "not a reference"
+\\&ouml; not a character entity
+.
+&lt;p&gt;*not emphasized*
+&lt;br/&gt; not a tag
+[not a link](/foo)
+\`not code\`
+1. not a list
+* not a list
+# not a heading
+[foo]: /url &quot;not a reference&quot;
+&amp;ouml; not a character entity&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If a backslash is itself escaped, the following character is not:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\\\*emphasis*
+.
+&lt;p&gt;\\&lt;em&gt;emphasis&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A backslash at the end of the line is a [hard line break]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo\\
+bar
+.
+&lt;p&gt;foo&lt;br /&gt;
+bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash escapes do not work in code blocks, code spans, autolinks, or
+raw HTML:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\` \\[\\\` \`\`
+.
+&lt;p&gt;&lt;code&gt;\\[\\\`&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    \\[\\]
+.
+&lt;pre&gt;&lt;code&gt;\\[\\]
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~
+\\[\\]
+~~~
+.
+&lt;pre&gt;&lt;code&gt;\\[\\]
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;https://\`text.com?find=\\*&gt;
+.
+&lt;p&gt;&lt;a href="https://\`text.com?find=%5C*"&gt;https://\`text.com?find=\\*&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="/bar\\/)"&gt;
+.
+&lt;a href="/bar\\/)"&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+But they work in all other contexts, including URLs and link titles,
+link references, and [info strings] in [fenced code blocks]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo](/bar\\* "ti\\*tle")
+.
+&lt;p&gt;&lt;a href="/bar*" title="ti*tle"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+
+[foo]: /bar\\* "ti\\*tle"
+.
+&lt;p&gt;&lt;a href="/bar*" title="ti*tle"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\` foo\\+bar
+foo
+\`\`\`
+.
+&lt;pre&gt;&lt;code class="language-foo+bar"&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Entity and numeric character references
+
+Valid HTML entity references and numeric character references
+can be used in place of the corresponding Unicode character,
+with the following exceptions:
+
+- Entity and character references are not recognized in code
+  blocks and code spans.
+
+- Entity and character references cannot stand in place of
+  special characters that define structural elements in
+  CommonMark.  For\`text, although \`&#42;\` can be used
+  in place of a literal \`*\` character, \`&#42;\` cannot replace
+  \`*\` in emphasis delimiters, bullet list markers, or thematic
+  breaks.
+
+Conforming CommonMark parsers need not store information about
+whether a particular character was represented in the source
+using a Unicode character or an entity reference.
+
+[Entity references](@) consist of \`&\` + any of the valid
+HTML5 entity names + \`;\`. The
+document &lt;https://html.spec.whatwg.org/entities.json&gt;
+is used as an authoritative source for the valid entity
+references and their corresponding code points.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&nbsp; &amp; &copy; &AElig; &Dcaron;
+&frac34; &HilbertSpace; &DifferentialD;
+&ClockwiseContourIntegral; &ngE;
+.
+&lt;p&gt;  &amp; © Æ Ď
+¾ ℋ ⅆ
+∲ ≧̸&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Decimal numeric character
+references](@)
+consist of \`&#\` + a string of 1--7 arabic digits + \`;\`. A
+numeric character reference is parsed as the corresponding
+Unicode character. Invalid Unicode code points will be replaced by
+the REPLACEMENT CHARACTER (\`U+FFFD\`).  For security reasons,
+the code point \`U+0000\` will also be replaced by \`U+FFFD\`.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&#35; &#1234; &#992; &#0;
+.
+&lt;p&gt;# Ӓ Ϡ �&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Hexadecimal numeric character
+references](@) consist of \`&#\` +
+either \`X\` or \`x\` + a string of 1-6 hexadecimal digits + \`;\`.
+They too are parsed as the corresponding Unicode character (this
+time specified with a hexadecimal numeral instead of decimal).
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&#X22; &#XD06; &#xcab;
+.
+&lt;p&gt;&quot; ആ ಫ&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here are some nonentities:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&nbsp &x; &#; &#x;
+&#87654321;
+&#abcdef0;
+&ThisIsNotDefined; &hi?;
+.
+&lt;p&gt;&amp;nbsp &amp;x; &amp;#; &amp;#x;
+&amp;#87654321;
+&amp;#abcdef0;
+&amp;ThisIsNotDefined; &amp;hi?;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Although HTML5 does accept some entity references
+without a trailing semicolon (such as \`&copy\`), these are not
+recognized here, because it makes the grammar too ambiguous:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&copy
+.
+&lt;p&gt;&amp;copy&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Strings that are not on the list of HTML5 named entities are not
+recognized as entity references either:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&MadeUpEntity;
+.
+&lt;p&gt;&amp;MadeUpEntity;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Entity and numeric character references are recognized in any
+context besides code spans or code blocks, including
+URLs, [link titles], and [fenced code block][] [info strings]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="&ouml;&ouml;.html"&gt;
+.
+&lt;a href="&ouml;&ouml;.html"&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo](/f&ouml;&ouml; "f&ouml;&ouml;")
+.
+&lt;p&gt;&lt;a href="/f%C3%B6%C3%B6" title="föö"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+
+[foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
+.
+&lt;p&gt;&lt;a href="/f%C3%B6%C3%B6" title="föö"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\` f&ouml;&ouml;
+foo
+\`\`\`
+.
+&lt;pre&gt;&lt;code class="language-föö"&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Entity and numeric character references are treated as literal
+text in code spans and code blocks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`f&ouml;&ouml;\`
+.
+&lt;p&gt;&lt;code&gt;f&amp;ouml;&amp;ouml;&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    f&ouml;f&ouml;
+.
+&lt;pre&gt;&lt;code&gt;f&amp;ouml;f&amp;ouml;
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Entity and numeric character references cannot be used
+in place of symbols indicating structure in CommonMark
+documents.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&#42;foo&#42;
+*foo*
+.
+&lt;p&gt;*foo*
+&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&#42; foo
+
+* foo
+.
+&lt;p&gt;* foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo&#10;&#10;bar
+.
+&lt;p&gt;foo
+
+bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&#9;foo
+.
+&lt;p&gt;→foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[a](url &quot;tit&quot;)
+.
+&lt;p&gt;[a](url &quot;tit&quot;)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+# Blocks and inlines
+
+We can think of a document as a sequence of
+[blocks](@)---structural elements like paragraphs, block
+quotations, lists, headings, rules, and code blocks.  Some blocks (like
+block quotes and list items) contain other blocks; others (like
+headings and paragraphs) contain [inline](@) content---text,
+links, emphasized text, images, code spans, and so on.
+
+## Precedence
+
+Indicators of block structure always take precedence over indicators
+of inline structure.  So, for\`text, the following is a list with
+two items, not a list with one item containing a code span:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- \`one
+- two\`
+.
+&lt;ul&gt;
+&lt;li&gt;\`one&lt;/li&gt;
+&lt;li&gt;two\`&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This means that parsing can proceed in two steps:  first, the block
+structure of the document can be discerned; second, text lines inside
+paragraphs, headings, and other block constructs can be parsed for inline
+structure.  The second step requires information about link reference
+definitions that will be available only at the end of the first
+step.  Note that the first step requires processing lines in sequence,
+but the second can be parallelized, since the inline parsing of
+one block element does not affect the inline parsing of any other.
+
+## Container blocks and leaf blocks
+
+We can divide blocks into two types:
+[container blocks](#container-blocks),
+which can contain other blocks, and [leaf blocks](#leaf-blocks),
+which cannot.
+
+# Leaf blocks
+
+This section describes the different kinds of leaf block that make up a
+Markdown document.
+
+## Thematic breaks
+
+A line consisting of optionally up to three spaces of indentation, followed by a
+sequence of three or more matching \`-\`, \`_\`, or \`*\` characters, each followed
+optionally by any number of spaces or tabs, forms a
+[thematic break](@).
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+***
+---
+___
+.
+&lt;hr /&gt;
+&lt;hr /&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Wrong characters:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
++++
+.
+&lt;p&gt;+++&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+===
+.
+&lt;p&gt;===&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Not enough characters:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+--
+**
+__
+.
+&lt;p&gt;--
+**
+__&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Up to three spaces of indentation are allowed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ ***
+  ***
+   ***
+.
+&lt;hr /&gt;
+&lt;hr /&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    ***
+.
+&lt;pre&gt;&lt;code&gt;***
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+    ***
+.
+&lt;p&gt;Foo
+***&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+More than three characters may be used:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_____________________________________
+.
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Spaces and tabs are allowed between the characters:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ - - -
+.
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ **  * ** * ** * **
+.
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-     -      -      -
+.
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Spaces and tabs are allowed at the end:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- - - -    
+.
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, no other characters may occur in the line:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_ _ _ _ a
+
+a------
+
+---a---
+.
+&lt;p&gt;_ _ _ _ a&lt;/p&gt;
+&lt;p&gt;a------&lt;/p&gt;
+&lt;p&gt;---a---&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+It is required that all of the characters other than spaces or tabs be the same.
+So, this is not a thematic break:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ *-*
+.
+&lt;p&gt;&lt;em&gt;-&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Thematic breaks do not need blank lines before or after:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+***
+- bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Thematic breaks can interrupt a paragraph:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+***
+bar
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;hr /&gt;
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If a line of dashes that meets the above conditions for being a
+thematic break could also be interpreted as the underline of a [setext
+heading], the interpretation as a
+[setext heading] takes precedence. Thus, for\`text,
+this is a setext heading, not a paragraph followed by a thematic break:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+---
+bar
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+When both a thematic break and a list item are possible
+interpretations of a line, the thematic break takes precedence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+* Foo
+* * *
+* Bar
+.
+&lt;ul&gt;
+&lt;li&gt;Foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+&lt;ul&gt;
+&lt;li&gt;Bar&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If you want a thematic break in a list item, use a different bullet:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- Foo
+- * * *
+.
+&lt;ul&gt;
+&lt;li&gt;Foo&lt;/li&gt;
+&lt;li&gt;
+&lt;hr /&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## ATX headings
+
+An [ATX heading](@)
+consists of a string of characters, parsed as inline content, between an
+opening sequence of 1--6 unescaped \`#\` characters and an optional
+closing sequence of any number of unescaped \`#\` characters.
+The opening sequence of \`#\` characters must be followed by spaces or tabs, or
+by the end of line. The optional closing sequence of \`#\`s must be preceded by
+spaces or tabs and may be followed by spaces or tabs only.  The opening
+\`#\` character may be preceded by up to three spaces of indentation.  The raw
+contents of the heading are stripped of leading and trailing space or tabs
+before being parsed as inline content.  The heading level is equal to the number
+of \`#\` characters in the opening sequence.
+
+Simple headings:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+# foo
+## foo
+### foo
+#### foo
+##### foo
+###### foo
+.
+&lt;h1&gt;foo&lt;/h1&gt;
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;h3&gt;foo&lt;/h3&gt;
+&lt;h4&gt;foo&lt;/h4&gt;
+&lt;h5&gt;foo&lt;/h5&gt;
+&lt;h6&gt;foo&lt;/h6&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+More than six \`#\` characters is not a heading:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+####### foo
+.
+&lt;p&gt;####### foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+At least one space or tab is required between the \`#\` characters and the
+heading's contents, unless the heading is empty.  Note that many
+implementations currently do not require the space.  However, the
+space was required by the
+[original ATX implementation](http://www.aaronsw.com/2002/atx/atx.py),
+and it helps prevent things like the following from being parsed as
+headings:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+#5 bolt
+
+#hashtag
+.
+&lt;p&gt;#5 bolt&lt;/p&gt;
+&lt;p&gt;#hashtag&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not a heading, because the first \`#\` is escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\## foo
+.
+&lt;p&gt;## foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Contents are parsed as inlines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+# foo *bar* \\*baz\\*
+.
+&lt;h1&gt;foo &lt;em&gt;bar&lt;/em&gt; *baz*&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Leading and trailing spaces or tabs are ignored in parsing inline content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+#                  foo                     
+.
+&lt;h1&gt;foo&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Up to three spaces of indentation are allowed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ ### foo
+  ## foo
+   # foo
+.
+&lt;h3&gt;foo&lt;/h3&gt;
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;h1&gt;foo&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    # foo
+.
+&lt;pre&gt;&lt;code&gt;# foo
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo
+    # bar
+.
+&lt;p&gt;foo
+# bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A closing sequence of \`#\` characters is optional:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+## foo ##
+  ###   bar    ###
+.
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;h3&gt;bar&lt;/h3&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+It need not be the same length as the opening sequence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+# foo ##################################
+##### foo ##
+.
+&lt;h1&gt;foo&lt;/h1&gt;
+&lt;h5&gt;foo&lt;/h5&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Spaces or tabs are allowed after the closing sequence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+### foo ###     
+.
+&lt;h3&gt;foo&lt;/h3&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A sequence of \`#\` characters with anything but spaces or tabs following it
+is not a closing sequence, but counts as part of the contents of the
+heading:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+### foo ### b
+.
+&lt;h3&gt;foo ### b&lt;/h3&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The closing sequence must be preceded by a space or tab:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+# foo#
+.
+&lt;h1&gt;foo#&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash-escaped \`#\` characters do not count as part
+of the closing sequence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+### foo \\###
+## foo #\\##
+# foo \\#
+.
+&lt;h3&gt;foo ###&lt;/h3&gt;
+&lt;h2&gt;foo ###&lt;/h2&gt;
+&lt;h1&gt;foo #&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+ATX headings need not be separated from surrounding content by blank
+lines, and they can interrupt paragraphs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+****
+## foo
+****
+.
+&lt;hr /&gt;
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo bar
+# baz
+Bar foo
+.
+&lt;p&gt;Foo bar&lt;/p&gt;
+&lt;h1&gt;baz&lt;/h1&gt;
+&lt;p&gt;Bar foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+ATX headings can be empty:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+## 
+#
+### ###
+.
+&lt;h2&gt;&lt;/h2&gt;
+&lt;h1&gt;&lt;/h1&gt;
+&lt;h3&gt;&lt;/h3&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Setext headings
+
+A [setext heading](@) consists of one or more
+lines of text, not interrupted by a blank line, of which the first line does not
+have more than 3 spaces of indentation, followed by
+a [setext heading underline].  The lines of text must be such
+that, were they not followed by the setext heading underline,
+they would be interpreted as a paragraph:  they cannot be
+interpretable as a [code fence], [ATX heading][ATX headings],
+[block quote][block quotes], [thematic break][thematic breaks],
+[list item][list items], or [HTML block][HTML blocks].
+
+A [setext heading underline](@) is a sequence of
+\`=\` characters or a sequence of \`-\` characters, with no more than 3
+spaces of indentation and any number of trailing spaces or tabs.
+
+The heading is a level 1 heading if \`=\` characters are used in
+the [setext heading underline], and a level 2 heading if \`-\`
+characters are used.  The contents of the heading are the result
+of parsing the preceding lines of text as CommonMark inline
+content.
+
+In general, a setext heading need not be preceded or followed by a
+blank line.  However, it cannot interrupt a paragraph, so when a
+setext heading comes after a paragraph, a blank line is needed between
+them.
+
+Simple examples:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo *bar*
+=========
+
+Foo *bar*
+---------
+.
+&lt;h1&gt;Foo &lt;em&gt;bar&lt;/em&gt;&lt;/h1&gt;
+&lt;h2&gt;Foo &lt;em&gt;bar&lt;/em&gt;&lt;/h2&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The content of the header may span more than one line:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo *bar
+baz*
+====
+.
+&lt;h1&gt;Foo &lt;em&gt;bar
+baz&lt;/em&gt;&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The contents are the result of parsing the headings's raw
+content as inlines.  The heading's raw content is formed by
+concatenating the lines and removing initial and final
+spaces or tabs.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  Foo *bar
+baz*→
+====
+.
+&lt;h1&gt;Foo &lt;em&gt;bar
+baz&lt;/em&gt;&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The underlining can be any length:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+-------------------------
+
+Foo
+=
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The heading content can be preceded by up to three spaces of indentation, and
+need not line up with the underlining:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   Foo
+---
+
+  Foo
+-----
+
+  Foo
+  ===
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    Foo
+    ---
+
+    Foo
+---
+.
+&lt;pre&gt;&lt;code&gt;Foo
+---
+
+Foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The setext heading underline can be preceded by up to three spaces of
+indentation, and may have trailing spaces or tabs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+   ----      
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+    ---
+.
+&lt;p&gt;Foo
+---&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The setext heading underline cannot contain internal spaces or tabs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+= =
+
+Foo
+--- -
+.
+&lt;p&gt;Foo
+= =&lt;/p&gt;
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Trailing spaces or tabs in the content line do not cause a hard line break:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo  
+-----
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Nor does a backslash at the end:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo\\
+----
+.
+&lt;h2&gt;Foo\\&lt;/h2&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Since indicators of block structure take precedence over
+indicators of inline structure, the following are setext headings:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`Foo
+----
+\`
+
+&lt;a title="a lot
+---
+of dashes"/&gt;
+.
+&lt;h2&gt;\`Foo&lt;/h2&gt;
+&lt;p&gt;\`&lt;/p&gt;
+&lt;h2&gt;&lt;a title=&quot;a lot&lt;/h2&gt;
+&lt;p&gt;of dashes&quot;/&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The setext heading underline cannot be a [lazy continuation
+line] in a list item or block quote:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; Foo
+---
+.
+&lt;blockquote&gt;
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+bar
+===
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar
+===&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- Foo
+---
+.
+&lt;ul&gt;
+&lt;li&gt;Foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A blank line is needed between a paragraph and a following
+setext heading, since otherwise the paragraph becomes part
+of the heading's content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+Bar
+---
+.
+&lt;h2&gt;Foo
+Bar&lt;/h2&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+But in general a blank line is not required before or after
+setext headings:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+---
+Foo
+---
+Bar
+---
+Baz
+.
+&lt;hr /&gt;
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h2&gt;Bar&lt;/h2&gt;
+&lt;p&gt;Baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Setext headings cannot be empty:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+
+====
+.
+&lt;p&gt;====&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Setext heading text lines must not be interpretable as block
+constructs other than paragraphs.  So, the line of dashes
+in these examples gets interpreted as a thematic break:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+---
+---
+.
+&lt;hr /&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+-----
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    foo
+---
+.
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+-----
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If you want a heading with \`&gt; foo\` as its literal text, you can
+use backslash escapes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\&gt; foo
+------
+.
+&lt;h2&gt;&gt; foo&lt;/h2&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+**Compatibility note:**  Most existing Markdown implementations
+do not allow the text of setext headings to span multiple lines.
+But there is no consensus about how to interpret
+
+\`\`\` markdown
+Foo
+bar
+---
+baz
+\`\`\`
+
+One can find four different interpretations:
+
+1. paragraph "Foo", heading "bar", paragraph "baz"
+2. paragraph "Foo bar", thematic break, paragraph "baz"
+3. paragraph "Foo bar --- baz"
+4. heading "Foo bar", paragraph "baz"
+
+We find interpretation 4 most natural, and interpretation 4
+increases the expressive power of CommonMark, by allowing
+multiline headings.  Authors who want interpretation 1 can
+put a blank line after the first paragraph:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+
+bar
+---
+baz
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;h2&gt;bar&lt;/h2&gt;
+&lt;p&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Authors who want interpretation 2 can put blank lines around
+the thematic break,
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+bar
+
+---
+
+baz
+.
+&lt;p&gt;Foo
+bar&lt;/p&gt;
+&lt;hr /&gt;
+&lt;p&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+or use a thematic break that cannot count as a [setext heading
+underline], such as
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+bar
+* * *
+baz
+.
+&lt;p&gt;Foo
+bar&lt;/p&gt;
+&lt;hr /&gt;
+&lt;p&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Authors who want interpretation 3 can use backslash escapes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+bar
+\\---
+baz
+.
+&lt;p&gt;Foo
+bar
+---
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Indented code blocks
+
+An [indented code block](@) is composed of one or more
+[indented chunks] separated by blank lines.
+An [indented chunk](@) is a sequence of non-blank lines,
+each preceded by four or more spaces of indentation. The contents of the code
+block are the literal contents of the lines, including trailing
+[line endings], minus four spaces of indentation.
+An indented code block has no [info string].
+
+An indented code block cannot interrupt a paragraph, so there must be
+a blank line between a paragraph and a following indented code block.
+(A blank line is not needed, however, between a code block and a following
+paragraph.)
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    a simple
+      indented code block
+.
+&lt;pre&gt;&lt;code&gt;a simple
+  indented code block
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If there is any ambiguity between an interpretation of indentation
+as a code block and as indicating that material belongs to a [list
+item][list items], the list item interpretation takes precedence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  - foo
+
+    bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1.  foo
+
+    - bar
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+The contents of a code block are literal text, and do not get parsed
+as Markdown:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    &lt;a/&gt;
+    *hi*
+
+    - one
+.
+&lt;pre&gt;&lt;code&gt;&lt;a/&gt;
+*hi*
+
+- one
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here we have three chunks separated by blank lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    chunk1
+
+    chunk2
+  
+ 
+ 
+    chunk3
+.
+&lt;pre&gt;&lt;code&gt;chunk1
+
+chunk2
+
+
+
+chunk3
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Any initial spaces or tabs beyond four spaces of indentation will be included in
+the content, even in interior blank lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    chunk1
+      
+      chunk2
+.
+&lt;pre&gt;&lt;code&gt;chunk1
+  
+  chunk2
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+An indented code block cannot interrupt a paragraph.  (This
+allows hanging indents and the like.)
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+    bar
+
+.
+&lt;p&gt;Foo
+bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, any non-blank line with fewer than four spaces of indentation ends
+the code block immediately.  So a paragraph may occur immediately
+after indented code:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    foo
+bar
+.
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+And indented code can occur immediately before and after other kinds of
+blocks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+# Heading
+    foo
+Heading
+------
+    foo
+----
+.
+&lt;h1&gt;Heading&lt;/h1&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;h2&gt;Heading&lt;/h2&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The first line can be preceded by more than four spaces of indentation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+        foo
+    bar
+.
+&lt;pre&gt;&lt;code&gt;    foo
+bar
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Blank lines preceding or following an indented code block
+are not included in it:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+
+    
+    foo
+    
+
+.
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Trailing spaces or tabs are included in the code block's content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    foo  
+.
+&lt;pre&gt;&lt;code&gt;foo  
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+## Fenced code blocks
+
+A [code fence](@) is a sequence
+of at least three consecutive backtick characters (\`\` \` \`\`) or
+tildes (\`~\`).  (Tildes and backticks cannot be mixed.)
+A [fenced code block](@)
+begins with a code fence, preceded by up to three spaces of indentation.
+
+The line with the opening code fence may optionally contain some text
+following the code fence; this is trimmed of leading and trailing
+spaces or tabs and called the [info string](@). If the [info string] comes
+after a backtick fence, it may not contain any backtick
+characters.  (The reason for this restriction is that otherwise
+some inline code would be incorrectly interpreted as the
+beginning of a fenced code block.)
+
+The content of the code block consists of all subsequent lines, until
+a closing [code fence] of the same type as the code block
+began with (backticks or tildes), and with at least as many backticks
+or tildes as the opening code fence.  If the leading code fence is
+preceded by N spaces of indentation, then up to N spaces of indentation are
+removed from each line of the content (if present).  (If a content line is not
+indented, it is preserved unchanged.  If it is indented N spaces or less, all
+of the indentation is removed.)
+
+The closing code fence may be preceded by up to three spaces of indentation, and
+may be followed only by spaces or tabs, which are ignored.  If the end of the
+containing block (or document) is reached and no closing code fence
+has been found, the code block contains all of the lines after the
+opening code fence until the end of the containing block (or
+document).  (An alternative spec would require backtracking in the
+event that a closing code fence is not found.  But this makes parsing
+much less efficient, and there seems to be no real downside to the
+behavior described here.)
+
+A fenced code block may interrupt a paragraph, and does not require
+a blank line either before or after.
+
+The content of a code fence is treated as literal text, not parsed
+as inlines.  The first word of the [info string] is typically used to
+specify the language of the code sample, and rendered in the \`class\`
+attribute of the \`code\` tag.  However, this spec does not mandate any
+particular treatment of the [info string].
+
+Here is a simple\`text with backticks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+&lt;
+ &gt;
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;&lt;
+ &gt;
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+With tildes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~
+&lt;
+ &gt;
+~~~
+.
+&lt;pre&gt;&lt;code&gt;&lt;
+ &gt;
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Fewer than three backticks is not enough:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`
+foo
+\`\`
+.
+&lt;p&gt;&lt;code&gt;foo&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The closing code fence must use the same character as the opening
+fence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+aaa
+~~~
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+~~~
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~
+aaa
+\`\`\`
+~~~
+.
+&lt;pre&gt;&lt;code&gt;aaa
+\`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The closing code fence must be at least as long as the opening fence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`\`
+aaa
+\`\`\`
+\`\`\`\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+\`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~~
+aaa
+~~~
+~~~~
+.
+&lt;pre&gt;&lt;code&gt;aaa
+~~~
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Unclosed code blocks are closed by the end of the document
+(or the enclosing [block quote][block quotes] or [list item][list items]):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`\`\`
+
+\`\`\`
+aaa
+.
+&lt;pre&gt;&lt;code&gt;
+\`\`\`
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; \`\`\`
+&gt; aaa
+
+bbb
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A code block can have all empty lines as its content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+
+  
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;
+  
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A code block can be empty:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Fences can be indented.  If the opening fence is indented,
+content lines will have equivalent opening indentation removed,
+if present:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ \`\`\`
+ aaa
+aaa
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  \`\`\`
+aaa
+  aaa
+aaa
+  \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+aaa
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   \`\`\`
+   aaa
+    aaa
+  aaa
+   \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+ aaa
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    \`\`\`
+    aaa
+    \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;\`\`\`
+aaa
+\`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Closing fences may be preceded by up to three spaces of indentation, and their
+indentation need not match that of the opening fence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+aaa
+  \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   \`\`\`
+aaa
+  \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not a closing fence, because it is indented 4 spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+aaa
+    \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+    \`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Code fences (opening and closing) cannot contain internal spaces or tabs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\` \`\`\`
+aaa
+.
+&lt;p&gt;&lt;code&gt; &lt;/code&gt;
+aaa&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~~~~
+aaa
+~~~ ~~
+.
+&lt;pre&gt;&lt;code&gt;aaa
+~~~ ~~
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Fenced code blocks can interrupt paragraphs, and can be followed
+directly by paragraphs, without a blank line between:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo
+\`\`\`
+bar
+\`\`\`
+baz
+.
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Other blocks can also occur before and after fenced code blocks
+without an intervening blank line:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo
+---
+~~~
+bar
+~~~
+# baz
+.
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;h1&gt;baz&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+An [info string] can be provided after the opening code fence.
+Although this spec doesn't mandate any particular treatment of
+the info string, the first word is typically used to specify
+the language of the code block. In HTML output, the language is
+normally indicated by adding a class to the \`code\` element consisting
+of \`language-\` followed by the language name.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`ruby
+def foo(x)
+  return 3
+end
+\`\`\`
+.
+&lt;pre&gt;&lt;code class="language-ruby"&gt;def foo(x)
+  return 3
+end
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~~    ruby startline=3 $%@#$
+def foo(x)
+  return 3
+end
+~~~~~~~
+.
+&lt;pre&gt;&lt;code class="language-ruby"&gt;def foo(x)
+  return 3
+end
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`\`;
+\`\`\`\`
+.
+&lt;pre&gt;&lt;code class="language-;"&gt;&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Info strings] for backtick code blocks cannot contain backticks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\` aa \`\`\`
+foo
+.
+&lt;p&gt;&lt;code&gt;aa&lt;/code&gt;
+foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Info strings] for tilde code blocks can contain backticks and tildes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+~~~ aa \`\`\` ~~~
+foo
+~~~
+.
+&lt;pre&gt;&lt;code class="language-aa"&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Closing code fences cannot have [info strings]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+\`\`\` aaa
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;\`\`\` aaa
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+## HTML blocks
+
+An [HTML block](@) is a group of lines that is treated
+as raw HTML (and will not be escaped in HTML output).
+
+There are seven kinds of [HTML block], which can be defined by their
+start and end conditions.  The block begins with a line that meets a
+[start condition](@) (after up to three optional spaces of indentation).
+It ends with the first subsequent line that meets a matching
+[end condition](@), or the last line of the document, or the last line of
+the [container block](#container-blocks) containing the current HTML
+block, if no line is encountered that meets the [end condition].  If
+the first line meets both the [start condition] and the [end
+condition], the block will contain just that line.
+
+1.  **Start condition:**  line begins with the string \`&lt;pre\`,
+\`&lt;script\`, \`&lt;style\`, or \`&lt;textarea\` (case-insensitive), followed by a space,
+a tab, the string \`&gt;\`, or the end of the line.\\
+**End condition:**  line contains an end tag
+\`&lt;/pre&gt;\`, \`&lt;/script&gt;\`, \`&lt;/style&gt;\`, or \`&lt;/textarea&gt;\` (case-insensitive; it
+need not match the start tag).
+
+2.  **Start condition:** line begins with the string \`&lt;!--\`.\\
+**End condition:**  line contains the string \`--&gt;\`.
+
+3.  **Start condition:** line begins with the string \`&lt;?\`.\\
+**End condition:** line contains the string \`?&gt;\`.
+
+4.  **Start condition:** line begins with the string \`&lt;!\`
+followed by an ASCII letter.\\
+**End condition:** line contains the character \`&gt;\`.
+
+5.  **Start condition:**  line begins with the string
+\`&lt;![CDATA[\`.\\
+**End condition:** line contains the string \`]]&gt;\`.
+
+6.  **Start condition:** line begins with the string \`&lt;\` or \`&lt;/\`
+followed by one of the strings (case-insensitive) \`address\`,
+\`article\`, \`aside\`, \`base\`, \`basefont\`, \`blockquote\`, \`body\`,
+\`caption\`, \`center\`, \`col\`, \`colgroup\`, \`dd\`, \`details\`, \`dialog\`,
+\`dir\`, \`div\`, \`dl\`, \`dt\`, \`fieldset\`, \`figcaption\`, \`figure\`,
+\`footer\`, \`form\`, \`frame\`, \`frameset\`,
+\`h1\`, \`h2\`, \`h3\`, \`h4\`, \`h5\`, \`h6\`, \`head\`, \`header\`, \`hr\`,
+\`html\`, \`iframe\`, \`legend\`, \`li\`, \`link\`, \`main\`, \`menu\`, \`menuitem\`,
+\`nav\`, \`noframes\`, \`ol\`, \`optgroup\`, \`option\`, \`p\`, \`param\`,
+\`search\`, \`section\`, \`summary\`, \`table\`, \`tbody\`, \`td\`,
+\`tfoot\`, \`th\`, \`thead\`, \`title\`, \`tr\`, \`track\`, \`ul\`, followed
+by a space, a tab, the end of the line, the string \`&gt;\`, or
+the string \`/&gt;\`.\\
+**End condition:** line is followed by a [blank line].
+
+7.  **Start condition:**  line begins with a complete [open tag]
+(with any [tag name] other than \`pre\`, \`script\`,
+\`style\`, or \`textarea\`) or a complete [closing tag],
+followed by zero or more spaces and tabs, followed by the end of the line.\\
+**End condition:** line is followed by a [blank line].
+
+HTML blocks continue until they are closed by their appropriate
+[end condition], or the last line of the document or other [container
+block](#container-blocks).  This means any HTML **within an HTML
+block** that might otherwise be recognised as a start condition will
+be ignored by the parser and passed through as-is, without changing
+the parser's state.
+
+For instance, \`&lt;pre&gt;\` within an HTML block started by \`&lt;table&gt;\` will not affect
+the parser state; as the HTML block was started in by start condition 6, it
+will end at any blank line. This can be surprising:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+&lt;pre&gt;
+**Hello**,
+
+_world_.
+&lt;/pre&gt;
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+.
+&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+&lt;pre&gt;
+**Hello**,
+&lt;p&gt;&lt;em&gt;world&lt;/em&gt;.
+&lt;/pre&gt;&lt;/p&gt;
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+In this case, the HTML block is terminated by the blank line — the \`**Hello**\`
+text remains verbatim — and regular parsing resumes, with a paragraph,
+emphasised \`world\` and inline and block HTML following.
+
+All types of [HTML blocks] except type 7 may interrupt
+a paragraph.  Blocks of type 7 may not interrupt a paragraph.
+(This restriction is intended to prevent unwanted interpretation
+of long tags inside a wrapped paragraph as starting HTML blocks.)
+
+Some simple examples follow.  Here are some basic HTML blocks
+of type 6:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;table&gt;
+  &lt;tr&gt;
+    &lt;td&gt;
+           hi
+    &lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+
+okay.
+.
+&lt;table&gt;
+  &lt;tr&gt;
+    &lt;td&gt;
+           hi
+    &lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+&lt;p&gt;okay.&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ &lt;div&gt;
+  *hello*
+         &lt;foo&gt;&lt;a&gt;
+.
+ &lt;div&gt;
+  *hello*
+         &lt;foo&gt;&lt;a&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A block can also start with a closing tag:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;/div&gt;
+*foo*
+.
+&lt;/div&gt;
+*foo*
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here we have two HTML blocks with a Markdown paragraph between them:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;DIV CLASS="foo"&gt;
+
+*Markdown*
+
+&lt;/DIV&gt;
+.
+&lt;DIV CLASS="foo"&gt;
+&lt;p&gt;&lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;
+&lt;/DIV&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The tag on the first line can be partial, as long
+as it is split where there would be whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div id="foo"
+  class="bar"&gt;
+&lt;/div&gt;
+.
+&lt;div id="foo"
+  class="bar"&gt;
+&lt;/div&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div id="foo" class="bar
+  baz"&gt;
+&lt;/div&gt;
+.
+&lt;div id="foo" class="bar
+  baz"&gt;
+&lt;/div&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+An open tag need not be closed:
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div&gt;
+*foo*
+
+*bar*
+.
+&lt;div&gt;
+*foo*
+&lt;p&gt;&lt;em&gt;bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+A partial tag need not even be completed (garbage
+in, garbage out):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div id="foo"
+*hi*
+.
+&lt;div id="foo"
+*hi*
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div class
+foo
+.
+&lt;div class
+foo
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The initial tag doesn't even need to be a valid
+tag, as long as it starts like one:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div *???-&&&-&lt;---
+*foo*
+.
+&lt;div *???-&&&-&lt;---
+*foo*
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In type 6 blocks, the initial tag need not be on a line by
+itself:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div&gt;&lt;a href="bar"&gt;*foo*&lt;/a&gt;&lt;/div&gt;
+.
+&lt;div&gt;&lt;a href="bar"&gt;*foo*&lt;/a&gt;&lt;/div&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+foo
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+.
+&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+foo
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Everything until the next blank line or end of document
+gets included in the HTML block.  So, in the following\`text, what looks like a Markdown code block
+is actually part of the HTML block, which continues until a blank
+line or the end of the document is reached:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div&gt;&lt;/div&gt;
+\`\`\` c
+int x = 33;
+\`\`\`
+.
+&lt;div&gt;&lt;/div&gt;
+\`\`\` c
+int x = 33;
+\`\`\`
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+To start an [HTML block] with a tag that is *not* in the
+list of block-level tags in (6), you must put the tag by
+itself on the first line (and it must be complete):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="foo"&gt;
+*bar*
+&lt;/a&gt;
+.
+&lt;a href="foo"&gt;
+*bar*
+&lt;/a&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In type 7 blocks, the [tag name] can be anything:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;Warning&gt;
+*bar*
+&lt;/Warning&gt;
+.
+&lt;Warning&gt;
+*bar*
+&lt;/Warning&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;i class="foo"&gt;
+*bar*
+&lt;/i&gt;
+.
+&lt;i class="foo"&gt;
+*bar*
+&lt;/i&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;/ins&gt;
+*bar*
+.
+&lt;/ins&gt;
+*bar*
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These rules are designed to allow us to work with tags that
+can function as either block-level or inline-level tags.
+The \`&lt;del&gt;\` tag is a nice\`text.  We can surround content with
+\`&lt;del&gt;\` tags in three different ways.  In this case, we get a raw
+HTML block, because the \`&lt;del&gt;\` tag is on a line by itself:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;del&gt;
+*foo*
+&lt;/del&gt;
+.
+&lt;del&gt;
+*foo*
+&lt;/del&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In this case, we get a raw HTML block that just includes
+the \`&lt;del&gt;\` tag (because it ends with the following blank
+line).  So the contents get interpreted as CommonMark:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;del&gt;
+
+*foo*
+
+&lt;/del&gt;
+.
+&lt;del&gt;
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+&lt;/del&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Finally, in this case, the \`&lt;del&gt;\` tags are interpreted
+as [raw HTML] *inside* the CommonMark paragraph.  (Because
+the tag is not on a line by itself, we get inline HTML
+rather than an [HTML block].)
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;del&gt;*foo*&lt;/del&gt;
+.
+&lt;p&gt;&lt;del&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/del&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+HTML tags designed to contain literal content
+(\`pre\`, \`script\`, \`style\`, \`textarea\`), comments, processing instructions,
+and declarations are treated somewhat differently.
+Instead of ending at the first blank line, these blocks
+end at the first line containing a corresponding end tag.
+As a result, these blocks can contain blank lines:
+
+A pre tag (type 1):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;pre language="haskell"&gt;&lt;code&gt;
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+&lt;/code&gt;&lt;/pre&gt;
+okay
+.
+&lt;pre language="haskell"&gt;&lt;code&gt;
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;okay&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A script tag (type 1):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;script type="text/javascript"&gt;
+// JavaScript\`text
+
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+&lt;/script&gt;
+okay
+.
+&lt;script type="text/javascript"&gt;
+// JavaScript\`text
+
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+&lt;/script&gt;
+&lt;p&gt;okay&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A textarea tag (type 1):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;textarea&gt;
+
+*foo*
+
+_bar_
+
+&lt;/textarea&gt;
+.
+&lt;textarea&gt;
+
+*foo*
+
+_bar_
+
+&lt;/textarea&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+A style tag (type 1):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;style
+  type="text/css"&gt;
+h1 {color:red;}
+
+p {color:blue;}
+&lt;/style&gt;
+okay
+.
+&lt;style
+  type="text/css"&gt;
+h1 {color:red;}
+
+p {color:blue;}
+&lt;/style&gt;
+&lt;p&gt;okay&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If there is no matching end tag, the block will end at the
+end of the document (or the enclosing [block quote][block quotes]
+or [list item][list items]):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;style
+  type="text/css"&gt;
+
+foo
+.
+&lt;style
+  type="text/css"&gt;
+
+foo
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; &lt;div&gt;
+&gt; foo
+
+bar
+.
+&lt;blockquote&gt;
+&lt;div&gt;
+foo
+&lt;/blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- &lt;div&gt;
+- foo
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;div&gt;
+&lt;/li&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The end tag can occur on the same line as the start tag:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;style&gt;p{color:red;}&lt;/style&gt;
+*foo*
+.
+&lt;style&gt;p{color:red;}&lt;/style&gt;
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;!-- foo --&gt;*bar*
+*baz*
+.
+&lt;!-- foo --&gt;*bar*
+&lt;p&gt;&lt;em&gt;baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that anything on the last line after the
+end tag will be included in the [HTML block]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;script&gt;
+foo
+&lt;/script&gt;1. *bar*
+.
+&lt;script&gt;
+foo
+&lt;/script&gt;1. *bar*
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A comment (type 2):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;!-- Foo
+
+bar
+   baz --&gt;
+okay
+.
+&lt;!-- Foo
+
+bar
+   baz --&gt;
+&lt;p&gt;okay&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+A processing instruction (type 3):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;?php
+
+  echo '&gt;';
+
+?&gt;
+okay
+.
+&lt;?php
+
+  echo '&gt;';
+
+?&gt;
+&lt;p&gt;okay&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A declaration (type 4):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;!DOCTYPE html&gt;
+.
+&lt;!DOCTYPE html&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+CDATA (type 5):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;![CDATA[
+function matchwo(a,b)
+{
+  if (a &lt; b && a &lt; 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]&gt;
+okay
+.
+&lt;![CDATA[
+function matchwo(a,b)
+{
+  if (a &lt; b && a &lt; 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]&gt;
+&lt;p&gt;okay&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The opening tag can be preceded by up to three spaces of indentation, but not
+four:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  &lt;!-- foo --&gt;
+
+    &lt;!-- foo --&gt;
+.
+  &lt;!-- foo --&gt;
+&lt;pre&gt;&lt;code&gt;&lt;!-- foo --&gt;
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  &lt;div&gt;
+
+    &lt;div&gt;
+.
+  &lt;div&gt;
+&lt;pre&gt;&lt;code&gt;&lt;div&gt;
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+An HTML block of types 1--6 can interrupt a paragraph, and need not be
+preceded by a blank line.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+&lt;div&gt;
+bar
+&lt;/div&gt;
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;div&gt;
+bar
+&lt;/div&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, a following blank line is needed, except at the end of
+a document, and except for blocks of types 1--5, [above][HTML
+block]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div&gt;
+bar
+&lt;/div&gt;
+*foo*
+.
+&lt;div&gt;
+bar
+&lt;/div&gt;
+*foo*
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+HTML blocks of type 7 cannot interrupt a paragraph:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+&lt;a href="bar"&gt;
+baz
+.
+&lt;p&gt;Foo
+&lt;a href="bar"&gt;
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This rule differs from John Gruber's original Markdown syntax
+specification, which says:
+
+&gt; The only restrictions are that block-level HTML elements —
+&gt; e.g. \`&lt;div&gt;\`, \`&lt;table&gt;\`, \`&lt;pre&gt;\`, \`&lt;p&gt;\`, etc. — must be separated from
+&gt; surrounding content by blank lines, and the start and end tags of the
+&gt; block should not be indented with spaces or tabs.
+
+In some ways Gruber's rule is more restrictive than the one given
+here:
+
+- It requires that an HTML block be preceded by a blank line.
+- It does not allow the start tag to be indented.
+- It requires a matching end tag, which it also does not allow to
+  be indented.
+
+Most Markdown implementations (including some of Gruber's own) do not
+respect all of these restrictions.
+
+There is one respect, however, in which Gruber's rule is more liberal
+than the one given here, since it allows blank lines to occur inside
+an HTML block.  There are two reasons for disallowing them here.
+First, it removes the need to parse balanced tags, which is
+expensive and can require backtracking from the end of the document
+if no matching end tag is found. Second, it provides a very simple
+and flexible way of including Markdown content inside HTML tags:
+simply separate the Markdown from the HTML using blank lines:
+
+Compare:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div&gt;
+
+*Emphasized* text.
+
+&lt;/div&gt;
+.
+&lt;div&gt;
+&lt;p&gt;&lt;em&gt;Emphasized&lt;/em&gt; text.&lt;/p&gt;
+&lt;/div&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;div&gt;
+*Emphasized* text.
+&lt;/div&gt;
+.
+&lt;div&gt;
+*Emphasized* text.
+&lt;/div&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Some Markdown implementations have adopted a convention of
+interpreting content inside tags as text if the open tag has
+the attribute \`markdown=1\`.  The rule given above seems a simpler and
+more elegant way of achieving the same expressive power, which is also
+much simpler to parse.
+
+The main potential drawback is that one can no longer paste HTML
+blocks into Markdown documents with 100% reliability.  However,
+*in most cases* this will work fine, because the blank lines in
+HTML are usually followed by HTML block tags.  For\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;table&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+Hi
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+.
+&lt;table&gt;
+&lt;tr&gt;
+&lt;td&gt;
+Hi
+&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/table&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+There are problems, however, if the inner tags are indented
+*and* separated by spaces, as then they will be interpreted as
+an indented code block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;table&gt;
+
+  &lt;tr&gt;
+
+    &lt;td&gt;
+      Hi
+    &lt;/td&gt;
+
+  &lt;/tr&gt;
+
+&lt;/table&gt;
+.
+&lt;table&gt;
+  &lt;tr&gt;
+&lt;pre&gt;&lt;code&gt;&lt;td&gt;
+  Hi
+&lt;/td&gt;
+&lt;/code&gt;&lt;/pre&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Fortunately, blank lines are usually not necessary and can be
+deleted.  The exception is inside \`&lt;pre&gt;\` tags, but as described
+[above][HTML blocks], raw HTML blocks starting with \`&lt;pre&gt;\`
+*can* contain blank lines.
+
+## Link reference definitions
+
+A [link reference definition](@)
+consists of a [link label], optionally preceded by up to three spaces of
+indentation, followed
+by a colon (\`:\`), optional spaces or tabs (including up to one
+[line ending]), a [link destination],
+optional spaces or tabs (including up to one
+[line ending]), and an optional [link
+title], which if it is present must be separated
+from the [link destination] by spaces or tabs.
+No further character may occur.
+
+A [link reference definition]
+does not correspond to a structural element of a document.  Instead, it
+defines a label which can be used in [reference links]
+and reference-style [images] elsewhere in the document.  [Link
+reference definitions] can come either before or after the links that use
+them.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url "title"
+
+[foo]
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   [foo]: 
+      /url  
+           'the title'  
+
+[foo]
+.
+&lt;p&gt;&lt;a href="/url" title="the title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[Foo*bar\\]]:my_(url) 'title (with parens)'
+
+[Foo*bar\\]]
+.
+&lt;p&gt;&lt;a href="my_(url)" title="title (with parens)"&gt;Foo*bar]&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[Foo bar]:
+&lt;my url&gt;
+'title'
+
+[Foo bar]
+.
+&lt;p&gt;&lt;a href="my%20url" title="title"&gt;Foo bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The title may extend over multiple lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url '
+title
+line1
+line2
+'
+
+[foo]
+.
+&lt;p&gt;&lt;a href="/url" title="
+title
+line1
+line2
+"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, it may not contain a [blank line]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url 'title
+
+with blank line'
+
+[foo]
+.
+&lt;p&gt;[foo]: /url 'title&lt;/p&gt;
+&lt;p&gt;with blank line'&lt;/p&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The title may be omitted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]:
+/url
+
+[foo]
+.
+&lt;p&gt;&lt;a href="/url"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link destination may not be omitted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]:
+
+[foo]
+.
+&lt;p&gt;[foo]:&lt;/p&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+ However, an empty link destination may be specified using
+ angle brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: &lt;&gt;
+
+[foo]
+.
+&lt;p&gt;&lt;a href=""&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The title must be separated from the link destination by
+spaces or tabs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: &lt;bar&gt;(baz)
+
+[foo]
+.
+&lt;p&gt;[foo]: &lt;bar&gt;(baz)&lt;/p&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Both title and destination can contain backslash escapes
+and literal backslashes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url\\bar\\*baz "foo\\"bar\\baz"
+
+[foo]
+.
+&lt;p&gt;&lt;a href="/url%5Cbar*baz" title="foo&quot;bar\\baz"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A link can come before its corresponding definition:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+
+[foo]: url
+.
+&lt;p&gt;&lt;a href="url"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If there are several matching definitions, the first one takes
+precedence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+
+[foo]: first
+[foo]: second
+.
+&lt;p&gt;&lt;a href="first"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+As noted in the section on [Links], matching of labels is
+case-insensitive (see [matches]).
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[FOO]: /url
+
+[Foo]
+.
+&lt;p&gt;&lt;a href="/url"&gt;Foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[ΑΓΩ]: /φου
+
+[αγω]
+.
+&lt;p&gt;&lt;a href="/%CF%86%CE%BF%CF%85"&gt;αγω&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Whether something is a [link reference definition] is
+independent of whether the link reference it defines is
+used in the document.  Thus, for\`text, the following
+document contains just a link reference definition, and
+no visible content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url
+.
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here is another one:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[
+foo
+]: /url
+bar
+.
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not a link reference definition, because there are
+characters other than spaces or tabs after the title:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url "title" ok
+.
+&lt;p&gt;[foo]: /url &quot;title&quot; ok&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is a link reference definition, but it has no title:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url
+"title" ok
+.
+&lt;p&gt;&quot;title&quot; ok&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not a link reference definition, because it is indented
+four spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    [foo]: /url "title"
+
+[foo]
+.
+&lt;pre&gt;&lt;code&gt;[foo]: /url &quot;title&quot;
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not a link reference definition, because it occurs inside
+a code block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`
+[foo]: /url
+\`\`\`
+
+[foo]
+.
+&lt;pre&gt;&lt;code&gt;[foo]: /url
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A [link reference definition] cannot interrupt a paragraph.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+[bar]: /baz
+
+[bar]
+.
+&lt;p&gt;Foo
+[bar]: /baz&lt;/p&gt;
+&lt;p&gt;[bar]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, it can directly follow other block elements, such as headings
+and thematic breaks, and it need not be followed by a blank line.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+# [Foo]
+[foo]: /url
+&gt; bar
+.
+&lt;h1&gt;&lt;a href="/url"&gt;Foo&lt;/a&gt;&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url
+bar
+===
+[foo]
+.
+&lt;h1&gt;bar&lt;/h1&gt;
+&lt;p&gt;&lt;a href="/url"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url
+===
+[foo]
+.
+&lt;p&gt;===
+&lt;a href="/url"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Several [link reference definitions]
+can occur one after another, without intervening blank lines.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /foo-url "foo"
+[bar]: /bar-url
+  "bar"
+[baz]: /baz-url
+
+[foo],
+[bar],
+[baz]
+.
+&lt;p&gt;&lt;a href="/foo-url" title="foo"&gt;foo&lt;/a&gt;,
+&lt;a href="/bar-url" title="bar"&gt;bar&lt;/a&gt;,
+&lt;a href="/baz-url"&gt;baz&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Link reference definitions] can occur
+inside block containers, like lists and block quotations.  They
+affect the entire document, not just the container in which they
+are defined:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+
+&gt; [foo]: /url
+.
+&lt;p&gt;&lt;a href="/url"&gt;foo&lt;/a&gt;&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Paragraphs
+
+A sequence of non-blank lines that cannot be interpreted as other
+kinds of blocks forms a [paragraph](@).
+The contents of the paragraph are the result of parsing the
+paragraph's raw content as inlines.  The paragraph's raw content
+is formed by concatenating the lines and removing initial and final
+spaces or tabs.
+
+A simple\`text with two paragraphs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+aaa
+
+bbb
+.
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Paragraphs can contain multiple lines, but no blank lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+aaa
+bbb
+
+ccc
+ddd
+.
+&lt;p&gt;aaa
+bbb&lt;/p&gt;
+&lt;p&gt;ccc
+ddd&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Multiple blank lines between paragraphs have no effect:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+aaa
+
+
+bbb
+.
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Leading spaces or tabs are skipped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  aaa
+ bbb
+.
+&lt;p&gt;aaa
+bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Lines after the first may be indented any amount, since indented
+code blocks cannot interrupt paragraphs.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+aaa
+             bbb
+                                       ccc
+.
+&lt;p&gt;aaa
+bbb
+ccc&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, the first line may be preceded by up to three spaces of indentation.
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   aaa
+bbb
+.
+&lt;p&gt;aaa
+bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    aaa
+bbb
+.
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Final spaces or tabs are stripped before inline parsing, so a paragraph
+that ends with two or more spaces will not end with a [hard line
+break]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+aaa     
+bbb     
+.
+&lt;p&gt;aaa&lt;br /&gt;
+bbb&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Blank lines
+
+[Blank lines] between block-level elements are ignored,
+except for the role they play in determining whether a [list]
+is [tight] or [loose].
+
+Blank lines at the beginning and end of the document are also ignored.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  
+
+aaa
+  
+
+# aaa
+
+  
+.
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;h1&gt;aaa&lt;/h1&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+# Container blocks
+
+A [container block](#container-blocks) is a block that has other
+blocks as its contents.  There are two basic kinds of container blocks:
+[block quotes] and [list items].
+[Lists] are meta-containers for [list items].
+
+We define the syntax for container blocks recursively.  The general
+form of the definition is:
+
+&gt; If X is a sequence of blocks, then the result of
+&gt; transforming X in such-and-such a way is a container of type Y
+&gt; with these blocks as its content.
+
+So, we explain what counts as a block quote or list item by explaining
+how these can be *generated* from their contents. This should suffice
+to define the syntax, although it does not give a recipe for *parsing*
+these constructions.  (A recipe is provided below in the section entitled
+[A parsing strategy](#appendix-a-parsing-strategy).)
+
+## Block quotes
+
+A [block quote marker](@),
+optionally preceded by up to three spaces of indentation,
+consists of (a) the character \`&gt;\` together with a following space of
+indentation, or (b) a single character \`&gt;\` not followed by a space of
+indentation.
+
+The following rules define [block quotes]:
+
+1.  **Basic case.**  If a string of lines *Ls* constitute a sequence
+    of blocks *Bs*, then the result of prepending a [block quote
+    marker] to the beginning of each line in *Ls*
+    is a [block quote](#block-quotes) containing *Bs*.
+
+2.  **Laziness.**  If a string of lines *Ls* constitute a [block
+    quote](#block-quotes) with contents *Bs*, then the result of deleting
+    the initial [block quote marker] from one or
+    more lines in which the next character other than a space or tab after the
+    [block quote marker] is [paragraph continuation
+    text] is a block quote with *Bs* as its content.
+    [Paragraph continuation text](@) is text
+    that will be parsed as part of the content of a paragraph, but does
+    not occur at the beginning of the paragraph.
+
+3.  **Consecutiveness.**  A document cannot contain two [block
+    quotes] in a row unless there is a [blank line] between them.
+
+Nothing else counts as a [block quote](#block-quotes).
+
+Here is a simple\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; # Foo
+&gt; bar
+&gt; baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The space or tab after the \`&gt;\` characters can be omitted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;# Foo
+&gt;bar
+&gt; baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The \`&gt;\` characters can be preceded by up to three spaces of indentation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   &gt; # Foo
+   &gt; bar
+ &gt; baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces of indentation is too many:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    &gt; # Foo
+    &gt; bar
+    &gt; baz
+.
+&lt;pre&gt;&lt;code&gt;&gt; # Foo
+&gt; bar
+&gt; baz
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The Laziness clause allows us to omit the \`&gt;\` before
+[paragraph continuation text]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; # Foo
+&gt; bar
+baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A block quote can contain some lazy and some non-lazy
+continuation lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; bar
+baz
+&gt; foo
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar
+baz
+foo&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Laziness only applies to lines that would have been continuations of
+paragraphs had they been prepended with [block quote markers].
+For\`text, the \`&gt; \` cannot be omitted in the second line of
+
+\`\`\` markdown
+&gt; foo
+&gt; ---
+\`\`\`
+
+without changing the meaning:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+---
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Similarly, if we omit the \`&gt; \` in the second line of
+
+\`\`\` markdown
+&gt; - foo
+&gt; - bar
+\`\`\`
+
+then the block quote ends after the first line:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; - foo
+- bar
+.
+&lt;blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+For the same reason, we can't omit the \`&gt; \` in front of
+subsequent lines of an indented or fenced code block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;     foo
+    bar
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; \`\`\`
+foo
+\`\`\`
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that in the following case, we have a [lazy
+continuation line]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+    - bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo
+- bar&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+To see why, note that in
+
+\`\`\`markdown
+&gt; foo
+&gt;     - bar
+\`\`\`
+
+the \`- bar\` is indented too far to start a list, and can't
+be an indented code block because indented code blocks cannot
+interrupt paragraphs, so it is [paragraph continuation text].
+
+A block quote can be empty:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;
+.
+&lt;blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;
+&gt;  
+&gt; 
+.
+&lt;blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A block quote can have initial or final blank lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;
+&gt; foo
+&gt;  
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A blank line always separates block quotes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+
+&gt; bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+(Most current Markdown implementations, including John Gruber's
+original \`Markdown.pl\`, will parse this\`text as a single block quote
+with two paragraphs.  But it seems better to allow the author to decide
+whether two block quotes or one are wanted.)
+
+Consecutiveness means that if we put these block quotes together,
+we get a single block quote:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+&gt; bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+To get a block quote with two paragraphs, use:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; foo
+&gt;
+&gt; bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Block quotes can interrupt paragraphs:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo
+&gt; bar
+.
+&lt;p&gt;foo&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In general, blank lines are not needed before or after block
+quotes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; aaa
+***
+&gt; bbb
+.
+&lt;blockquote&gt;
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, because of laziness, a blank line is needed between
+a block quote and a following paragraph:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; bar
+baz
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; bar
+
+baz
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; bar
+&gt;
+baz
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+It is a consequence of the Laziness rule that any number
+of initial \`&gt;\`s may be omitted on a continuation line of a
+nested block quote:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; &gt; &gt; foo
+bar
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;&gt;&gt; foo
+&gt; bar
+&gt;&gt;baz
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+When including an indented code block in a block quote,
+remember that the [block quote marker] includes
+both the \`&gt;\` and a following space of indentation.  So *five spaces* are needed
+after the \`&gt;\`:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;     code
+
+&gt;    not code
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;not code&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+## List items
+
+A [list marker](@) is a
+[bullet list marker] or an [ordered list marker].
+
+A [bullet list marker](@)
+is a \`-\`, \`+\`, or \`*\` character.
+
+An [ordered list marker](@)
+is a sequence of 1--9 arabic digits (\`0-9\`), followed by either a
+\`.\` character or a \`)\` character.  (The reason for the length
+limit is that with 10 digits we start seeing integer overflows
+in some browsers.)
+
+The following rules define [list items]:
+
+1.  **Basic case.**  If a sequence of lines *Ls* constitute a sequence of
+    blocks *Bs* starting with a character other than a space or tab, and *M* is
+    a list marker of width *W* followed by 1 ≤ *N* ≤ 4 spaces of indentation,
+    then the result of prepending *M* and the following spaces to the first line
+    of *Ls*, and indenting subsequent lines of *Ls* by *W + N* spaces, is a
+    list item with *Bs* as its contents.  The type of the list item
+    (bullet or ordered) is determined by the type of its list marker.
+    If the list item is ordered, then it is also assigned a start
+    number, based on the ordered list marker.
+
+    Exceptions:
+
+    1. When the first list item in a [list] interrupts
+       a paragraph---that is, when it starts on a line that would
+       otherwise count as [paragraph continuation text]---then (a)
+       the lines *Ls* must not begin with a blank line, and (b) if
+       the list item is ordered, the start number must be 1.
+    2. If any line is a [thematic break][thematic breaks] then
+       that line is not a list item.
+
+For\`text, let *Ls* be the lines
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+A paragraph
+with two lines.
+
+    indented code
+
+&gt; A block quote.
+.
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+And let *M* be the marker \`1.\`, and *N* = 2.  Then rule #1 says
+that the following is an ordered list item with start number 1,
+and the same contents as *Ls*:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1.  A paragraph
+    with two lines.
+
+        indented code
+
+    &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The most important thing to notice is that the position of
+the text after the list marker determines how much indentation
+is needed in subsequent blocks in the list item.  If the list
+marker takes up two spaces of indentation, and there are three spaces between
+the list marker and the next character other than a space or tab, then blocks
+must be indented five spaces in order to fall under the list
+item.
+
+Here are some examples showing how far content must be indented to be
+put under the list item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- one
+
+ two
+.
+&lt;ul&gt;
+&lt;li&gt;one&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;two&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- one
+
+  two
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ -    one
+
+     two
+.
+&lt;ul&gt;
+&lt;li&gt;one&lt;/li&gt;
+&lt;/ul&gt;
+&lt;pre&gt;&lt;code&gt; two
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ -    one
+
+      two
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+It is tempting to think of this in terms of columns:  the continuation
+blocks must be indented at least to the column of the first character other than
+a space or tab after the list marker.  However, that is not quite right.
+The spaces of indentation after the list marker determine how much relative
+indentation is needed.  Which column this indentation reaches will depend on
+how the list item is embedded in other constructions, as shown by
+this\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   &gt; &gt; 1.  one
+&gt;&gt;
+&gt;&gt;     two
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here \`two\` occurs in the same column as the list marker \`1.\`,
+but is actually contained in the list item, because there is
+sufficient indentation after the last containing blockquote marker.
+
+The converse is also possible.  In the following\`text, the word \`two\`
+occurs far to the right of the initial text of the list item, \`one\`, but
+it is not considered part of the list item, because it is not indented
+far enough past the blockquote marker:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt;&gt;- one
+&gt;&gt;
+  &gt;  &gt; two
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;one&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that at least one space or tab is needed between the list marker and
+any following content, so these are not list items:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-one
+
+2.two
+.
+&lt;p&gt;-one&lt;/p&gt;
+&lt;p&gt;2.two&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list item may contain blocks that are separated by more than
+one blank line.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+
+
+  bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list item may contain any kind of block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1.  foo
+
+    \`\`\`
+    bar
+    \`\`\`
+
+    baz
+
+    &gt; bam
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bam&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list item that contains an indented code block will preserve
+empty lines within the code block verbatim.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- Foo
+
+      bar
+
+
+      baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+
+
+baz
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Note that ordered list start numbers must be nine digits or less:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+123456789. ok
+.
+&lt;ol start="123456789"&gt;
+&lt;li&gt;ok&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1234567890. not ok
+.
+&lt;p&gt;1234567890. not ok&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A start number may begin with 0s:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+0. ok
+.
+&lt;ol start="0"&gt;
+&lt;li&gt;ok&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+003. ok
+.
+&lt;ol start="3"&gt;
+&lt;li&gt;ok&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A start number may not be negative:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-1. not ok
+.
+&lt;p&gt;-1. not ok&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+2.  **Item starting with indented code.**  If a sequence of lines *Ls*
+    constitute a sequence of blocks *Bs* starting with an indented code
+    block, and *M* is a list marker of width *W* followed by
+    one space of indentation, then the result of prepending *M* and the
+    following space to the first line of *Ls*, and indenting subsequent lines
+    of *Ls* by *W + 1* spaces, is a list item with *Bs* as its contents.
+    If a line is empty, then it need not be indented.  The type of the
+    list item (bullet or ordered) is determined by the type of its list
+    marker.  If the list item is ordered, then it is also assigned a
+    start number, based on the ordered list marker.
+
+An indented code block will have to be preceded by four spaces of indentation
+beyond the edge of the region where text will be included in the list item.
+In the following case that is 6 spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+
+      bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+And in this case it is 11 spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  10.  foo
+
+           bar
+.
+&lt;ol start="10"&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If the *first* block in the list item is an indented code block,
+then by rule #2, the contents must be preceded by *one* space of indentation
+after the list marker:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    indented code
+
+paragraph
+
+    more code
+.
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;paragraph&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;more code
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1.     indented code
+
+   paragraph
+
+       more code
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;paragraph&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;more code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that an additional space of indentation is interpreted as space
+inside the code block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1.      indented code
+
+   paragraph
+
+       more code
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt; indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;paragraph&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;more code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that rules #1 and #2 only apply to two cases:  (a) cases
+in which the lines to be included in a list item begin with a
+character other than a space or tab, and (b) cases in which
+they begin with an indented code
+block.  In a case like the following, where the first block begins with
+three spaces of indentation, the rules do not allow us to form a list item by
+indenting the whole thing and prepending a list marker:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   foo
+
+bar
+.
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-    foo
+
+  bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not a significant restriction, because when a block is preceded by up to
+three spaces of indentation, the indentation can always be removed without
+a change in interpretation, allowing rule #1 to be applied.  So, in
+the above case:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-  foo
+
+   bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+3.  **Item starting with a blank line.**  If a sequence of lines *Ls*
+    starting with a single [blank line] constitute a (possibly empty)
+    sequence of blocks *Bs*, and *M* is a list marker of width *W*,
+    then the result of prepending *M* to the first line of *Ls*, and
+    preceding subsequent lines of *Ls* by *W + 1* spaces of indentation, is a
+    list item with *Bs* as its contents.
+    If a line is empty, then it need not be indented.  The type of the
+    list item (bullet or ordered) is determined by the type of its list
+    marker.  If the list item is ordered, then it is also assigned a
+    start number, based on the ordered list marker.
+
+Here are some list items that start with a blank line but are not empty:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-
+  foo
+-
+  \`\`\`
+  bar
+  \`\`\`
+-
+      baz
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;baz
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+When the list item starts with a blank line, the number of spaces
+following the list marker doesn't change the required indentation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-   
+  foo
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list item can begin with at most one blank line.
+In the following\`text, \`foo\` is not part of the list
+item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-
+
+  foo
+.
+&lt;ul&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here is an empty bullet list item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+-
+- bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+It does not matter whether there are spaces or tabs following the [list marker]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+-   
+- bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here is an empty ordered list item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1. foo
+2.
+3. bar
+.
+&lt;ol&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list may start or end with an empty list item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*
+.
+&lt;ul&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+However, an empty list item cannot interrupt a paragraph:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo
+*
+
+foo
+1.
+.
+&lt;p&gt;foo
+*&lt;/p&gt;
+&lt;p&gt;foo
+1.&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+4.  **Indentation.**  If a sequence of lines *Ls* constitutes a list item
+    according to rule #1, #2, or #3, then the result of preceding each line
+    of *Ls* by up to three spaces of indentation (the same for each line) also
+    constitutes a list item with the same contents and attributes.  If a line is
+    empty, then it need not be indented.
+
+Indented one space:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+ 1.  A paragraph
+     with two lines.
+
+         indented code
+
+     &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Indented two spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  1.  A paragraph
+      with two lines.
+
+          indented code
+
+      &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Indented three spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+   1.  A paragraph
+       with two lines.
+
+           indented code
+
+       &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Four spaces indent gives a code block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+    1.  A paragraph
+        with two lines.
+
+            indented code
+
+        &gt; A block quote.
+.
+&lt;pre&gt;&lt;code&gt;1.  A paragraph
+    with two lines.
+
+        indented code
+
+    &gt; A block quote.
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+5.  **Laziness.**  If a string of lines *Ls* constitute a [list
+    item](#list-items) with contents *Bs*, then the result of deleting
+    some or all of the indentation from one or more lines in which the
+    next character other than a space or tab after the indentation is
+    [paragraph continuation text] is a
+    list item with the same contents and attributes.  The unindented
+    lines are called
+    [lazy continuation line](@)s.
+
+Here is an\`text with [lazy continuation lines]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  1.  A paragraph
+with two lines.
+
+          indented code
+
+      &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Indentation can be partially deleted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+  1.  A paragraph
+    with two lines.
+.
+&lt;ol&gt;
+&lt;li&gt;A paragraph
+with two lines.&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These examples show how laziness can work in nested structures:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; 1. &gt; Blockquote
+continued here.
+.
+&lt;blockquote&gt;
+&lt;ol&gt;
+&lt;li&gt;
+&lt;blockquote&gt;
+&lt;p&gt;Blockquote
+continued here.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&gt; 1. &gt; Blockquote
+&gt; continued here.
+.
+&lt;blockquote&gt;
+&lt;ol&gt;
+&lt;li&gt;
+&lt;blockquote&gt;
+&lt;p&gt;Blockquote
+continued here.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/blockquote&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+6.  **That's all.** Nothing that is not counted as a list item by rules
+    #1--5 counts as a [list item](#list-items).
+
+The rules for sublists follow from the general rules
+[above][List items].  A sublist must be indented the same number
+of spaces of indentation a paragraph would need to be in order to be included
+in the list item.
+
+So, in this case we need two spaces indent:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+  - bar
+    - baz
+      - boo
+.
+&lt;ul&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar
+&lt;ul&gt;
+&lt;li&gt;baz
+&lt;ul&gt;
+&lt;li&gt;boo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+One is not enough:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+ - bar
+  - baz
+   - boo
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;li&gt;boo&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here we need four, because the list marker is wider:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+10) foo
+    - bar
+.
+&lt;ol start="10"&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Three is not enough:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+10) foo
+   - bar
+.
+&lt;ol start="10"&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ol&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list may be the first block in a list item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- - foo
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1. - 2. foo
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;ul&gt;
+&lt;li&gt;
+&lt;ol start="2"&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A list item can contain a heading:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- # Foo
+- Bar
+  ---
+  baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;h2&gt;Bar&lt;/h2&gt;
+baz&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+### Motivation
+
+John Gruber's Markdown spec says the following about list items:
+
+1. "List markers typically start at the left margin, but may be indented
+   by up to three spaces. List markers must be followed by one or more
+   spaces or a tab."
+
+2. "To make lists look nice, you can wrap items with hanging indents....
+   But if you don't want to, you don't have to."
+
+3. "List items may consist of multiple paragraphs. Each subsequent
+   paragraph in a list item must be indented by either 4 spaces or one
+   tab."
+
+4. "It looks nice if you indent every line of the subsequent paragraphs,
+   but here again, Markdown will allow you to be lazy."
+
+5. "To put a blockquote within a list item, the blockquote's \`&gt;\`
+   delimiters need to be indented."
+
+6. "To put a code block within a list item, the code block needs to be
+   indented twice — 8 spaces or two tabs."
+
+These rules specify that a paragraph under a list item must be indented
+four spaces (presumably, from the left margin, rather than the start of
+the list marker, but this is not said), and that code under a list item
+must be indented eight spaces instead of the usual four.  They also say
+that a block quote must be indented, but not by how much; however, the\`text given has four spaces indentation.  Although nothing is said
+about other kinds of block-level content, it is certainly reasonable to
+infer that *all* block elements under a list item, including other
+lists, must be indented four spaces.  This principle has been called the
+*four-space rule*.
+
+The four-space rule is clear and principled, and if the reference
+implementation \`Markdown.pl\` had followed it, it probably would have
+become the standard.  However, \`Markdown.pl\` allowed paragraphs and
+sublists to start with only two spaces indentation, at least on the
+outer level.  Worse, its behavior was inconsistent: a sublist of an
+outer-level list needed two spaces indentation, but a sublist of this
+sublist needed three spaces.  It is not surprising, then, that different
+implementations of Markdown have developed very different rules for
+determining what comes under a list item.  (Pandoc and python-Markdown,
+for\`text, stuck with Gruber's syntax description and the four-space
+rule, while discount, redcarpet, marked, PHP Markdown, and others
+followed \`Markdown.pl\`'s behavior more closely.)
+
+Unfortunately, given the divergences between implementations, there
+is no way to give a spec for list items that will be guaranteed not
+to break any existing documents.  However, the spec given here should
+correctly handle lists formatted with either the four-space rule or
+the more forgiving \`Markdown.pl\` behavior, provided they are laid out
+in a way that is natural for a human to read.
+
+The strategy here is to let the width and indentation of the list marker
+determine the indentation necessary for blocks to fall under the list
+item, rather than having a fixed and arbitrary number.  The writer can
+think of the body of the list item as a unit which gets indented to the
+right enough to fit the list marker (and any indentation on the list
+marker).  (The laziness rule, #5, then allows continuation lines to be
+unindented if needed.)
+
+This rule is superior, we claim, to any rule requiring a fixed level of
+indentation from the margin.  The four-space rule is clear but
+unnatural. It is quite unintuitive that
+
+\`\`\` markdown
+- foo
+
+  bar
+
+  - baz
+\`\`\`
+
+should be parsed as two lists with an intervening paragraph,
+
+\`\`\` html
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`
+
+as the four-space rule demands, rather than a single list,
+
+\`\`\` html
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`
+
+The choice of four spaces is arbitrary.  It can be learned, but it is
+not likely to be guessed, and it trips up beginners regularly.
+
+Would it help to adopt a two-space rule?  The problem is that such
+a rule, together with the rule allowing up to three spaces of indentation for
+the initial list marker, allows text that is indented *less than* the
+original list marker to be included in the list item. For\`text,
+\`Markdown.pl\` parses
+
+\`\`\` markdown
+   - one
+
+  two
+\`\`\`
+
+as a single list item, with \`two\` a continuation paragraph:
+
+\`\`\` html
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`
+
+and similarly
+
+\`\`\` markdown
+&gt;   - one
+&gt;
+&gt;  two
+\`\`\`
+
+as
+
+\`\`\` html
+&lt;blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/blockquote&gt;
+\`\`\`
+
+This is extremely unintuitive.
+
+Rather than requiring a fixed indent from the margin, we could require
+a fixed indent (say, two spaces, or even one space) from the list marker (which
+may itself be indented).  This proposal would remove the last anomaly
+discussed.  Unlike the spec presented above, it would count the following
+as a list item with a subparagraph, even though the paragraph \`bar\`
+is not indented as far as the first paragraph \`foo\`:
+
+\`\`\` markdown
+ 10. foo
+
+   bar  
+\`\`\`
+
+Arguably this text does read like a list item with \`bar\` as a subparagraph,
+which may count in favor of the proposal.  However, on this proposal indented
+code would have to be indented six spaces after the list marker.  And this
+would break a lot of existing Markdown, which has the pattern:
+
+\`\`\` markdown
+1.  foo
+
+        indented code
+\`\`\`
+
+where the code is indented eight spaces.  The spec above, by contrast, will
+parse this text as expected, since the code block's indentation is measured
+from the beginning of \`foo\`.
+
+The one case that needs special treatment is a list item that *starts*
+with indented code.  How much indentation is required in that case, since
+we don't have a "first paragraph" to measure from?  Rule #2 simply stipulates
+that in such cases, we require one space indentation from the list marker
+(and then the normal four spaces for the indented code).  This will match the
+four-space rule in cases where the list marker plus its initial indentation
+takes four spaces (a common case), but diverge in other cases.
+
+## Lists
+
+A [list](@) is a sequence of one or more
+list items [of the same type].  The list items
+may be separated by any number of blank lines.
+
+Two list items are [of the same type](@)
+if they begin with a [list marker] of the same type.
+Two list markers are of the
+same type if (a) they are bullet list markers using the same character
+(\`-\`, \`+\`, or \`*\`) or (b) they are ordered list numbers with the same
+delimiter (either \`.\` or \`)\`).
+
+A list is an [ordered list](@)
+if its constituent list items begin with
+[ordered list markers], and a
+[bullet list](@) if its constituent list
+items begin with [bullet list markers].
+
+The [start number](@)
+of an [ordered list] is determined by the list number of
+its initial list item.  The numbers of subsequent list items are
+disregarded.
+
+A list is [loose](@) if any of its constituent
+list items are separated by blank lines, or if any of its constituent
+list items directly contain two block-level elements with a blank line
+between them.  Otherwise a list is [tight](@).
+(The difference in HTML output is that paragraphs in a loose list are
+wrapped in \`&lt;p&gt;\` tags, while paragraphs in a tight list are not.)
+
+Changing the bullet or ordered list delimiter starts a new list:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+- bar
++ baz
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1. foo
+2. bar
+3) baz
+.
+&lt;ol&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ol&gt;
+&lt;ol start="3"&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In CommonMark, a list can interrupt a paragraph. That is,
+no blank line is needed to separate a paragraph from a following
+list:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo
+- bar
+- baz
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`Markdown.pl\` does not allow this, through fear of triggering a list
+via a numeral in a hard-wrapped line:
+
+\`\`\` markdown
+The number of windows in my house is
+14.  The number of doors is 6.
+\`\`\`
+
+Oddly, though, \`Markdown.pl\` *does* allow a blockquote to
+interrupt a paragraph, even though the same considerations might
+apply.
+
+In CommonMark, we do allow lists to interrupt paragraphs, for
+two reasons.  First, it is natural and not uncommon for people
+to start lists without blank lines:
+
+\`\`\` markdown
+I need to buy
+- new shoes
+- a coat
+- a plane ticket
+\`\`\`
+
+Second, we are attracted to a
+
+&gt; [principle of uniformity](@):
+&gt; if a chunk of text has a certain
+&gt; meaning, it will continue to have the same meaning when put into a
+&gt; container block (such as a list item or blockquote).
+
+(Indeed, the spec for [list items] and [block quotes] presupposes
+this principle.) This principle implies that if
+
+\`\`\` markdown
+  * I need to buy
+    - new shoes
+    - a coat
+    - a plane ticket
+\`\`\`
+
+is a list item containing a paragraph followed by a nested sublist,
+as all Markdown implementations agree it is (though the paragraph
+may be rendered without \`&lt;p&gt;\` tags, since the list is "tight"),
+then
+
+\`\`\` markdown
+I need to buy
+- new shoes
+- a coat
+- a plane ticket
+\`\`\`
+
+by itself should be a paragraph followed by a nested sublist.
+
+Since it is well established Markdown practice to allow lists to
+interrupt paragraphs inside list items, the [principle of
+uniformity] requires us to allow this outside list items as
+well.  ([reStructuredText](https://docutils.sourceforge.net/rst.html)
+takes a different approach, requiring blank lines before lists
+even inside other list items.)
+
+In order to solve the problem of unwanted lists in paragraphs with
+hard-wrapped numerals, we allow only lists starting with \`1\` to
+interrupt paragraphs.  Thus,
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+The number of windows in my house is
+14.  The number of doors is 6.
+.
+&lt;p&gt;The number of windows in my house is
+14.  The number of doors is 6.&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+We may still get an unintended result in cases like
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+The number of windows in my house is
+1.  The number of doors is 6.
+.
+&lt;p&gt;The number of windows in my house is&lt;/p&gt;
+&lt;ol&gt;
+&lt;li&gt;The number of doors is 6.&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+but this rule should prevent most spurious list captures.
+
+There can be any number of blank lines between items:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+
+- bar
+
+
+- baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+  - bar
+    - baz
+
+
+      bim
+.
+&lt;ul&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;p&gt;bim&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+To separate consecutive lists of the same type, or to separate a
+list from an indented code block that would otherwise be parsed
+as a subparagraph of the final list item, you can insert a blank HTML
+comment:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- foo
+- bar
+
+&lt;!-- --&gt;
+
+- baz
+- bim
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;!-- --&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;li&gt;bim&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+-   foo
+
+    notcode
+
+-   foo
+
+&lt;!-- --&gt;
+
+    code
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;notcode&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;!-- --&gt;
+&lt;pre&gt;&lt;code&gt;code
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+List items need not be indented to the same level.  The following
+list items will be treated as items at the same list level,
+since none is indented enough to belong to the previous list
+item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+ - b
+  - c
+   - d
+  - e
+ - f
+- g
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;li&gt;d&lt;/li&gt;
+&lt;li&gt;e&lt;/li&gt;
+&lt;li&gt;f&lt;/li&gt;
+&lt;li&gt;g&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1. a
+
+  2. b
+
+   3. c
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Note, however, that list items may not be preceded by more than
+three spaces of indentation.  Here \`- e\` is treated as a paragraph continuation
+line, because it is indented more than three spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+ - b
+  - c
+   - d
+    - e
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;li&gt;d
+- e&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+And here, \`3. c\` is treated as in indented code block,
+because it is indented four spaces and preceded by a
+blank line.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1. a
+
+  2. b
+
+    3. c
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;pre&gt;&lt;code&gt;3. c
+&lt;/code&gt;&lt;/pre&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is a loose list, because there is a blank line between
+two of the list items:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+- b
+
+- c
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+So is this, with a empty second item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+* a
+*
+
+* c
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These are loose lists, even though there are no blank lines between the items,
+because one of the items directly contains two block-level elements
+with a blank line between them:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+- b
+
+  c
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;d&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+- b
+
+  [ref]: /url
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;d&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is a tight list, because the blank lines are in a code block:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+- \`\`\`
+  b
+
+
+  \`\`\`
+- c
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;b
+
+
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is a tight list, because the blank line is between two
+paragraphs of a sublist.  So the sublist is loose while
+the outer list is tight:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+  - b
+
+    c
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;li&gt;d&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is a tight list, because the blank line is inside the
+block quote:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+* a
+  &gt; b
+  &gt;
+* c
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;blockquote&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This list is tight, because the consecutive block elements
+are not separated by blank lines:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+  &gt; b
+  \`\`\`
+  c
+  \`\`\`
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;blockquote&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;pre&gt;&lt;code&gt;c
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;li&gt;d&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A single-paragraph list is tight:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+  - b
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;ul&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This list is loose, because of the blank line between the
+two block elements in the list item:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+1. \`\`\`
+   foo
+   \`\`\`
+
+   bar
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here the outer list is loose, the inner list tight:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+* foo
+  * bar
+
+  baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+- a
+  - b
+  - c
+
+- d
+  - e
+  - f
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;d&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;e&lt;/li&gt;
+&lt;li&gt;f&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+# Inlines
+
+Inlines are parsed sequentially from the beginning of the character
+stream to the end (left to right, in left-to-right languages).
+Thus, for\`text, in
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`hi\`lo\`
+.
+&lt;p&gt;&lt;code&gt;hi&lt;/code&gt;lo\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`hi\` is parsed as code, leaving the backtick at the end as a literal
+backtick.
+
+
+
+## Code spans
+
+A [backtick string](@)
+is a string of one or more backtick characters (\`\` \` \`\`) that is neither
+preceded nor followed by a backtick.
+
+A [code span](@) begins with a backtick string and ends with
+a backtick string of equal length.  The contents of the code span are
+the characters between these two backtick strings, normalized in the
+following ways:
+
+- First, [line endings] are converted to [spaces].
+- If the resulting string both begins *and* ends with a [space]
+  character, but does not consist entirely of [space]
+  characters, a single [space] character is removed from the
+  front and back.  This allows you to include code that begins
+  or ends with backtick characters, which must be separated by
+  whitespace from the opening or closing backtick strings.
+
+This is a simple code span:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`foo\`
+.
+&lt;p&gt;&lt;code&gt;foo&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here two backticks are used, because the code contains a backtick.
+This\`text also illustrates stripping of a single leading and
+trailing space:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\` foo \` bar \`\`
+.
+&lt;p&gt;&lt;code&gt;foo \` bar&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This\`text shows the motivation for stripping leading and trailing
+spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\` \`\` \`
+.
+&lt;p&gt;&lt;code&gt;\`\`&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Note that only *one* space is stripped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`  \`\`  \`
+.
+&lt;p&gt;&lt;code&gt; \`\` &lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The stripping only happens if the space is on both
+sides of the string:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\` a\`
+.
+&lt;p&gt;&lt;code&gt; a&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Only [spaces], and not [unicode whitespace] in general, are
+stripped in this way:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\` b \`
+.
+&lt;p&gt;&lt;code&gt; b &lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+No stripping occurs if the code span contains only spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\` \`
+\`  \`
+.
+&lt;p&gt;&lt;code&gt; &lt;/code&gt;
+&lt;code&gt;  &lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Line endings] are treated like spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`
+foo
+bar  
+baz
+\`\`
+.
+&lt;p&gt;&lt;code&gt;foo bar   baz&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`
+foo 
+\`\`
+.
+&lt;p&gt;&lt;code&gt;foo &lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Interior spaces are not collapsed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`foo   bar 
+baz\`
+.
+&lt;p&gt;&lt;code&gt;foo   bar  baz&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Note that browsers will typically collapse consecutive spaces
+when rendering \`&lt;code&gt;\` elements, so it is recommended that
+the following CSS be used:
+
+    code{white-space: pre-wrap;}
+
+
+Note that backslash escapes do not work in code spans. All backslashes
+are treated literally:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`foo\\\`bar\`
+.
+&lt;p&gt;&lt;code&gt;foo\\&lt;/code&gt;bar\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash escapes are never needed, because one can always choose a
+string of *n* backtick characters as delimiters, where the code does
+not contain any strings of exactly *n* backtick characters.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`foo\`bar\`\`
+.
+&lt;p&gt;&lt;code&gt;foo\`bar&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\` foo \`\` bar \`
+.
+&lt;p&gt;&lt;code&gt;foo \`\` bar&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Code span backticks have higher precedence than any other inline
+constructs except HTML tags and autolinks.  Thus, for\`text, this is
+not parsed as emphasized text, since the second \`*\` is part of a code
+span:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo\`*\`
+.
+&lt;p&gt;*foo&lt;code&gt;*&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+And this is not parsed as a link:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[not a \`link](/foo\`)
+.
+&lt;p&gt;[not a &lt;code&gt;link](/foo&lt;/code&gt;)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Code spans, HTML tags, and autolinks have the same precedence.
+Thus, this is code:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`&lt;a href="\`"&gt;\`
+.
+&lt;p&gt;&lt;code&gt;&lt;a href=&quot;&lt;/code&gt;&quot;&gt;\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+But this is an HTML tag:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="\`"&gt;\`
+.
+&lt;p&gt;&lt;a href="\`"&gt;\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+And this is code:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`&lt;https://foo.bar.\`baz&gt;\`
+.
+&lt;p&gt;&lt;code&gt;&lt;https://foo.bar.&lt;/code&gt;baz&gt;\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+But this is an autolink:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;https://foo.bar.\`baz&gt;\`
+.
+&lt;p&gt;&lt;a href="https://foo.bar.%60baz"&gt;https://foo.bar.\`baz&lt;/a&gt;\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+When a backtick string is not closed by a matching backtick string,
+we just have literal backticks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`\`\`foo\`\`
+.
+&lt;p&gt;\`\`\`foo\`\`&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`foo
+.
+&lt;p&gt;\`foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The following case also illustrates the need for opening and
+closing backtick strings to be equal in length:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`foo\`\`bar\`\`
+.
+&lt;p&gt;\`foo&lt;code&gt;bar&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Emphasis and strong emphasis
+
+John Gruber's original [Markdown syntax
+description](https://daringfireball.net/projects/markdown/syntax#em) says:
+
+&gt; Markdown treats asterisks (\`*\`) and underscores (\`_\`) as indicators of
+&gt; emphasis. Text wrapped with one \`*\` or \`_\` will be wrapped with an HTML
+&gt; \`&lt;em&gt;\` tag; double \`*\`'s or \`_\`'s will be wrapped with an HTML \`&lt;strong&gt;\`
+&gt; tag.
+
+This is enough for most users, but these rules leave much undecided,
+especially when it comes to nested emphasis.  The original
+\`Markdown.pl\` test suite makes it clear that triple \`***\` and
+\`___\` delimiters can be used for strong emphasis, and most
+implementations have also allowed the following patterns:
+
+\`\`\` markdown
+***strong emph***
+***strong** in emph*
+***emph* in strong**
+**in strong *emph***
+*in emph **strong***
+\`\`\`
+
+The following patterns are less widely supported, but the intent
+is clear and they are useful (especially in contexts like bibliography
+entries):
+
+\`\`\` markdown
+*emph *with emph* in it*
+**strong **with strong** in it**
+\`\`\`
+
+Many implementations have also restricted intraword emphasis to
+the \`*\` forms, to avoid unwanted emphasis in words containing
+internal underscores.  (It is best practice to put these in code
+spans, but users often do not.)
+
+\`\`\` markdown
+internal emphasis: foo*bar*baz
+no emphasis: foo_bar_baz
+\`\`\`
+
+The rules given below capture all of these patterns, while allowing
+for efficient parsing strategies that do not backtrack.
+
+First, some definitions.  A [delimiter run](@) is either
+a sequence of one or more \`*\` characters that is not preceded or
+followed by a non-backslash-escaped \`*\` character, or a sequence
+of one or more \`_\` characters that is not preceded or followed by
+a non-backslash-escaped \`_\` character.
+
+A [left-flanking delimiter run](@) is
+a [delimiter run] that is (1) not followed by [Unicode whitespace],
+and either (2a) not followed by a [Unicode punctuation character], or
+(2b) followed by a [Unicode punctuation character] and
+preceded by [Unicode whitespace] or a [Unicode punctuation character].
+For purposes of this definition, the beginning and the end of
+the line count as Unicode whitespace.
+
+A [right-flanking delimiter run](@) is
+a [delimiter run] that is (1) not preceded by [Unicode whitespace],
+and either (2a) not preceded by a [Unicode punctuation character], or
+(2b) preceded by a [Unicode punctuation character] and
+followed by [Unicode whitespace] or a [Unicode punctuation character].
+For purposes of this definition, the beginning and the end of
+the line count as Unicode whitespace.
+
+Here are some examples of delimiter runs.
+
+  - left-flanking but not right-flanking:
+
+    \`\`\`
+    ***abc
+      _abc
+    **"abc"
+     _"abc"
+    \`\`\`
+
+  - right-flanking but not left-flanking:
+
+    \`\`\`
+     abc***
+     abc_
+    "abc"**
+    "abc"_
+    \`\`\`
+
+  - Both left and right-flanking:
+
+    \`\`\`
+     abc***def
+    "abc"_"def"
+    \`\`\`
+
+  - Neither left nor right-flanking:
+
+    \`\`\`
+    abc *** def
+    a _ b
+    \`\`\`
+
+(The idea of distinguishing left-flanking and right-flanking
+delimiter runs based on the character before and the character
+after comes from Roopesh Chander's
+[vfmd](https://web.archive.org/web/20220608143320/http://www.vfmd.org/vfmd-spec/specification/#procedure-for-identifying-emphasis-tags).
+vfmd uses the terminology "emphasis indicator string" instead of "delimiter
+run," and its rules for distinguishing left- and right-flanking runs
+are a bit more complex than the ones given here.)
+
+The following rules define emphasis and strong emphasis:
+
+1.  A single \`*\` character [can open emphasis](@)
+    iff (if and only if) it is part of a [left-flanking delimiter run].
+
+2.  A single \`_\` character [can open emphasis] iff
+    it is part of a [left-flanking delimiter run]
+    and either (a) not part of a [right-flanking delimiter run]
+    or (b) part of a [right-flanking delimiter run]
+    preceded by a [Unicode punctuation character].
+
+3.  A single \`*\` character [can close emphasis](@)
+    iff it is part of a [right-flanking delimiter run].
+
+4.  A single \`_\` character [can close emphasis] iff
+    it is part of a [right-flanking delimiter run]
+    and either (a) not part of a [left-flanking delimiter run]
+    or (b) part of a [left-flanking delimiter run]
+    followed by a [Unicode punctuation character].
+
+5.  A double \`**\` [can open strong emphasis](@)
+    iff it is part of a [left-flanking delimiter run].
+
+6.  A double \`__\` [can open strong emphasis] iff
+    it is part of a [left-flanking delimiter run]
+    and either (a) not part of a [right-flanking delimiter run]
+    or (b) part of a [right-flanking delimiter run]
+    preceded by a [Unicode punctuation character].
+
+7.  A double \`**\` [can close strong emphasis](@)
+    iff it is part of a [right-flanking delimiter run].
+
+8.  A double \`__\` [can close strong emphasis] iff
+    it is part of a [right-flanking delimiter run]
+    and either (a) not part of a [left-flanking delimiter run]
+    or (b) part of a [left-flanking delimiter run]
+    followed by a [Unicode punctuation character].
+
+9.  Emphasis begins with a delimiter that [can open emphasis] and ends
+    with a delimiter that [can close emphasis], and that uses the same
+    character (\`_\` or \`*\`) as the opening delimiter.  The
+    opening and closing delimiters must belong to separate
+    [delimiter runs].  If one of the delimiters can both
+    open and close emphasis, then the sum of the lengths of the
+    delimiter runs containing the opening and closing delimiters
+    must not be a multiple of 3 unless both lengths are
+    multiples of 3.
+
+10. Strong emphasis begins with a delimiter that
+    [can open strong emphasis] and ends with a delimiter that
+    [can close strong emphasis], and that uses the same character
+    (\`_\` or \`*\`) as the opening delimiter.  The
+    opening and closing delimiters must belong to separate
+    [delimiter runs].  If one of the delimiters can both open
+    and close strong emphasis, then the sum of the lengths of
+    the delimiter runs containing the opening and closing
+    delimiters must not be a multiple of 3 unless both lengths
+    are multiples of 3.
+
+11. A literal \`*\` character cannot occur at the beginning or end of
+    \`*\`-delimited emphasis or \`**\`-delimited strong emphasis, unless it
+    is backslash-escaped.
+
+12. A literal \`_\` character cannot occur at the beginning or end of
+    \`_\`-delimited emphasis or \`__\`-delimited strong emphasis, unless it
+    is backslash-escaped.
+
+Where rules 1--12 above are compatible with multiple parsings,
+the following principles resolve ambiguity:
+
+13. The number of nestings should be minimized. Thus, for\`text,
+    an interpretation \`&lt;strong&gt;...&lt;/strong&gt;\` is always preferred to
+    \`&lt;em&gt;&lt;em&gt;...&lt;/em&gt;&lt;/em&gt;\`.
+
+14. An interpretation \`&lt;em&gt;&lt;strong&gt;...&lt;/strong&gt;&lt;/em&gt;\` is always
+    preferred to \`&lt;strong&gt;&lt;em&gt;...&lt;/em&gt;&lt;/strong&gt;\`.
+
+15. When two potential emphasis or strong emphasis spans overlap,
+    so that the second begins before the first ends and ends after
+    the first ends, the first takes precedence. Thus, for\`text,
+    \`*foo _bar* baz_\` is parsed as \`&lt;em&gt;foo _bar&lt;/em&gt; baz_\` rather
+    than \`*foo &lt;em&gt;bar* baz&lt;/em&gt;\`.
+
+16. When there are two potential emphasis or strong emphasis spans
+    with the same closing delimiter, the shorter one (the one that
+    opens later) takes precedence. Thus, for\`text,
+    \`**foo **bar baz**\` is parsed as \`**foo &lt;strong&gt;bar baz&lt;/strong&gt;\`
+    rather than \`&lt;strong&gt;foo **bar baz&lt;/strong&gt;\`.
+
+17. Inline code spans, links, images, and HTML tags group more tightly
+    than emphasis.  So, when there is a choice between an interpretation
+    that contains one of these elements and one that does not, the
+    former always wins.  Thus, for\`text, \`*[foo*](bar)\` is
+    parsed as \`*&lt;a href="bar"&gt;foo*&lt;/a&gt;\` rather than as
+    \`&lt;em&gt;[foo&lt;/em&gt;](bar)\`.
+
+These rules can be illustrated through a series of examples.
+
+Rule 1:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo bar*
+.
+&lt;p&gt;&lt;em&gt;foo bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the opening \`*\` is followed by
+whitespace, and hence not part of a [left-flanking delimiter run]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+a * foo bar*
+.
+&lt;p&gt;a * foo bar*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the opening \`*\` is preceded
+by an alphanumeric and followed by punctuation, and hence
+not part of a [left-flanking delimiter run]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+a*"foo"*
+.
+&lt;p&gt;a*&quot;foo&quot;*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Unicode nonbreaking spaces count as whitespace, too:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+* a *
+.
+&lt;p&gt;* a *&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Unicode symbols count as punctuation, too:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*$*alpha.
+
+*£*bravo.
+
+*€*charlie.
+.
+&lt;p&gt;*$*alpha.&lt;/p&gt;
+&lt;p&gt;*£*bravo.&lt;/p&gt;
+&lt;p&gt;*€*charlie.&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword emphasis with \`*\` is permitted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo*bar*
+.
+&lt;p&gt;foo&lt;em&gt;bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+5*6*78
+.
+&lt;p&gt;5&lt;em&gt;6&lt;/em&gt;78&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 2:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo bar_
+.
+&lt;p&gt;&lt;em&gt;foo bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the opening \`_\` is followed by
+whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_ foo bar_
+.
+&lt;p&gt;_ foo bar_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the opening \`_\` is preceded
+by an alphanumeric and followed by punctuation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+a_"foo"_
+.
+&lt;p&gt;a_&quot;foo&quot;_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Emphasis with \`_\` is not allowed inside words:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo_bar_
+.
+&lt;p&gt;foo_bar_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+5_6_78
+.
+&lt;p&gt;5_6_78&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+пристаням_стремятся_
+.
+&lt;p&gt;пристаням_стремятся_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here \`_\` does not generate emphasis, because the first delimiter run
+is right-flanking and the second left-flanking:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+aa_"bb"_cc
+.
+&lt;p&gt;aa_&quot;bb&quot;_cc&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is emphasis, even though the opening delimiter is
+both left- and right-flanking, because it is preceded by
+punctuation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo-_(bar)_
+.
+&lt;p&gt;foo-&lt;em&gt;(bar)&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 3:
+
+This is not emphasis, because the closing delimiter does
+not match the opening delimiter:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo*
+.
+&lt;p&gt;_foo*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the closing \`*\` is preceded by
+whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo bar *
+.
+&lt;p&gt;*foo bar *&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A line ending also counts as whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo bar
+*
+.
+&lt;p&gt;*foo bar
+*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the second \`*\` is
+preceded by punctuation and followed by an alphanumeric
+(hence it is not part of a [right-flanking delimiter run]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*(*foo)
+.
+&lt;p&gt;*(*foo)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The point of this restriction is more easily appreciated
+with this\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*(*foo*)*
+.
+&lt;p&gt;&lt;em&gt;(&lt;em&gt;foo&lt;/em&gt;)&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword emphasis with \`*\` is allowed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo*bar
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Rule 4:
+
+This is not emphasis, because the closing \`_\` is preceded by
+whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo bar _
+.
+&lt;p&gt;_foo bar _&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not emphasis, because the second \`_\` is
+preceded by punctuation and followed by an alphanumeric:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_(_foo)
+.
+&lt;p&gt;_(_foo)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is emphasis within emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_(_foo_)_
+.
+&lt;p&gt;&lt;em&gt;(&lt;em&gt;foo&lt;/em&gt;)&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword emphasis is disallowed for \`_\`:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo_bar
+.
+&lt;p&gt;_foo_bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_пристаням_стремятся
+.
+&lt;p&gt;_пристаням_стремятся&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo_bar_baz_
+.
+&lt;p&gt;&lt;em&gt;foo_bar_baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is emphasis, even though the closing delimiter is
+both left- and right-flanking, because it is followed by
+punctuation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_(bar)_.
+.
+&lt;p&gt;&lt;em&gt;(bar)&lt;/em&gt;.&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 5:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo bar**
+.
+&lt;p&gt;&lt;strong&gt;foo bar&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not strong emphasis, because the opening delimiter is
+followed by whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+** foo bar**
+.
+&lt;p&gt;** foo bar**&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not strong emphasis, because the opening \`**\` is preceded
+by an alphanumeric and followed by punctuation, and hence
+not part of a [left-flanking delimiter run]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+a**"foo"**
+.
+&lt;p&gt;a**&quot;foo&quot;**&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword strong emphasis with \`**\` is permitted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo**bar**
+.
+&lt;p&gt;foo&lt;strong&gt;bar&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 6:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo bar__
+.
+&lt;p&gt;&lt;strong&gt;foo bar&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not strong emphasis, because the opening delimiter is
+followed by whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__ foo bar__
+.
+&lt;p&gt;__ foo bar__&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A line ending counts as whitespace:
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__
+foo bar__
+.
+&lt;p&gt;__
+foo bar__&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not strong emphasis, because the opening \`__\` is preceded
+by an alphanumeric and followed by punctuation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+a__"foo"__
+.
+&lt;p&gt;a__&quot;foo&quot;__&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword strong emphasis is forbidden with \`__\`:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo__bar__
+.
+&lt;p&gt;foo__bar__&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+5__6__78
+.
+&lt;p&gt;5__6__78&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+пристаням__стремятся__
+.
+&lt;p&gt;пристаням__стремятся__&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo, __bar__, baz__
+.
+&lt;p&gt;&lt;strong&gt;foo, &lt;strong&gt;bar&lt;/strong&gt;, baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is strong emphasis, even though the opening delimiter is
+both left- and right-flanking, because it is preceded by
+punctuation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo-__(bar)__
+.
+&lt;p&gt;foo-&lt;strong&gt;(bar)&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Rule 7:
+
+This is not strong emphasis, because the closing delimiter is preceded
+by whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo bar **
+.
+&lt;p&gt;**foo bar **&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+(Nor can it be interpreted as an emphasized \`*foo bar *\`, because of
+Rule 11.)
+
+This is not strong emphasis, because the second \`**\` is
+preceded by punctuation and followed by an alphanumeric:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**(**foo)
+.
+&lt;p&gt;**(**foo)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The point of this restriction is more easily appreciated
+with these examples:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*(**foo**)*
+.
+&lt;p&gt;&lt;em&gt;(&lt;strong&gt;foo&lt;/strong&gt;)&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**Gomphocarpus (*Gomphocarpus physocarpus*, syn.
+*Asclepias physocarpa*)**
+.
+&lt;p&gt;&lt;strong&gt;Gomphocarpus (&lt;em&gt;Gomphocarpus physocarpus&lt;/em&gt;, syn.
+&lt;em&gt;Asclepias physocarpa&lt;/em&gt;)&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo "*bar*" foo**
+.
+&lt;p&gt;&lt;strong&gt;foo &quot;&lt;em&gt;bar&lt;/em&gt;&quot; foo&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo**bar
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 8:
+
+This is not strong emphasis, because the closing delimiter is
+preceded by whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo bar __
+.
+&lt;p&gt;__foo bar __&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is not strong emphasis, because the second \`__\` is
+preceded by punctuation and followed by an alphanumeric:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__(__foo)
+.
+&lt;p&gt;__(__foo)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The point of this restriction is more easily appreciated
+with this\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_(__foo__)_
+.
+&lt;p&gt;&lt;em&gt;(&lt;strong&gt;foo&lt;/strong&gt;)&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Intraword strong emphasis is forbidden with \`__\`:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo__bar
+.
+&lt;p&gt;__foo__bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__пристаням__стремятся
+.
+&lt;p&gt;__пристаням__стремятся&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo__bar__baz__
+.
+&lt;p&gt;&lt;strong&gt;foo__bar__baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is strong emphasis, even though the closing delimiter is
+both left- and right-flanking, because it is followed by
+punctuation:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__(bar)__.
+.
+&lt;p&gt;&lt;strong&gt;(bar)&lt;/strong&gt;.&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 9:
+
+Any nonempty sequence of inline elements can be the contents of an
+emphasized span.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo [bar](/url)*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;a href="/url"&gt;bar&lt;/a&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo
+bar*
+.
+&lt;p&gt;&lt;em&gt;foo
+bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In particular, emphasis and strong emphasis can be nested
+inside emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo __bar__ baz_
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo _bar_ baz_
+.
+&lt;p&gt;&lt;em&gt;foo &lt;em&gt;bar&lt;/em&gt; baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo_ bar_
+.
+&lt;p&gt;&lt;em&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo *bar**
+.
+&lt;p&gt;&lt;em&gt;foo &lt;em&gt;bar&lt;/em&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo **bar** baz*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo**bar**baz*
+.
+&lt;p&gt;&lt;em&gt;foo&lt;strong&gt;bar&lt;/strong&gt;baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Note that in the preceding case, the interpretation
+
+\`\`\` markdown
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;&lt;em&gt;bar&lt;em&gt;&lt;/em&gt;baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`
+
+
+is precluded by the condition that a delimiter that
+can both open and close (like the \`*\` after \`foo\`)
+cannot form emphasis if the sum of the lengths of
+the delimiter runs containing the opening and
+closing delimiters is a multiple of 3 unless
+both lengths are multiples of 3.
+
+
+For the same reason, we don't get two consecutive
+emphasis sections in this\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo**bar*
+.
+&lt;p&gt;&lt;em&gt;foo**bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The same condition ensures that the following
+cases are all strong emphasis nested inside
+emphasis, even when the interior whitespace is
+omitted:
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+***foo** bar*
+.
+&lt;p&gt;&lt;em&gt;&lt;strong&gt;foo&lt;/strong&gt; bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo **bar***
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo**bar***
+.
+&lt;p&gt;&lt;em&gt;foo&lt;strong&gt;bar&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+When the lengths of the interior closing and opening
+delimiter runs are *both* multiples of 3, though,
+they can match to create emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo***bar***baz
+.
+&lt;p&gt;foo&lt;em&gt;&lt;strong&gt;bar&lt;/strong&gt;&lt;/em&gt;baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo******bar*********baz
+.
+&lt;p&gt;foo&lt;strong&gt;&lt;strong&gt;&lt;strong&gt;bar&lt;/strong&gt;&lt;/strong&gt;&lt;/strong&gt;***baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Indefinite levels of nesting are possible:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo **bar *baz* bim** bop*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar &lt;em&gt;baz&lt;/em&gt; bim&lt;/strong&gt; bop&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo [*bar*](/url)*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;a href="/url"&gt;&lt;em&gt;bar&lt;/em&gt;&lt;/a&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+There can be no empty emphasis or strong emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+** is not an empty emphasis
+.
+&lt;p&gt;** is not an empty emphasis&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**** is not an empty strong emphasis
+.
+&lt;p&gt;**** is not an empty strong emphasis&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Rule 10:
+
+Any nonempty sequence of inline elements can be the contents of an
+strongly emphasized span.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo [bar](/url)**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;a href="/url"&gt;bar&lt;/a&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo
+bar**
+.
+&lt;p&gt;&lt;strong&gt;foo
+bar&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+In particular, emphasis and strong emphasis can be nested
+inside strong emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo _bar_ baz__
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar&lt;/em&gt; baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo __bar__ baz__
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;strong&gt;bar&lt;/strong&gt; baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+____foo__ bar__
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt; bar&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo **bar****
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;strong&gt;bar&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo *bar* baz**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar&lt;/em&gt; baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo*bar*baz**
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;em&gt;bar&lt;/em&gt;baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+***foo* bar**
+.
+&lt;p&gt;&lt;strong&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo *bar***
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar&lt;/em&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Indefinite levels of nesting are possible:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo *bar **baz**
+bim* bop**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar &lt;strong&gt;baz&lt;/strong&gt;
+bim&lt;/em&gt; bop&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo [*bar*](/url)**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;a href="/url"&gt;&lt;em&gt;bar&lt;/em&gt;&lt;/a&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+There can be no empty emphasis or strong emphasis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__ is not an empty emphasis
+.
+&lt;p&gt;__ is not an empty emphasis&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+____ is not an empty strong emphasis
+.
+&lt;p&gt;____ is not an empty strong emphasis&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Rule 11:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo ***
+.
+&lt;p&gt;foo ***&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo *\\**
+.
+&lt;p&gt;foo &lt;em&gt;*&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo *_*
+.
+&lt;p&gt;foo &lt;em&gt;_&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo *****
+.
+&lt;p&gt;foo *****&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo **\\***
+.
+&lt;p&gt;foo &lt;strong&gt;*&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo **_**
+.
+&lt;p&gt;foo &lt;strong&gt;_&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that when delimiters do not match evenly, Rule 11 determines
+that the excess literal \`*\` characters will appear outside of the
+emphasis, rather than inside it:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo*
+.
+&lt;p&gt;*&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo**
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+***foo**
+.
+&lt;p&gt;*&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+****foo*
+.
+&lt;p&gt;***&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo***
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo****
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;***&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Rule 12:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo ___
+.
+&lt;p&gt;foo ___&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo _\\__
+.
+&lt;p&gt;foo &lt;em&gt;_&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo _*_
+.
+&lt;p&gt;foo &lt;em&gt;*&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo _____
+.
+&lt;p&gt;foo _____&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo __\\___
+.
+&lt;p&gt;foo &lt;strong&gt;_&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo __*__
+.
+&lt;p&gt;foo &lt;strong&gt;*&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo_
+.
+&lt;p&gt;_&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that when delimiters do not match evenly, Rule 12 determines
+that the excess literal \`_\` characters will appear outside of the
+emphasis, rather than inside it:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo__
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+___foo__
+.
+&lt;p&gt;_&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+____foo_
+.
+&lt;p&gt;___&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo___
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo____
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;___&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 13 implies that if you want emphasis nested directly inside
+emphasis, you must use different delimiters:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo**
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*_foo_*
+.
+&lt;p&gt;&lt;em&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__foo__
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_*foo*_
+.
+&lt;p&gt;&lt;em&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, strong emphasis within strong emphasis is possible without
+switching delimiters:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+****foo****
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+____foo____
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+Rule 13 can be applied to arbitrarily long sequences of
+delimiters:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+******foo******
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 14:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+***foo***
+.
+&lt;p&gt;&lt;em&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_____foo_____
+.
+&lt;p&gt;&lt;em&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 15:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo _bar* baz_
+.
+&lt;p&gt;&lt;em&gt;foo _bar&lt;/em&gt; baz_&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo __bar *baz bim__ bam*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar *baz bim&lt;/strong&gt; bam&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 16:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**foo **bar baz**
+.
+&lt;p&gt;**foo &lt;strong&gt;bar baz&lt;/strong&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo *bar baz*
+.
+&lt;p&gt;*foo &lt;em&gt;bar baz&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Rule 17:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*[bar*](/url)
+.
+&lt;p&gt;*&lt;a href="/url"&gt;bar*&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_foo [bar_](/url)
+.
+&lt;p&gt;_foo &lt;a href="/url"&gt;bar_&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*&lt;img src="foo" title="*"/&gt;
+.
+&lt;p&gt;*&lt;img src="foo" title="*"/&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**&lt;a href="**"&gt;
+.
+&lt;p&gt;**&lt;a href="**"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__&lt;a href="__"&gt;
+.
+&lt;p&gt;__&lt;a href="__"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*a \`*\`*
+.
+&lt;p&gt;&lt;em&gt;a &lt;code&gt;*&lt;/code&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+_a \`_\`_
+.
+&lt;p&gt;&lt;em&gt;a &lt;code&gt;_&lt;/code&gt;&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+**a&lt;https://foo.bar/?q=**&gt;
+.
+&lt;p&gt;**a&lt;a href="https://foo.bar/?q=**"&gt;https://foo.bar/?q=**&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+__a&lt;https://foo.bar/?q=__&gt;
+.
+&lt;p&gt;__a&lt;a href="https://foo.bar/?q=__"&gt;https://foo.bar/?q=__&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+## Links
+
+A link contains [link text] (the visible text), a [link destination]
+(the URI that is the link destination), and optionally a [link title].
+There are two basic kinds of links in Markdown.  In [inline links] the
+destination and title are given immediately after the link text.  In
+[reference links] the destination and title are defined elsewhere in
+the document.
+
+A [link text](@) consists of a sequence of zero or more
+inline elements enclosed by square brackets (\`[\` and \`]\`).  The
+following rules apply:
+
+- Links may not contain other links, at any level of nesting. If
+  multiple otherwise valid link definitions appear nested inside each
+  other, the inner-most definition is used.
+
+- Brackets are allowed in the [link text] only if (a) they
+  are backslash-escaped or (b) they appear as a matched pair of brackets,
+  with an open bracket \`[\`, a sequence of zero or more inlines, and
+  a close bracket \`]\`.
+
+- Backtick [code spans], [autolinks], and raw [HTML tags] bind more tightly
+  than the brackets in link text.  Thus, for\`text,
+  \`\` [foo\`]\` \`\` could not be a link text, since the second \`]\`
+  is part of a code span.
+
+- The brackets in link text bind more tightly than markers for
+  [emphasis and strong emphasis]. Thus, for\`text, \`*[foo*](url)\` is a link.
+
+A [link destination](@) consists of either
+
+- a sequence of zero or more characters between an opening \`&lt;\` and a
+  closing \`&gt;\` that contains no line endings or unescaped
+  \`&lt;\` or \`&gt;\` characters, or
+
+- a nonempty sequence of characters that does not start with \`&lt;\`,
+  does not include [ASCII control characters][ASCII control character]
+  or [space] character, and includes parentheses only if (a) they are
+  backslash-escaped or (b) they are part of a balanced pair of
+  unescaped parentheses.
+  (Implementations may impose limits on parentheses nesting to
+  avoid performance issues, but at least three levels of nesting
+  should be supported.)
+
+A [link title](@)  consists of either
+
+- a sequence of zero or more characters between straight double-quote
+  characters (\`"\`), including a \`"\` character only if it is
+  backslash-escaped, or
+
+- a sequence of zero or more characters between straight single-quote
+  characters (\`'\`), including a \`'\` character only if it is
+  backslash-escaped, or
+
+- a sequence of zero or more characters between matching parentheses
+  (\`(...)\`), including a \`(\` or \`)\` character only if it is
+  backslash-escaped.
+
+Although [link titles] may span multiple lines, they may not contain
+a [blank line].
+
+An [inline link](@) consists of a [link text] followed immediately
+by a left parenthesis \`(\`, an optional [link destination], an optional
+[link title], and a right parenthesis \`)\`.
+These four components may be separated by spaces, tabs, and up to one line
+ending.
+If both [link destination] and [link title] are present, they *must* be
+separated by spaces, tabs, and up to one line ending.
+
+The link's text consists of the inlines contained
+in the [link text] (excluding the enclosing square brackets).
+The link's URI consists of the link destination, excluding enclosing
+\`&lt;...&gt;\` if present, with backslash-escapes in effect as described
+above.  The link's title consists of the link title, excluding its
+enclosing delimiters, with backslash-escapes in effect as described
+above.
+
+Here is a simple inline link:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/uri "title")
+.
+&lt;p&gt;&lt;a href="/uri" title="title"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The title, the link text and even 
+the destination may be omitted:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/uri)
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[](./target.md)
+.
+&lt;p&gt;&lt;a href="./target.md"&gt;&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link]()
+.
+&lt;p&gt;&lt;a href=""&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](&lt;&gt;)
+.
+&lt;p&gt;&lt;a href=""&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[]()
+.
+&lt;p&gt;&lt;a href=""&gt;&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The destination can only contain spaces if it is
+enclosed in pointy brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/my uri)
+.
+&lt;p&gt;[link](/my uri)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](&lt;/my uri&gt;)
+.
+&lt;p&gt;&lt;a href="/my%20uri"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The destination cannot contain line endings,
+even if enclosed in pointy brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo
+bar)
+.
+&lt;p&gt;[link](foo
+bar)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](&lt;foo
+bar&gt;)
+.
+&lt;p&gt;[link](&lt;foo
+bar&gt;)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+The destination can contain \`)\` if it is enclosed
+in pointy brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[a](&lt;b)c&gt;)
+.
+&lt;p&gt;&lt;a href="b)c"&gt;a&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Pointy brackets that enclose links must be unescaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](&lt;foo\\&gt;)
+.
+&lt;p&gt;[link](&lt;foo&gt;)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+These are not links, because the opening pointy bracket
+is not matched properly:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[a](&lt;b)c
+[a](&lt;b)c&gt;
+[a](&lt;b&gt;c)
+.
+&lt;p&gt;[a](&lt;b)c
+[a](&lt;b)c&gt;
+[a](&lt;b&gt;c)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Parentheses inside the link destination may be escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](\\(foo\\))
+.
+&lt;p&gt;&lt;a href="(foo)"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Any number of parentheses are allowed without escaping, as long as they are
+balanced:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo(and(bar)))
+.
+&lt;p&gt;&lt;a href="foo(and(bar))"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+However, if you have unbalanced parentheses, you need to escape or use the
+\`&lt;...&gt;\` form:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo(and(bar))
+.
+&lt;p&gt;[link](foo(and(bar))&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo\\(and\\(bar\\))
+.
+&lt;p&gt;&lt;a href="foo(and(bar)"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](&lt;foo(and(bar)&gt;)
+.
+&lt;p&gt;&lt;a href="foo(and(bar)"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Parentheses and other symbols can also be escaped, as usual
+in Markdown:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo\\)\\:)
+.
+&lt;p&gt;&lt;a href="foo):"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A link can contain fragment identifiers and queries:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](#fragment)
+
+[link](https://\`text.com#fragment)
+
+[link](https://\`text.com?foo=3#frag)
+.
+&lt;p&gt;&lt;a href="#fragment"&gt;link&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://\`text.com#fragment"&gt;link&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://\`text.com?foo=3#frag"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that a backslash before a non-escapable character is
+just a backslash:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo\\bar)
+.
+&lt;p&gt;&lt;a href="foo%5Cbar"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+URL-escaping should be left alone inside the destination, as all
+URL-escaped characters are also valid URL characters. Entity and
+numerical character references in the destination will be parsed
+into the corresponding Unicode code points, as usual.  These may
+be optionally URL-escaped when written as HTML, but this spec
+does not enforce any particular policy for rendering URLs in
+HTML or other formats.  Renderers may make different decisions
+about how to escape or normalize URLs in the output.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](foo%20b&auml;)
+.
+&lt;p&gt;&lt;a href="foo%20b%C3%A4"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that, because titles can often be parsed as destinations,
+if you try to omit the destination and keep the title, you'll
+get unexpected results:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link]("title")
+.
+&lt;p&gt;&lt;a href="%22title%22"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Titles may be in single quotes, double quotes, or parentheses:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/url "title")
+[link](/url 'title')
+[link](/url (title))
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;link&lt;/a&gt;
+&lt;a href="/url" title="title"&gt;link&lt;/a&gt;
+&lt;a href="/url" title="title"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash escapes and entity and numeric character references
+may be used in titles:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/url "title \\"&quot;")
+.
+&lt;p&gt;&lt;a href="/url" title="title &quot;&quot;"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Titles must be separated from the link using spaces, tabs, and up to one line
+ending.
+Other [Unicode whitespace] like non-breaking space doesn't work.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/url "title")
+.
+&lt;p&gt;&lt;a href="/url%C2%A0%22title%22"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Nested balanced quotes are not allowed without escaping:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/url "title "and" title")
+.
+&lt;p&gt;[link](/url &quot;title &quot;and&quot; title&quot;)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+But it is easy to work around this by using a different quote type:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](/url 'title "and" title')
+.
+&lt;p&gt;&lt;a href="/url" title="title &quot;and&quot; title"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+(Note:  \`Markdown.pl\` did allow double quotes inside a double-quoted
+title, and its test suite included a test demonstrating this.
+But it is hard to see a good rationale for the extra complexity this
+brings, since there are already many ways---backslash escaping,
+entity and numeric character references, or using a different
+quote type for the enclosing title---to write titles containing
+double quotes.  \`Markdown.pl\`'s handling of titles has a number
+of other strange features.  For\`text, it allows single-quoted
+titles in inline links, but not reference links.  And, in
+reference links but not inline links, it allows a title to begin
+with \`"\` and end with \`)\`.  \`Markdown.pl\` 1.0.1 even allows
+titles with no closing quotation mark, though 1.0.2b8 does not.
+It seems preferable to adopt a simple, rational rule that works
+the same way in inline links and link reference definitions.)
+
+Spaces, tabs, and up to one line ending is allowed around the destination and
+title:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link](   /uri
+  "title"  )
+.
+&lt;p&gt;&lt;a href="/uri" title="title"&gt;link&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+But it is not allowed between the link text and the
+following parenthesis:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link] (/uri)
+.
+&lt;p&gt;[link] (/uri)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link text may contain balanced brackets, but not unbalanced ones,
+unless they are escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link [foo [bar]]](/uri)
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link [foo [bar]]&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link] bar](/uri)
+.
+&lt;p&gt;[link] bar](/uri)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link [bar](/uri)
+.
+&lt;p&gt;[link &lt;a href="/uri"&gt;bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link \\[bar](/uri)
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link [bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link text may contain inline content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link *foo **bar** \`#\`*](/uri)
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link &lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; &lt;code&gt;#&lt;/code&gt;&lt;/em&gt;&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[![moon](moon.jpg)](/uri)
+.
+&lt;p&gt;&lt;a href="/uri"&gt;&lt;img src="moon.jpg" alt="moon" /&gt;&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, links may not contain other links, at any level of nesting.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo [bar](/uri)](/uri)
+.
+&lt;p&gt;[foo &lt;a href="/uri"&gt;bar&lt;/a&gt;](/uri)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo *[bar [baz](/uri)](/uri)*](/uri)
+.
+&lt;p&gt;[foo &lt;em&gt;[bar &lt;a href="/uri"&gt;baz&lt;/a&gt;](/uri)&lt;/em&gt;](/uri)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![[[foo](uri1)](uri2)](uri3)
+.
+&lt;p&gt;&lt;img src="uri3" alt="[foo](uri2)" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These cases illustrate the precedence of link text grouping over
+emphasis grouping:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*[foo*](/uri)
+.
+&lt;p&gt;*&lt;a href="/uri"&gt;foo*&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo *bar](baz*)
+.
+&lt;p&gt;&lt;a href="baz*"&gt;foo *bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that brackets that *aren't* part of links do not take
+precedence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo [bar* baz]
+.
+&lt;p&gt;&lt;em&gt;foo [bar&lt;/em&gt; baz]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These cases illustrate the precedence of HTML tags, code spans,
+and autolinks over link grouping:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo &lt;bar attr="](baz)"&gt;
+.
+&lt;p&gt;[foo &lt;bar attr="](baz)"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo\`](/uri)\`
+.
+&lt;p&gt;[foo&lt;code&gt;](/uri)&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo&lt;https://\`text.com/?search=](uri)&gt;
+.
+&lt;p&gt;[foo&lt;a href="https://\`text.com/?search=%5D(uri)"&gt;https://\`text.com/?search=](uri)&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+There are three kinds of [reference link](@)s:
+[full](#full-reference-link), [collapsed](#collapsed-reference-link),
+and [shortcut](#shortcut-reference-link).
+
+A [full reference link](@)
+consists of a [link text] immediately followed by a [link label]
+that [matches] a [link reference definition] elsewhere in the document.
+
+A [link label](@)  begins with a left bracket (\`[\`) and ends
+with the first right bracket (\`]\`) that is not backslash-escaped.
+Between these brackets there must be at least one character that is not a space,
+tab, or line ending.
+Unescaped square bracket characters are not allowed inside the
+opening and closing square brackets of [link labels].  A link
+label can have at most 999 characters inside the square
+brackets.
+
+One label [matches](@)
+another just in case their normalized forms are equal.  To normalize a
+label, strip off the opening and closing brackets,
+perform the *Unicode case fold*, strip leading and trailing
+spaces, tabs, and line endings, and collapse consecutive internal
+spaces, tabs, and line endings to a single space.  If there are multiple
+matching reference link definitions, the one that comes first in the
+document is used.  (It is desirable in such cases to emit a warning.)
+
+The link's URI and title are provided by the matching [link
+reference definition].
+
+Here is a simple\`text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][bar]
+
+[bar]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The rules for the [link text] are the same as with
+[inline links].  Thus:
+
+The link text may contain balanced brackets, but not unbalanced ones,
+unless they are escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link [foo [bar]]][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link [foo [bar]]&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link \\[bar][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link [bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link text may contain inline content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[link *foo **bar** \`#\`*][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href="/uri"&gt;link &lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; &lt;code&gt;#&lt;/code&gt;&lt;/em&gt;&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[![moon](moon.jpg)][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href="/uri"&gt;&lt;img src="moon.jpg" alt="moon" /&gt;&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+However, links may not contain other links, at any level of nesting.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo [bar](/uri)][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;[foo &lt;a href="/uri"&gt;bar&lt;/a&gt;]&lt;a href="/uri"&gt;ref&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo *bar [baz][ref]*][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;[foo &lt;em&gt;bar &lt;a href="/uri"&gt;baz&lt;/a&gt;&lt;/em&gt;]&lt;a href="/uri"&gt;ref&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+(In the examples above, we have two [shortcut reference links]
+instead of one [full reference link].)
+
+The following cases illustrate the precedence of link text grouping over
+emphasis grouping:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*[foo*][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;*&lt;a href="/uri"&gt;foo*&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo *bar][ref]*
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href="/uri"&gt;foo *bar&lt;/a&gt;*&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These cases illustrate the precedence of HTML tags, code spans,
+and autolinks over link grouping:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo &lt;bar attr="][ref]"&gt;
+
+[ref]: /uri
+.
+&lt;p&gt;[foo &lt;bar attr="][ref]"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo\`][ref]\`
+
+[ref]: /uri
+.
+&lt;p&gt;[foo&lt;code&gt;][ref]&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo&lt;https://\`text.com/?search=][ref]&gt;
+
+[ref]: /uri
+.
+&lt;p&gt;[foo&lt;a href="https://\`text.com/?search=%5D%5Bref%5D"&gt;https://\`text.com/?search=][ref]&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Matching is case-insensitive:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][BaR]
+
+[bar]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Unicode case fold is used:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[ẞ]
+
+[SS]: /url
+.
+&lt;p&gt;&lt;a href="/url"&gt;ẞ&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Consecutive internal spaces, tabs, and line endings are treated as one space for
+purposes of determining matching:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[Foo
+  bar]: /url
+
+[Baz][Foo bar]
+.
+&lt;p&gt;&lt;a href="/url"&gt;Baz&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+No spaces, tabs, or line endings are allowed between the [link text] and the
+[link label]:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo] [bar]
+
+[bar]: /url "title"
+.
+&lt;p&gt;[foo] &lt;a href="/url" title="title"&gt;bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+[bar]
+
+[bar]: /url "title"
+.
+&lt;p&gt;[foo]
+&lt;a href="/url" title="title"&gt;bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+This is a departure from John Gruber's original Markdown syntax
+description, which explicitly allows whitespace between the link
+text and the link label.  It brings reference links in line with
+[inline links], which (according to both original Markdown and
+this spec) cannot have whitespace after the link text.  More
+importantly, it prevents inadvertent capture of consecutive
+[shortcut reference links]. If whitespace is allowed between the
+link text and the link label, then in the following we will have
+a single reference link, not two shortcut reference links, as
+intended:
+
+\`\`\` markdown
+[foo]
+[bar]
+
+[foo]: /url1
+[bar]: /url2
+\`\`\`
+
+(Note that [shortcut reference links] were introduced by Gruber
+himself in a beta version of \`Markdown.pl\`, but never included
+in the official syntax description.  Without shortcut reference
+links, it is harmless to allow space between the link text and
+link label; but once shortcut references are introduced, it is
+too dangerous to allow this, as it frequently leads to
+unintended results.)
+
+When there are multiple matching [link reference definitions],
+the first is used:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]: /url1
+
+[foo]: /url2
+
+[bar][foo]
+.
+&lt;p&gt;&lt;a href="/url1"&gt;bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that matching is performed on normalized strings, not parsed
+inline content.  So the following does not match, even though the
+labels define equivalent inline content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[bar][foo\\!]
+
+[foo!]: /url
+.
+&lt;p&gt;[bar][foo!]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+[Link labels] cannot contain brackets, unless they are
+backslash-escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][ref[]
+
+[ref[]: /uri
+.
+&lt;p&gt;[foo][ref[]&lt;/p&gt;
+&lt;p&gt;[ref[]: /uri&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][ref[bar]]
+
+[ref[bar]]: /uri
+.
+&lt;p&gt;[foo][ref[bar]]&lt;/p&gt;
+&lt;p&gt;[ref[bar]]: /uri&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[[[foo]]]
+
+[[[foo]]]: /url
+.
+&lt;p&gt;[[[foo]]]&lt;/p&gt;
+&lt;p&gt;[[[foo]]]: /url&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][ref\\[]
+
+[ref\\[]: /uri
+.
+&lt;p&gt;&lt;a href="/uri"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that in this\`text \`]\` is not backslash-escaped:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[bar\\\\]: /uri
+
+[bar\\\\]
+.
+&lt;p&gt;&lt;a href="/uri"&gt;bar\\&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A [link label] must contain at least one character that is not a space, tab, or
+line ending:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[]
+
+[]: /uri
+.
+&lt;p&gt;[]&lt;/p&gt;
+&lt;p&gt;[]: /uri&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[
+ ]
+
+[
+ ]: /uri
+.
+&lt;p&gt;[
+]&lt;/p&gt;
+&lt;p&gt;[
+]: /uri&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A [collapsed reference link](@)
+consists of a [link label] that [matches] a
+[link reference definition] elsewhere in the
+document, followed by the string \`[]\`.
+The contents of the link label are parsed as inlines,
+which are used as the link's text.  The link's URI and title are
+provided by the matching reference link definition.  Thus,
+\`[foo][]\` is equivalent to \`[foo][foo]\`.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[*foo* bar][]
+
+[*foo* bar]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link labels are case-insensitive:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[Foo][]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;Foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+As with full reference links, spaces, tabs, or line endings are not
+allowed between the two sets of brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo] 
+[]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;
+[]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A [shortcut reference link](@)
+consists of a [link label] that [matches] a
+[link reference definition] elsewhere in the
+document and is not followed by \`[]\` or a link label.
+The contents of the link label are parsed as inlines,
+which are used as the link's text.  The link's URI and title
+are provided by the matching link reference definition.
+Thus, \`[foo]\` is equivalent to \`[foo][]\`.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[*foo* bar]
+
+[*foo* bar]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[[*foo* bar]]
+
+[*foo* bar]: /url "title"
+.
+&lt;p&gt;[&lt;a href="/url" title="title"&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/a&gt;]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[[bar [foo]
+
+[foo]: /url
+.
+&lt;p&gt;[[bar &lt;a href="/url"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link labels are case-insensitive:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[Foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;a href="/url" title="title"&gt;Foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A space after the link text should be preserved:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo] bar
+
+[foo]: /url
+.
+&lt;p&gt;&lt;a href="/url"&gt;foo&lt;/a&gt; bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If you just want bracketed text, you can backslash-escape the
+opening bracket to avoid links:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\[foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;[foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that this is a link, because a link label ends with the first
+following closing bracket:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo*]: /url
+
+*[foo*]
+.
+&lt;p&gt;*&lt;a href="/url"&gt;foo*&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Full and collapsed references take precedence over shortcut
+references:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][bar]
+
+[foo]: /url1
+[bar]: /url2
+.
+&lt;p&gt;&lt;a href="/url2"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][]
+
+[foo]: /url1
+.
+&lt;p&gt;&lt;a href="/url1"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+Inline links also take precedence:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo]()
+
+[foo]: /url1
+.
+&lt;p&gt;&lt;a href=""&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo](not a link)
+
+[foo]: /url1
+.
+&lt;p&gt;&lt;a href="/url1"&gt;foo&lt;/a&gt;(not a link)&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+In the following case \`[bar][baz]\` is parsed as a reference,
+\`[foo]\` as normal text:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][bar][baz]
+
+[baz]: /url
+.
+&lt;p&gt;[foo]&lt;a href="/url"&gt;bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here, though, \`[foo][bar]\` is parsed as a reference, since
+\`[bar]\` is defined:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][bar][baz]
+
+[baz]: /url1
+[bar]: /url2
+.
+&lt;p&gt;&lt;a href="/url2"&gt;foo&lt;/a&gt;&lt;a href="/url1"&gt;baz&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Here \`[foo]\` is not parsed as a shortcut reference, because it
+is followed by a link label (even though \`[bar]\` is not defined):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+[foo][bar][baz]
+
+[baz]: /url1
+[foo]: /url2
+.
+&lt;p&gt;[foo]&lt;a href="/url1"&gt;bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+
+## Images
+
+Syntax for images is like the syntax for links, with one
+difference. Instead of [link text], we have an
+[image description](@).  The rules for this are the
+same as for [link text], except that (a) an
+image description starts with \`![\` rather than \`[\`, and
+(b) an image description may contain links.
+An image description has inline elements
+as its contents.  When an image is rendered to HTML,
+this is standardly used as the image's \`alt\` attribute.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo](/url "title")
+.
+&lt;p&gt;&lt;img src="/url" alt="foo" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo *bar*]
+
+[foo *bar*]: train.jpg "train & tracks"
+.
+&lt;p&gt;&lt;img src="train.jpg" alt="foo bar" title="train &amp; tracks" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo ![bar](/url)](/url2)
+.
+&lt;p&gt;&lt;img src="/url2" alt="foo bar" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo [bar](/url)](/url2)
+.
+&lt;p&gt;&lt;img src="/url2" alt="foo bar" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Though this spec is concerned with parsing, not rendering, it is
+recommended that in rendering to HTML, only the plain string content
+of the [image description] be used.  Note that in
+the above\`text, the alt attribute's value is \`foo bar\`, not \`foo
+[bar](/url)\` or \`foo &lt;a href="/url"&gt;bar&lt;/a&gt;\`.  Only the plain string
+content is rendered, without formatting.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo *bar*][]
+
+[foo *bar*]: train.jpg "train & tracks"
+.
+&lt;p&gt;&lt;img src="train.jpg" alt="foo bar" title="train &amp; tracks" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo *bar*][foobar]
+
+[FOOBAR]: train.jpg "train & tracks"
+.
+&lt;p&gt;&lt;img src="train.jpg" alt="foo bar" title="train &amp; tracks" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo](train.jpg)
+.
+&lt;p&gt;&lt;img src="train.jpg" alt="foo" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+My ![foo bar](/path/to/train.jpg  "title"   )
+.
+&lt;p&gt;My &lt;img src="/path/to/train.jpg" alt="foo bar" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo](&lt;url&gt;)
+.
+&lt;p&gt;&lt;img src="url" alt="foo" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![](/url)
+.
+&lt;p&gt;&lt;img src="/url" alt="" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Reference-style:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo][bar]
+
+[bar]: /url
+.
+&lt;p&gt;&lt;img src="/url" alt="foo" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo][bar]
+
+[BAR]: /url
+.
+&lt;p&gt;&lt;img src="/url" alt="foo" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Collapsed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo][]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="foo" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![*foo* bar][]
+
+[*foo* bar]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="foo bar" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The labels are case-insensitive:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![Foo][]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="Foo" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+As with reference links, spaces, tabs, and line endings, are not allowed
+between the two sets of brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo] 
+[]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="foo" title="title" /&gt;
+[]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Shortcut:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="foo" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![*foo* bar]
+
+[*foo* bar]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="foo bar" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that link labels cannot contain unescaped brackets:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![[foo]]
+
+[[foo]]: /url "title"
+.
+&lt;p&gt;![[foo]]&lt;/p&gt;
+&lt;p&gt;[[foo]]: /url &quot;title&quot;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+The link labels are case-insensitive:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+![Foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;&lt;img src="/url" alt="Foo" title="title" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If you just want a literal \`!\` followed by bracketed text, you can
+backslash-escape the opening \`[\`:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+!\\[foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;![foo]&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+If you want a link after a literal \`!\`, backslash-escape the
+\`!\`:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\\![foo]
+
+[foo]: /url "title"
+.
+&lt;p&gt;!&lt;a href="/url" title="title"&gt;foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Autolinks
+
+[Autolink](@)s are absolute URIs and email addresses inside
+\`&lt;\` and \`&gt;\`. They are parsed as links, with the URL or email address
+as the link label.
+
+A [URI autolink](@) consists of \`&lt;\`, followed by an
+[absolute URI] followed by \`&gt;\`.  It is parsed as
+a link to the URI, with the URI as the link's label.
+
+An [absolute URI](@),
+for these purposes, consists of a [scheme] followed by a colon (\`:\`)
+followed by zero or more characters other than [ASCII control
+characters][ASCII control character], [space], \`&lt;\`, and \`&gt;\`.
+If the URI includes these characters, they must be percent-encoded
+(e.g. \`%20\` for a space).
+
+For purposes of this spec, a [scheme](@) is any sequence
+of 2--32 characters beginning with an ASCII letter and followed
+by any combination of ASCII letters, digits, or the symbols plus
+("+"), period ("."), or hyphen ("-").
+
+Here are some valid autolinks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;http://foo.bar.baz&gt;
+.
+&lt;p&gt;&lt;a href="http://foo.bar.baz"&gt;http://foo.bar.baz&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;https://foo.bar.baz/test?q=hello&id=22&boolean&gt;
+.
+&lt;p&gt;&lt;a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean"&gt;https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;irc://foo.bar:2233/baz&gt;
+.
+&lt;p&gt;&lt;a href="irc://foo.bar:2233/baz"&gt;irc://foo.bar:2233/baz&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Uppercase is also fine:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;MAILTO:FOO@BAR.BAZ&gt;
+.
+&lt;p&gt;&lt;a href="MAILTO:FOO@BAR.BAZ"&gt;MAILTO:FOO@BAR.BAZ&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Note that many strings that count as [absolute URIs] for
+purposes of this spec are not valid URIs, because their
+schemes are not registered or because of other problems
+with their syntax:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a+b+c:d&gt;
+.
+&lt;p&gt;&lt;a href="a+b+c:d"&gt;a+b+c:d&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;made-up-scheme://foo,bar&gt;
+.
+&lt;p&gt;&lt;a href="made-up-scheme://foo,bar"&gt;made-up-scheme://foo,bar&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;https://../&gt;
+.
+&lt;p&gt;&lt;a href="https://../"&gt;https://../&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;localhost:5001/foo&gt;
+.
+&lt;p&gt;&lt;a href="localhost:5001/foo"&gt;localhost:5001/foo&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Spaces are not allowed in autolinks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;https://foo.bar/baz bim&gt;
+.
+&lt;p&gt;&lt;https://foo.bar/baz bim&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash-escapes do not work inside autolinks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;https://\`text.com/\\[\\&gt;
+.
+&lt;p&gt;&lt;a href="https://\`text.com/%5C%5B%5C"&gt;https://\`text.com/\\[\\&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+An [email autolink](@)
+consists of \`&lt;\`, followed by an [email address],
+followed by \`&gt;\`.  The link's label is the email address,
+and the URL is \`mailto:\` followed by the email address.
+
+An [email address](@),
+for these purposes, is anything that matches
+the [non-normative regex from the HTML5
+spec](https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email)):
+
+    /^[a-zA-Z0-9.!#$%&'*+/=?^_\`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
+    (?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+
+Examples of email autolinks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;foo@bar.\`text.com&gt;
+.
+&lt;p&gt;&lt;a href="mailto:foo@bar.\`text.com"&gt;foo@bar.\`text.com&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;foo+special@Bar.baz-bar0.com&gt;
+.
+&lt;p&gt;&lt;a href="mailto:foo+special@Bar.baz-bar0.com"&gt;foo+special@Bar.baz-bar0.com&lt;/a&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash-escapes do not work inside email autolinks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;foo\\+@bar.\`text.com&gt;
+.
+&lt;p&gt;&lt;foo+@bar.\`text.com&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+These are not autolinks:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;&gt;
+.
+&lt;p&gt;&lt;&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt; https://foo.bar &gt;
+.
+&lt;p&gt;&lt; https://foo.bar &gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;m:abc&gt;
+.
+&lt;p&gt;&lt;m:abc&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;foo.bar.baz&gt;
+.
+&lt;p&gt;&lt;foo.bar.baz&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+https://\`text.com
+.
+&lt;p&gt;https://\`text.com&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo@bar.\`text.com
+.
+&lt;p&gt;foo@bar.\`text.com&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Raw HTML
+
+Text between \`&lt;\` and \`&gt;\` that looks like an HTML tag is parsed as a
+raw HTML tag and will be rendered in HTML without escaping.
+Tag and attribute names are not limited to current HTML tags,
+so custom tags (and even, say, DocBook tags) may be used.
+
+Here is the grammar for tags:
+
+A [tag name](@) consists of an ASCII letter
+followed by zero or more ASCII letters, digits, or
+hyphens (\`-\`).
+
+An [attribute](@) consists of spaces, tabs, and up to one line ending,
+an [attribute name], and an optional
+[attribute value specification].
+
+An [attribute name](@)
+consists of an ASCII letter, \`_\`, or \`:\`, followed by zero or more ASCII
+letters, digits, \`_\`, \`.\`, \`:\`, or \`-\`.  (Note:  This is the XML
+specification restricted to ASCII.  HTML5 is laxer.)
+
+An [attribute value specification](@)
+consists of optional spaces, tabs, and up to one line ending,
+a \`=\` character, optional spaces, tabs, and up to one line ending,
+and an [attribute value].
+
+An [attribute value](@)
+consists of an [unquoted attribute value],
+a [single-quoted attribute value], or a [double-quoted attribute value].
+
+An [unquoted attribute value](@)
+is a nonempty string of characters not
+including spaces, tabs, line endings, \`"\`, \`'\`, \`=\`, \`&lt;\`, \`&gt;\`, or \`\` \` \`\`.
+
+A [single-quoted attribute value](@)
+consists of \`'\`, zero or more
+characters not including \`'\`, and a final \`'\`.
+
+A [double-quoted attribute value](@)
+consists of \`"\`, zero or more
+characters not including \`"\`, and a final \`"\`.
+
+An [open tag](@) consists of a \`&lt;\` character, a [tag name],
+zero or more [attributes], optional spaces, tabs, and up to one line ending,
+an optional \`/\` character, and a \`&gt;\` character.
+
+A [closing tag](@) consists of the string \`&lt;/\`, a
+[tag name], optional spaces, tabs, and up to one line ending, and the character
+\`&gt;\`.
+
+An [HTML comment](@) consists of \`&lt;!--&gt;\`, \`&lt;!---&gt;\`, or  \`&lt;!--\`, a string of
+characters not including the string \`--&gt;\`, and \`--&gt;\` (see the
+[HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state)).
+
+A [processing instruction](@)
+consists of the string \`&lt;?\`, a string
+of characters not including the string \`?&gt;\`, and the string
+\`?&gt;\`.
+
+A [declaration](@) consists of the string \`&lt;!\`, an ASCII letter, zero or more
+characters not including the character \`&gt;\`, and the character \`&gt;\`.
+
+A [CDATA section](@) consists of
+the string \`&lt;![CDATA[\`, a string of characters not including the string
+\`]]&gt;\`, and the string \`]]&gt;\`.
+
+An [HTML tag](@) consists of an [open tag], a [closing tag],
+an [HTML comment], a [processing instruction], a [declaration],
+or a [CDATA section].
+
+Here are some simple open tags:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a&gt;&lt;bab&gt;&lt;c2c&gt;
+.
+&lt;p&gt;&lt;a&gt;&lt;bab&gt;&lt;c2c&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Empty elements:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a/&gt;&lt;b2/&gt;
+.
+&lt;p&gt;&lt;a/&gt;&lt;b2/&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Whitespace is allowed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a  /&gt;&lt;b2
+data="foo" &gt;
+.
+&lt;p&gt;&lt;a  /&gt;&lt;b2
+data="foo" &gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+With attributes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a foo="bar" bam = 'baz &lt;em&gt;"&lt;/em&gt;'
+_boolean zoop:33=zoop:33 /&gt;
+.
+&lt;p&gt;&lt;a foo="bar" bam = 'baz &lt;em&gt;"&lt;/em&gt;'
+_boolean zoop:33=zoop:33 /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Custom tag names can be used:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo &lt;responsive-image src="foo.jpg" /&gt;
+.
+&lt;p&gt;Foo &lt;responsive-image src="foo.jpg" /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Illegal tag names, not parsed as HTML:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;33&gt; &lt;__&gt;
+.
+&lt;p&gt;&lt;33&gt; &lt;__&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Illegal attribute names:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a h*#ref="hi"&gt;
+.
+&lt;p&gt;&lt;a h*#ref=&quot;hi&quot;&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Illegal attribute values:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="hi'&gt; &lt;a href=hi'&gt;
+.
+&lt;p&gt;&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Illegal whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt; a&gt;&lt;
+foo&gt;&lt;bar/ &gt;
+&lt;foo bar=baz
+bim!bop /&gt;
+.
+&lt;p&gt;&lt; a&gt;&lt;
+foo&gt;&lt;bar/ &gt;
+&lt;foo bar=baz
+bim!bop /&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Missing whitespace:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href='bar'title=title&gt;
+.
+&lt;p&gt;&lt;a href='bar'title=title&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Closing tags:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;/a&gt;&lt;/foo &gt;
+.
+&lt;p&gt;&lt;/a&gt;&lt;/foo &gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Illegal attributes in closing tag:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;/a href="foo"&gt;
+.
+&lt;p&gt;&lt;/a href=&quot;foo&quot;&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Comments:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;!-- this is a --
+comment - with hyphens --&gt;
+.
+&lt;p&gt;foo &lt;!-- this is a --
+comment - with hyphens --&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;!--&gt; foo --&gt;
+
+foo &lt;!---&gt; foo --&gt;
+.
+&lt;p&gt;foo &lt;!--&gt; foo --&gt;&lt;/p&gt;
+&lt;p&gt;foo &lt;!---&gt; foo --&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Processing instructions:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;?php echo $a; ?&gt;
+.
+&lt;p&gt;foo &lt;?php echo $a; ?&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Declarations:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;!ELEMENT br EMPTY&gt;
+.
+&lt;p&gt;foo &lt;!ELEMENT br EMPTY&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+CDATA sections:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;![CDATA[&gt;&&lt;]]&gt;
+.
+&lt;p&gt;foo &lt;![CDATA[&gt;&&lt;]]&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Entity and numeric character references are preserved in HTML
+attributes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;a href="&ouml;"&gt;
+.
+&lt;p&gt;foo &lt;a href="&ouml;"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Backslash escapes do not work in HTML attributes:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo &lt;a href="\\*"&gt;
+.
+&lt;p&gt;foo &lt;a href="\\*"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="\\""&gt;
+.
+&lt;p&gt;&lt;a href=&quot;&quot;&quot;&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Hard line breaks
+
+A line ending (not in a code span or HTML tag) that is preceded
+by two or more spaces and does not occur at the end of a block
+is parsed as a [hard line break](@) (rendered
+in HTML as a \`&lt;br /&gt;\` tag):
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo  
+baz
+.
+&lt;p&gt;foo&lt;br /&gt;
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+For a more visible alternative, a backslash before the
+[line ending] may be used instead of two or more spaces:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo\\
+baz
+.
+&lt;p&gt;foo&lt;br /&gt;
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+More than two spaces can be used:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo       
+baz
+.
+&lt;p&gt;foo&lt;br /&gt;
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Leading spaces at the beginning of the next line are ignored:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo  
+     bar
+.
+&lt;p&gt;foo&lt;br /&gt;
+bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo\\
+     bar
+.
+&lt;p&gt;foo&lt;br /&gt;
+bar&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Hard line breaks can occur inside emphasis, links, and other constructs
+that allow inline content:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo  
+bar*
+.
+&lt;p&gt;&lt;em&gt;foo&lt;br /&gt;
+bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+*foo\\
+bar*
+.
+&lt;p&gt;&lt;em&gt;foo&lt;br /&gt;
+bar&lt;/em&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Hard line breaks do not occur inside code spans
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`code  
+span\`
+.
+&lt;p&gt;&lt;code&gt;code   span&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+\`code\\
+span\`
+.
+&lt;p&gt;&lt;code&gt;code\\ span&lt;/code&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+or HTML tags:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="foo  
+bar"&gt;
+.
+&lt;p&gt;&lt;a href="foo  
+bar"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+&lt;a href="foo\\
+bar"&gt;
+.
+&lt;p&gt;&lt;a href="foo\\
+bar"&gt;&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Hard line breaks are for separating inline content within a block.
+Neither syntax for hard line breaks works at the end of a paragraph or
+other block element:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo\\
+.
+&lt;p&gt;foo\\&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo  
+.
+&lt;p&gt;foo&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+### foo\\
+.
+&lt;h3&gt;foo\\&lt;/h3&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+### foo  
+.
+&lt;h3&gt;foo&lt;/h3&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+## Soft line breaks
+
+A regular line ending (not in a code span or HTML tag) that is not
+preceded by two or more spaces or a backslash is parsed as a
+[softbreak](@).  (A soft line break may be rendered in HTML either as a
+[line ending] or as a space. The result will be the same in
+browsers. In the examples here, a [line ending] will be used.)
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo
+baz
+.
+&lt;p&gt;foo
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Spaces at the end of the line and beginning of the next line are
+removed:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+foo 
+ baz
+.
+&lt;p&gt;foo
+baz&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+A conforming parser may render a soft line break in HTML either as a
+line ending or as a space.
+
+A renderer may also provide an option to render soft line breaks
+as hard line breaks.
+
+## Textual content
+
+Any characters not given an interpretation by the above rules will
+be parsed as plain textual content.
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+hello $.;'there
+.
+&lt;p&gt;hello $.;'there&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Foo χρῆν
+.
+&lt;p&gt;Foo χρῆν&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+Internal spaces are preserved verbatim:
+
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`text
+Multiple     spaces
+.
+&lt;p&gt;Multiple     spaces&lt;/p&gt;
+\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`\`
+
+
+&lt;!-- END TESTS --&gt;
+
+# Appendix: A parsing strategy
+
+In this appendix we describe some features of the parsing strategy
+used in the CommonMark reference implementations.
+
+## Overview
+
+Parsing has two phases:
+
+1. In the first phase, lines of input are consumed and the block
+structure of the document---its division into paragraphs, block quotes,
+list items, and so on---is constructed.  Text is assigned to these
+blocks but not parsed. Link reference definitions are parsed and a
+map of links is constructed.
+
+2. In the second phase, the raw text contents of paragraphs and headings
+are parsed into sequences of Markdown inline elements (strings,
+code spans, links, emphasis, and so on), using the map of link
+references constructed in phase 1.
+
+At each point in processing, the document is represented as a tree of
+**blocks**.  The root of the tree is a \`document\` block.  The \`document\`
+may have any number of other blocks as **children**.  These children
+may, in turn, have other blocks as children.  The last child of a block
+is normally considered **open**, meaning that subsequent lines of input
+can alter its contents.  (Blocks that are not open are **closed**.)
+Here, for\`text, is a possible document tree, with the open blocks
+marked by arrows:
+
+\`\`\` tree
+-&gt; document
+  -&gt; block_quote
+       paragraph
+         "Lorem ipsum dolor\\nsit amet."
+    -&gt; list (type=bullet tight=true bullet_char=-)
+         list_item
+           paragraph
+             "Qui *quodsi iracundia*"
+      -&gt; list_item
+        -&gt; paragraph
+             "aliquando id"
+\`\`\`
+
+## Phase 1: block structure
+
+Each line that is processed has an effect on this tree.  The line is
+analyzed and, depending on its contents, the document may be altered
+in one or more of the following ways:
+
+1. One or more open blocks may be closed.
+2. One or more new blocks may be created as children of the
+   last open block.
+3. Text may be added to the last (deepest) open block remaining
+   on the tree.
+
+Once a line has been incorporated into the tree in this way,
+it can be discarded, so input can be read in a stream.
+
+For each line, we follow this procedure:
+
+1. First we iterate through the open blocks, starting with the
+root document, and descending through last children down to the last
+open block.  Each block imposes a condition that the line must satisfy
+if the block is to remain open.  For\`text, a block quote requires a
+\`&gt;\` character.  A paragraph requires a non-blank line.
+In this phase we may match all or just some of the open
+blocks.  But we cannot close unmatched blocks yet, because we may have a
+[lazy continuation line].
+
+2.  Next, after consuming the continuation markers for existing
+blocks, we look for new block starts (e.g. \`&gt;\` for a block quote).
+If we encounter a new block start, we close any blocks unmatched
+in step 1 before creating the new block as a child of the last
+matched container block.
+
+3.  Finally, we look at the remainder of the line (after block
+markers like \`&gt;\`, list markers, and indentation have been consumed).
+This is text that can be incorporated into the last open
+block (a paragraph, code block, heading, or raw HTML).
+
+Setext headings are formed when we see a line of a paragraph
+that is a [setext heading underline].
+
+Reference link definitions are detected when a paragraph is closed;
+the accumulated text lines are parsed to see if they begin with
+one or more reference link definitions.  Any remainder becomes a
+normal paragraph.
+
+We can see how this works by considering how the tree above is
+generated by four lines of Markdown:
+
+\`\`\` markdown
+&gt; Lorem ipsum dolor
+sit amet.
+&gt; - Qui *quodsi iracundia*
+&gt; - aliquando id
+\`\`\`
+
+At the outset, our document model is just
+
+\`\`\` tree
+-&gt; document
+\`\`\`
+
+The first line of our text,
+
+\`\`\` markdown
+&gt; Lorem ipsum dolor
+\`\`\`
+
+causes a \`block_quote\` block to be created as a child of our
+open \`document\` block, and a \`paragraph\` block as a child of
+the \`block_quote\`.  Then the text is added to the last open
+block, the \`paragraph\`:
+
+\`\`\` tree
+-&gt; document
+  -&gt; block_quote
+    -&gt; paragraph
+         "Lorem ipsum dolor"
+\`\`\`
+
+The next line,
+
+\`\`\` markdown
+sit amet.
+\`\`\`
+
+is a "lazy continuation" of the open \`paragraph\`, so it gets added
+to the paragraph's text:
+
+\`\`\` tree
+-&gt; document
+  -&gt; block_quote
+    -&gt; paragraph
+         "Lorem ipsum dolor\\nsit amet."
+\`\`\`
+
+The third line,
+
+\`\`\` markdown
+&gt; - Qui *quodsi iracundia*
+\`\`\`
+
+causes the \`paragraph\` block to be closed, and a new \`list\` block
+opened as a child of the \`block_quote\`.  A \`list_item\` is also
+added as a child of the \`list\`, and a \`paragraph\` as a child of
+the \`list_item\`.  The text is then added to the new \`paragraph\`:
+
+\`\`\` tree
+-&gt; document
+  -&gt; block_quote
+       paragraph
+         "Lorem ipsum dolor\\nsit amet."
+    -&gt; list (type=bullet tight=true bullet_char=-)
+      -&gt; list_item
+        -&gt; paragraph
+             "Qui *quodsi iracundia*"
+\`\`\`
+
+The fourth line,
+
+\`\`\` markdown
+&gt; - aliquando id
+\`\`\`
+
+causes the \`list_item\` (and its child the \`paragraph\`) to be closed,
+and a new \`list_item\` opened up as child of the \`list\`.  A \`paragraph\`
+is added as a child of the new \`list_item\`, to contain the text.
+We thus obtain the final tree:
+
+\`\`\` tree
+-&gt; document
+  -&gt; block_quote
+       paragraph
+         "Lorem ipsum dolor\\nsit amet."
+    -&gt; list (type=bullet tight=true bullet_char=-)
+         list_item
+           paragraph
+             "Qui *quodsi iracundia*"
+      -&gt; list_item
+        -&gt; paragraph
+             "aliquando id"
+\`\`\`
+
+## Phase 2: inline structure
+
+Once all of the input has been parsed, all open blocks are closed.
+
+We then "walk the tree," visiting every node, and parse raw
+string contents of paragraphs and headings as inlines.  At this
+point we have seen all the link reference definitions, so we can
+resolve reference links as we go.
+
+\`\`\` tree
+document
+  block_quote
+    paragraph
+      str "Lorem ipsum dolor"
+      softbreak
+      str "sit amet."
+    list (type=bullet tight=true bullet_char=-)
+      list_item
+        paragraph
+          str "Qui "
+          emph
+            str "quodsi iracundia"
+      list_item
+        paragraph
+          str "aliquando id"
+\`\`\`
+
+Notice how the [line ending] in the first paragraph has
+been parsed as a \`softbreak\`, and the asterisks in the first list item
+have become an \`emph\`.
+
+### An algorithm for parsing nested emphasis and links
+
+By far the trickiest part of inline parsing is handling emphasis,
+strong emphasis, links, and images.  This is done using the following
+algorithm.
+
+When we're parsing inlines and we hit either
+
+- a run of \`*\` or \`_\` characters, or
+- a \`[\` or \`![\`
+
+we insert a text node with these symbols as its literal content, and we
+add a pointer to this text node to the [delimiter stack](@).
+
+The [delimiter stack] is a doubly linked list.  Each
+element contains a pointer to a text node, plus information about
+
+- the type of delimiter (\`[\`, \`![\`, \`*\`, \`_\`)
+- the number of delimiters,
+- whether the delimiter is "active" (all are active to start), and
+- whether the delimiter is a potential opener, a potential closer,
+  or both (which depends on what sort of characters precede
+  and follow the delimiters).
+
+When we hit a \`]\` character, we call the *look for link or image*
+procedure (see below).
+
+When we hit the end of the input, we call the *process emphasis*
+procedure (see below), with \`stack_bottom\` = NULL.
+
+#### *look for link or image*
+
+Starting at the top of the delimiter stack, we look backwards
+through the stack for an opening \`[\` or \`![\` delimiter.
+
+- If we don't find one, we return a literal text node \`]\`.
+
+- If we do find one, but it's not *active*, we remove the inactive
+  delimiter from the stack, and return a literal text node \`]\`.
+
+- If we find one and it's active, then we parse ahead to see if
+  we have an inline link/image, reference link/image, collapsed reference
+  link/image, or shortcut reference link/image.
+
+  + If we don't, then we remove the opening delimiter from the
+    delimiter stack and return a literal text node \`]\`.
+
+  + If we do, then
+
+    * We return a link or image node whose children are the inlines
+      after the text node pointed to by the opening delimiter.
+
+    * We run *process emphasis* on these inlines, with the \`[\` opener
+      as \`stack_bottom\`.
+
+    * We remove the opening delimiter.
+
+    * If we have a link (and not an image), we also set all
+      \`[\` delimiters before the opening delimiter to *inactive*.  (This
+      will prevent us from getting links within links.)
+
+#### *process emphasis*
+
+Parameter \`stack_bottom\` sets a lower bound to how far we
+descend in the [delimiter stack].  If it is NULL, we can
+go all the way to the bottom.  Otherwise, we stop before
+visiting \`stack_bottom\`.
+
+Let \`current_position\` point to the element on the [delimiter stack]
+just above \`stack_bottom\` (or the first element if \`stack_bottom\`
+is NULL).
+
+We keep track of the \`openers_bottom\` for each delimiter
+type (\`*\`, \`_\`), indexed to the length of the closing delimiter run
+(modulo 3) and to whether the closing delimiter can also be an
+opener.  Initialize this to \`stack_bottom\`.
+
+Then we repeat the following until we run out of potential
+closers:
+
+- Move \`current_position\` forward in the delimiter stack (if needed)
+  until we find the first potential closer with delimiter \`*\` or \`_\`.
+  (This will be the potential closer closest
+  to the beginning of the input -- the first one in parse order.)
+
+- Now, look back in the stack (staying above \`stack_bottom\` and
+  the \`openers_bottom\` for this delimiter type) for the
+  first matching potential opener ("matching" means same delimiter).
+
+- If one is found:
+
+  + Figure out whether we have emphasis or strong emphasis:
+    if both closer and opener spans have length &gt;= 2, we have
+    strong, otherwise regular.
+
+  + Insert an emph or strong emph node accordingly, after
+    the text node corresponding to the opener.
+
+  + Remove any delimiters between the opener and closer from
+    the delimiter stack.
+
+  + Remove 1 (for regular emph) or 2 (for strong emph) delimiters
+    from the opening and closing text nodes.  If they become empty
+    as a result, remove them and remove the corresponding element
+    of the delimiter stack.  If the closing node is removed, reset
+    \`current_position\` to the next element in the stack.
+
+- If none is found:
+
+  + Set \`openers_bottom\` to the element before \`current_position\`.
+    (We know that there are no openers for this kind of closer up to and
+    including this point, so this puts a lower bound on future searches.)
+
+  + If the closer at \`current_position\` is not a potential opener,
+    remove it from the delimiter stack (since we know it can't
+    be a closer either).
+
+  + Advance \`current_position\` to the next element in the stack.
+
+After we're done, we remove all delimiters above \`stack_bottom\` from the
+delimiter stack.
+
+        </code>
+      </pre>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/shared-ux/markdown/impl/markdown.test.tsx
+++ b/packages/shared-ux/markdown/impl/markdown.test.tsx
@@ -8,7 +8,8 @@
 
 import React from 'react';
 import { Markdown } from './markdown';
-import { render, screen } from '@testing-library/react';
+import { text as specText } from 'commonmark-spec';
+import { render, screen, waitFor } from '@testing-library/react';
 
 describe('shared ux markdown component', () => {
   it('renders markdown editor by default', () => {
@@ -37,6 +38,28 @@ describe('shared ux markdown component', () => {
   it('renders EuiMarkdownEditor without style passed', () => {
     render(<Markdown style={{ color: 'red' }} data-test-subj="editor" />);
     expect(screen.getByTestId('editor')).not.toHaveStyle({ color: 'red' });
+  });
+
+  it('EuiMarkdownFormat renders consistently matches to spec', async () => {
+    const renderSignal = jest.fn();
+
+    // remove language annotation of arbitrary 'example' language for code snippets in spec to prevent rendering error,
+    // because EUI implementation requires that the language annotation type be registered
+    // for proper syntax highlighting.
+    const cleanedText = specText.replace(/\s?example\b/gm, '`text').replace(/\\/, '');
+
+    render(
+      <Markdown
+        onRender={renderSignal}
+        data-test-subj="spec-validation"
+        markdownContent={cleanedText}
+        readOnly
+      />
+    );
+
+    await waitFor(() => expect(renderSignal).toHaveBeenCalled());
+
+    expect(screen.getByTestId('spec-validation')).toMatchSnapshot();
   });
 
   it('renders EuiMarkdownFormat with style passed', () => {

--- a/packages/shared-ux/markdown/impl/tsconfig.json
+++ b/packages/shared-ux/markdown/impl/tsconfig.json
@@ -7,6 +7,7 @@
       "node",
       "react",
       "@kbn/ambient-ui-types",
+      "../../../../typings/commonmark-spec"
     ]
   },
   "include": [

--- a/src/plugins/kibana_react/public/markdown/__snapshots__/markdown.test.tsx.snap
+++ b/src/plugins/kibana_react/public/markdown/__snapshots__/markdown.test.tsx.snap
@@ -47,6 +47,7192 @@ exports[`render 1`] = `
 />
 `;
 
+exports[`render will always match spec 1`] = `
+<div
+  className="kbnMarkdown__body"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<hr>
+<p>title: CommonMark Spec
+author: John MacFarlane
+version: '0.31.2'
+date: '2024-01-28'
+license: '<a href=\\"https://creativecommons.org/licenses/by-sa/4.0/\\">CC-BY-SA 4.0</a>'
+...</p>
+<h1>Introduction</h1>
+<h2>What is Markdown?</h2>
+<p>Markdown is a plain text format for writing structured documents,
+based on conventions for indicating formatting in email
+and usenet posts.  It was developed by John Gruber (with
+help from Aaron Swartz) and released in 2004 in the form of a
+<a href=\\"https://daringfireball.net/projects/markdown/syntax\\">syntax description</a>
+and a Perl script (<code>Markdown.pl</code>) for converting Markdown to
+HTML.  In the next decade, dozens of implementations were
+developed in many languages.  Some extended the original
+Markdown syntax with conventions for footnotes, tables, and
+other document elements.  Some allowed Markdown documents to be
+rendered in formats other than HTML.  Websites like Reddit,
+StackOverflow, and GitHub had millions of people using Markdown.
+And Markdown started to be used beyond the web, to author books,
+articles, slide shows, letters, and lecture notes.</p>
+<p>What distinguishes Markdown from many other lightweight markup
+syntaxes, which are often easier to write, is its readability.
+As Gruber writes:</p>
+<blockquote>
+<p>The overriding design goal for Markdown's formatting syntax is
+to make it as readable as possible. The idea is that a
+Markdown-formatted document should be publishable as-is, as
+plain text, without looking like it's been marked up with tags
+or formatting instructions.
+(<a href=\\"https://daringfireball.net/projects/markdown/\\">https://daringfireball.net/projects/markdown/</a>)</p>
+</blockquote>
+<p>The point can be illustrated by comparing a sample of
+<a href=\\"https://asciidoc.org/\\">AsciiDoc</a> with
+an equivalent sample of Markdown.  Here is a sample of
+AsciiDoc from the AsciiDoc manual:</p>
+<pre><code>1. List item one.
++
+List item one continued with a second paragraph followed by an
+Indented block.
++
+.................
+$ ls *.sh
+$ mv *.sh ~/tmp
+.................
++
+List item continued with a third paragraph.
+
+2. List item two continued with an open block.
++
+--
+This paragraph is part of the preceding list item.
+
+a. This list is nested and does not require explicit item
+continuation.
++
+This paragraph is part of the preceding list item.
+
+b. List item b.
+
+This paragraph belongs to item two of the outer list.
+--
+</code></pre>
+<p>And here is the equivalent in Markdown:</p>
+<pre><code>1.  List item one.
+
+    List item one continued with a second paragraph followed by an
+    Indented block.
+
+        $ ls *.sh
+        $ mv *.sh ~/tmp
+
+    List item continued with a third paragraph.
+
+2.  List item two continued with an open block.
+
+    This paragraph is part of the preceding list item.
+
+    1. This list is nested and does not require explicit item continuation.
+
+       This paragraph is part of the preceding list item.
+
+    2. List item b.
+
+    This paragraph belongs to item two of the outer list.
+</code></pre>
+<p>The AsciiDoc version is, arguably, easier to write. You don't need
+to worry about indentation.  But the Markdown version is much easier
+to read.  The nesting of list items is apparent to the eye in the
+source, not just in the processed document.</p>
+<h2>Why is a spec needed?</h2>
+<p>John Gruber's <a href=\\"https://daringfireball.net/projects/markdown/syntax\\">canonical description of Markdown's
+syntax</a>
+does not specify the syntax unambiguously.  Here are some examples of
+questions it does not answer:</p>
+<ol>
+<li>
+<p>How much indentation is needed for a sublist?  The spec says that
+continuation paragraphs need to be indented four spaces, but is
+not fully explicit about sublists.  It is natural to think that
+they, too, must be indented four spaces, but <code>Markdown.pl</code> does
+not require that.  This is hardly a &quot;corner case,&quot; and divergences
+between implementations on this issue often lead to surprises for
+users in real documents. (See <a href=\\"https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/1997\\">this comment by John
+Gruber</a>.)</p>
+</li>
+<li>
+<p>Is a blank line needed before a block quote or heading?
+Most implementations do not require the blank line.  However,
+this can lead to unexpected results in hard-wrapped text, and
+also to ambiguities in parsing (note that some implementations
+put the heading inside the blockquote, while others do not).
+(John Gruber has also spoken <a href=\\"https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/2146\\">in favor of requiring the blank
+lines</a>.)</p>
+</li>
+<li>
+<p>Is a blank line needed before an indented code block?
+(<code>Markdown.pl</code> requires it, but this is not mentioned in the
+documentation, and some implementations do not require it.)</p>
+<pre><code class=\\"language-markdown\\">paragraph
+    code?
+</code></pre>
+</li>
+<li>
+<p>What is the exact rule for determining when list items get
+wrapped in <code>&lt;p&gt;</code> tags?  Can a list be partially &quot;loose&quot; and partially
+&quot;tight&quot;?  What should we do with a list like this?</p>
+<pre><code class=\\"language-markdown\\">1. one
+
+2. two
+3. three
+</code></pre>
+<p>Or this?</p>
+<pre><code class=\\"language-markdown\\">1.  one
+    - a
+
+    - b
+2.  two
+</code></pre>
+<p>(There are some relevant comments by John Gruber
+<a href=\\"https://web.archive.org/web/20170611172104/http://article.gmane.org/gmane.text.markdown.general/2554\\">here</a>.)</p>
+</li>
+<li>
+<p>Can list markers be indented?  Can ordered list markers be right-aligned?</p>
+<pre><code class=\\"language-markdown\\"> 8. item 1
+ 9. item 2
+10. item 2a
+</code></pre>
+</li>
+<li>
+<p>Is this one list with a thematic break in its second item,
+or two lists separated by a thematic break?</p>
+<pre><code class=\\"language-markdown\\">* a
+* * * * *
+* b
+</code></pre>
+</li>
+<li>
+<p>When list markers change from numbers to bullets, do we have
+two lists or one?  (The Markdown syntax description suggests two,
+but the perl scripts and many other implementations produce one.)</p>
+<pre><code class=\\"language-markdown\\">1. fee
+2. fie
+-  foe
+-  fum
+</code></pre>
+</li>
+<li>
+<p>What are the precedence rules for the markers of inline structure?
+For example, is the following a valid link, or does the code span
+take precedence ?</p>
+<pre><code class=\\"language-markdown\\">[a backtick (\`)](/url) and [another backtick (\`)](/url).
+</code></pre>
+</li>
+<li>
+<p>What are the precedence rules for markers of emphasis and strong
+emphasis?  For example, how should the following be parsed?</p>
+<pre><code class=\\"language-markdown\\">*foo *bar* baz*
+</code></pre>
+</li>
+<li>
+<p>What are the precedence rules between block-level and inline-level
+structure?  For example, how should the following be parsed?</p>
+<pre><code class=\\"language-markdown\\">- \`a long code span can contain a hyphen like this
+  - and it can screw things up\`
+</code></pre>
+</li>
+<li>
+<p>Can list items include section headings?  (<code>Markdown.pl</code> does not
+allow this, but does allow blockquotes to include headings.)</p>
+<pre><code class=\\"language-markdown\\">- # Heading
+</code></pre>
+</li>
+<li>
+<p>Can list items be empty?</p>
+<pre><code class=\\"language-markdown\\">* a
+*
+* b
+</code></pre>
+</li>
+<li>
+<p>Can link references be defined inside block quotes or list items?</p>
+<pre><code class=\\"language-markdown\\">&gt; Blockquote [foo].
+&gt;
+&gt; [foo]: /url
+</code></pre>
+</li>
+<li>
+<p>If there are multiple definitions for the same reference, which takes
+precedence?</p>
+<pre><code class=\\"language-markdown\\">[foo]: /url1
+[foo]: /url2
+
+[foo][]
+</code></pre>
+</li>
+</ol>
+<p>In the absence of a spec, early implementers consulted <code>Markdown.pl</code>
+to resolve these ambiguities.  But <code>Markdown.pl</code> was quite buggy, and
+gave manifestly bad results in many cases, so it was not a
+satisfactory replacement for a spec.</p>
+<p>Because there is no unambiguous spec, implementations have diverged
+considerably.  As a result, users are often surprised to find that
+a document that renders one way on one system (say, a GitHub wiki)
+renders differently on another (say, converting to docbook using
+pandoc).  To make matters worse, because nothing in Markdown counts
+as a &quot;syntax error,&quot; the divergence often isn't discovered right away.</p>
+<h2>About this document</h2>
+<p>This document attempts to specify Markdown syntax unambiguously.
+It contains many examples with side-by-side Markdown and
+HTML.  These are intended to double as conformance tests.  An
+accompanying script <code>spec_tests.py</code> can be used to run the tests
+against any Markdown program:</p>
+<pre><code>python test/spec_tests.py --spec spec.txt --program PROGRAM
+</code></pre>
+<p>Since this document describes how Markdown is to be parsed into
+an abstract syntax tree, it would have made sense to use an abstract
+representation of the syntax tree instead of HTML.  But HTML is capable
+of representing the structural distinctions we need to make, and the
+choice of HTML for the tests makes it possible to run the tests against
+an implementation without writing an abstract syntax tree renderer.</p>
+<p>Note that not every feature of the HTML samples is mandated by
+the spec.  For example, the spec says what counts as a link
+destination, but it doesn't mandate that non-ASCII characters in
+the URL be percent-encoded.  To use the automatic tests,
+implementers will need to provide a renderer that conforms to
+the expectations of the spec examples (percent-encoding
+non-ASCII characters in URLs).  But a conforming implementation
+can use a different renderer and may choose not to
+percent-encode non-ASCII characters in URLs.</p>
+<p>This document is generated from a text file, <code>spec.txt</code>, written
+in Markdown with a small extension for the side-by-side tests.
+The script <code>tools/makespec.py</code> can be used to convert <code>spec.txt</code> into
+HTML or CommonMark (which can then be converted into other formats).</p>
+<p>In the examples, the <code>→</code> character is used to represent tabs.</p>
+<h1>Preliminaries</h1>
+<h2>Characters and lines</h2>
+<p>Any sequence of [characters] is a valid CommonMark
+document.</p>
+<p>A <a href=\\"@\\">character</a> is a Unicode code point.  Although some
+code points (for example, combining accents) do not correspond to
+characters in an intuitive sense, all code points count as characters
+for purposes of this spec.</p>
+<p>This spec does not specify an encoding; it thinks of lines as composed
+of [characters] rather than bytes.  A conforming parser may be limited
+to a certain encoding.</p>
+<p>A <a href=\\"@\\">line</a> is a sequence of zero or more [characters]
+other than line feed (<code>U+000A</code>) or carriage return (<code>U+000D</code>),
+followed by a [line ending] or by the end of file.</p>
+<p>A <a href=\\"@\\">line ending</a> is a line feed (<code>U+000A</code>), a carriage return
+(<code>U+000D</code>) not followed by a line feed, or a carriage return and a
+following line feed.</p>
+<p>A line containing no characters, or a line containing only spaces
+(<code>U+0020</code>) or tabs (<code>U+0009</code>), is called a <a href=\\"@\\">blank line</a>.</p>
+<p>The following definitions of character classes will be used in this spec:</p>
+<p>A <a href=\\"@\\">Unicode whitespace character</a> is a character in the Unicode <code>Zs</code> general
+category, or a tab (<code>U+0009</code>), line feed (<code>U+000A</code>), form feed (<code>U+000C</code>), or
+carriage return (<code>U+000D</code>).</p>
+<p><a href=\\"@\\">Unicode whitespace</a> is a sequence of one or more
+[Unicode whitespace characters].</p>
+<p>A <a href=\\"@\\">tab</a> is <code>U+0009</code>.</p>
+<p>A <a href=\\"@\\">space</a> is <code>U+0020</code>.</p>
+<p>An <a href=\\"@\\">ASCII control character</a> is a character between <code>U+0000–1F</code> (both
+including) or <code>U+007F</code>.</p>
+<p>An <a href=\\"@\\">ASCII punctuation character</a>
+is <code>!</code>, <code>&quot;</code>, <code>#</code>, <code>$</code>, <code>%</code>, <code>&amp;</code>, <code>'</code>, <code>(</code>, <code>)</code>,
+<code>*</code>, <code>+</code>, <code>,</code>, <code>-</code>, <code>.</code>, <code>/</code> (U+0021–2F),
+<code>:</code>, <code>;</code>, <code>&lt;</code>, <code>=</code>, <code>&gt;</code>, <code>?</code>, <code>@</code> (U+003A–0040),
+<code>[</code>, <code>\\\\</code>, <code>]</code>, <code>^</code>, <code>_</code>, <code>\`</code> (U+005B–0060),
+<code>{</code>, <code>|</code>, <code>}</code>, or <code>~</code> (U+007B–007E).</p>
+<p>A <a href=\\"@\\">Unicode punctuation character</a> is a character in the Unicode <code>P</code>
+(puncuation) or <code>S</code> (symbol) general categories.</p>
+<h2>Tabs</h2>
+<p>Tabs in lines are not expanded to [spaces].  However,
+in contexts where spaces help to define block structure,
+tabs behave as if they were replaced by spaces with a tab stop
+of 4 characters.</p>
+<p>Thus, for example, a tab can be used instead of four spaces
+in an indented code block.  (Note, however, that internal
+tabs are passed through as literal tabs, not expanded to
+spaces.)</p>
+<pre><code class=\\"language-example\\">→foo→baz→→bim
+.
+&lt;pre&gt;&lt;code&gt;foo→baz→→bim
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">  →foo→baz→→bim
+.
+&lt;pre&gt;&lt;code&gt;foo→baz→→bim
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">    a→a
+    ὐ→a
+.
+&lt;pre&gt;&lt;code&gt;a→a
+ὐ→a
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>In the following example, a continuation paragraph of a list
+item is indented with a tab; this has exactly the same effect
+as indentation with four spaces would:</p>
+<pre><code class=\\"language-example\\">  - foo
+
+→bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- foo
+
+→→bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;  bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>Normally the <code>&gt;</code> that begins a block quote may be followed
+optionally by a space, which is not considered part of the
+content.  In the following case <code>&gt;</code> is followed by a tab,
+which is treated as if it were expanded into three spaces.
+Since one of these spaces is considered part of the
+delimiter, <code>foo</code> is considered to be indented six spaces
+inside the block quote context, so we get an indented
+code block starting with two spaces.</p>
+<pre><code class=\\"language-example\\">&gt;→→foo
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;  foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">-→→foo
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;  foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">    foo
+→bar
+.
+&lt;pre&gt;&lt;code&gt;foo
+bar
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\"> - foo
+   - bar
+→ - baz
+.
+&lt;ul&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">#→Foo
+.
+&lt;h1&gt;Foo&lt;/h1&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*→*→*→
+.
+&lt;hr /&gt;
+</code></pre>
+<h2>Insecure characters</h2>
+<p>For security reasons, the Unicode character <code>U+0000</code> must be replaced
+with the REPLACEMENT CHARACTER (<code>U+FFFD</code>).</p>
+<h2>Backslash escapes</h2>
+<p>Any ASCII punctuation character may be backslash-escaped:</p>
+<pre><code class=\\"language-example\\">\\\\!\\\\&quot;\\\\#\\\\$\\\\%\\\\&amp;\\\\'\\\\(\\\\)\\\\*\\\\+\\\\,\\\\-\\\\.\\\\/\\\\:\\\\;\\\\&lt;\\\\=\\\\&gt;\\\\?\\\\@\\\\[\\\\\\\\\\\\]\\\\^\\\\_\\\\\`\\\\{\\\\|\\\\}\\\\~
+.
+&lt;p&gt;!&amp;quot;#$%&amp;amp;'()*+,-./:;&amp;lt;=&amp;gt;?@[\\\\]^_\`{|}~&lt;/p&gt;
+</code></pre>
+<p>Backslashes before other characters are treated as literal
+backslashes:</p>
+<pre><code class=\\"language-example\\">\\\\→\\\\A\\\\a\\\\ \\\\3\\\\φ\\\\«
+.
+&lt;p&gt;\\\\→\\\\A\\\\a\\\\ \\\\3\\\\φ\\\\«&lt;/p&gt;
+</code></pre>
+<p>Escaped characters are treated as regular characters and do
+not have their usual Markdown meanings:</p>
+<pre><code class=\\"language-example\\">\\\\*not emphasized*
+\\\\&lt;br/&gt; not a tag
+\\\\[not a link](/foo)
+\\\\\`not code\`
+1\\\\. not a list
+\\\\* not a list
+\\\\# not a heading
+\\\\[foo]: /url &quot;not a reference&quot;
+\\\\&amp;ouml; not a character entity
+.
+&lt;p&gt;*not emphasized*
+&amp;lt;br/&amp;gt; not a tag
+[not a link](/foo)
+\`not code\`
+1. not a list
+* not a list
+# not a heading
+[foo]: /url &amp;quot;not a reference&amp;quot;
+&amp;amp;ouml; not a character entity&lt;/p&gt;
+</code></pre>
+<p>If a backslash is itself escaped, the following character is not:</p>
+<pre><code class=\\"language-example\\">\\\\\\\\*emphasis*
+.
+&lt;p&gt;\\\\&lt;em&gt;emphasis&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>A backslash at the end of the line is a [hard line break]:</p>
+<pre><code class=\\"language-example\\">foo\\\\
+bar
+.
+&lt;p&gt;foo&lt;br /&gt;
+bar&lt;/p&gt;
+</code></pre>
+<p>Backslash escapes do not work in code blocks, code spans, autolinks, or
+raw HTML:</p>
+<pre><code class=\\"language-example\\">\`\` \\\\[\\\\\` \`\`
+.
+&lt;p&gt;&lt;code&gt;\\\\[\\\\\`&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">    \\\\[\\\\]
+.
+&lt;pre&gt;&lt;code&gt;\\\\[\\\\]
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">~~~
+\\\\[\\\\]
+~~~
+.
+&lt;pre&gt;&lt;code&gt;\\\\[\\\\]
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;https://example.com?find=\\\\*&gt;
+.
+&lt;p&gt;&lt;a href=&quot;https://example.com?find=%5C*&quot;&gt;https://example.com?find=\\\\*&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;/bar\\\\/)&quot;&gt;
+.
+&lt;a href=&quot;/bar\\\\/)&quot;&gt;
+</code></pre>
+<p>But they work in all other contexts, including URLs and link titles,
+link references, and [info strings] in [fenced code blocks]:</p>
+<pre><code class=\\"language-example\\">[foo](/bar\\\\* &quot;ti\\\\*tle&quot;)
+.
+&lt;p&gt;&lt;a href=&quot;/bar*&quot; title=&quot;ti*tle&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo]
+
+[foo]: /bar\\\\* &quot;ti\\\\*tle&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/bar*&quot; title=&quot;ti*tle&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`\`\` foo\\\\+bar
+foo
+\`\`\`
+.
+&lt;pre&gt;&lt;code class=&quot;language-foo+bar&quot;&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<h2>Entity and numeric character references</h2>
+<p>Valid HTML entity references and numeric character references
+can be used in place of the corresponding Unicode character,
+with the following exceptions:</p>
+<ul>
+<li>
+<p>Entity and character references are not recognized in code
+blocks and code spans.</p>
+</li>
+<li>
+<p>Entity and character references cannot stand in place of
+special characters that define structural elements in
+CommonMark.  For example, although <code>&amp;#42;</code> can be used
+in place of a literal <code>*</code> character, <code>&amp;#42;</code> cannot replace
+<code>*</code> in emphasis delimiters, bullet list markers, or thematic
+breaks.</p>
+</li>
+</ul>
+<p>Conforming CommonMark parsers need not store information about
+whether a particular character was represented in the source
+using a Unicode character or an entity reference.</p>
+<p><a href=\\"@\\">Entity references</a> consist of <code>&amp;</code> + any of the valid
+HTML5 entity names + <code>;</code>. The
+document <a href=\\"https://html.spec.whatwg.org/entities.json\\">https://html.spec.whatwg.org/entities.json</a>
+is used as an authoritative source for the valid entity
+references and their corresponding code points.</p>
+<pre><code class=\\"language-example\\">&amp;nbsp; &amp;amp; &amp;copy; &amp;AElig; &amp;Dcaron;
+&amp;frac34; &amp;HilbertSpace; &amp;DifferentialD;
+&amp;ClockwiseContourIntegral; &amp;ngE;
+.
+&lt;p&gt;  &amp;amp; © Æ Ď
+¾ ℋ ⅆ
+∲ ≧̸&lt;/p&gt;
+</code></pre>
+<p><a href=\\"@\\">Decimal numeric character
+references</a>
+consist of <code>&amp;#</code> + a string of 1--7 arabic digits + <code>;</code>. A
+numeric character reference is parsed as the corresponding
+Unicode character. Invalid Unicode code points will be replaced by
+the REPLACEMENT CHARACTER (<code>U+FFFD</code>).  For security reasons,
+the code point <code>U+0000</code> will also be replaced by <code>U+FFFD</code>.</p>
+<pre><code class=\\"language-example\\">&amp;#35; &amp;#1234; &amp;#992; &amp;#0;
+.
+&lt;p&gt;# Ӓ Ϡ �&lt;/p&gt;
+</code></pre>
+<p><a href=\\"@\\">Hexadecimal numeric character
+references</a> consist of <code>&amp;#</code> +
+either <code>X</code> or <code>x</code> + a string of 1-6 hexadecimal digits + <code>;</code>.
+They too are parsed as the corresponding Unicode character (this
+time specified with a hexadecimal numeral instead of decimal).</p>
+<pre><code class=\\"language-example\\">&amp;#X22; &amp;#XD06; &amp;#xcab;
+.
+&lt;p&gt;&amp;quot; ആ ಫ&lt;/p&gt;
+</code></pre>
+<p>Here are some nonentities:</p>
+<pre><code class=\\"language-example\\">&amp;nbsp &amp;x; &amp;#; &amp;#x;
+&amp;#87654321;
+&amp;#abcdef0;
+&amp;ThisIsNotDefined; &amp;hi?;
+.
+&lt;p&gt;&amp;amp;nbsp &amp;amp;x; &amp;amp;#; &amp;amp;#x;
+&amp;amp;#87654321;
+&amp;amp;#abcdef0;
+&amp;amp;ThisIsNotDefined; &amp;amp;hi?;&lt;/p&gt;
+</code></pre>
+<p>Although HTML5 does accept some entity references
+without a trailing semicolon (such as <code>&amp;copy</code>), these are not
+recognized here, because it makes the grammar too ambiguous:</p>
+<pre><code class=\\"language-example\\">&amp;copy
+.
+&lt;p&gt;&amp;amp;copy&lt;/p&gt;
+</code></pre>
+<p>Strings that are not on the list of HTML5 named entities are not
+recognized as entity references either:</p>
+<pre><code class=\\"language-example\\">&amp;MadeUpEntity;
+.
+&lt;p&gt;&amp;amp;MadeUpEntity;&lt;/p&gt;
+</code></pre>
+<p>Entity and numeric character references are recognized in any
+context besides code spans or code blocks, including
+URLs, [link titles], and [fenced code block][] [info strings]:</p>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;&amp;ouml;&amp;ouml;.html&quot;&gt;
+.
+&lt;a href=&quot;&amp;ouml;&amp;ouml;.html&quot;&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo](/f&amp;ouml;&amp;ouml; &quot;f&amp;ouml;&amp;ouml;&quot;)
+.
+&lt;p&gt;&lt;a href=&quot;/f%C3%B6%C3%B6&quot; title=&quot;föö&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo]
+
+[foo]: /f&amp;ouml;&amp;ouml; &quot;f&amp;ouml;&amp;ouml;&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/f%C3%B6%C3%B6&quot; title=&quot;föö&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`\`\` f&amp;ouml;&amp;ouml;
+foo
+\`\`\`
+.
+&lt;pre&gt;&lt;code class=&quot;language-föö&quot;&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Entity and numeric character references are treated as literal
+text in code spans and code blocks:</p>
+<pre><code class=\\"language-example\\">\`f&amp;ouml;&amp;ouml;\`
+.
+&lt;p&gt;&lt;code&gt;f&amp;amp;ouml;&amp;amp;ouml;&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">    f&amp;ouml;f&amp;ouml;
+.
+&lt;pre&gt;&lt;code&gt;f&amp;amp;ouml;f&amp;amp;ouml;
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Entity and numeric character references cannot be used
+in place of symbols indicating structure in CommonMark
+documents.</p>
+<pre><code class=\\"language-example\\">&amp;#42;foo&amp;#42;
+*foo*
+.
+&lt;p&gt;*foo*
+&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&amp;#42; foo
+
+* foo
+.
+&lt;p&gt;* foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo&amp;#10;&amp;#10;bar
+.
+&lt;p&gt;foo
+
+bar&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&amp;#9;foo
+.
+&lt;p&gt;→foo&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[a](url &amp;quot;tit&amp;quot;)
+.
+&lt;p&gt;[a](url &amp;quot;tit&amp;quot;)&lt;/p&gt;
+</code></pre>
+<h1>Blocks and inlines</h1>
+<p>We can think of a document as a sequence of
+<a href=\\"@\\">blocks</a>---structural elements like paragraphs, block
+quotations, lists, headings, rules, and code blocks.  Some blocks (like
+block quotes and list items) contain other blocks; others (like
+headings and paragraphs) contain <a href=\\"@\\">inline</a> content---text,
+links, emphasized text, images, code spans, and so on.</p>
+<h2>Precedence</h2>
+<p>Indicators of block structure always take precedence over indicators
+of inline structure.  So, for example, the following is a list with
+two items, not a list with one item containing a code span:</p>
+<pre><code class=\\"language-example\\">- \`one
+- two\`
+.
+&lt;ul&gt;
+&lt;li&gt;\`one&lt;/li&gt;
+&lt;li&gt;two\`&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>This means that parsing can proceed in two steps:  first, the block
+structure of the document can be discerned; second, text lines inside
+paragraphs, headings, and other block constructs can be parsed for inline
+structure.  The second step requires information about link reference
+definitions that will be available only at the end of the first
+step.  Note that the first step requires processing lines in sequence,
+but the second can be parallelized, since the inline parsing of
+one block element does not affect the inline parsing of any other.</p>
+<h2>Container blocks and leaf blocks</h2>
+<p>We can divide blocks into two types:
+<a href=\\"#container-blocks\\">container blocks</a>,
+which can contain other blocks, and <a href=\\"#leaf-blocks\\">leaf blocks</a>,
+which cannot.</p>
+<h1>Leaf blocks</h1>
+<p>This section describes the different kinds of leaf block that make up a
+Markdown document.</p>
+<h2>Thematic breaks</h2>
+<p>A line consisting of optionally up to three spaces of indentation, followed by a
+sequence of three or more matching <code>-</code>, <code>_</code>, or <code>*</code> characters, each followed
+optionally by any number of spaces or tabs, forms a
+<a href=\\"@\\">thematic break</a>.</p>
+<pre><code class=\\"language-example\\">***
+---
+___
+.
+&lt;hr /&gt;
+&lt;hr /&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>Wrong characters:</p>
+<pre><code class=\\"language-example\\">+++
+.
+&lt;p&gt;+++&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">===
+.
+&lt;p&gt;===&lt;/p&gt;
+</code></pre>
+<p>Not enough characters:</p>
+<pre><code class=\\"language-example\\">--
+**
+__
+.
+&lt;p&gt;--
+**
+__&lt;/p&gt;
+</code></pre>
+<p>Up to three spaces of indentation are allowed:</p>
+<pre><code class=\\"language-example\\"> ***
+  ***
+   ***
+.
+&lt;hr /&gt;
+&lt;hr /&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">    ***
+.
+&lt;pre&gt;&lt;code&gt;***
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">Foo
+    ***
+.
+&lt;p&gt;Foo
+***&lt;/p&gt;
+</code></pre>
+<p>More than three characters may be used:</p>
+<pre><code class=\\"language-example\\">_____________________________________
+.
+&lt;hr /&gt;
+</code></pre>
+<p>Spaces and tabs are allowed between the characters:</p>
+<pre><code class=\\"language-example\\"> - - -
+.
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\"> **  * ** * ** * **
+.
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">-     -      -      -
+.
+&lt;hr /&gt;
+</code></pre>
+<p>Spaces and tabs are allowed at the end:</p>
+<pre><code class=\\"language-example\\">- - - -    
+.
+&lt;hr /&gt;
+</code></pre>
+<p>However, no other characters may occur in the line:</p>
+<pre><code class=\\"language-example\\">_ _ _ _ a
+
+a------
+
+---a---
+.
+&lt;p&gt;_ _ _ _ a&lt;/p&gt;
+&lt;p&gt;a------&lt;/p&gt;
+&lt;p&gt;---a---&lt;/p&gt;
+</code></pre>
+<p>It is required that all of the characters other than spaces or tabs be the same.
+So, this is not a thematic break:</p>
+<pre><code class=\\"language-example\\"> *-*
+.
+&lt;p&gt;&lt;em&gt;-&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Thematic breaks do not need blank lines before or after:</p>
+<pre><code class=\\"language-example\\">- foo
+***
+- bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>Thematic breaks can interrupt a paragraph:</p>
+<pre><code class=\\"language-example\\">Foo
+***
+bar
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;hr /&gt;
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<p>If a line of dashes that meets the above conditions for being a
+thematic break could also be interpreted as the underline of a [setext
+heading], the interpretation as a
+[setext heading] takes precedence. Thus, for example,
+this is a setext heading, not a paragraph followed by a thematic break:</p>
+<pre><code class=\\"language-example\\">Foo
+---
+bar
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<p>When both a thematic break and a list item are possible
+interpretations of a line, the thematic break takes precedence:</p>
+<pre><code class=\\"language-example\\">* Foo
+* * *
+* Bar
+.
+&lt;ul&gt;
+&lt;li&gt;Foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+&lt;ul&gt;
+&lt;li&gt;Bar&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>If you want a thematic break in a list item, use a different bullet:</p>
+<pre><code class=\\"language-example\\">- Foo
+- * * *
+.
+&lt;ul&gt;
+&lt;li&gt;Foo&lt;/li&gt;
+&lt;li&gt;
+&lt;hr /&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<h2>ATX headings</h2>
+<p>An <a href=\\"@\\">ATX heading</a>
+consists of a string of characters, parsed as inline content, between an
+opening sequence of 1--6 unescaped <code>#</code> characters and an optional
+closing sequence of any number of unescaped <code>#</code> characters.
+The opening sequence of <code>#</code> characters must be followed by spaces or tabs, or
+by the end of line. The optional closing sequence of <code>#</code>s must be preceded by
+spaces or tabs and may be followed by spaces or tabs only.  The opening
+<code>#</code> character may be preceded by up to three spaces of indentation.  The raw
+contents of the heading are stripped of leading and trailing space or tabs
+before being parsed as inline content.  The heading level is equal to the number
+of <code>#</code> characters in the opening sequence.</p>
+<p>Simple headings:</p>
+<pre><code class=\\"language-example\\"># foo
+## foo
+### foo
+#### foo
+##### foo
+###### foo
+.
+&lt;h1&gt;foo&lt;/h1&gt;
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;h3&gt;foo&lt;/h3&gt;
+&lt;h4&gt;foo&lt;/h4&gt;
+&lt;h5&gt;foo&lt;/h5&gt;
+&lt;h6&gt;foo&lt;/h6&gt;
+</code></pre>
+<p>More than six <code>#</code> characters is not a heading:</p>
+<pre><code class=\\"language-example\\">####### foo
+.
+&lt;p&gt;####### foo&lt;/p&gt;
+</code></pre>
+<p>At least one space or tab is required between the <code>#</code> characters and the
+heading's contents, unless the heading is empty.  Note that many
+implementations currently do not require the space.  However, the
+space was required by the
+<a href=\\"http://www.aaronsw.com/2002/atx/atx.py\\">original ATX implementation</a>,
+and it helps prevent things like the following from being parsed as
+headings:</p>
+<pre><code class=\\"language-example\\">#5 bolt
+
+#hashtag
+.
+&lt;p&gt;#5 bolt&lt;/p&gt;
+&lt;p&gt;#hashtag&lt;/p&gt;
+</code></pre>
+<p>This is not a heading, because the first <code>#</code> is escaped:</p>
+<pre><code class=\\"language-example\\">\\\\## foo
+.
+&lt;p&gt;## foo&lt;/p&gt;
+</code></pre>
+<p>Contents are parsed as inlines:</p>
+<pre><code class=\\"language-example\\"># foo *bar* \\\\*baz\\\\*
+.
+&lt;h1&gt;foo &lt;em&gt;bar&lt;/em&gt; *baz*&lt;/h1&gt;
+</code></pre>
+<p>Leading and trailing spaces or tabs are ignored in parsing inline content:</p>
+<pre><code class=\\"language-example\\">#                  foo                     
+.
+&lt;h1&gt;foo&lt;/h1&gt;
+</code></pre>
+<p>Up to three spaces of indentation are allowed:</p>
+<pre><code class=\\"language-example\\"> ### foo
+  ## foo
+   # foo
+.
+&lt;h3&gt;foo&lt;/h3&gt;
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;h1&gt;foo&lt;/h1&gt;
+</code></pre>
+<p>Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">    # foo
+.
+&lt;pre&gt;&lt;code&gt;# foo
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo
+    # bar
+.
+&lt;p&gt;foo
+# bar&lt;/p&gt;
+</code></pre>
+<p>A closing sequence of <code>#</code> characters is optional:</p>
+<pre><code class=\\"language-example\\">## foo ##
+  ###   bar    ###
+.
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;h3&gt;bar&lt;/h3&gt;
+</code></pre>
+<p>It need not be the same length as the opening sequence:</p>
+<pre><code class=\\"language-example\\"># foo ##################################
+##### foo ##
+.
+&lt;h1&gt;foo&lt;/h1&gt;
+&lt;h5&gt;foo&lt;/h5&gt;
+</code></pre>
+<p>Spaces or tabs are allowed after the closing sequence:</p>
+<pre><code class=\\"language-example\\">### foo ###     
+.
+&lt;h3&gt;foo&lt;/h3&gt;
+</code></pre>
+<p>A sequence of <code>#</code> characters with anything but spaces or tabs following it
+is not a closing sequence, but counts as part of the contents of the
+heading:</p>
+<pre><code class=\\"language-example\\">### foo ### b
+.
+&lt;h3&gt;foo ### b&lt;/h3&gt;
+</code></pre>
+<p>The closing sequence must be preceded by a space or tab:</p>
+<pre><code class=\\"language-example\\"># foo#
+.
+&lt;h1&gt;foo#&lt;/h1&gt;
+</code></pre>
+<p>Backslash-escaped <code>#</code> characters do not count as part
+of the closing sequence:</p>
+<pre><code class=\\"language-example\\">### foo \\\\###
+## foo #\\\\##
+# foo \\\\#
+.
+&lt;h3&gt;foo ###&lt;/h3&gt;
+&lt;h2&gt;foo ###&lt;/h2&gt;
+&lt;h1&gt;foo #&lt;/h1&gt;
+</code></pre>
+<p>ATX headings need not be separated from surrounding content by blank
+lines, and they can interrupt paragraphs:</p>
+<pre><code class=\\"language-example\\">****
+## foo
+****
+.
+&lt;hr /&gt;
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">Foo bar
+# baz
+Bar foo
+.
+&lt;p&gt;Foo bar&lt;/p&gt;
+&lt;h1&gt;baz&lt;/h1&gt;
+&lt;p&gt;Bar foo&lt;/p&gt;
+</code></pre>
+<p>ATX headings can be empty:</p>
+<pre><code class=\\"language-example\\">## 
+#
+### ###
+.
+&lt;h2&gt;&lt;/h2&gt;
+&lt;h1&gt;&lt;/h1&gt;
+&lt;h3&gt;&lt;/h3&gt;
+</code></pre>
+<h2>Setext headings</h2>
+<p>A <a href=\\"@\\">setext heading</a> consists of one or more
+lines of text, not interrupted by a blank line, of which the first line does not
+have more than 3 spaces of indentation, followed by
+a [setext heading underline].  The lines of text must be such
+that, were they not followed by the setext heading underline,
+they would be interpreted as a paragraph:  they cannot be
+interpretable as a [code fence], [ATX heading][ATX headings],
+[block quote][block quotes], [thematic break][thematic breaks],
+[list item][list items], or [HTML block][HTML blocks].</p>
+<p>A <a href=\\"@\\">setext heading underline</a> is a sequence of
+<code>=</code> characters or a sequence of <code>-</code> characters, with no more than 3
+spaces of indentation and any number of trailing spaces or tabs.</p>
+<p>The heading is a level 1 heading if <code>=</code> characters are used in
+the [setext heading underline], and a level 2 heading if <code>-</code>
+characters are used.  The contents of the heading are the result
+of parsing the preceding lines of text as CommonMark inline
+content.</p>
+<p>In general, a setext heading need not be preceded or followed by a
+blank line.  However, it cannot interrupt a paragraph, so when a
+setext heading comes after a paragraph, a blank line is needed between
+them.</p>
+<p>Simple examples:</p>
+<pre><code class=\\"language-example\\">Foo *bar*
+=========
+
+Foo *bar*
+---------
+.
+&lt;h1&gt;Foo &lt;em&gt;bar&lt;/em&gt;&lt;/h1&gt;
+&lt;h2&gt;Foo &lt;em&gt;bar&lt;/em&gt;&lt;/h2&gt;
+</code></pre>
+<p>The content of the header may span more than one line:</p>
+<pre><code class=\\"language-example\\">Foo *bar
+baz*
+====
+.
+&lt;h1&gt;Foo &lt;em&gt;bar
+baz&lt;/em&gt;&lt;/h1&gt;
+</code></pre>
+<p>The contents are the result of parsing the headings's raw
+content as inlines.  The heading's raw content is formed by
+concatenating the lines and removing initial and final
+spaces or tabs.</p>
+<pre><code class=\\"language-example\\">  Foo *bar
+baz*→
+====
+.
+&lt;h1&gt;Foo &lt;em&gt;bar
+baz&lt;/em&gt;&lt;/h1&gt;
+</code></pre>
+<p>The underlining can be any length:</p>
+<pre><code class=\\"language-example\\">Foo
+-------------------------
+
+Foo
+=
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+</code></pre>
+<p>The heading content can be preceded by up to three spaces of indentation, and
+need not line up with the underlining:</p>
+<pre><code class=\\"language-example\\">   Foo
+---
+
+  Foo
+-----
+
+  Foo
+  ===
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+</code></pre>
+<p>Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">    Foo
+    ---
+
+    Foo
+---
+.
+&lt;pre&gt;&lt;code&gt;Foo
+---
+
+Foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>The setext heading underline can be preceded by up to three spaces of
+indentation, and may have trailing spaces or tabs:</p>
+<pre><code class=\\"language-example\\">Foo
+   ----      
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+</code></pre>
+<p>Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">Foo
+    ---
+.
+&lt;p&gt;Foo
+---&lt;/p&gt;
+</code></pre>
+<p>The setext heading underline cannot contain internal spaces or tabs:</p>
+<pre><code class=\\"language-example\\">Foo
+= =
+
+Foo
+--- -
+.
+&lt;p&gt;Foo
+= =&lt;/p&gt;
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>Trailing spaces or tabs in the content line do not cause a hard line break:</p>
+<pre><code class=\\"language-example\\">Foo  
+-----
+.
+&lt;h2&gt;Foo&lt;/h2&gt;
+</code></pre>
+<p>Nor does a backslash at the end:</p>
+<pre><code class=\\"language-example\\">Foo\\\\
+----
+.
+&lt;h2&gt;Foo\\\\&lt;/h2&gt;
+</code></pre>
+<p>Since indicators of block structure take precedence over
+indicators of inline structure, the following are setext headings:</p>
+<pre><code class=\\"language-example\\">\`Foo
+----
+\`
+
+&lt;a title=&quot;a lot
+---
+of dashes&quot;/&gt;
+.
+&lt;h2&gt;\`Foo&lt;/h2&gt;
+&lt;p&gt;\`&lt;/p&gt;
+&lt;h2&gt;&amp;lt;a title=&amp;quot;a lot&lt;/h2&gt;
+&lt;p&gt;of dashes&amp;quot;/&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>The setext heading underline cannot be a [lazy continuation
+line] in a list item or block quote:</p>
+<pre><code class=\\"language-example\\">&gt; Foo
+---
+.
+&lt;blockquote&gt;
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; foo
+bar
+===
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar
+===&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- Foo
+---
+.
+&lt;ul&gt;
+&lt;li&gt;Foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>A blank line is needed between a paragraph and a following
+setext heading, since otherwise the paragraph becomes part
+of the heading's content:</p>
+<pre><code class=\\"language-example\\">Foo
+Bar
+---
+.
+&lt;h2&gt;Foo
+Bar&lt;/h2&gt;
+</code></pre>
+<p>But in general a blank line is not required before or after
+setext headings:</p>
+<pre><code class=\\"language-example\\">---
+Foo
+---
+Bar
+---
+Baz
+.
+&lt;hr /&gt;
+&lt;h2&gt;Foo&lt;/h2&gt;
+&lt;h2&gt;Bar&lt;/h2&gt;
+&lt;p&gt;Baz&lt;/p&gt;
+</code></pre>
+<p>Setext headings cannot be empty:</p>
+<pre><code class=\\"language-example\\">
+====
+.
+&lt;p&gt;====&lt;/p&gt;
+</code></pre>
+<p>Setext heading text lines must not be interpretable as block
+constructs other than paragraphs.  So, the line of dashes
+in these examples gets interpreted as a thematic break:</p>
+<pre><code class=\\"language-example\\">---
+---
+.
+&lt;hr /&gt;
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- foo
+-----
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">    foo
+---
+.
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;hr /&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; foo
+-----
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>If you want a heading with <code>&gt; foo</code> as its literal text, you can
+use backslash escapes:</p>
+<pre><code class=\\"language-example\\">\\\\&gt; foo
+------
+.
+&lt;h2&gt;&amp;gt; foo&lt;/h2&gt;
+</code></pre>
+<p><strong>Compatibility note:</strong>  Most existing Markdown implementations
+do not allow the text of setext headings to span multiple lines.
+But there is no consensus about how to interpret</p>
+<pre><code class=\\"language-markdown\\">Foo
+bar
+---
+baz
+</code></pre>
+<p>One can find four different interpretations:</p>
+<ol>
+<li>paragraph &quot;Foo&quot;, heading &quot;bar&quot;, paragraph &quot;baz&quot;</li>
+<li>paragraph &quot;Foo bar&quot;, thematic break, paragraph &quot;baz&quot;</li>
+<li>paragraph &quot;Foo bar --- baz&quot;</li>
+<li>heading &quot;Foo bar&quot;, paragraph &quot;baz&quot;</li>
+</ol>
+<p>We find interpretation 4 most natural, and interpretation 4
+increases the expressive power of CommonMark, by allowing
+multiline headings.  Authors who want interpretation 1 can
+put a blank line after the first paragraph:</p>
+<pre><code class=\\"language-example\\">Foo
+
+bar
+---
+baz
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;h2&gt;bar&lt;/h2&gt;
+&lt;p&gt;baz&lt;/p&gt;
+</code></pre>
+<p>Authors who want interpretation 2 can put blank lines around
+the thematic break,</p>
+<pre><code class=\\"language-example\\">Foo
+bar
+
+---
+
+baz
+.
+&lt;p&gt;Foo
+bar&lt;/p&gt;
+&lt;hr /&gt;
+&lt;p&gt;baz&lt;/p&gt;
+</code></pre>
+<p>or use a thematic break that cannot count as a [setext heading
+underline], such as</p>
+<pre><code class=\\"language-example\\">Foo
+bar
+* * *
+baz
+.
+&lt;p&gt;Foo
+bar&lt;/p&gt;
+&lt;hr /&gt;
+&lt;p&gt;baz&lt;/p&gt;
+</code></pre>
+<p>Authors who want interpretation 3 can use backslash escapes:</p>
+<pre><code class=\\"language-example\\">Foo
+bar
+\\\\---
+baz
+.
+&lt;p&gt;Foo
+bar
+---
+baz&lt;/p&gt;
+</code></pre>
+<h2>Indented code blocks</h2>
+<p>An <a href=\\"@\\">indented code block</a> is composed of one or more
+[indented chunks] separated by blank lines.
+An <a href=\\"@\\">indented chunk</a> is a sequence of non-blank lines,
+each preceded by four or more spaces of indentation. The contents of the code
+block are the literal contents of the lines, including trailing
+[line endings], minus four spaces of indentation.
+An indented code block has no [info string].</p>
+<p>An indented code block cannot interrupt a paragraph, so there must be
+a blank line between a paragraph and a following indented code block.
+(A blank line is not needed, however, between a code block and a following
+paragraph.)</p>
+<pre><code class=\\"language-example\\">    a simple
+      indented code block
+.
+&lt;pre&gt;&lt;code&gt;a simple
+  indented code block
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>If there is any ambiguity between an interpretation of indentation
+as a code block and as indicating that material belongs to a [list
+item][list items], the list item interpretation takes precedence:</p>
+<pre><code class=\\"language-example\\">  - foo
+
+    bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">1.  foo
+
+    - bar
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>The contents of a code block are literal text, and do not get parsed
+as Markdown:</p>
+<pre><code class=\\"language-example\\">    &lt;a/&gt;
+    *hi*
+
+    - one
+.
+&lt;pre&gt;&lt;code&gt;&amp;lt;a/&amp;gt;
+*hi*
+
+- one
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Here we have three chunks separated by blank lines:</p>
+<pre><code class=\\"language-example\\">    chunk1
+
+    chunk2
+  
+ 
+ 
+    chunk3
+.
+&lt;pre&gt;&lt;code&gt;chunk1
+
+chunk2
+
+
+
+chunk3
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Any initial spaces or tabs beyond four spaces of indentation will be included in
+the content, even in interior blank lines:</p>
+<pre><code class=\\"language-example\\">    chunk1
+      
+      chunk2
+.
+&lt;pre&gt;&lt;code&gt;chunk1
+  
+  chunk2
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>An indented code block cannot interrupt a paragraph.  (This
+allows hanging indents and the like.)</p>
+<pre><code class=\\"language-example\\">Foo
+    bar
+
+.
+&lt;p&gt;Foo
+bar&lt;/p&gt;
+</code></pre>
+<p>However, any non-blank line with fewer than four spaces of indentation ends
+the code block immediately.  So a paragraph may occur immediately
+after indented code:</p>
+<pre><code class=\\"language-example\\">    foo
+bar
+.
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<p>And indented code can occur immediately before and after other kinds of
+blocks:</p>
+<pre><code class=\\"language-example\\"># Heading
+    foo
+Heading
+------
+    foo
+----
+.
+&lt;h1&gt;Heading&lt;/h1&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;h2&gt;Heading&lt;/h2&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>The first line can be preceded by more than four spaces of indentation:</p>
+<pre><code class=\\"language-example\\">        foo
+    bar
+.
+&lt;pre&gt;&lt;code&gt;    foo
+bar
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Blank lines preceding or following an indented code block
+are not included in it:</p>
+<pre><code class=\\"language-example\\">
+    
+    foo
+    
+
+.
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Trailing spaces or tabs are included in the code block's content:</p>
+<pre><code class=\\"language-example\\">    foo  
+.
+&lt;pre&gt;&lt;code&gt;foo  
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<h2>Fenced code blocks</h2>
+<p>A <a href=\\"@\\">code fence</a> is a sequence
+of at least three consecutive backtick characters (<code>\`</code>) or
+tildes (<code>~</code>).  (Tildes and backticks cannot be mixed.)
+A <a href=\\"@\\">fenced code block</a>
+begins with a code fence, preceded by up to three spaces of indentation.</p>
+<p>The line with the opening code fence may optionally contain some text
+following the code fence; this is trimmed of leading and trailing
+spaces or tabs and called the <a href=\\"@\\">info string</a>. If the [info string] comes
+after a backtick fence, it may not contain any backtick
+characters.  (The reason for this restriction is that otherwise
+some inline code would be incorrectly interpreted as the
+beginning of a fenced code block.)</p>
+<p>The content of the code block consists of all subsequent lines, until
+a closing [code fence] of the same type as the code block
+began with (backticks or tildes), and with at least as many backticks
+or tildes as the opening code fence.  If the leading code fence is
+preceded by N spaces of indentation, then up to N spaces of indentation are
+removed from each line of the content (if present).  (If a content line is not
+indented, it is preserved unchanged.  If it is indented N spaces or less, all
+of the indentation is removed.)</p>
+<p>The closing code fence may be preceded by up to three spaces of indentation, and
+may be followed only by spaces or tabs, which are ignored.  If the end of the
+containing block (or document) is reached and no closing code fence
+has been found, the code block contains all of the lines after the
+opening code fence until the end of the containing block (or
+document).  (An alternative spec would require backtracking in the
+event that a closing code fence is not found.  But this makes parsing
+much less efficient, and there seems to be no real downside to the
+behavior described here.)</p>
+<p>A fenced code block may interrupt a paragraph, and does not require
+a blank line either before or after.</p>
+<p>The content of a code fence is treated as literal text, not parsed
+as inlines.  The first word of the [info string] is typically used to
+specify the language of the code sample, and rendered in the <code>class</code>
+attribute of the <code>code</code> tag.  However, this spec does not mandate any
+particular treatment of the [info string].</p>
+<p>Here is a simple example with backticks:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+&lt;
+ &gt;
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;&amp;lt;
+ &amp;gt;
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>With tildes:</p>
+<pre><code class=\\"language-example\\">~~~
+&lt;
+ &gt;
+~~~
+.
+&lt;pre&gt;&lt;code&gt;&amp;lt;
+ &amp;gt;
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Fewer than three backticks is not enough:</p>
+<pre><code class=\\"language-example\\">\`\`
+foo
+\`\`
+.
+&lt;p&gt;&lt;code&gt;foo&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>The closing code fence must use the same character as the opening
+fence:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+aaa
+~~~
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+~~~
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">~~~
+aaa
+\`\`\`
+~~~
+.
+&lt;pre&gt;&lt;code&gt;aaa
+\`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>The closing code fence must be at least as long as the opening fence:</p>
+<pre><code class=\\"language-example\\">\`\`\`\`
+aaa
+\`\`\`
+\`\`\`\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+\`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">~~~~
+aaa
+~~~
+~~~~
+.
+&lt;pre&gt;&lt;code&gt;aaa
+~~~
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Unclosed code blocks are closed by the end of the document
+(or the enclosing [block quote][block quotes] or [list item][list items]):</p>
+<pre><code class=\\"language-example\\">\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`\`\`\`\`
+
+\`\`\`
+aaa
+.
+&lt;pre&gt;&lt;code&gt;
+\`\`\`
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; \`\`\`
+&gt; aaa
+
+bbb
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+</code></pre>
+<p>A code block can have all empty lines as its content:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+
+  
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;
+  
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>A code block can be empty:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Fences can be indented.  If the opening fence is indented,
+content lines will have equivalent opening indentation removed,
+if present:</p>
+<pre><code class=\\"language-example\\"> \`\`\`
+ aaa
+aaa
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">  \`\`\`
+aaa
+  aaa
+aaa
+  \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+aaa
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">   \`\`\`
+   aaa
+    aaa
+  aaa
+   \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+ aaa
+aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">    \`\`\`
+    aaa
+    \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;\`\`\`
+aaa
+\`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Closing fences may be preceded by up to three spaces of indentation, and their
+indentation need not match that of the opening fence:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+aaa
+  \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">   \`\`\`
+aaa
+  \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>This is not a closing fence, because it is indented 4 spaces:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+aaa
+    \`\`\`
+.
+&lt;pre&gt;&lt;code&gt;aaa
+    \`\`\`
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Code fences (opening and closing) cannot contain internal spaces or tabs:</p>
+<pre><code class=\\"language-example\\">\`\`\` \`\`\`
+aaa
+.
+&lt;p&gt;&lt;code&gt; &lt;/code&gt;
+aaa&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">~~~~~~
+aaa
+~~~ ~~
+.
+&lt;pre&gt;&lt;code&gt;aaa
+~~~ ~~
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Fenced code blocks can interrupt paragraphs, and can be followed
+directly by paragraphs, without a blank line between:</p>
+<pre><code class=\\"language-example\\">foo
+\`\`\`
+bar
+\`\`\`
+baz
+.
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;baz&lt;/p&gt;
+</code></pre>
+<p>Other blocks can also occur before and after fenced code blocks
+without an intervening blank line:</p>
+<pre><code class=\\"language-example\\">foo
+---
+~~~
+bar
+~~~
+# baz
+.
+&lt;h2&gt;foo&lt;/h2&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;h1&gt;baz&lt;/h1&gt;
+</code></pre>
+<p>An [info string] can be provided after the opening code fence.
+Although this spec doesn't mandate any particular treatment of
+the info string, the first word is typically used to specify
+the language of the code block. In HTML output, the language is
+normally indicated by adding a class to the <code>code</code> element consisting
+of <code>language-</code> followed by the language name.</p>
+<pre><code class=\\"language-example\\">\`\`\`ruby
+def foo(x)
+  return 3
+end
+\`\`\`
+.
+&lt;pre&gt;&lt;code class=&quot;language-ruby&quot;&gt;def foo(x)
+  return 3
+end
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">~~~~    ruby startline=3 $%@#$
+def foo(x)
+  return 3
+end
+~~~~~~~
+.
+&lt;pre&gt;&lt;code class=&quot;language-ruby&quot;&gt;def foo(x)
+  return 3
+end
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`\`\`\`;
+\`\`\`\`
+.
+&lt;pre&gt;&lt;code class=&quot;language-;&quot;&gt;&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>[Info strings] for backtick code blocks cannot contain backticks:</p>
+<pre><code class=\\"language-example\\">\`\`\` aa \`\`\`
+foo
+.
+&lt;p&gt;&lt;code&gt;aa&lt;/code&gt;
+foo&lt;/p&gt;
+</code></pre>
+<p>[Info strings] for tilde code blocks can contain backticks and tildes:</p>
+<pre><code class=\\"language-example\\">~~~ aa \`\`\` ~~~
+foo
+~~~
+.
+&lt;pre&gt;&lt;code class=&quot;language-aa&quot;&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Closing code fences cannot have [info strings]:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+\`\`\` aaa
+\`\`\`
+.
+&lt;pre&gt;&lt;code&gt;\`\`\` aaa
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<h2>HTML blocks</h2>
+<p>An <a href=\\"@\\">HTML block</a> is a group of lines that is treated
+as raw HTML (and will not be escaped in HTML output).</p>
+<p>There are seven kinds of [HTML block], which can be defined by their
+start and end conditions.  The block begins with a line that meets a
+<a href=\\"@\\">start condition</a> (after up to three optional spaces of indentation).
+It ends with the first subsequent line that meets a matching
+<a href=\\"@\\">end condition</a>, or the last line of the document, or the last line of
+the <a href=\\"#container-blocks\\">container block</a> containing the current HTML
+block, if no line is encountered that meets the [end condition].  If
+the first line meets both the [start condition] and the [end
+condition], the block will contain just that line.</p>
+<ol>
+<li>
+<p><strong>Start condition:</strong>  line begins with the string <code>&lt;pre</code>,
+<code>&lt;script</code>, <code>&lt;style</code>, or <code>&lt;textarea</code> (case-insensitive), followed by a space,
+a tab, the string <code>&gt;</code>, or the end of the line.<br>
+<strong>End condition:</strong>  line contains an end tag
+<code>&lt;/pre&gt;</code>, <code>&lt;/script&gt;</code>, <code>&lt;/style&gt;</code>, or <code>&lt;/textarea&gt;</code> (case-insensitive; it
+need not match the start tag).</p>
+</li>
+<li>
+<p><strong>Start condition:</strong> line begins with the string <code>&lt;!--</code>.<br>
+<strong>End condition:</strong>  line contains the string <code>--&gt;</code>.</p>
+</li>
+<li>
+<p><strong>Start condition:</strong> line begins with the string <code>&lt;?</code>.<br>
+<strong>End condition:</strong> line contains the string <code>?&gt;</code>.</p>
+</li>
+<li>
+<p><strong>Start condition:</strong> line begins with the string <code>&lt;!</code>
+followed by an ASCII letter.<br>
+<strong>End condition:</strong> line contains the character <code>&gt;</code>.</p>
+</li>
+<li>
+<p><strong>Start condition:</strong>  line begins with the string
+<code>&lt;![CDATA[</code>.<br>
+<strong>End condition:</strong> line contains the string <code>]]&gt;</code>.</p>
+</li>
+<li>
+<p><strong>Start condition:</strong> line begins with the string <code>&lt;</code> or <code>&lt;/</code>
+followed by one of the strings (case-insensitive) <code>address</code>,
+<code>article</code>, <code>aside</code>, <code>base</code>, <code>basefont</code>, <code>blockquote</code>, <code>body</code>,
+<code>caption</code>, <code>center</code>, <code>col</code>, <code>colgroup</code>, <code>dd</code>, <code>details</code>, <code>dialog</code>,
+<code>dir</code>, <code>div</code>, <code>dl</code>, <code>dt</code>, <code>fieldset</code>, <code>figcaption</code>, <code>figure</code>,
+<code>footer</code>, <code>form</code>, <code>frame</code>, <code>frameset</code>,
+<code>h1</code>, <code>h2</code>, <code>h3</code>, <code>h4</code>, <code>h5</code>, <code>h6</code>, <code>head</code>, <code>header</code>, <code>hr</code>,
+<code>html</code>, <code>iframe</code>, <code>legend</code>, <code>li</code>, <code>link</code>, <code>main</code>, <code>menu</code>, <code>menuitem</code>,
+<code>nav</code>, <code>noframes</code>, <code>ol</code>, <code>optgroup</code>, <code>option</code>, <code>p</code>, <code>param</code>,
+<code>search</code>, <code>section</code>, <code>summary</code>, <code>table</code>, <code>tbody</code>, <code>td</code>,
+<code>tfoot</code>, <code>th</code>, <code>thead</code>, <code>title</code>, <code>tr</code>, <code>track</code>, <code>ul</code>, followed
+by a space, a tab, the end of the line, the string <code>&gt;</code>, or
+the string <code>/&gt;</code>.<br>
+<strong>End condition:</strong> line is followed by a [blank line].</p>
+</li>
+<li>
+<p><strong>Start condition:</strong>  line begins with a complete [open tag]
+(with any [tag name] other than <code>pre</code>, <code>script</code>,
+<code>style</code>, or <code>textarea</code>) or a complete [closing tag],
+followed by zero or more spaces and tabs, followed by the end of the line.<br>
+<strong>End condition:</strong> line is followed by a [blank line].</p>
+</li>
+</ol>
+<p>HTML blocks continue until they are closed by their appropriate
+[end condition], or the last line of the document or other <a href=\\"#container-blocks\\">container
+block</a>.  This means any HTML <strong>within an HTML
+block</strong> that might otherwise be recognised as a start condition will
+be ignored by the parser and passed through as-is, without changing
+the parser's state.</p>
+<p>For instance, <code>&lt;pre&gt;</code> within an HTML block started by <code>&lt;table&gt;</code> will not affect
+the parser state; as the HTML block was started in by start condition 6, it
+will end at any blank line. This can be surprising:</p>
+<pre><code class=\\"language-example\\">&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+&lt;pre&gt;
+**Hello**,
+
+_world_.
+&lt;/pre&gt;
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+.
+&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+&lt;pre&gt;
+**Hello**,
+&lt;p&gt;&lt;em&gt;world&lt;/em&gt;.
+&lt;/pre&gt;&lt;/p&gt;
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+</code></pre>
+<p>In this case, the HTML block is terminated by the blank line — the <code>**Hello**</code>
+text remains verbatim — and regular parsing resumes, with a paragraph,
+emphasised <code>world</code> and inline and block HTML following.</p>
+<p>All types of [HTML blocks] except type 7 may interrupt
+a paragraph.  Blocks of type 7 may not interrupt a paragraph.
+(This restriction is intended to prevent unwanted interpretation
+of long tags inside a wrapped paragraph as starting HTML blocks.)</p>
+<p>Some simple examples follow.  Here are some basic HTML blocks
+of type 6:</p>
+<pre><code class=\\"language-example\\">&lt;table&gt;
+  &lt;tr&gt;
+    &lt;td&gt;
+           hi
+    &lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+
+okay.
+.
+&lt;table&gt;
+  &lt;tr&gt;
+    &lt;td&gt;
+           hi
+    &lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+&lt;p&gt;okay.&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\"> &lt;div&gt;
+  *hello*
+         &lt;foo&gt;&lt;a&gt;
+.
+ &lt;div&gt;
+  *hello*
+         &lt;foo&gt;&lt;a&gt;
+</code></pre>
+<p>A block can also start with a closing tag:</p>
+<pre><code class=\\"language-example\\">&lt;/div&gt;
+*foo*
+.
+&lt;/div&gt;
+*foo*
+</code></pre>
+<p>Here we have two HTML blocks with a Markdown paragraph between them:</p>
+<pre><code class=\\"language-example\\">&lt;DIV CLASS=&quot;foo&quot;&gt;
+
+*Markdown*
+
+&lt;/DIV&gt;
+.
+&lt;DIV CLASS=&quot;foo&quot;&gt;
+&lt;p&gt;&lt;em&gt;Markdown&lt;/em&gt;&lt;/p&gt;
+&lt;/DIV&gt;
+</code></pre>
+<p>The tag on the first line can be partial, as long
+as it is split where there would be whitespace:</p>
+<pre><code class=\\"language-example\\">&lt;div id=&quot;foo&quot;
+  class=&quot;bar&quot;&gt;
+&lt;/div&gt;
+.
+&lt;div id=&quot;foo&quot;
+  class=&quot;bar&quot;&gt;
+&lt;/div&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;div id=&quot;foo&quot; class=&quot;bar
+  baz&quot;&gt;
+&lt;/div&gt;
+.
+&lt;div id=&quot;foo&quot; class=&quot;bar
+  baz&quot;&gt;
+&lt;/div&gt;
+</code></pre>
+<p>An open tag need not be closed:</p>
+<pre><code class=\\"language-example\\">&lt;div&gt;
+*foo*
+
+*bar*
+.
+&lt;div&gt;
+*foo*
+&lt;p&gt;&lt;em&gt;bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>A partial tag need not even be completed (garbage
+in, garbage out):</p>
+<pre><code class=\\"language-example\\">&lt;div id=&quot;foo&quot;
+*hi*
+.
+&lt;div id=&quot;foo&quot;
+*hi*
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;div class
+foo
+.
+&lt;div class
+foo
+</code></pre>
+<p>The initial tag doesn't even need to be a valid
+tag, as long as it starts like one:</p>
+<pre><code class=\\"language-example\\">&lt;div *???-&amp;&amp;&amp;-&lt;---
+*foo*
+.
+&lt;div *???-&amp;&amp;&amp;-&lt;---
+*foo*
+</code></pre>
+<p>In type 6 blocks, the initial tag need not be on a line by
+itself:</p>
+<pre><code class=\\"language-example\\">&lt;div&gt;&lt;a href=&quot;bar&quot;&gt;*foo*&lt;/a&gt;&lt;/div&gt;
+.
+&lt;div&gt;&lt;a href=&quot;bar&quot;&gt;*foo*&lt;/a&gt;&lt;/div&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+foo
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+.
+&lt;table&gt;&lt;tr&gt;&lt;td&gt;
+foo
+&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
+</code></pre>
+<p>Everything until the next blank line or end of document
+gets included in the HTML block.  So, in the following
+example, what looks like a Markdown code block
+is actually part of the HTML block, which continues until a blank
+line or the end of the document is reached:</p>
+<pre><code class=\\"language-example\\">&lt;div&gt;&lt;/div&gt;
+\`\`\` c
+int x = 33;
+\`\`\`
+.
+&lt;div&gt;&lt;/div&gt;
+\`\`\` c
+int x = 33;
+\`\`\`
+</code></pre>
+<p>To start an [HTML block] with a tag that is <em>not</em> in the
+list of block-level tags in (6), you must put the tag by
+itself on the first line (and it must be complete):</p>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;foo&quot;&gt;
+*bar*
+&lt;/a&gt;
+.
+&lt;a href=&quot;foo&quot;&gt;
+*bar*
+&lt;/a&gt;
+</code></pre>
+<p>In type 7 blocks, the [tag name] can be anything:</p>
+<pre><code class=\\"language-example\\">&lt;Warning&gt;
+*bar*
+&lt;/Warning&gt;
+.
+&lt;Warning&gt;
+*bar*
+&lt;/Warning&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;i class=&quot;foo&quot;&gt;
+*bar*
+&lt;/i&gt;
+.
+&lt;i class=&quot;foo&quot;&gt;
+*bar*
+&lt;/i&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;/ins&gt;
+*bar*
+.
+&lt;/ins&gt;
+*bar*
+</code></pre>
+<p>These rules are designed to allow us to work with tags that
+can function as either block-level or inline-level tags.
+The <code>&lt;del&gt;</code> tag is a nice example.  We can surround content with
+<code>&lt;del&gt;</code> tags in three different ways.  In this case, we get a raw
+HTML block, because the <code>&lt;del&gt;</code> tag is on a line by itself:</p>
+<pre><code class=\\"language-example\\">&lt;del&gt;
+*foo*
+&lt;/del&gt;
+.
+&lt;del&gt;
+*foo*
+&lt;/del&gt;
+</code></pre>
+<p>In this case, we get a raw HTML block that just includes
+the <code>&lt;del&gt;</code> tag (because it ends with the following blank
+line).  So the contents get interpreted as CommonMark:</p>
+<pre><code class=\\"language-example\\">&lt;del&gt;
+
+*foo*
+
+&lt;/del&gt;
+.
+&lt;del&gt;
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+&lt;/del&gt;
+</code></pre>
+<p>Finally, in this case, the <code>&lt;del&gt;</code> tags are interpreted
+as [raw HTML] <em>inside</em> the CommonMark paragraph.  (Because
+the tag is not on a line by itself, we get inline HTML
+rather than an [HTML block].)</p>
+<pre><code class=\\"language-example\\">&lt;del&gt;*foo*&lt;/del&gt;
+.
+&lt;p&gt;&lt;del&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/del&gt;&lt;/p&gt;
+</code></pre>
+<p>HTML tags designed to contain literal content
+(<code>pre</code>, <code>script</code>, <code>style</code>, <code>textarea</code>), comments, processing instructions,
+and declarations are treated somewhat differently.
+Instead of ending at the first blank line, these blocks
+end at the first line containing a corresponding end tag.
+As a result, these blocks can contain blank lines:</p>
+<p>A pre tag (type 1):</p>
+<pre><code class=\\"language-example\\">&lt;pre language=&quot;haskell&quot;&gt;&lt;code&gt;
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+&lt;/code&gt;&lt;/pre&gt;
+okay
+.
+&lt;pre language=&quot;haskell&quot;&gt;&lt;code&gt;
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;okay&lt;/p&gt;
+</code></pre>
+<p>A script tag (type 1):</p>
+<pre><code class=\\"language-example\\">&lt;script type=&quot;text/javascript&quot;&gt;
+// JavaScript example
+
+document.getElementById(&quot;demo&quot;).innerHTML = &quot;Hello JavaScript!&quot;;
+&lt;/script&gt;
+okay
+.
+&lt;script type=&quot;text/javascript&quot;&gt;
+// JavaScript example
+
+document.getElementById(&quot;demo&quot;).innerHTML = &quot;Hello JavaScript!&quot;;
+&lt;/script&gt;
+&lt;p&gt;okay&lt;/p&gt;
+</code></pre>
+<p>A textarea tag (type 1):</p>
+<pre><code class=\\"language-example\\">&lt;textarea&gt;
+
+*foo*
+
+_bar_
+
+&lt;/textarea&gt;
+.
+&lt;textarea&gt;
+
+*foo*
+
+_bar_
+
+&lt;/textarea&gt;
+</code></pre>
+<p>A style tag (type 1):</p>
+<pre><code class=\\"language-example\\">&lt;style
+  type=&quot;text/css&quot;&gt;
+h1 {color:red;}
+
+p {color:blue;}
+&lt;/style&gt;
+okay
+.
+&lt;style
+  type=&quot;text/css&quot;&gt;
+h1 {color:red;}
+
+p {color:blue;}
+&lt;/style&gt;
+&lt;p&gt;okay&lt;/p&gt;
+</code></pre>
+<p>If there is no matching end tag, the block will end at the
+end of the document (or the enclosing [block quote][block quotes]
+or [list item][list items]):</p>
+<pre><code class=\\"language-example\\">&lt;style
+  type=&quot;text/css&quot;&gt;
+
+foo
+.
+&lt;style
+  type=&quot;text/css&quot;&gt;
+
+foo
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; &lt;div&gt;
+&gt; foo
+
+bar
+.
+&lt;blockquote&gt;
+&lt;div&gt;
+foo
+&lt;/blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- &lt;div&gt;
+- foo
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;div&gt;
+&lt;/li&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>The end tag can occur on the same line as the start tag:</p>
+<pre><code class=\\"language-example\\">&lt;style&gt;p{color:red;}&lt;/style&gt;
+*foo*
+.
+&lt;style&gt;p{color:red;}&lt;/style&gt;
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;!-- foo --&gt;*bar*
+*baz*
+.
+&lt;!-- foo --&gt;*bar*
+&lt;p&gt;&lt;em&gt;baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that anything on the last line after the
+end tag will be included in the [HTML block]:</p>
+<pre><code class=\\"language-example\\">&lt;script&gt;
+foo
+&lt;/script&gt;1. *bar*
+.
+&lt;script&gt;
+foo
+&lt;/script&gt;1. *bar*
+</code></pre>
+<p>A comment (type 2):</p>
+<pre><code class=\\"language-example\\">&lt;!-- Foo
+
+bar
+   baz --&gt;
+okay
+.
+&lt;!-- Foo
+
+bar
+   baz --&gt;
+&lt;p&gt;okay&lt;/p&gt;
+</code></pre>
+<p>A processing instruction (type 3):</p>
+<pre><code class=\\"language-example\\">&lt;?php
+
+  echo '&gt;';
+
+?&gt;
+okay
+.
+&lt;?php
+
+  echo '&gt;';
+
+?&gt;
+&lt;p&gt;okay&lt;/p&gt;
+</code></pre>
+<p>A declaration (type 4):</p>
+<pre><code class=\\"language-example\\">&lt;!DOCTYPE html&gt;
+.
+&lt;!DOCTYPE html&gt;
+</code></pre>
+<p>CDATA (type 5):</p>
+<pre><code class=\\"language-example\\">&lt;![CDATA[
+function matchwo(a,b)
+{
+  if (a &lt; b &amp;&amp; a &lt; 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]&gt;
+okay
+.
+&lt;![CDATA[
+function matchwo(a,b)
+{
+  if (a &lt; b &amp;&amp; a &lt; 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]&gt;
+&lt;p&gt;okay&lt;/p&gt;
+</code></pre>
+<p>The opening tag can be preceded by up to three spaces of indentation, but not
+four:</p>
+<pre><code class=\\"language-example\\">  &lt;!-- foo --&gt;
+
+    &lt;!-- foo --&gt;
+.
+  &lt;!-- foo --&gt;
+&lt;pre&gt;&lt;code&gt;&amp;lt;!-- foo --&amp;gt;
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">  &lt;div&gt;
+
+    &lt;div&gt;
+.
+  &lt;div&gt;
+&lt;pre&gt;&lt;code&gt;&amp;lt;div&amp;gt;
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>An HTML block of types 1--6 can interrupt a paragraph, and need not be
+preceded by a blank line.</p>
+<pre><code class=\\"language-example\\">Foo
+&lt;div&gt;
+bar
+&lt;/div&gt;
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;div&gt;
+bar
+&lt;/div&gt;
+</code></pre>
+<p>However, a following blank line is needed, except at the end of
+a document, and except for blocks of types 1--5, [above][HTML
+block]:</p>
+<pre><code class=\\"language-example\\">&lt;div&gt;
+bar
+&lt;/div&gt;
+*foo*
+.
+&lt;div&gt;
+bar
+&lt;/div&gt;
+*foo*
+</code></pre>
+<p>HTML blocks of type 7 cannot interrupt a paragraph:</p>
+<pre><code class=\\"language-example\\">Foo
+&lt;a href=&quot;bar&quot;&gt;
+baz
+.
+&lt;p&gt;Foo
+&lt;a href=&quot;bar&quot;&gt;
+baz&lt;/p&gt;
+</code></pre>
+<p>This rule differs from John Gruber's original Markdown syntax
+specification, which says:</p>
+<blockquote>
+<p>The only restrictions are that block-level HTML elements —
+e.g. <code>&lt;div&gt;</code>, <code>&lt;table&gt;</code>, <code>&lt;pre&gt;</code>, <code>&lt;p&gt;</code>, etc. — must be separated from
+surrounding content by blank lines, and the start and end tags of the
+block should not be indented with spaces or tabs.</p>
+</blockquote>
+<p>In some ways Gruber's rule is more restrictive than the one given
+here:</p>
+<ul>
+<li>It requires that an HTML block be preceded by a blank line.</li>
+<li>It does not allow the start tag to be indented.</li>
+<li>It requires a matching end tag, which it also does not allow to
+be indented.</li>
+</ul>
+<p>Most Markdown implementations (including some of Gruber's own) do not
+respect all of these restrictions.</p>
+<p>There is one respect, however, in which Gruber's rule is more liberal
+than the one given here, since it allows blank lines to occur inside
+an HTML block.  There are two reasons for disallowing them here.
+First, it removes the need to parse balanced tags, which is
+expensive and can require backtracking from the end of the document
+if no matching end tag is found. Second, it provides a very simple
+and flexible way of including Markdown content inside HTML tags:
+simply separate the Markdown from the HTML using blank lines:</p>
+<p>Compare:</p>
+<pre><code class=\\"language-example\\">&lt;div&gt;
+
+*Emphasized* text.
+
+&lt;/div&gt;
+.
+&lt;div&gt;
+&lt;p&gt;&lt;em&gt;Emphasized&lt;/em&gt; text.&lt;/p&gt;
+&lt;/div&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;div&gt;
+*Emphasized* text.
+&lt;/div&gt;
+.
+&lt;div&gt;
+*Emphasized* text.
+&lt;/div&gt;
+</code></pre>
+<p>Some Markdown implementations have adopted a convention of
+interpreting content inside tags as text if the open tag has
+the attribute <code>markdown=1</code>.  The rule given above seems a simpler and
+more elegant way of achieving the same expressive power, which is also
+much simpler to parse.</p>
+<p>The main potential drawback is that one can no longer paste HTML
+blocks into Markdown documents with 100% reliability.  However,
+<em>in most cases</em> this will work fine, because the blank lines in
+HTML are usually followed by HTML block tags.  For example:</p>
+<pre><code class=\\"language-example\\">&lt;table&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+Hi
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+.
+&lt;table&gt;
+&lt;tr&gt;
+&lt;td&gt;
+Hi
+&lt;/td&gt;
+&lt;/tr&gt;
+&lt;/table&gt;
+</code></pre>
+<p>There are problems, however, if the inner tags are indented
+<em>and</em> separated by spaces, as then they will be interpreted as
+an indented code block:</p>
+<pre><code class=\\"language-example\\">&lt;table&gt;
+
+  &lt;tr&gt;
+
+    &lt;td&gt;
+      Hi
+    &lt;/td&gt;
+
+  &lt;/tr&gt;
+
+&lt;/table&gt;
+.
+&lt;table&gt;
+  &lt;tr&gt;
+&lt;pre&gt;&lt;code&gt;&amp;lt;td&amp;gt;
+  Hi
+&amp;lt;/td&amp;gt;
+&lt;/code&gt;&lt;/pre&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;
+</code></pre>
+<p>Fortunately, blank lines are usually not necessary and can be
+deleted.  The exception is inside <code>&lt;pre&gt;</code> tags, but as described
+[above][HTML blocks], raw HTML blocks starting with <code>&lt;pre&gt;</code>
+<em>can</em> contain blank lines.</p>
+<h2>Link reference definitions</h2>
+<p>A <a href=\\"@\\">link reference definition</a>
+consists of a [link label], optionally preceded by up to three spaces of
+indentation, followed
+by a colon (<code>:</code>), optional spaces or tabs (including up to one
+[line ending]), a [link destination],
+optional spaces or tabs (including up to one
+[line ending]), and an optional [link
+title], which if it is present must be separated
+from the [link destination] by spaces or tabs.
+No further character may occur.</p>
+<p>A [link reference definition]
+does not correspond to a structural element of a document.  Instead, it
+defines a label which can be used in [reference links]
+and reference-style [images] elsewhere in the document.  [Link
+reference definitions] can come either before or after the links that use
+them.</p>
+<pre><code class=\\"language-example\\">[foo]: /url &quot;title&quot;
+
+[foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">   [foo]: 
+      /url  
+           'the title'  
+
+[foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;the title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[Foo*bar\\\\]]:my_(url) 'title (with parens)'
+
+[Foo*bar\\\\]]
+.
+&lt;p&gt;&lt;a href=&quot;my_(url)&quot; title=&quot;title (with parens)&quot;&gt;Foo*bar]&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[Foo bar]:
+&lt;my url&gt;
+'title'
+
+[Foo bar]
+.
+&lt;p&gt;&lt;a href=&quot;my%20url&quot; title=&quot;title&quot;&gt;Foo bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The title may extend over multiple lines:</p>
+<pre><code class=\\"language-example\\">[foo]: /url '
+title
+line1
+line2
+'
+
+[foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;
+title
+line1
+line2
+&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>However, it may not contain a [blank line]:</p>
+<pre><code class=\\"language-example\\">[foo]: /url 'title
+
+with blank line'
+
+[foo]
+.
+&lt;p&gt;[foo]: /url 'title&lt;/p&gt;
+&lt;p&gt;with blank line'&lt;/p&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+</code></pre>
+<p>The title may be omitted:</p>
+<pre><code class=\\"language-example\\">[foo]:
+/url
+
+[foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The link destination may not be omitted:</p>
+<pre><code class=\\"language-example\\">[foo]:
+
+[foo]
+.
+&lt;p&gt;[foo]:&lt;/p&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+</code></pre>
+<p>However, an empty link destination may be specified using
+angle brackets:</p>
+<pre><code class=\\"language-example\\">[foo]: &lt;&gt;
+
+[foo]
+.
+&lt;p&gt;&lt;a href=&quot;&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The title must be separated from the link destination by
+spaces or tabs:</p>
+<pre><code class=\\"language-example\\">[foo]: &lt;bar&gt;(baz)
+
+[foo]
+.
+&lt;p&gt;[foo]: &lt;bar&gt;(baz)&lt;/p&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+</code></pre>
+<p>Both title and destination can contain backslash escapes
+and literal backslashes:</p>
+<pre><code class=\\"language-example\\">[foo]: /url\\\\bar\\\\*baz &quot;foo\\\\&quot;bar\\\\baz&quot;
+
+[foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url%5Cbar*baz&quot; title=&quot;foo&amp;quot;bar\\\\baz&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>A link can come before its corresponding definition:</p>
+<pre><code class=\\"language-example\\">[foo]
+
+[foo]: url
+.
+&lt;p&gt;&lt;a href=&quot;url&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>If there are several matching definitions, the first one takes
+precedence:</p>
+<pre><code class=\\"language-example\\">[foo]
+
+[foo]: first
+[foo]: second
+.
+&lt;p&gt;&lt;a href=&quot;first&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>As noted in the section on [Links], matching of labels is
+case-insensitive (see [matches]).</p>
+<pre><code class=\\"language-example\\">[FOO]: /url
+
+[Foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;Foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[ΑΓΩ]: /φου
+
+[αγω]
+.
+&lt;p&gt;&lt;a href=&quot;/%CF%86%CE%BF%CF%85&quot;&gt;αγω&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Whether something is a [link reference definition] is
+independent of whether the link reference it defines is
+used in the document.  Thus, for example, the following
+document contains just a link reference definition, and
+no visible content:</p>
+<pre><code class=\\"language-example\\">[foo]: /url
+.
+</code></pre>
+<p>Here is another one:</p>
+<pre><code class=\\"language-example\\">[
+foo
+]: /url
+bar
+.
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<p>This is not a link reference definition, because there are
+characters other than spaces or tabs after the title:</p>
+<pre><code class=\\"language-example\\">[foo]: /url &quot;title&quot; ok
+.
+&lt;p&gt;[foo]: /url &amp;quot;title&amp;quot; ok&lt;/p&gt;
+</code></pre>
+<p>This is a link reference definition, but it has no title:</p>
+<pre><code class=\\"language-example\\">[foo]: /url
+&quot;title&quot; ok
+.
+&lt;p&gt;&amp;quot;title&amp;quot; ok&lt;/p&gt;
+</code></pre>
+<p>This is not a link reference definition, because it is indented
+four spaces:</p>
+<pre><code class=\\"language-example\\">    [foo]: /url &quot;title&quot;
+
+[foo]
+.
+&lt;pre&gt;&lt;code&gt;[foo]: /url &amp;quot;title&amp;quot;
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+</code></pre>
+<p>This is not a link reference definition, because it occurs inside
+a code block:</p>
+<pre><code class=\\"language-example\\">\`\`\`
+[foo]: /url
+\`\`\`
+
+[foo]
+.
+&lt;pre&gt;&lt;code&gt;[foo]: /url
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;[foo]&lt;/p&gt;
+</code></pre>
+<p>A [link reference definition] cannot interrupt a paragraph.</p>
+<pre><code class=\\"language-example\\">Foo
+[bar]: /baz
+
+[bar]
+.
+&lt;p&gt;Foo
+[bar]: /baz&lt;/p&gt;
+&lt;p&gt;[bar]&lt;/p&gt;
+</code></pre>
+<p>However, it can directly follow other block elements, such as headings
+and thematic breaks, and it need not be followed by a blank line.</p>
+<pre><code class=\\"language-example\\"># [Foo]
+[foo]: /url
+&gt; bar
+.
+&lt;h1&gt;&lt;a href=&quot;/url&quot;&gt;Foo&lt;/a&gt;&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo]: /url
+bar
+===
+[foo]
+.
+&lt;h1&gt;bar&lt;/h1&gt;
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo]: /url
+===
+[foo]
+.
+&lt;p&gt;===
+&lt;a href=&quot;/url&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Several [link reference definitions]
+can occur one after another, without intervening blank lines.</p>
+<pre><code class=\\"language-example\\">[foo]: /foo-url &quot;foo&quot;
+[bar]: /bar-url
+  &quot;bar&quot;
+[baz]: /baz-url
+
+[foo],
+[bar],
+[baz]
+.
+&lt;p&gt;&lt;a href=&quot;/foo-url&quot; title=&quot;foo&quot;&gt;foo&lt;/a&gt;,
+&lt;a href=&quot;/bar-url&quot; title=&quot;bar&quot;&gt;bar&lt;/a&gt;,
+&lt;a href=&quot;/baz-url&quot;&gt;baz&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>[Link reference definitions] can occur
+inside block containers, like lists and block quotations.  They
+affect the entire document, not just the container in which they
+are defined:</p>
+<pre><code class=\\"language-example\\">[foo]
+
+&gt; [foo]: /url
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<h2>Paragraphs</h2>
+<p>A sequence of non-blank lines that cannot be interpreted as other
+kinds of blocks forms a <a href=\\"@\\">paragraph</a>.
+The contents of the paragraph are the result of parsing the
+paragraph's raw content as inlines.  The paragraph's raw content
+is formed by concatenating the lines and removing initial and final
+spaces or tabs.</p>
+<p>A simple example with two paragraphs:</p>
+<pre><code class=\\"language-example\\">aaa
+
+bbb
+.
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+</code></pre>
+<p>Paragraphs can contain multiple lines, but no blank lines:</p>
+<pre><code class=\\"language-example\\">aaa
+bbb
+
+ccc
+ddd
+.
+&lt;p&gt;aaa
+bbb&lt;/p&gt;
+&lt;p&gt;ccc
+ddd&lt;/p&gt;
+</code></pre>
+<p>Multiple blank lines between paragraphs have no effect:</p>
+<pre><code class=\\"language-example\\">aaa
+
+
+bbb
+.
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+</code></pre>
+<p>Leading spaces or tabs are skipped:</p>
+<pre><code class=\\"language-example\\">  aaa
+ bbb
+.
+&lt;p&gt;aaa
+bbb&lt;/p&gt;
+</code></pre>
+<p>Lines after the first may be indented any amount, since indented
+code blocks cannot interrupt paragraphs.</p>
+<pre><code class=\\"language-example\\">aaa
+             bbb
+                                       ccc
+.
+&lt;p&gt;aaa
+bbb
+ccc&lt;/p&gt;
+</code></pre>
+<p>However, the first line may be preceded by up to three spaces of indentation.
+Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">   aaa
+bbb
+.
+&lt;p&gt;aaa
+bbb&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">    aaa
+bbb
+.
+&lt;pre&gt;&lt;code&gt;aaa
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+</code></pre>
+<p>Final spaces or tabs are stripped before inline parsing, so a paragraph
+that ends with two or more spaces will not end with a [hard line
+break]:</p>
+<pre><code class=\\"language-example\\">aaa     
+bbb     
+.
+&lt;p&gt;aaa&lt;br /&gt;
+bbb&lt;/p&gt;
+</code></pre>
+<h2>Blank lines</h2>
+<p>[Blank lines] between block-level elements are ignored,
+except for the role they play in determining whether a [list]
+is [tight] or [loose].</p>
+<p>Blank lines at the beginning and end of the document are also ignored.</p>
+<pre><code class=\\"language-example\\">  
+
+aaa
+  
+
+# aaa
+
+  
+.
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;h1&gt;aaa&lt;/h1&gt;
+</code></pre>
+<h1>Container blocks</h1>
+<p>A <a href=\\"#container-blocks\\">container block</a> is a block that has other
+blocks as its contents.  There are two basic kinds of container blocks:
+[block quotes] and [list items].
+[Lists] are meta-containers for [list items].</p>
+<p>We define the syntax for container blocks recursively.  The general
+form of the definition is:</p>
+<blockquote>
+<p>If X is a sequence of blocks, then the result of
+transforming X in such-and-such a way is a container of type Y
+with these blocks as its content.</p>
+</blockquote>
+<p>So, we explain what counts as a block quote or list item by explaining
+how these can be <em>generated</em> from their contents. This should suffice
+to define the syntax, although it does not give a recipe for <em>parsing</em>
+these constructions.  (A recipe is provided below in the section entitled
+<a href=\\"#appendix-a-parsing-strategy\\">A parsing strategy</a>.)</p>
+<h2>Block quotes</h2>
+<p>A <a href=\\"@\\">block quote marker</a>,
+optionally preceded by up to three spaces of indentation,
+consists of (a) the character <code>&gt;</code> together with a following space of
+indentation, or (b) a single character <code>&gt;</code> not followed by a space of
+indentation.</p>
+<p>The following rules define [block quotes]:</p>
+<ol>
+<li>
+<p><strong>Basic case.</strong>  If a string of lines <em>Ls</em> constitute a sequence
+of blocks <em>Bs</em>, then the result of prepending a [block quote
+marker] to the beginning of each line in <em>Ls</em>
+is a <a href=\\"#block-quotes\\">block quote</a> containing <em>Bs</em>.</p>
+</li>
+<li>
+<p><strong>Laziness.</strong>  If a string of lines <em>Ls</em> constitute a <a href=\\"#block-quotes\\">block
+quote</a> with contents <em>Bs</em>, then the result of deleting
+the initial [block quote marker] from one or
+more lines in which the next character other than a space or tab after the
+[block quote marker] is [paragraph continuation
+text] is a block quote with <em>Bs</em> as its content.
+<a href=\\"@\\">Paragraph continuation text</a> is text
+that will be parsed as part of the content of a paragraph, but does
+not occur at the beginning of the paragraph.</p>
+</li>
+<li>
+<p><strong>Consecutiveness.</strong>  A document cannot contain two [block
+quotes] in a row unless there is a [blank line] between them.</p>
+</li>
+</ol>
+<p>Nothing else counts as a <a href=\\"#block-quotes\\">block quote</a>.</p>
+<p>Here is a simple example:</p>
+<pre><code class=\\"language-example\\">&gt; # Foo
+&gt; bar
+&gt; baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>The space or tab after the <code>&gt;</code> characters can be omitted:</p>
+<pre><code class=\\"language-example\\">&gt;# Foo
+&gt;bar
+&gt; baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>The <code>&gt;</code> characters can be preceded by up to three spaces of indentation:</p>
+<pre><code class=\\"language-example\\">   &gt; # Foo
+   &gt; bar
+ &gt; baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>Four spaces of indentation is too many:</p>
+<pre><code class=\\"language-example\\">    &gt; # Foo
+    &gt; bar
+    &gt; baz
+.
+&lt;pre&gt;&lt;code&gt;&amp;gt; # Foo
+&amp;gt; bar
+&amp;gt; baz
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>The Laziness clause allows us to omit the <code>&gt;</code> before
+[paragraph continuation text]:</p>
+<pre><code class=\\"language-example\\">&gt; # Foo
+&gt; bar
+baz
+.
+&lt;blockquote&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>A block quote can contain some lazy and some non-lazy
+continuation lines:</p>
+<pre><code class=\\"language-example\\">&gt; bar
+baz
+&gt; foo
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar
+baz
+foo&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>Laziness only applies to lines that would have been continuations of
+paragraphs had they been prepended with [block quote markers].
+For example, the <code>&gt; </code> cannot be omitted in the second line of</p>
+<pre><code class=\\"language-markdown\\">&gt; foo
+&gt; ---
+</code></pre>
+<p>without changing the meaning:</p>
+<pre><code class=\\"language-example\\">&gt; foo
+---
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+</code></pre>
+<p>Similarly, if we omit the <code>&gt; </code> in the second line of</p>
+<pre><code class=\\"language-markdown\\">&gt; - foo
+&gt; - bar
+</code></pre>
+<p>then the block quote ends after the first line:</p>
+<pre><code class=\\"language-example\\">&gt; - foo
+- bar
+.
+&lt;blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>For the same reason, we can't omit the <code>&gt; </code> in front of
+subsequent lines of an indented or fenced code block:</p>
+<pre><code class=\\"language-example\\">&gt;     foo
+    bar
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; \`\`\`
+foo
+\`\`\`
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>Note that in the following case, we have a [lazy
+continuation line]:</p>
+<pre><code class=\\"language-example\\">&gt; foo
+    - bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo
+- bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>To see why, note that in</p>
+<pre><code class=\\"language-markdown\\">&gt; foo
+&gt;     - bar
+</code></pre>
+<p>the <code>- bar</code> is indented too far to start a list, and can't
+be an indented code block because indented code blocks cannot
+interrupt paragraphs, so it is [paragraph continuation text].</p>
+<p>A block quote can be empty:</p>
+<pre><code class=\\"language-example\\">&gt;
+.
+&lt;blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt;
+&gt;  
+&gt; 
+.
+&lt;blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>A block quote can have initial or final blank lines:</p>
+<pre><code class=\\"language-example\\">&gt;
+&gt; foo
+&gt;  
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>A blank line always separates block quotes:</p>
+<pre><code class=\\"language-example\\">&gt; foo
+
+&gt; bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>(Most current Markdown implementations, including John Gruber's
+original <code>Markdown.pl</code>, will parse this example as a single block quote
+with two paragraphs.  But it seems better to allow the author to decide
+whether two block quotes or one are wanted.)</p>
+<p>Consecutiveness means that if we put these block quotes together,
+we get a single block quote:</p>
+<pre><code class=\\"language-example\\">&gt; foo
+&gt; bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>To get a block quote with two paragraphs, use:</p>
+<pre><code class=\\"language-example\\">&gt; foo
+&gt;
+&gt; bar
+.
+&lt;blockquote&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>Block quotes can interrupt paragraphs:</p>
+<pre><code class=\\"language-example\\">foo
+&gt; bar
+.
+&lt;p&gt;foo&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>In general, blank lines are not needed before or after block
+quotes:</p>
+<pre><code class=\\"language-example\\">&gt; aaa
+***
+&gt; bbb
+.
+&lt;blockquote&gt;
+&lt;p&gt;aaa&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;hr /&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bbb&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>However, because of laziness, a blank line is needed between
+a block quote and a following paragraph:</p>
+<pre><code class=\\"language-example\\">&gt; bar
+baz
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; bar
+
+baz
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;baz&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; bar
+&gt;
+baz
+.
+&lt;blockquote&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;baz&lt;/p&gt;
+</code></pre>
+<p>It is a consequence of the Laziness rule that any number
+of initial <code>&gt;</code>s may be omitted on a continuation line of a
+nested block quote:</p>
+<pre><code class=\\"language-example\\">&gt; &gt; &gt; foo
+bar
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt;&gt;&gt; foo
+&gt; bar
+&gt;&gt;baz
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;foo
+bar
+baz&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>When including an indented code block in a block quote,
+remember that the [block quote marker] includes
+both the <code>&gt;</code> and a following space of indentation.  So <em>five spaces</em> are needed
+after the <code>&gt;</code>:</p>
+<pre><code class=\\"language-example\\">&gt;     code
+
+&gt;    not code
+.
+&lt;blockquote&gt;
+&lt;pre&gt;&lt;code&gt;code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/blockquote&gt;
+&lt;blockquote&gt;
+&lt;p&gt;not code&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<h2>List items</h2>
+<p>A <a href=\\"@\\">list marker</a> is a
+[bullet list marker] or an [ordered list marker].</p>
+<p>A <a href=\\"@\\">bullet list marker</a>
+is a <code>-</code>, <code>+</code>, or <code>*</code> character.</p>
+<p>An <a href=\\"@\\">ordered list marker</a>
+is a sequence of 1--9 arabic digits (<code>0-9</code>), followed by either a
+<code>.</code> character or a <code>)</code> character.  (The reason for the length
+limit is that with 10 digits we start seeing integer overflows
+in some browsers.)</p>
+<p>The following rules define [list items]:</p>
+<ol>
+<li>
+<p><strong>Basic case.</strong>  If a sequence of lines <em>Ls</em> constitute a sequence of
+blocks <em>Bs</em> starting with a character other than a space or tab, and <em>M</em> is
+a list marker of width <em>W</em> followed by 1 ≤ <em>N</em> ≤ 4 spaces of indentation,
+then the result of prepending <em>M</em> and the following spaces to the first line
+of <em>Ls</em>, and indenting subsequent lines of <em>Ls</em> by <em>W + N</em> spaces, is a
+list item with <em>Bs</em> as its contents.  The type of the list item
+(bullet or ordered) is determined by the type of its list marker.
+If the list item is ordered, then it is also assigned a start
+number, based on the ordered list marker.</p>
+<p>Exceptions:</p>
+<ol>
+<li>When the first list item in a [list] interrupts
+a paragraph---that is, when it starts on a line that would
+otherwise count as [paragraph continuation text]---then (a)
+the lines <em>Ls</em> must not begin with a blank line, and (b) if
+the list item is ordered, the start number must be 1.</li>
+<li>If any line is a [thematic break][thematic breaks] then
+that line is not a list item.</li>
+</ol>
+</li>
+</ol>
+<p>For example, let <em>Ls</em> be the lines</p>
+<pre><code class=\\"language-example\\">A paragraph
+with two lines.
+
+    indented code
+
+&gt; A block quote.
+.
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>And let <em>M</em> be the marker <code>1.</code>, and <em>N</em> = 2.  Then rule #1 says
+that the following is an ordered list item with start number 1,
+and the same contents as <em>Ls</em>:</p>
+<pre><code class=\\"language-example\\">1.  A paragraph
+    with two lines.
+
+        indented code
+
+    &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>The most important thing to notice is that the position of
+the text after the list marker determines how much indentation
+is needed in subsequent blocks in the list item.  If the list
+marker takes up two spaces of indentation, and there are three spaces between
+the list marker and the next character other than a space or tab, then blocks
+must be indented five spaces in order to fall under the list
+item.</p>
+<p>Here are some examples showing how far content must be indented to be
+put under the list item:</p>
+<pre><code class=\\"language-example\\">- one
+
+ two
+.
+&lt;ul&gt;
+&lt;li&gt;one&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;two&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- one
+
+  two
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\"> -    one
+
+     two
+.
+&lt;ul&gt;
+&lt;li&gt;one&lt;/li&gt;
+&lt;/ul&gt;
+&lt;pre&gt;&lt;code&gt; two
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\"> -    one
+
+      two
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>It is tempting to think of this in terms of columns:  the continuation
+blocks must be indented at least to the column of the first character other than
+a space or tab after the list marker.  However, that is not quite right.
+The spaces of indentation after the list marker determine how much relative
+indentation is needed.  Which column this indentation reaches will depend on
+how the list item is embedded in other constructions, as shown by
+this example:</p>
+<pre><code class=\\"language-example\\">   &gt; &gt; 1.  one
+&gt;&gt;
+&gt;&gt;     two
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>Here <code>two</code> occurs in the same column as the list marker <code>1.</code>,
+but is actually contained in the list item, because there is
+sufficient indentation after the last containing blockquote marker.</p>
+<p>The converse is also possible.  In the following example, the word <code>two</code>
+occurs far to the right of the initial text of the list item, <code>one</code>, but
+it is not considered part of the list item, because it is not indented
+far enough past the blockquote marker:</p>
+<pre><code class=\\"language-example\\">&gt;&gt;- one
+&gt;&gt;
+  &gt;  &gt; two
+.
+&lt;blockquote&gt;
+&lt;blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;one&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>Note that at least one space or tab is needed between the list marker and
+any following content, so these are not list items:</p>
+<pre><code class=\\"language-example\\">-one
+
+2.two
+.
+&lt;p&gt;-one&lt;/p&gt;
+&lt;p&gt;2.two&lt;/p&gt;
+</code></pre>
+<p>A list item may contain blocks that are separated by more than
+one blank line.</p>
+<pre><code class=\\"language-example\\">- foo
+
+
+  bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>A list item may contain any kind of block:</p>
+<pre><code class=\\"language-example\\">1.  foo
+
+    \`\`\`
+    bar
+    \`\`\`
+
+    baz
+
+    &gt; bam
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;p&gt;bam&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>A list item that contains an indented code block will preserve
+empty lines within the code block verbatim.</p>
+<pre><code class=\\"language-example\\">- Foo
+
+      bar
+
+
+      baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+
+
+baz
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>Note that ordered list start numbers must be nine digits or less:</p>
+<pre><code class=\\"language-example\\">123456789. ok
+.
+&lt;ol start=&quot;123456789&quot;&gt;
+&lt;li&gt;ok&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">1234567890. not ok
+.
+&lt;p&gt;1234567890. not ok&lt;/p&gt;
+</code></pre>
+<p>A start number may begin with 0s:</p>
+<pre><code class=\\"language-example\\">0. ok
+.
+&lt;ol start=&quot;0&quot;&gt;
+&lt;li&gt;ok&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">003. ok
+.
+&lt;ol start=&quot;3&quot;&gt;
+&lt;li&gt;ok&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>A start number may not be negative:</p>
+<pre><code class=\\"language-example\\">-1. not ok
+.
+&lt;p&gt;-1. not ok&lt;/p&gt;
+</code></pre>
+<ol start=\\"2\\">
+<li><strong>Item starting with indented code.</strong>  If a sequence of lines <em>Ls</em>
+constitute a sequence of blocks <em>Bs</em> starting with an indented code
+block, and <em>M</em> is a list marker of width <em>W</em> followed by
+one space of indentation, then the result of prepending <em>M</em> and the
+following space to the first line of <em>Ls</em>, and indenting subsequent lines
+of <em>Ls</em> by <em>W + 1</em> spaces, is a list item with <em>Bs</em> as its contents.
+If a line is empty, then it need not be indented.  The type of the
+list item (bullet or ordered) is determined by the type of its list
+marker.  If the list item is ordered, then it is also assigned a
+start number, based on the ordered list marker.</li>
+</ol>
+<p>An indented code block will have to be preceded by four spaces of indentation
+beyond the edge of the region where text will be included in the list item.
+In the following case that is 6 spaces:</p>
+<pre><code class=\\"language-example\\">- foo
+
+      bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>And in this case it is 11 spaces:</p>
+<pre><code class=\\"language-example\\">  10.  foo
+
+           bar
+.
+&lt;ol start=&quot;10&quot;&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>If the <em>first</em> block in the list item is an indented code block,
+then by rule #2, the contents must be preceded by <em>one</em> space of indentation
+after the list marker:</p>
+<pre><code class=\\"language-example\\">    indented code
+
+paragraph
+
+    more code
+.
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;paragraph&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;more code
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">1.     indented code
+
+   paragraph
+
+       more code
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;paragraph&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;more code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Note that an additional space of indentation is interpreted as space
+inside the code block:</p>
+<pre><code class=\\"language-example\\">1.      indented code
+
+   paragraph
+
+       more code
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt; indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;paragraph&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;more code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Note that rules #1 and #2 only apply to two cases:  (a) cases
+in which the lines to be included in a list item begin with a
+character other than a space or tab, and (b) cases in which
+they begin with an indented code
+block.  In a case like the following, where the first block begins with
+three spaces of indentation, the rules do not allow us to form a list item by
+indenting the whole thing and prepending a list marker:</p>
+<pre><code class=\\"language-example\\">   foo
+
+bar
+.
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">-    foo
+
+  bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;bar&lt;/p&gt;
+</code></pre>
+<p>This is not a significant restriction, because when a block is preceded by up to
+three spaces of indentation, the indentation can always be removed without
+a change in interpretation, allowing rule #1 to be applied.  So, in
+the above case:</p>
+<pre><code class=\\"language-example\\">-  foo
+
+   bar
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<ol start=\\"3\\">
+<li><strong>Item starting with a blank line.</strong>  If a sequence of lines <em>Ls</em>
+starting with a single [blank line] constitute a (possibly empty)
+sequence of blocks <em>Bs</em>, and <em>M</em> is a list marker of width <em>W</em>,
+then the result of prepending <em>M</em> to the first line of <em>Ls</em>, and
+preceding subsequent lines of <em>Ls</em> by <em>W + 1</em> spaces of indentation, is a
+list item with <em>Bs</em> as its contents.
+If a line is empty, then it need not be indented.  The type of the
+list item (bullet or ordered) is determined by the type of its list
+marker.  If the list item is ordered, then it is also assigned a
+start number, based on the ordered list marker.</li>
+</ol>
+<p>Here are some list items that start with a blank line but are not empty:</p>
+<pre><code class=\\"language-example\\">-
+  foo
+-
+  \`\`\`
+  bar
+  \`\`\`
+-
+      baz
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;bar
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;baz
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>When the list item starts with a blank line, the number of spaces
+following the list marker doesn't change the required indentation:</p>
+<pre><code class=\\"language-example\\">-   
+  foo
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>A list item can begin with at most one blank line.
+In the following example, <code>foo</code> is not part of the list
+item:</p>
+<pre><code class=\\"language-example\\">-
+
+  foo
+.
+&lt;ul&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;foo&lt;/p&gt;
+</code></pre>
+<p>Here is an empty bullet list item:</p>
+<pre><code class=\\"language-example\\">- foo
+-
+- bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>It does not matter whether there are spaces or tabs following the [list marker]:</p>
+<pre><code class=\\"language-example\\">- foo
+-   
+- bar
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>Here is an empty ordered list item:</p>
+<pre><code class=\\"language-example\\">1. foo
+2.
+3. bar
+.
+&lt;ol&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>A list may start or end with an empty list item:</p>
+<pre><code class=\\"language-example\\">*
+.
+&lt;ul&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>However, an empty list item cannot interrupt a paragraph:</p>
+<pre><code class=\\"language-example\\">foo
+*
+
+foo
+1.
+.
+&lt;p&gt;foo
+*&lt;/p&gt;
+&lt;p&gt;foo
+1.&lt;/p&gt;
+</code></pre>
+<ol start=\\"4\\">
+<li><strong>Indentation.</strong>  If a sequence of lines <em>Ls</em> constitutes a list item
+according to rule #1, #2, or #3, then the result of preceding each line
+of <em>Ls</em> by up to three spaces of indentation (the same for each line) also
+constitutes a list item with the same contents and attributes.  If a line is
+empty, then it need not be indented.</li>
+</ol>
+<p>Indented one space:</p>
+<pre><code class=\\"language-example\\"> 1.  A paragraph
+     with two lines.
+
+         indented code
+
+     &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Indented two spaces:</p>
+<pre><code class=\\"language-example\\">  1.  A paragraph
+      with two lines.
+
+          indented code
+
+      &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Indented three spaces:</p>
+<pre><code class=\\"language-example\\">   1.  A paragraph
+       with two lines.
+
+           indented code
+
+       &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Four spaces indent gives a code block:</p>
+<pre><code class=\\"language-example\\">    1.  A paragraph
+        with two lines.
+
+            indented code
+
+        &gt; A block quote.
+.
+&lt;pre&gt;&lt;code&gt;1.  A paragraph
+    with two lines.
+
+        indented code
+
+    &amp;gt; A block quote.
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<ol start=\\"5\\">
+<li><strong>Laziness.</strong>  If a string of lines <em>Ls</em> constitute a <a href=\\"#list-items\\">list
+item</a> with contents <em>Bs</em>, then the result of deleting
+some or all of the indentation from one or more lines in which the
+next character other than a space or tab after the indentation is
+[paragraph continuation text] is a
+list item with the same contents and attributes.  The unindented
+lines are called
+<a href=\\"@\\">lazy continuation line</a>s.</li>
+</ol>
+<p>Here is an example with [lazy continuation lines]:</p>
+<pre><code class=\\"language-example\\">  1.  A paragraph
+with two lines.
+
+          indented code
+
+      &gt; A block quote.
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;A paragraph
+with two lines.&lt;/p&gt;
+&lt;pre&gt;&lt;code&gt;indented code
+&lt;/code&gt;&lt;/pre&gt;
+&lt;blockquote&gt;
+&lt;p&gt;A block quote.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Indentation can be partially deleted:</p>
+<pre><code class=\\"language-example\\">  1.  A paragraph
+    with two lines.
+.
+&lt;ol&gt;
+&lt;li&gt;A paragraph
+with two lines.&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>These examples show how laziness can work in nested structures:</p>
+<pre><code class=\\"language-example\\">&gt; 1. &gt; Blockquote
+continued here.
+.
+&lt;blockquote&gt;
+&lt;ol&gt;
+&lt;li&gt;
+&lt;blockquote&gt;
+&lt;p&gt;Blockquote
+continued here.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&gt; 1. &gt; Blockquote
+&gt; continued here.
+.
+&lt;blockquote&gt;
+&lt;ol&gt;
+&lt;li&gt;
+&lt;blockquote&gt;
+&lt;p&gt;Blockquote
+continued here.&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<ol start=\\"6\\">
+<li><strong>That's all.</strong> Nothing that is not counted as a list item by rules
+#1--5 counts as a <a href=\\"#list-items\\">list item</a>.</li>
+</ol>
+<p>The rules for sublists follow from the general rules
+[above][List items].  A sublist must be indented the same number
+of spaces of indentation a paragraph would need to be in order to be included
+in the list item.</p>
+<p>So, in this case we need two spaces indent:</p>
+<pre><code class=\\"language-example\\">- foo
+  - bar
+    - baz
+      - boo
+.
+&lt;ul&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar
+&lt;ul&gt;
+&lt;li&gt;baz
+&lt;ul&gt;
+&lt;li&gt;boo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>One is not enough:</p>
+<pre><code class=\\"language-example\\">- foo
+ - bar
+  - baz
+   - boo
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;li&gt;boo&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>Here we need four, because the list marker is wider:</p>
+<pre><code class=\\"language-example\\">10) foo
+    - bar
+.
+&lt;ol start=&quot;10&quot;&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Three is not enough:</p>
+<pre><code class=\\"language-example\\">10) foo
+   - bar
+.
+&lt;ol start=&quot;10&quot;&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ol&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>A list may be the first block in a list item:</p>
+<pre><code class=\\"language-example\\">- - foo
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">1. - 2. foo
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;ul&gt;
+&lt;li&gt;
+&lt;ol start=&quot;2&quot;&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ol&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>A list item can contain a heading:</p>
+<pre><code class=\\"language-example\\">- # Foo
+- Bar
+  ---
+  baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;h1&gt;Foo&lt;/h1&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;h2&gt;Bar&lt;/h2&gt;
+baz&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<h3>Motivation</h3>
+<p>John Gruber's Markdown spec says the following about list items:</p>
+<ol>
+<li>
+<p>&quot;List markers typically start at the left margin, but may be indented
+by up to three spaces. List markers must be followed by one or more
+spaces or a tab.&quot;</p>
+</li>
+<li>
+<p>&quot;To make lists look nice, you can wrap items with hanging indents....
+But if you don't want to, you don't have to.&quot;</p>
+</li>
+<li>
+<p>&quot;List items may consist of multiple paragraphs. Each subsequent
+paragraph in a list item must be indented by either 4 spaces or one
+tab.&quot;</p>
+</li>
+<li>
+<p>&quot;It looks nice if you indent every line of the subsequent paragraphs,
+but here again, Markdown will allow you to be lazy.&quot;</p>
+</li>
+<li>
+<p>&quot;To put a blockquote within a list item, the blockquote's <code>&gt;</code>
+delimiters need to be indented.&quot;</p>
+</li>
+<li>
+<p>&quot;To put a code block within a list item, the code block needs to be
+indented twice — 8 spaces or two tabs.&quot;</p>
+</li>
+</ol>
+<p>These rules specify that a paragraph under a list item must be indented
+four spaces (presumably, from the left margin, rather than the start of
+the list marker, but this is not said), and that code under a list item
+must be indented eight spaces instead of the usual four.  They also say
+that a block quote must be indented, but not by how much; however, the
+example given has four spaces indentation.  Although nothing is said
+about other kinds of block-level content, it is certainly reasonable to
+infer that <em>all</em> block elements under a list item, including other
+lists, must be indented four spaces.  This principle has been called the
+<em>four-space rule</em>.</p>
+<p>The four-space rule is clear and principled, and if the reference
+implementation <code>Markdown.pl</code> had followed it, it probably would have
+become the standard.  However, <code>Markdown.pl</code> allowed paragraphs and
+sublists to start with only two spaces indentation, at least on the
+outer level.  Worse, its behavior was inconsistent: a sublist of an
+outer-level list needed two spaces indentation, but a sublist of this
+sublist needed three spaces.  It is not surprising, then, that different
+implementations of Markdown have developed very different rules for
+determining what comes under a list item.  (Pandoc and python-Markdown,
+for example, stuck with Gruber's syntax description and the four-space
+rule, while discount, redcarpet, marked, PHP Markdown, and others
+followed <code>Markdown.pl</code>'s behavior more closely.)</p>
+<p>Unfortunately, given the divergences between implementations, there
+is no way to give a spec for list items that will be guaranteed not
+to break any existing documents.  However, the spec given here should
+correctly handle lists formatted with either the four-space rule or
+the more forgiving <code>Markdown.pl</code> behavior, provided they are laid out
+in a way that is natural for a human to read.</p>
+<p>The strategy here is to let the width and indentation of the list marker
+determine the indentation necessary for blocks to fall under the list
+item, rather than having a fixed and arbitrary number.  The writer can
+think of the body of the list item as a unit which gets indented to the
+right enough to fit the list marker (and any indentation on the list
+marker).  (The laziness rule, #5, then allows continuation lines to be
+unindented if needed.)</p>
+<p>This rule is superior, we claim, to any rule requiring a fixed level of
+indentation from the margin.  The four-space rule is clear but
+unnatural. It is quite unintuitive that</p>
+<pre><code class=\\"language-markdown\\">- foo
+
+  bar
+
+  - baz
+</code></pre>
+<p>should be parsed as two lists with an intervening paragraph,</p>
+<pre><code class=\\"language-html\\">&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>as the four-space rule demands, rather than a single list,</p>
+<pre><code class=\\"language-html\\">&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>The choice of four spaces is arbitrary.  It can be learned, but it is
+not likely to be guessed, and it trips up beginners regularly.</p>
+<p>Would it help to adopt a two-space rule?  The problem is that such
+a rule, together with the rule allowing up to three spaces of indentation for
+the initial list marker, allows text that is indented <em>less than</em> the
+original list marker to be included in the list item. For example,
+<code>Markdown.pl</code> parses</p>
+<pre><code class=\\"language-markdown\\">   - one
+
+  two
+</code></pre>
+<p>as a single list item, with <code>two</code> a continuation paragraph:</p>
+<pre><code class=\\"language-html\\">&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>and similarly</p>
+<pre><code class=\\"language-markdown\\">&gt;   - one
+&gt;
+&gt;  two
+</code></pre>
+<p>as</p>
+<pre><code class=\\"language-html\\">&lt;blockquote&gt;
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;one&lt;/p&gt;
+&lt;p&gt;two&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/blockquote&gt;
+</code></pre>
+<p>This is extremely unintuitive.</p>
+<p>Rather than requiring a fixed indent from the margin, we could require
+a fixed indent (say, two spaces, or even one space) from the list marker (which
+may itself be indented).  This proposal would remove the last anomaly
+discussed.  Unlike the spec presented above, it would count the following
+as a list item with a subparagraph, even though the paragraph <code>bar</code>
+is not indented as far as the first paragraph <code>foo</code>:</p>
+<pre><code class=\\"language-markdown\\"> 10. foo
+
+   bar  
+</code></pre>
+<p>Arguably this text does read like a list item with <code>bar</code> as a subparagraph,
+which may count in favor of the proposal.  However, on this proposal indented
+code would have to be indented six spaces after the list marker.  And this
+would break a lot of existing Markdown, which has the pattern:</p>
+<pre><code class=\\"language-markdown\\">1.  foo
+
+        indented code
+</code></pre>
+<p>where the code is indented eight spaces.  The spec above, by contrast, will
+parse this text as expected, since the code block's indentation is measured
+from the beginning of <code>foo</code>.</p>
+<p>The one case that needs special treatment is a list item that <em>starts</em>
+with indented code.  How much indentation is required in that case, since
+we don't have a &quot;first paragraph&quot; to measure from?  Rule #2 simply stipulates
+that in such cases, we require one space indentation from the list marker
+(and then the normal four spaces for the indented code).  This will match the
+four-space rule in cases where the list marker plus its initial indentation
+takes four spaces (a common case), but diverge in other cases.</p>
+<h2>Lists</h2>
+<p>A <a href=\\"@\\">list</a> is a sequence of one or more
+list items [of the same type].  The list items
+may be separated by any number of blank lines.</p>
+<p>Two list items are <a href=\\"@\\">of the same type</a>
+if they begin with a [list marker] of the same type.
+Two list markers are of the
+same type if (a) they are bullet list markers using the same character
+(<code>-</code>, <code>+</code>, or <code>*</code>) or (b) they are ordered list numbers with the same
+delimiter (either <code>.</code> or <code>)</code>).</p>
+<p>A list is an <a href=\\"@\\">ordered list</a>
+if its constituent list items begin with
+[ordered list markers], and a
+<a href=\\"@\\">bullet list</a> if its constituent list
+items begin with [bullet list markers].</p>
+<p>The <a href=\\"@\\">start number</a>
+of an [ordered list] is determined by the list number of
+its initial list item.  The numbers of subsequent list items are
+disregarded.</p>
+<p>A list is <a href=\\"@\\">loose</a> if any of its constituent
+list items are separated by blank lines, or if any of its constituent
+list items directly contain two block-level elements with a blank line
+between them.  Otherwise a list is <a href=\\"@\\">tight</a>.
+(The difference in HTML output is that paragraphs in a loose list are
+wrapped in <code>&lt;p&gt;</code> tags, while paragraphs in a tight list are not.)</p>
+<p>Changing the bullet or ordered list delimiter starts a new list:</p>
+<pre><code class=\\"language-example\\">- foo
+- bar
++ baz
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">1. foo
+2. bar
+3) baz
+.
+&lt;ol&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ol&gt;
+&lt;ol start=&quot;3&quot;&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>In CommonMark, a list can interrupt a paragraph. That is,
+no blank line is needed to separate a paragraph from a following
+list:</p>
+<pre><code class=\\"language-example\\">Foo
+- bar
+- baz
+.
+&lt;p&gt;Foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p><code>Markdown.pl</code> does not allow this, through fear of triggering a list
+via a numeral in a hard-wrapped line:</p>
+<pre><code class=\\"language-markdown\\">The number of windows in my house is
+14.  The number of doors is 6.
+</code></pre>
+<p>Oddly, though, <code>Markdown.pl</code> <em>does</em> allow a blockquote to
+interrupt a paragraph, even though the same considerations might
+apply.</p>
+<p>In CommonMark, we do allow lists to interrupt paragraphs, for
+two reasons.  First, it is natural and not uncommon for people
+to start lists without blank lines:</p>
+<pre><code class=\\"language-markdown\\">I need to buy
+- new shoes
+- a coat
+- a plane ticket
+</code></pre>
+<p>Second, we are attracted to a</p>
+<blockquote>
+<p><a href=\\"@\\">principle of uniformity</a>:
+if a chunk of text has a certain
+meaning, it will continue to have the same meaning when put into a
+container block (such as a list item or blockquote).</p>
+</blockquote>
+<p>(Indeed, the spec for [list items] and [block quotes] presupposes
+this principle.) This principle implies that if</p>
+<pre><code class=\\"language-markdown\\">  * I need to buy
+    - new shoes
+    - a coat
+    - a plane ticket
+</code></pre>
+<p>is a list item containing a paragraph followed by a nested sublist,
+as all Markdown implementations agree it is (though the paragraph
+may be rendered without <code>&lt;p&gt;</code> tags, since the list is &quot;tight&quot;),
+then</p>
+<pre><code class=\\"language-markdown\\">I need to buy
+- new shoes
+- a coat
+- a plane ticket
+</code></pre>
+<p>by itself should be a paragraph followed by a nested sublist.</p>
+<p>Since it is well established Markdown practice to allow lists to
+interrupt paragraphs inside list items, the [principle of
+uniformity] requires us to allow this outside list items as
+well.  (<a href=\\"https://docutils.sourceforge.net/rst.html\\">reStructuredText</a>
+takes a different approach, requiring blank lines before lists
+even inside other list items.)</p>
+<p>In order to solve the problem of unwanted lists in paragraphs with
+hard-wrapped numerals, we allow only lists starting with <code>1</code> to
+interrupt paragraphs.  Thus,</p>
+<pre><code class=\\"language-example\\">The number of windows in my house is
+14.  The number of doors is 6.
+.
+&lt;p&gt;The number of windows in my house is
+14.  The number of doors is 6.&lt;/p&gt;
+</code></pre>
+<p>We may still get an unintended result in cases like</p>
+<pre><code class=\\"language-example\\">The number of windows in my house is
+1.  The number of doors is 6.
+.
+&lt;p&gt;The number of windows in my house is&lt;/p&gt;
+&lt;ol&gt;
+&lt;li&gt;The number of doors is 6.&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>but this rule should prevent most spurious list captures.</p>
+<p>There can be any number of blank lines between items:</p>
+<pre><code class=\\"language-example\\">- foo
+
+- bar
+
+
+- baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- foo
+  - bar
+    - baz
+
+
+      bim
+.
+&lt;ul&gt;
+&lt;li&gt;foo
+&lt;ul&gt;
+&lt;li&gt;bar
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;p&gt;bim&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>To separate consecutive lists of the same type, or to separate a
+list from an indented code block that would otherwise be parsed
+as a subparagraph of the final list item, you can insert a blank HTML
+comment:</p>
+<pre><code class=\\"language-example\\">- foo
+- bar
+
+&lt;!-- --&gt;
+
+- baz
+- bim
+.
+&lt;ul&gt;
+&lt;li&gt;foo&lt;/li&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;!-- --&gt;
+&lt;ul&gt;
+&lt;li&gt;baz&lt;/li&gt;
+&lt;li&gt;bim&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">-   foo
+
+    notcode
+
+-   foo
+
+&lt;!-- --&gt;
+
+    code
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;p&gt;notcode&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;!-- --&gt;
+&lt;pre&gt;&lt;code&gt;code
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>List items need not be indented to the same level.  The following
+list items will be treated as items at the same list level,
+since none is indented enough to belong to the previous list
+item:</p>
+<pre><code class=\\"language-example\\">- a
+ - b
+  - c
+   - d
+  - e
+ - f
+- g
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;li&gt;d&lt;/li&gt;
+&lt;li&gt;e&lt;/li&gt;
+&lt;li&gt;f&lt;/li&gt;
+&lt;li&gt;g&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">1. a
+
+  2. b
+
+   3. c
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Note, however, that list items may not be preceded by more than
+three spaces of indentation.  Here <code>- e</code> is treated as a paragraph continuation
+line, because it is indented more than three spaces:</p>
+<pre><code class=\\"language-example\\">- a
+ - b
+  - c
+   - d
+    - e
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;li&gt;d
+- e&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>And here, <code>3. c</code> is treated as in indented code block,
+because it is indented four spaces and preceded by a
+blank line.</p>
+<pre><code class=\\"language-example\\">1. a
+
+  2. b
+
+    3. c
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+&lt;pre&gt;&lt;code&gt;3. c
+&lt;/code&gt;&lt;/pre&gt;
+</code></pre>
+<p>This is a loose list, because there is a blank line between
+two of the list items:</p>
+<pre><code class=\\"language-example\\">- a
+- b
+
+- c
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>So is this, with a empty second item:</p>
+<pre><code class=\\"language-example\\">* a
+*
+
+* c
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>These are loose lists, even though there are no blank lines between the items,
+because one of the items directly contains two block-level elements
+with a blank line between them:</p>
+<pre><code class=\\"language-example\\">- a
+- b
+
+  c
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;d&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- a
+- b
+
+  [ref]: /url
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;d&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>This is a tight list, because the blank lines are in a code block:</p>
+<pre><code class=\\"language-example\\">- a
+- \`\`\`
+  b
+
+
+  \`\`\`
+- c
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;b
+
+
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>This is a tight list, because the blank line is between two
+paragraphs of a sublist.  So the sublist is loose while
+the outer list is tight:</p>
+<pre><code class=\\"language-example\\">- a
+  - b
+
+    c
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;p&gt;c&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;li&gt;d&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>This is a tight list, because the blank line is inside the
+block quote:</p>
+<pre><code class=\\"language-example\\">* a
+  &gt; b
+  &gt;
+* c
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;blockquote&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>This list is tight, because the consecutive block elements
+are not separated by blank lines:</p>
+<pre><code class=\\"language-example\\">- a
+  &gt; b
+  \`\`\`
+  c
+  \`\`\`
+- d
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;blockquote&gt;
+&lt;p&gt;b&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;pre&gt;&lt;code&gt;c
+&lt;/code&gt;&lt;/pre&gt;
+&lt;/li&gt;
+&lt;li&gt;d&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>A single-paragraph list is tight:</p>
+<pre><code class=\\"language-example\\">- a
+.
+&lt;ul&gt;
+&lt;li&gt;a&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- a
+  - b
+.
+&lt;ul&gt;
+&lt;li&gt;a
+&lt;ul&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<p>This list is loose, because of the blank line between the
+two block elements in the list item:</p>
+<pre><code class=\\"language-example\\">1. \`\`\`
+   foo
+   \`\`\`
+
+   bar
+.
+&lt;ol&gt;
+&lt;li&gt;
+&lt;pre&gt;&lt;code&gt;foo
+&lt;/code&gt;&lt;/pre&gt;
+&lt;p&gt;bar&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+<p>Here the outer list is loose, the inner list tight:</p>
+<pre><code class=\\"language-example\\">* foo
+  * bar
+
+  baz
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;foo&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;bar&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;baz&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">- a
+  - b
+  - c
+
+- d
+  - e
+  - f
+.
+&lt;ul&gt;
+&lt;li&gt;
+&lt;p&gt;a&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;b&lt;/li&gt;
+&lt;li&gt;c&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;li&gt;
+&lt;p&gt;d&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;e&lt;/li&gt;
+&lt;li&gt;f&lt;/li&gt;
+&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+<h1>Inlines</h1>
+<p>Inlines are parsed sequentially from the beginning of the character
+stream to the end (left to right, in left-to-right languages).
+Thus, for example, in</p>
+<pre><code class=\\"language-example\\">\`hi\`lo\`
+.
+&lt;p&gt;&lt;code&gt;hi&lt;/code&gt;lo\`&lt;/p&gt;
+</code></pre>
+<p><code>hi</code> is parsed as code, leaving the backtick at the end as a literal
+backtick.</p>
+<h2>Code spans</h2>
+<p>A <a href=\\"@\\">backtick string</a>
+is a string of one or more backtick characters (<code>\`</code>) that is neither
+preceded nor followed by a backtick.</p>
+<p>A <a href=\\"@\\">code span</a> begins with a backtick string and ends with
+a backtick string of equal length.  The contents of the code span are
+the characters between these two backtick strings, normalized in the
+following ways:</p>
+<ul>
+<li>First, [line endings] are converted to [spaces].</li>
+<li>If the resulting string both begins <em>and</em> ends with a [space]
+character, but does not consist entirely of [space]
+characters, a single [space] character is removed from the
+front and back.  This allows you to include code that begins
+or ends with backtick characters, which must be separated by
+whitespace from the opening or closing backtick strings.</li>
+</ul>
+<p>This is a simple code span:</p>
+<pre><code class=\\"language-example\\">\`foo\`
+.
+&lt;p&gt;&lt;code&gt;foo&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>Here two backticks are used, because the code contains a backtick.
+This example also illustrates stripping of a single leading and
+trailing space:</p>
+<pre><code class=\\"language-example\\">\`\` foo \` bar \`\`
+.
+&lt;p&gt;&lt;code&gt;foo \` bar&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>This example shows the motivation for stripping leading and trailing
+spaces:</p>
+<pre><code class=\\"language-example\\">\` \`\` \`
+.
+&lt;p&gt;&lt;code&gt;\`\`&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that only <em>one</em> space is stripped:</p>
+<pre><code class=\\"language-example\\">\`  \`\`  \`
+.
+&lt;p&gt;&lt;code&gt; \`\` &lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>The stripping only happens if the space is on both
+sides of the string:</p>
+<pre><code class=\\"language-example\\">\` a\`
+.
+&lt;p&gt;&lt;code&gt; a&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>Only [spaces], and not [unicode whitespace] in general, are
+stripped in this way:</p>
+<pre><code class=\\"language-example\\">\` b \`
+.
+&lt;p&gt;&lt;code&gt; b &lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>No stripping occurs if the code span contains only spaces:</p>
+<pre><code class=\\"language-example\\">\` \`
+\`  \`
+.
+&lt;p&gt;&lt;code&gt; &lt;/code&gt;
+&lt;code&gt;  &lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>[Line endings] are treated like spaces:</p>
+<pre><code class=\\"language-example\\">\`\`
+foo
+bar  
+baz
+\`\`
+.
+&lt;p&gt;&lt;code&gt;foo bar   baz&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`\`
+foo 
+\`\`
+.
+&lt;p&gt;&lt;code&gt;foo &lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>Interior spaces are not collapsed:</p>
+<pre><code class=\\"language-example\\">\`foo   bar 
+baz\`
+.
+&lt;p&gt;&lt;code&gt;foo   bar  baz&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that browsers will typically collapse consecutive spaces
+when rendering <code>&lt;code&gt;</code> elements, so it is recommended that
+the following CSS be used:</p>
+<pre><code>code{white-space: pre-wrap;}
+</code></pre>
+<p>Note that backslash escapes do not work in code spans. All backslashes
+are treated literally:</p>
+<pre><code class=\\"language-example\\">\`foo\\\\\`bar\`
+.
+&lt;p&gt;&lt;code&gt;foo\\\\&lt;/code&gt;bar\`&lt;/p&gt;
+</code></pre>
+<p>Backslash escapes are never needed, because one can always choose a
+string of <em>n</em> backtick characters as delimiters, where the code does
+not contain any strings of exactly <em>n</em> backtick characters.</p>
+<pre><code class=\\"language-example\\">\`\`foo\`bar\`\`
+.
+&lt;p&gt;&lt;code&gt;foo\`bar&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\` foo \`\` bar \`
+.
+&lt;p&gt;&lt;code&gt;foo \`\` bar&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>Code span backticks have higher precedence than any other inline
+constructs except HTML tags and autolinks.  Thus, for example, this is
+not parsed as emphasized text, since the second <code>*</code> is part of a code
+span:</p>
+<pre><code class=\\"language-example\\">*foo\`*\`
+.
+&lt;p&gt;*foo&lt;code&gt;*&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>And this is not parsed as a link:</p>
+<pre><code class=\\"language-example\\">[not a \`link](/foo\`)
+.
+&lt;p&gt;[not a &lt;code&gt;link](/foo&lt;/code&gt;)&lt;/p&gt;
+</code></pre>
+<p>Code spans, HTML tags, and autolinks have the same precedence.
+Thus, this is code:</p>
+<pre><code class=\\"language-example\\">\`&lt;a href=&quot;\`&quot;&gt;\`
+.
+&lt;p&gt;&lt;code&gt;&amp;lt;a href=&amp;quot;&lt;/code&gt;&amp;quot;&amp;gt;\`&lt;/p&gt;
+</code></pre>
+<p>But this is an HTML tag:</p>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;\`&quot;&gt;\`
+.
+&lt;p&gt;&lt;a href=&quot;\`&quot;&gt;\`&lt;/p&gt;
+</code></pre>
+<p>And this is code:</p>
+<pre><code class=\\"language-example\\">\`&lt;https://foo.bar.\`baz&gt;\`
+.
+&lt;p&gt;&lt;code&gt;&amp;lt;https://foo.bar.&lt;/code&gt;baz&amp;gt;\`&lt;/p&gt;
+</code></pre>
+<p>But this is an autolink:</p>
+<pre><code class=\\"language-example\\">&lt;https://foo.bar.\`baz&gt;\`
+.
+&lt;p&gt;&lt;a href=&quot;https://foo.bar.%60baz&quot;&gt;https://foo.bar.\`baz&lt;/a&gt;\`&lt;/p&gt;
+</code></pre>
+<p>When a backtick string is not closed by a matching backtick string,
+we just have literal backticks:</p>
+<pre><code class=\\"language-example\\">\`\`\`foo\`\`
+.
+&lt;p&gt;\`\`\`foo\`\`&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`foo
+.
+&lt;p&gt;\`foo&lt;/p&gt;
+</code></pre>
+<p>The following case also illustrates the need for opening and
+closing backtick strings to be equal in length:</p>
+<pre><code class=\\"language-example\\">\`foo\`\`bar\`\`
+.
+&lt;p&gt;\`foo&lt;code&gt;bar&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<h2>Emphasis and strong emphasis</h2>
+<p>John Gruber's original <a href=\\"https://daringfireball.net/projects/markdown/syntax#em\\">Markdown syntax
+description</a> says:</p>
+<blockquote>
+<p>Markdown treats asterisks (<code>*</code>) and underscores (<code>_</code>) as indicators of
+emphasis. Text wrapped with one <code>*</code> or <code>_</code> will be wrapped with an HTML
+<code>&lt;em&gt;</code> tag; double <code>*</code>'s or <code>_</code>'s will be wrapped with an HTML <code>&lt;strong&gt;</code>
+tag.</p>
+</blockquote>
+<p>This is enough for most users, but these rules leave much undecided,
+especially when it comes to nested emphasis.  The original
+<code>Markdown.pl</code> test suite makes it clear that triple <code>***</code> and
+<code>___</code> delimiters can be used for strong emphasis, and most
+implementations have also allowed the following patterns:</p>
+<pre><code class=\\"language-markdown\\">***strong emph***
+***strong** in emph*
+***emph* in strong**
+**in strong *emph***
+*in emph **strong***
+</code></pre>
+<p>The following patterns are less widely supported, but the intent
+is clear and they are useful (especially in contexts like bibliography
+entries):</p>
+<pre><code class=\\"language-markdown\\">*emph *with emph* in it*
+**strong **with strong** in it**
+</code></pre>
+<p>Many implementations have also restricted intraword emphasis to
+the <code>*</code> forms, to avoid unwanted emphasis in words containing
+internal underscores.  (It is best practice to put these in code
+spans, but users often do not.)</p>
+<pre><code class=\\"language-markdown\\">internal emphasis: foo*bar*baz
+no emphasis: foo_bar_baz
+</code></pre>
+<p>The rules given below capture all of these patterns, while allowing
+for efficient parsing strategies that do not backtrack.</p>
+<p>First, some definitions.  A <a href=\\"@\\">delimiter run</a> is either
+a sequence of one or more <code>*</code> characters that is not preceded or
+followed by a non-backslash-escaped <code>*</code> character, or a sequence
+of one or more <code>_</code> characters that is not preceded or followed by
+a non-backslash-escaped <code>_</code> character.</p>
+<p>A <a href=\\"@\\">left-flanking delimiter run</a> is
+a [delimiter run] that is (1) not followed by [Unicode whitespace],
+and either (2a) not followed by a [Unicode punctuation character], or
+(2b) followed by a [Unicode punctuation character] and
+preceded by [Unicode whitespace] or a [Unicode punctuation character].
+For purposes of this definition, the beginning and the end of
+the line count as Unicode whitespace.</p>
+<p>A <a href=\\"@\\">right-flanking delimiter run</a> is
+a [delimiter run] that is (1) not preceded by [Unicode whitespace],
+and either (2a) not preceded by a [Unicode punctuation character], or
+(2b) preceded by a [Unicode punctuation character] and
+followed by [Unicode whitespace] or a [Unicode punctuation character].
+For purposes of this definition, the beginning and the end of
+the line count as Unicode whitespace.</p>
+<p>Here are some examples of delimiter runs.</p>
+<ul>
+<li>
+<p>left-flanking but not right-flanking:</p>
+<pre><code>***abc
+  _abc
+**&quot;abc&quot;
+ _&quot;abc&quot;
+</code></pre>
+</li>
+<li>
+<p>right-flanking but not left-flanking:</p>
+<pre><code> abc***
+ abc_
+&quot;abc&quot;**
+&quot;abc&quot;_
+</code></pre>
+</li>
+<li>
+<p>Both left and right-flanking:</p>
+<pre><code> abc***def
+&quot;abc&quot;_&quot;def&quot;
+</code></pre>
+</li>
+<li>
+<p>Neither left nor right-flanking:</p>
+<pre><code>abc *** def
+a _ b
+</code></pre>
+</li>
+</ul>
+<p>(The idea of distinguishing left-flanking and right-flanking
+delimiter runs based on the character before and the character
+after comes from Roopesh Chander's
+<a href=\\"https://web.archive.org/web/20220608143320/http://www.vfmd.org/vfmd-spec/specification/#procedure-for-identifying-emphasis-tags\\">vfmd</a>.
+vfmd uses the terminology &quot;emphasis indicator string&quot; instead of &quot;delimiter
+run,&quot; and its rules for distinguishing left- and right-flanking runs
+are a bit more complex than the ones given here.)</p>
+<p>The following rules define emphasis and strong emphasis:</p>
+<ol>
+<li>
+<p>A single <code>*</code> character <a href=\\"@\\">can open emphasis</a>
+iff (if and only if) it is part of a [left-flanking delimiter run].</p>
+</li>
+<li>
+<p>A single <code>_</code> character [can open emphasis] iff
+it is part of a [left-flanking delimiter run]
+and either (a) not part of a [right-flanking delimiter run]
+or (b) part of a [right-flanking delimiter run]
+preceded by a [Unicode punctuation character].</p>
+</li>
+<li>
+<p>A single <code>*</code> character <a href=\\"@\\">can close emphasis</a>
+iff it is part of a [right-flanking delimiter run].</p>
+</li>
+<li>
+<p>A single <code>_</code> character [can close emphasis] iff
+it is part of a [right-flanking delimiter run]
+and either (a) not part of a [left-flanking delimiter run]
+or (b) part of a [left-flanking delimiter run]
+followed by a [Unicode punctuation character].</p>
+</li>
+<li>
+<p>A double <code>**</code> <a href=\\"@\\">can open strong emphasis</a>
+iff it is part of a [left-flanking delimiter run].</p>
+</li>
+<li>
+<p>A double <code>__</code> [can open strong emphasis] iff
+it is part of a [left-flanking delimiter run]
+and either (a) not part of a [right-flanking delimiter run]
+or (b) part of a [right-flanking delimiter run]
+preceded by a [Unicode punctuation character].</p>
+</li>
+<li>
+<p>A double <code>**</code> <a href=\\"@\\">can close strong emphasis</a>
+iff it is part of a [right-flanking delimiter run].</p>
+</li>
+<li>
+<p>A double <code>__</code> [can close strong emphasis] iff
+it is part of a [right-flanking delimiter run]
+and either (a) not part of a [left-flanking delimiter run]
+or (b) part of a [left-flanking delimiter run]
+followed by a [Unicode punctuation character].</p>
+</li>
+<li>
+<p>Emphasis begins with a delimiter that [can open emphasis] and ends
+with a delimiter that [can close emphasis], and that uses the same
+character (<code>_</code> or <code>*</code>) as the opening delimiter.  The
+opening and closing delimiters must belong to separate
+[delimiter runs].  If one of the delimiters can both
+open and close emphasis, then the sum of the lengths of the
+delimiter runs containing the opening and closing delimiters
+must not be a multiple of 3 unless both lengths are
+multiples of 3.</p>
+</li>
+<li>
+<p>Strong emphasis begins with a delimiter that
+[can open strong emphasis] and ends with a delimiter that
+[can close strong emphasis], and that uses the same character
+(<code>_</code> or <code>*</code>) as the opening delimiter.  The
+opening and closing delimiters must belong to separate
+[delimiter runs].  If one of the delimiters can both open
+and close strong emphasis, then the sum of the lengths of
+the delimiter runs containing the opening and closing
+delimiters must not be a multiple of 3 unless both lengths
+are multiples of 3.</p>
+</li>
+<li>
+<p>A literal <code>*</code> character cannot occur at the beginning or end of
+<code>*</code>-delimited emphasis or <code>**</code>-delimited strong emphasis, unless it
+is backslash-escaped.</p>
+</li>
+<li>
+<p>A literal <code>_</code> character cannot occur at the beginning or end of
+<code>_</code>-delimited emphasis or <code>__</code>-delimited strong emphasis, unless it
+is backslash-escaped.</p>
+</li>
+</ol>
+<p>Where rules 1--12 above are compatible with multiple parsings,
+the following principles resolve ambiguity:</p>
+<ol start=\\"13\\">
+<li>
+<p>The number of nestings should be minimized. Thus, for example,
+an interpretation <code>&lt;strong&gt;...&lt;/strong&gt;</code> is always preferred to
+<code>&lt;em&gt;&lt;em&gt;...&lt;/em&gt;&lt;/em&gt;</code>.</p>
+</li>
+<li>
+<p>An interpretation <code>&lt;em&gt;&lt;strong&gt;...&lt;/strong&gt;&lt;/em&gt;</code> is always
+preferred to <code>&lt;strong&gt;&lt;em&gt;...&lt;/em&gt;&lt;/strong&gt;</code>.</p>
+</li>
+<li>
+<p>When two potential emphasis or strong emphasis spans overlap,
+so that the second begins before the first ends and ends after
+the first ends, the first takes precedence. Thus, for example,
+<code>*foo _bar* baz_</code> is parsed as <code>&lt;em&gt;foo _bar&lt;/em&gt; baz_</code> rather
+than <code>*foo &lt;em&gt;bar* baz&lt;/em&gt;</code>.</p>
+</li>
+<li>
+<p>When there are two potential emphasis or strong emphasis spans
+with the same closing delimiter, the shorter one (the one that
+opens later) takes precedence. Thus, for example,
+<code>**foo **bar baz**</code> is parsed as <code>**foo &lt;strong&gt;bar baz&lt;/strong&gt;</code>
+rather than <code>&lt;strong&gt;foo **bar baz&lt;/strong&gt;</code>.</p>
+</li>
+<li>
+<p>Inline code spans, links, images, and HTML tags group more tightly
+than emphasis.  So, when there is a choice between an interpretation
+that contains one of these elements and one that does not, the
+former always wins.  Thus, for example, <code>*[foo*](bar)</code> is
+parsed as <code>*&lt;a href=&quot;bar&quot;&gt;foo*&lt;/a&gt;</code> rather than as
+<code>&lt;em&gt;[foo&lt;/em&gt;](bar)</code>.</p>
+</li>
+</ol>
+<p>These rules can be illustrated through a series of examples.</p>
+<p>Rule 1:</p>
+<pre><code class=\\"language-example\\">*foo bar*
+.
+&lt;p&gt;&lt;em&gt;foo bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the opening <code>*</code> is followed by
+whitespace, and hence not part of a [left-flanking delimiter run]:</p>
+<pre><code class=\\"language-example\\">a * foo bar*
+.
+&lt;p&gt;a * foo bar*&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the opening <code>*</code> is preceded
+by an alphanumeric and followed by punctuation, and hence
+not part of a [left-flanking delimiter run]:</p>
+<pre><code class=\\"language-example\\">a*&quot;foo&quot;*
+.
+&lt;p&gt;a*&amp;quot;foo&amp;quot;*&lt;/p&gt;
+</code></pre>
+<p>Unicode nonbreaking spaces count as whitespace, too:</p>
+<pre><code class=\\"language-example\\">* a *
+.
+&lt;p&gt;* a *&lt;/p&gt;
+</code></pre>
+<p>Unicode symbols count as punctuation, too:</p>
+<pre><code class=\\"language-example\\">*$*alpha.
+
+*£*bravo.
+
+*€*charlie.
+.
+&lt;p&gt;*$*alpha.&lt;/p&gt;
+&lt;p&gt;*£*bravo.&lt;/p&gt;
+&lt;p&gt;*€*charlie.&lt;/p&gt;
+</code></pre>
+<p>Intraword emphasis with <code>*</code> is permitted:</p>
+<pre><code class=\\"language-example\\">foo*bar*
+.
+&lt;p&gt;foo&lt;em&gt;bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">5*6*78
+.
+&lt;p&gt;5&lt;em&gt;6&lt;/em&gt;78&lt;/p&gt;
+</code></pre>
+<p>Rule 2:</p>
+<pre><code class=\\"language-example\\">_foo bar_
+.
+&lt;p&gt;&lt;em&gt;foo bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the opening <code>_</code> is followed by
+whitespace:</p>
+<pre><code class=\\"language-example\\">_ foo bar_
+.
+&lt;p&gt;_ foo bar_&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the opening <code>_</code> is preceded
+by an alphanumeric and followed by punctuation:</p>
+<pre><code class=\\"language-example\\">a_&quot;foo&quot;_
+.
+&lt;p&gt;a_&amp;quot;foo&amp;quot;_&lt;/p&gt;
+</code></pre>
+<p>Emphasis with <code>_</code> is not allowed inside words:</p>
+<pre><code class=\\"language-example\\">foo_bar_
+.
+&lt;p&gt;foo_bar_&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">5_6_78
+.
+&lt;p&gt;5_6_78&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">пристаням_стремятся_
+.
+&lt;p&gt;пристаням_стремятся_&lt;/p&gt;
+</code></pre>
+<p>Here <code>_</code> does not generate emphasis, because the first delimiter run
+is right-flanking and the second left-flanking:</p>
+<pre><code class=\\"language-example\\">aa_&quot;bb&quot;_cc
+.
+&lt;p&gt;aa_&amp;quot;bb&amp;quot;_cc&lt;/p&gt;
+</code></pre>
+<p>This is emphasis, even though the opening delimiter is
+both left- and right-flanking, because it is preceded by
+punctuation:</p>
+<pre><code class=\\"language-example\\">foo-_(bar)_
+.
+&lt;p&gt;foo-&lt;em&gt;(bar)&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 3:</p>
+<p>This is not emphasis, because the closing delimiter does
+not match the opening delimiter:</p>
+<pre><code class=\\"language-example\\">_foo*
+.
+&lt;p&gt;_foo*&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the closing <code>*</code> is preceded by
+whitespace:</p>
+<pre><code class=\\"language-example\\">*foo bar *
+.
+&lt;p&gt;*foo bar *&lt;/p&gt;
+</code></pre>
+<p>A line ending also counts as whitespace:</p>
+<pre><code class=\\"language-example\\">*foo bar
+*
+.
+&lt;p&gt;*foo bar
+*&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the second <code>*</code> is
+preceded by punctuation and followed by an alphanumeric
+(hence it is not part of a [right-flanking delimiter run]:</p>
+<pre><code class=\\"language-example\\">*(*foo)
+.
+&lt;p&gt;*(*foo)&lt;/p&gt;
+</code></pre>
+<p>The point of this restriction is more easily appreciated
+with this example:</p>
+<pre><code class=\\"language-example\\">*(*foo*)*
+.
+&lt;p&gt;&lt;em&gt;(&lt;em&gt;foo&lt;/em&gt;)&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Intraword emphasis with <code>*</code> is allowed:</p>
+<pre><code class=\\"language-example\\">*foo*bar
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;bar&lt;/p&gt;
+</code></pre>
+<p>Rule 4:</p>
+<p>This is not emphasis, because the closing <code>_</code> is preceded by
+whitespace:</p>
+<pre><code class=\\"language-example\\">_foo bar _
+.
+&lt;p&gt;_foo bar _&lt;/p&gt;
+</code></pre>
+<p>This is not emphasis, because the second <code>_</code> is
+preceded by punctuation and followed by an alphanumeric:</p>
+<pre><code class=\\"language-example\\">_(_foo)
+.
+&lt;p&gt;_(_foo)&lt;/p&gt;
+</code></pre>
+<p>This is emphasis within emphasis:</p>
+<pre><code class=\\"language-example\\">_(_foo_)_
+.
+&lt;p&gt;&lt;em&gt;(&lt;em&gt;foo&lt;/em&gt;)&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Intraword emphasis is disallowed for <code>_</code>:</p>
+<pre><code class=\\"language-example\\">_foo_bar
+.
+&lt;p&gt;_foo_bar&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_пристаням_стремятся
+.
+&lt;p&gt;_пристаням_стремятся&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_foo_bar_baz_
+.
+&lt;p&gt;&lt;em&gt;foo_bar_baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>This is emphasis, even though the closing delimiter is
+both left- and right-flanking, because it is followed by
+punctuation:</p>
+<pre><code class=\\"language-example\\">_(bar)_.
+.
+&lt;p&gt;&lt;em&gt;(bar)&lt;/em&gt;.&lt;/p&gt;
+</code></pre>
+<p>Rule 5:</p>
+<pre><code class=\\"language-example\\">**foo bar**
+.
+&lt;p&gt;&lt;strong&gt;foo bar&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>This is not strong emphasis, because the opening delimiter is
+followed by whitespace:</p>
+<pre><code class=\\"language-example\\">** foo bar**
+.
+&lt;p&gt;** foo bar**&lt;/p&gt;
+</code></pre>
+<p>This is not strong emphasis, because the opening <code>**</code> is preceded
+by an alphanumeric and followed by punctuation, and hence
+not part of a [left-flanking delimiter run]:</p>
+<pre><code class=\\"language-example\\">a**&quot;foo&quot;**
+.
+&lt;p&gt;a**&amp;quot;foo&amp;quot;**&lt;/p&gt;
+</code></pre>
+<p>Intraword strong emphasis with <code>**</code> is permitted:</p>
+<pre><code class=\\"language-example\\">foo**bar**
+.
+&lt;p&gt;foo&lt;strong&gt;bar&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 6:</p>
+<pre><code class=\\"language-example\\">__foo bar__
+.
+&lt;p&gt;&lt;strong&gt;foo bar&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>This is not strong emphasis, because the opening delimiter is
+followed by whitespace:</p>
+<pre><code class=\\"language-example\\">__ foo bar__
+.
+&lt;p&gt;__ foo bar__&lt;/p&gt;
+</code></pre>
+<p>A line ending counts as whitespace:</p>
+<pre><code class=\\"language-example\\">__
+foo bar__
+.
+&lt;p&gt;__
+foo bar__&lt;/p&gt;
+</code></pre>
+<p>This is not strong emphasis, because the opening <code>__</code> is preceded
+by an alphanumeric and followed by punctuation:</p>
+<pre><code class=\\"language-example\\">a__&quot;foo&quot;__
+.
+&lt;p&gt;a__&amp;quot;foo&amp;quot;__&lt;/p&gt;
+</code></pre>
+<p>Intraword strong emphasis is forbidden with <code>__</code>:</p>
+<pre><code class=\\"language-example\\">foo__bar__
+.
+&lt;p&gt;foo__bar__&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">5__6__78
+.
+&lt;p&gt;5__6__78&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">пристаням__стремятся__
+.
+&lt;p&gt;пристаням__стремятся__&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo, __bar__, baz__
+.
+&lt;p&gt;&lt;strong&gt;foo, &lt;strong&gt;bar&lt;/strong&gt;, baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>This is strong emphasis, even though the opening delimiter is
+both left- and right-flanking, because it is preceded by
+punctuation:</p>
+<pre><code class=\\"language-example\\">foo-__(bar)__
+.
+&lt;p&gt;foo-&lt;strong&gt;(bar)&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 7:</p>
+<p>This is not strong emphasis, because the closing delimiter is preceded
+by whitespace:</p>
+<pre><code class=\\"language-example\\">**foo bar **
+.
+&lt;p&gt;**foo bar **&lt;/p&gt;
+</code></pre>
+<p>(Nor can it be interpreted as an emphasized <code>*foo bar *</code>, because of
+Rule 11.)</p>
+<p>This is not strong emphasis, because the second <code>**</code> is
+preceded by punctuation and followed by an alphanumeric:</p>
+<pre><code class=\\"language-example\\">**(**foo)
+.
+&lt;p&gt;**(**foo)&lt;/p&gt;
+</code></pre>
+<p>The point of this restriction is more easily appreciated
+with these examples:</p>
+<pre><code class=\\"language-example\\">*(**foo**)*
+.
+&lt;p&gt;&lt;em&gt;(&lt;strong&gt;foo&lt;/strong&gt;)&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**Gomphocarpus (*Gomphocarpus physocarpus*, syn.
+*Asclepias physocarpa*)**
+.
+&lt;p&gt;&lt;strong&gt;Gomphocarpus (&lt;em&gt;Gomphocarpus physocarpus&lt;/em&gt;, syn.
+&lt;em&gt;Asclepias physocarpa&lt;/em&gt;)&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo &quot;*bar*&quot; foo**
+.
+&lt;p&gt;&lt;strong&gt;foo &amp;quot;&lt;em&gt;bar&lt;/em&gt;&amp;quot; foo&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Intraword emphasis:</p>
+<pre><code class=\\"language-example\\">**foo**bar
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;bar&lt;/p&gt;
+</code></pre>
+<p>Rule 8:</p>
+<p>This is not strong emphasis, because the closing delimiter is
+preceded by whitespace:</p>
+<pre><code class=\\"language-example\\">__foo bar __
+.
+&lt;p&gt;__foo bar __&lt;/p&gt;
+</code></pre>
+<p>This is not strong emphasis, because the second <code>__</code> is
+preceded by punctuation and followed by an alphanumeric:</p>
+<pre><code class=\\"language-example\\">__(__foo)
+.
+&lt;p&gt;__(__foo)&lt;/p&gt;
+</code></pre>
+<p>The point of this restriction is more easily appreciated
+with this example:</p>
+<pre><code class=\\"language-example\\">_(__foo__)_
+.
+&lt;p&gt;&lt;em&gt;(&lt;strong&gt;foo&lt;/strong&gt;)&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Intraword strong emphasis is forbidden with <code>__</code>:</p>
+<pre><code class=\\"language-example\\">__foo__bar
+.
+&lt;p&gt;__foo__bar&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__пристаням__стремятся
+.
+&lt;p&gt;__пристаням__стремятся&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo__bar__baz__
+.
+&lt;p&gt;&lt;strong&gt;foo__bar__baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>This is strong emphasis, even though the closing delimiter is
+both left- and right-flanking, because it is followed by
+punctuation:</p>
+<pre><code class=\\"language-example\\">__(bar)__.
+.
+&lt;p&gt;&lt;strong&gt;(bar)&lt;/strong&gt;.&lt;/p&gt;
+</code></pre>
+<p>Rule 9:</p>
+<p>Any nonempty sequence of inline elements can be the contents of an
+emphasized span.</p>
+<pre><code class=\\"language-example\\">*foo [bar](/url)*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;a href=&quot;/url&quot;&gt;bar&lt;/a&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo
+bar*
+.
+&lt;p&gt;&lt;em&gt;foo
+bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>In particular, emphasis and strong emphasis can be nested
+inside emphasis:</p>
+<pre><code class=\\"language-example\\">_foo __bar__ baz_
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_foo _bar_ baz_
+.
+&lt;p&gt;&lt;em&gt;foo &lt;em&gt;bar&lt;/em&gt; baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo_ bar_
+.
+&lt;p&gt;&lt;em&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo *bar**
+.
+&lt;p&gt;&lt;em&gt;foo &lt;em&gt;bar&lt;/em&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo **bar** baz*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo**bar**baz*
+.
+&lt;p&gt;&lt;em&gt;foo&lt;strong&gt;bar&lt;/strong&gt;baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that in the preceding case, the interpretation</p>
+<pre><code class=\\"language-markdown\\">&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;&lt;em&gt;bar&lt;em&gt;&lt;/em&gt;baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>is precluded by the condition that a delimiter that
+can both open and close (like the <code>*</code> after <code>foo</code>)
+cannot form emphasis if the sum of the lengths of
+the delimiter runs containing the opening and
+closing delimiters is a multiple of 3 unless
+both lengths are multiples of 3.</p>
+<p>For the same reason, we don't get two consecutive
+emphasis sections in this example:</p>
+<pre><code class=\\"language-example\\">*foo**bar*
+.
+&lt;p&gt;&lt;em&gt;foo**bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>The same condition ensures that the following
+cases are all strong emphasis nested inside
+emphasis, even when the interior whitespace is
+omitted:</p>
+<pre><code class=\\"language-example\\">***foo** bar*
+.
+&lt;p&gt;&lt;em&gt;&lt;strong&gt;foo&lt;/strong&gt; bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo **bar***
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo**bar***
+.
+&lt;p&gt;&lt;em&gt;foo&lt;strong&gt;bar&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>When the lengths of the interior closing and opening
+delimiter runs are <em>both</em> multiples of 3, though,
+they can match to create emphasis:</p>
+<pre><code class=\\"language-example\\">foo***bar***baz
+.
+&lt;p&gt;foo&lt;em&gt;&lt;strong&gt;bar&lt;/strong&gt;&lt;/em&gt;baz&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo******bar*********baz
+.
+&lt;p&gt;foo&lt;strong&gt;&lt;strong&gt;&lt;strong&gt;bar&lt;/strong&gt;&lt;/strong&gt;&lt;/strong&gt;***baz&lt;/p&gt;
+</code></pre>
+<p>Indefinite levels of nesting are possible:</p>
+<pre><code class=\\"language-example\\">*foo **bar *baz* bim** bop*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar &lt;em&gt;baz&lt;/em&gt; bim&lt;/strong&gt; bop&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo [*bar*](/url)*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;a href=&quot;/url&quot;&gt;&lt;em&gt;bar&lt;/em&gt;&lt;/a&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>There can be no empty emphasis or strong emphasis:</p>
+<pre><code class=\\"language-example\\">** is not an empty emphasis
+.
+&lt;p&gt;** is not an empty emphasis&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**** is not an empty strong emphasis
+.
+&lt;p&gt;**** is not an empty strong emphasis&lt;/p&gt;
+</code></pre>
+<p>Rule 10:</p>
+<p>Any nonempty sequence of inline elements can be the contents of an
+strongly emphasized span.</p>
+<pre><code class=\\"language-example\\">**foo [bar](/url)**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;a href=&quot;/url&quot;&gt;bar&lt;/a&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo
+bar**
+.
+&lt;p&gt;&lt;strong&gt;foo
+bar&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>In particular, emphasis and strong emphasis can be nested
+inside strong emphasis:</p>
+<pre><code class=\\"language-example\\">__foo _bar_ baz__
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar&lt;/em&gt; baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo __bar__ baz__
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;strong&gt;bar&lt;/strong&gt; baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">____foo__ bar__
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt; bar&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo **bar****
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;strong&gt;bar&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo *bar* baz**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar&lt;/em&gt; baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo*bar*baz**
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;em&gt;bar&lt;/em&gt;baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">***foo* bar**
+.
+&lt;p&gt;&lt;strong&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo *bar***
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar&lt;/em&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Indefinite levels of nesting are possible:</p>
+<pre><code class=\\"language-example\\">**foo *bar **baz**
+bim* bop**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;em&gt;bar &lt;strong&gt;baz&lt;/strong&gt;
+bim&lt;/em&gt; bop&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo [*bar*](/url)**
+.
+&lt;p&gt;&lt;strong&gt;foo &lt;a href=&quot;/url&quot;&gt;&lt;em&gt;bar&lt;/em&gt;&lt;/a&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>There can be no empty emphasis or strong emphasis:</p>
+<pre><code class=\\"language-example\\">__ is not an empty emphasis
+.
+&lt;p&gt;__ is not an empty emphasis&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">____ is not an empty strong emphasis
+.
+&lt;p&gt;____ is not an empty strong emphasis&lt;/p&gt;
+</code></pre>
+<p>Rule 11:</p>
+<pre><code class=\\"language-example\\">foo ***
+.
+&lt;p&gt;foo ***&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo *\\\\**
+.
+&lt;p&gt;foo &lt;em&gt;*&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo *_*
+.
+&lt;p&gt;foo &lt;em&gt;_&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo *****
+.
+&lt;p&gt;foo *****&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo **\\\\***
+.
+&lt;p&gt;foo &lt;strong&gt;*&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo **_**
+.
+&lt;p&gt;foo &lt;strong&gt;_&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that when delimiters do not match evenly, Rule 11 determines
+that the excess literal <code>*</code> characters will appear outside of the
+emphasis, rather than inside it:</p>
+<pre><code class=\\"language-example\\">**foo*
+.
+&lt;p&gt;*&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo**
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;*&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">***foo**
+.
+&lt;p&gt;*&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">****foo*
+.
+&lt;p&gt;***&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**foo***
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;*&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo****
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;***&lt;/p&gt;
+</code></pre>
+<p>Rule 12:</p>
+<pre><code class=\\"language-example\\">foo ___
+.
+&lt;p&gt;foo ___&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo _\\\\__
+.
+&lt;p&gt;foo &lt;em&gt;_&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo _*_
+.
+&lt;p&gt;foo &lt;em&gt;*&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo _____
+.
+&lt;p&gt;foo _____&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo __\\\\___
+.
+&lt;p&gt;foo &lt;strong&gt;_&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo __*__
+.
+&lt;p&gt;foo &lt;strong&gt;*&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo_
+.
+&lt;p&gt;_&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that when delimiters do not match evenly, Rule 12 determines
+that the excess literal <code>_</code> characters will appear outside of the
+emphasis, rather than inside it:</p>
+<pre><code class=\\"language-example\\">_foo__
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;_&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">___foo__
+.
+&lt;p&gt;_&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">____foo_
+.
+&lt;p&gt;___&lt;em&gt;foo&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo___
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;_&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_foo____
+.
+&lt;p&gt;&lt;em&gt;foo&lt;/em&gt;___&lt;/p&gt;
+</code></pre>
+<p>Rule 13 implies that if you want emphasis nested directly inside
+emphasis, you must use different delimiters:</p>
+<pre><code class=\\"language-example\\">**foo**
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*_foo_*
+.
+&lt;p&gt;&lt;em&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__foo__
+.
+&lt;p&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_*foo*_
+.
+&lt;p&gt;&lt;em&gt;&lt;em&gt;foo&lt;/em&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>However, strong emphasis within strong emphasis is possible without
+switching delimiters:</p>
+<pre><code class=\\"language-example\\">****foo****
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">____foo____
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 13 can be applied to arbitrarily long sequences of
+delimiters:</p>
+<pre><code class=\\"language-example\\">******foo******
+.
+&lt;p&gt;&lt;strong&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 14:</p>
+<pre><code class=\\"language-example\\">***foo***
+.
+&lt;p&gt;&lt;em&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_____foo_____
+.
+&lt;p&gt;&lt;em&gt;&lt;strong&gt;&lt;strong&gt;foo&lt;/strong&gt;&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 15:</p>
+<pre><code class=\\"language-example\\">*foo _bar* baz_
+.
+&lt;p&gt;&lt;em&gt;foo _bar&lt;/em&gt; baz_&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo __bar *baz bim__ bam*
+.
+&lt;p&gt;&lt;em&gt;foo &lt;strong&gt;bar *baz bim&lt;/strong&gt; bam&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 16:</p>
+<pre><code class=\\"language-example\\">**foo **bar baz**
+.
+&lt;p&gt;**foo &lt;strong&gt;bar baz&lt;/strong&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo *bar baz*
+.
+&lt;p&gt;*foo &lt;em&gt;bar baz&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Rule 17:</p>
+<pre><code class=\\"language-example\\">*[bar*](/url)
+.
+&lt;p&gt;*&lt;a href=&quot;/url&quot;&gt;bar*&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_foo [bar_](/url)
+.
+&lt;p&gt;_foo &lt;a href=&quot;/url&quot;&gt;bar_&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*&lt;img src=&quot;foo&quot; title=&quot;*&quot;/&gt;
+.
+&lt;p&gt;*&lt;img src=&quot;foo&quot; title=&quot;*&quot;/&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**&lt;a href=&quot;**&quot;&gt;
+.
+&lt;p&gt;**&lt;a href=&quot;**&quot;&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__&lt;a href=&quot;__&quot;&gt;
+.
+&lt;p&gt;__&lt;a href=&quot;__&quot;&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*a \`*\`*
+.
+&lt;p&gt;&lt;em&gt;a &lt;code&gt;*&lt;/code&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">_a \`_\`_
+.
+&lt;p&gt;&lt;em&gt;a &lt;code&gt;_&lt;/code&gt;&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">**a&lt;https://foo.bar/?q=**&gt;
+.
+&lt;p&gt;**a&lt;a href=&quot;https://foo.bar/?q=**&quot;&gt;https://foo.bar/?q=**&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">__a&lt;https://foo.bar/?q=__&gt;
+.
+&lt;p&gt;__a&lt;a href=&quot;https://foo.bar/?q=__&quot;&gt;https://foo.bar/?q=__&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<h2>Links</h2>
+<p>A link contains [link text] (the visible text), a [link destination]
+(the URI that is the link destination), and optionally a [link title].
+There are two basic kinds of links in Markdown.  In [inline links] the
+destination and title are given immediately after the link text.  In
+[reference links] the destination and title are defined elsewhere in
+the document.</p>
+<p>A <a href=\\"@\\">link text</a> consists of a sequence of zero or more
+inline elements enclosed by square brackets (<code>[</code> and <code>]</code>).  The
+following rules apply:</p>
+<ul>
+<li>
+<p>Links may not contain other links, at any level of nesting. If
+multiple otherwise valid link definitions appear nested inside each
+other, the inner-most definition is used.</p>
+</li>
+<li>
+<p>Brackets are allowed in the [link text] only if (a) they
+are backslash-escaped or (b) they appear as a matched pair of brackets,
+with an open bracket <code>[</code>, a sequence of zero or more inlines, and
+a close bracket <code>]</code>.</p>
+</li>
+<li>
+<p>Backtick [code spans], [autolinks], and raw [HTML tags] bind more tightly
+than the brackets in link text.  Thus, for example,
+<code>[foo\`]\`</code> could not be a link text, since the second <code>]</code>
+is part of a code span.</p>
+</li>
+<li>
+<p>The brackets in link text bind more tightly than markers for
+[emphasis and strong emphasis]. Thus, for example, <code>*[foo*](url)</code> is a link.</p>
+</li>
+</ul>
+<p>A <a href=\\"@\\">link destination</a> consists of either</p>
+<ul>
+<li>
+<p>a sequence of zero or more characters between an opening <code>&lt;</code> and a
+closing <code>&gt;</code> that contains no line endings or unescaped
+<code>&lt;</code> or <code>&gt;</code> characters, or</p>
+</li>
+<li>
+<p>a nonempty sequence of characters that does not start with <code>&lt;</code>,
+does not include [ASCII control characters][ASCII control character]
+or [space] character, and includes parentheses only if (a) they are
+backslash-escaped or (b) they are part of a balanced pair of
+unescaped parentheses.
+(Implementations may impose limits on parentheses nesting to
+avoid performance issues, but at least three levels of nesting
+should be supported.)</p>
+</li>
+</ul>
+<p>A <a href=\\"@\\">link title</a>  consists of either</p>
+<ul>
+<li>
+<p>a sequence of zero or more characters between straight double-quote
+characters (<code>&quot;</code>), including a <code>&quot;</code> character only if it is
+backslash-escaped, or</p>
+</li>
+<li>
+<p>a sequence of zero or more characters between straight single-quote
+characters (<code>'</code>), including a <code>'</code> character only if it is
+backslash-escaped, or</p>
+</li>
+<li>
+<p>a sequence of zero or more characters between matching parentheses
+(<code>(...)</code>), including a <code>(</code> or <code>)</code> character only if it is
+backslash-escaped.</p>
+</li>
+</ul>
+<p>Although [link titles] may span multiple lines, they may not contain
+a [blank line].</p>
+<p>An <a href=\\"@\\">inline link</a> consists of a [link text] followed immediately
+by a left parenthesis <code>(</code>, an optional [link destination], an optional
+[link title], and a right parenthesis <code>)</code>.
+These four components may be separated by spaces, tabs, and up to one line
+ending.
+If both [link destination] and [link title] are present, they <em>must</em> be
+separated by spaces, tabs, and up to one line ending.</p>
+<p>The link's text consists of the inlines contained
+in the [link text] (excluding the enclosing square brackets).
+The link's URI consists of the link destination, excluding enclosing
+<code>&lt;...&gt;</code> if present, with backslash-escapes in effect as described
+above.  The link's title consists of the link title, excluding its
+enclosing delimiters, with backslash-escapes in effect as described
+above.</p>
+<p>Here is a simple inline link:</p>
+<pre><code class=\\"language-example\\">[link](/uri &quot;title&quot;)
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot; title=&quot;title&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The title, the link text and even
+the destination may be omitted:</p>
+<pre><code class=\\"language-example\\">[link](/uri)
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[](./target.md)
+.
+&lt;p&gt;&lt;a href=&quot;./target.md&quot;&gt;&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link]()
+.
+&lt;p&gt;&lt;a href=&quot;&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link](&lt;&gt;)
+.
+&lt;p&gt;&lt;a href=&quot;&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[]()
+.
+&lt;p&gt;&lt;a href=&quot;&quot;&gt;&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The destination can only contain spaces if it is
+enclosed in pointy brackets:</p>
+<pre><code class=\\"language-example\\">[link](/my uri)
+.
+&lt;p&gt;[link](/my uri)&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link](&lt;/my uri&gt;)
+.
+&lt;p&gt;&lt;a href=&quot;/my%20uri&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The destination cannot contain line endings,
+even if enclosed in pointy brackets:</p>
+<pre><code class=\\"language-example\\">[link](foo
+bar)
+.
+&lt;p&gt;[link](foo
+bar)&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link](&lt;foo
+bar&gt;)
+.
+&lt;p&gt;[link](&lt;foo
+bar&gt;)&lt;/p&gt;
+</code></pre>
+<p>The destination can contain <code>)</code> if it is enclosed
+in pointy brackets:</p>
+<pre><code class=\\"language-example\\">[a](&lt;b)c&gt;)
+.
+&lt;p&gt;&lt;a href=&quot;b)c&quot;&gt;a&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Pointy brackets that enclose links must be unescaped:</p>
+<pre><code class=\\"language-example\\">[link](&lt;foo\\\\&gt;)
+.
+&lt;p&gt;[link](&amp;lt;foo&amp;gt;)&lt;/p&gt;
+</code></pre>
+<p>These are not links, because the opening pointy bracket
+is not matched properly:</p>
+<pre><code class=\\"language-example\\">[a](&lt;b)c
+[a](&lt;b)c&gt;
+[a](&lt;b&gt;c)
+.
+&lt;p&gt;[a](&amp;lt;b)c
+[a](&amp;lt;b)c&amp;gt;
+[a](&lt;b&gt;c)&lt;/p&gt;
+</code></pre>
+<p>Parentheses inside the link destination may be escaped:</p>
+<pre><code class=\\"language-example\\">[link](\\\\(foo\\\\))
+.
+&lt;p&gt;&lt;a href=&quot;(foo)&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Any number of parentheses are allowed without escaping, as long as they are
+balanced:</p>
+<pre><code class=\\"language-example\\">[link](foo(and(bar)))
+.
+&lt;p&gt;&lt;a href=&quot;foo(and(bar))&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>However, if you have unbalanced parentheses, you need to escape or use the
+<code>&lt;...&gt;</code> form:</p>
+<pre><code class=\\"language-example\\">[link](foo(and(bar))
+.
+&lt;p&gt;[link](foo(and(bar))&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link](foo\\\\(and\\\\(bar\\\\))
+.
+&lt;p&gt;&lt;a href=&quot;foo(and(bar)&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link](&lt;foo(and(bar)&gt;)
+.
+&lt;p&gt;&lt;a href=&quot;foo(and(bar)&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Parentheses and other symbols can also be escaped, as usual
+in Markdown:</p>
+<pre><code class=\\"language-example\\">[link](foo\\\\)\\\\:)
+.
+&lt;p&gt;&lt;a href=&quot;foo):&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>A link can contain fragment identifiers and queries:</p>
+<pre><code class=\\"language-example\\">[link](#fragment)
+
+[link](https://example.com#fragment)
+
+[link](https://example.com?foo=3#frag)
+.
+&lt;p&gt;&lt;a href=&quot;#fragment&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://example.com#fragment&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://example.com?foo=3#frag&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that a backslash before a non-escapable character is
+just a backslash:</p>
+<pre><code class=\\"language-example\\">[link](foo\\\\bar)
+.
+&lt;p&gt;&lt;a href=&quot;foo%5Cbar&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>URL-escaping should be left alone inside the destination, as all
+URL-escaped characters are also valid URL characters. Entity and
+numerical character references in the destination will be parsed
+into the corresponding Unicode code points, as usual.  These may
+be optionally URL-escaped when written as HTML, but this spec
+does not enforce any particular policy for rendering URLs in
+HTML or other formats.  Renderers may make different decisions
+about how to escape or normalize URLs in the output.</p>
+<pre><code class=\\"language-example\\">[link](foo%20b&amp;auml;)
+.
+&lt;p&gt;&lt;a href=&quot;foo%20b%C3%A4&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that, because titles can often be parsed as destinations,
+if you try to omit the destination and keep the title, you'll
+get unexpected results:</p>
+<pre><code class=\\"language-example\\">[link](&quot;title&quot;)
+.
+&lt;p&gt;&lt;a href=&quot;%22title%22&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Titles may be in single quotes, double quotes, or parentheses:</p>
+<pre><code class=\\"language-example\\">[link](/url &quot;title&quot;)
+[link](/url 'title')
+[link](/url (title))
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;link&lt;/a&gt;
+&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;link&lt;/a&gt;
+&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Backslash escapes and entity and numeric character references
+may be used in titles:</p>
+<pre><code class=\\"language-example\\">[link](/url &quot;title \\\\&quot;&amp;quot;&quot;)
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title &amp;quot;&amp;quot;&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Titles must be separated from the link using spaces, tabs, and up to one line
+ending.
+Other [Unicode whitespace] like non-breaking space doesn't work.</p>
+<pre><code class=\\"language-example\\">[link](/url &quot;title&quot;)
+.
+&lt;p&gt;&lt;a href=&quot;/url%C2%A0%22title%22&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Nested balanced quotes are not allowed without escaping:</p>
+<pre><code class=\\"language-example\\">[link](/url &quot;title &quot;and&quot; title&quot;)
+.
+&lt;p&gt;[link](/url &amp;quot;title &amp;quot;and&amp;quot; title&amp;quot;)&lt;/p&gt;
+</code></pre>
+<p>But it is easy to work around this by using a different quote type:</p>
+<pre><code class=\\"language-example\\">[link](/url 'title &quot;and&quot; title')
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title &amp;quot;and&amp;quot; title&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>(Note:  <code>Markdown.pl</code> did allow double quotes inside a double-quoted
+title, and its test suite included a test demonstrating this.
+But it is hard to see a good rationale for the extra complexity this
+brings, since there are already many ways---backslash escaping,
+entity and numeric character references, or using a different
+quote type for the enclosing title---to write titles containing
+double quotes.  <code>Markdown.pl</code>'s handling of titles has a number
+of other strange features.  For example, it allows single-quoted
+titles in inline links, but not reference links.  And, in
+reference links but not inline links, it allows a title to begin
+with <code>&quot;</code> and end with <code>)</code>.  <code>Markdown.pl</code> 1.0.1 even allows
+titles with no closing quotation mark, though 1.0.2b8 does not.
+It seems preferable to adopt a simple, rational rule that works
+the same way in inline links and link reference definitions.)</p>
+<p>Spaces, tabs, and up to one line ending is allowed around the destination and
+title:</p>
+<pre><code class=\\"language-example\\">[link](   /uri
+  &quot;title&quot;  )
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot; title=&quot;title&quot;&gt;link&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>But it is not allowed between the link text and the
+following parenthesis:</p>
+<pre><code class=\\"language-example\\">[link] (/uri)
+.
+&lt;p&gt;[link] (/uri)&lt;/p&gt;
+</code></pre>
+<p>The link text may contain balanced brackets, but not unbalanced ones,
+unless they are escaped:</p>
+<pre><code class=\\"language-example\\">[link [foo [bar]]](/uri)
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link [foo [bar]]&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link] bar](/uri)
+.
+&lt;p&gt;[link] bar](/uri)&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link [bar](/uri)
+.
+&lt;p&gt;[link &lt;a href=&quot;/uri&quot;&gt;bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link \\\\[bar](/uri)
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link [bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The link text may contain inline content:</p>
+<pre><code class=\\"language-example\\">[link *foo **bar** \`#\`*](/uri)
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link &lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; &lt;code&gt;#&lt;/code&gt;&lt;/em&gt;&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[![moon](moon.jpg)](/uri)
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;&lt;img src=&quot;moon.jpg&quot; alt=&quot;moon&quot; /&gt;&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>However, links may not contain other links, at any level of nesting.</p>
+<pre><code class=\\"language-example\\">[foo [bar](/uri)](/uri)
+.
+&lt;p&gt;[foo &lt;a href=&quot;/uri&quot;&gt;bar&lt;/a&gt;](/uri)&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo *[bar [baz](/uri)](/uri)*](/uri)
+.
+&lt;p&gt;[foo &lt;em&gt;[bar &lt;a href=&quot;/uri&quot;&gt;baz&lt;/a&gt;](/uri)&lt;/em&gt;](/uri)&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![[[foo](uri1)](uri2)](uri3)
+.
+&lt;p&gt;&lt;img src=&quot;uri3&quot; alt=&quot;[foo](uri2)&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>These cases illustrate the precedence of link text grouping over
+emphasis grouping:</p>
+<pre><code class=\\"language-example\\">*[foo*](/uri)
+.
+&lt;p&gt;*&lt;a href=&quot;/uri&quot;&gt;foo*&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo *bar](baz*)
+.
+&lt;p&gt;&lt;a href=&quot;baz*&quot;&gt;foo *bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that brackets that <em>aren't</em> part of links do not take
+precedence:</p>
+<pre><code class=\\"language-example\\">*foo [bar* baz]
+.
+&lt;p&gt;&lt;em&gt;foo [bar&lt;/em&gt; baz]&lt;/p&gt;
+</code></pre>
+<p>These cases illustrate the precedence of HTML tags, code spans,
+and autolinks over link grouping:</p>
+<pre><code class=\\"language-example\\">[foo &lt;bar attr=&quot;](baz)&quot;&gt;
+.
+&lt;p&gt;[foo &lt;bar attr=&quot;](baz)&quot;&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo\`](/uri)\`
+.
+&lt;p&gt;[foo&lt;code&gt;](/uri)&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo&lt;https://example.com/?search=](uri)&gt;
+.
+&lt;p&gt;[foo&lt;a href=&quot;https://example.com/?search=%5D(uri)&quot;&gt;https://example.com/?search=](uri)&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>There are three kinds of <a href=\\"@\\">reference link</a>s:
+<a href=\\"#full-reference-link\\">full</a>, <a href=\\"#collapsed-reference-link\\">collapsed</a>,
+and <a href=\\"#shortcut-reference-link\\">shortcut</a>.</p>
+<p>A <a href=\\"@\\">full reference link</a>
+consists of a [link text] immediately followed by a [link label]
+that [matches] a [link reference definition] elsewhere in the document.</p>
+<p>A <a href=\\"@\\">link label</a>  begins with a left bracket (<code>[</code>) and ends
+with the first right bracket (<code>]</code>) that is not backslash-escaped.
+Between these brackets there must be at least one character that is not a space,
+tab, or line ending.
+Unescaped square bracket characters are not allowed inside the
+opening and closing square brackets of [link labels].  A link
+label can have at most 999 characters inside the square
+brackets.</p>
+<p>One label <a href=\\"@\\">matches</a>
+another just in case their normalized forms are equal.  To normalize a
+label, strip off the opening and closing brackets,
+perform the <em>Unicode case fold</em>, strip leading and trailing
+spaces, tabs, and line endings, and collapse consecutive internal
+spaces, tabs, and line endings to a single space.  If there are multiple
+matching reference link definitions, the one that comes first in the
+document is used.  (It is desirable in such cases to emit a warning.)</p>
+<p>The link's URI and title are provided by the matching [link
+reference definition].</p>
+<p>Here is a simple example:</p>
+<pre><code class=\\"language-example\\">[foo][bar]
+
+[bar]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The rules for the [link text] are the same as with
+[inline links].  Thus:</p>
+<p>The link text may contain balanced brackets, but not unbalanced ones,
+unless they are escaped:</p>
+<pre><code class=\\"language-example\\">[link [foo [bar]]][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link [foo [bar]]&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[link \\\\[bar][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link [bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The link text may contain inline content:</p>
+<pre><code class=\\"language-example\\">[link *foo **bar** \`#\`*][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;link &lt;em&gt;foo &lt;strong&gt;bar&lt;/strong&gt; &lt;code&gt;#&lt;/code&gt;&lt;/em&gt;&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[![moon](moon.jpg)][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;&lt;img src=&quot;moon.jpg&quot; alt=&quot;moon&quot; /&gt;&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>However, links may not contain other links, at any level of nesting.</p>
+<pre><code class=\\"language-example\\">[foo [bar](/uri)][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;[foo &lt;a href=&quot;/uri&quot;&gt;bar&lt;/a&gt;]&lt;a href=&quot;/uri&quot;&gt;ref&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo *bar [baz][ref]*][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;[foo &lt;em&gt;bar &lt;a href=&quot;/uri&quot;&gt;baz&lt;/a&gt;&lt;/em&gt;]&lt;a href=&quot;/uri&quot;&gt;ref&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>(In the examples above, we have two [shortcut reference links]
+instead of one [full reference link].)</p>
+<p>The following cases illustrate the precedence of link text grouping over
+emphasis grouping:</p>
+<pre><code class=\\"language-example\\">*[foo*][ref]
+
+[ref]: /uri
+.
+&lt;p&gt;*&lt;a href=&quot;/uri&quot;&gt;foo*&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo *bar][ref]*
+
+[ref]: /uri
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;foo *bar&lt;/a&gt;*&lt;/p&gt;
+</code></pre>
+<p>These cases illustrate the precedence of HTML tags, code spans,
+and autolinks over link grouping:</p>
+<pre><code class=\\"language-example\\">[foo &lt;bar attr=&quot;][ref]&quot;&gt;
+
+[ref]: /uri
+.
+&lt;p&gt;[foo &lt;bar attr=&quot;][ref]&quot;&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo\`][ref]\`
+
+[ref]: /uri
+.
+&lt;p&gt;[foo&lt;code&gt;][ref]&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo&lt;https://example.com/?search=][ref]&gt;
+
+[ref]: /uri
+.
+&lt;p&gt;[foo&lt;a href=&quot;https://example.com/?search=%5D%5Bref%5D&quot;&gt;https://example.com/?search=][ref]&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Matching is case-insensitive:</p>
+<pre><code class=\\"language-example\\">[foo][BaR]
+
+[bar]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Unicode case fold is used:</p>
+<pre><code class=\\"language-example\\">[ẞ]
+
+[SS]: /url
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;ẞ&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Consecutive internal spaces, tabs, and line endings are treated as one space for
+purposes of determining matching:</p>
+<pre><code class=\\"language-example\\">[Foo
+  bar]: /url
+
+[Baz][Foo bar]
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;Baz&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>No spaces, tabs, or line endings are allowed between the [link text] and the
+[link label]:</p>
+<pre><code class=\\"language-example\\">[foo] [bar]
+
+[bar]: /url &quot;title&quot;
+.
+&lt;p&gt;[foo] &lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo]
+[bar]
+
+[bar]: /url &quot;title&quot;
+.
+&lt;p&gt;[foo]
+&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>This is a departure from John Gruber's original Markdown syntax
+description, which explicitly allows whitespace between the link
+text and the link label.  It brings reference links in line with
+[inline links], which (according to both original Markdown and
+this spec) cannot have whitespace after the link text.  More
+importantly, it prevents inadvertent capture of consecutive
+[shortcut reference links]. If whitespace is allowed between the
+link text and the link label, then in the following we will have
+a single reference link, not two shortcut reference links, as
+intended:</p>
+<pre><code class=\\"language-markdown\\">[foo]
+[bar]
+
+[foo]: /url1
+[bar]: /url2
+</code></pre>
+<p>(Note that [shortcut reference links] were introduced by Gruber
+himself in a beta version of <code>Markdown.pl</code>, but never included
+in the official syntax description.  Without shortcut reference
+links, it is harmless to allow space between the link text and
+link label; but once shortcut references are introduced, it is
+too dangerous to allow this, as it frequently leads to
+unintended results.)</p>
+<p>When there are multiple matching [link reference definitions],
+the first is used:</p>
+<pre><code class=\\"language-example\\">[foo]: /url1
+
+[foo]: /url2
+
+[bar][foo]
+.
+&lt;p&gt;&lt;a href=&quot;/url1&quot;&gt;bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that matching is performed on normalized strings, not parsed
+inline content.  So the following does not match, even though the
+labels define equivalent inline content:</p>
+<pre><code class=\\"language-example\\">[bar][foo\\\\!]
+
+[foo!]: /url
+.
+&lt;p&gt;[bar][foo!]&lt;/p&gt;
+</code></pre>
+<p>[Link labels] cannot contain brackets, unless they are
+backslash-escaped:</p>
+<pre><code class=\\"language-example\\">[foo][ref[]
+
+[ref[]: /uri
+.
+&lt;p&gt;[foo][ref[]&lt;/p&gt;
+&lt;p&gt;[ref[]: /uri&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo][ref[bar]]
+
+[ref[bar]]: /uri
+.
+&lt;p&gt;[foo][ref[bar]]&lt;/p&gt;
+&lt;p&gt;[ref[bar]]: /uri&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[[[foo]]]
+
+[[[foo]]]: /url
+.
+&lt;p&gt;[[[foo]]]&lt;/p&gt;
+&lt;p&gt;[[[foo]]]: /url&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo][ref\\\\[]
+
+[ref\\\\[]: /uri
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that in this example <code>]</code> is not backslash-escaped:</p>
+<pre><code class=\\"language-example\\">[bar\\\\\\\\]: /uri
+
+[bar\\\\\\\\]
+.
+&lt;p&gt;&lt;a href=&quot;/uri&quot;&gt;bar\\\\&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>A [link label] must contain at least one character that is not a space, tab, or
+line ending:</p>
+<pre><code class=\\"language-example\\">[]
+
+[]: /uri
+.
+&lt;p&gt;[]&lt;/p&gt;
+&lt;p&gt;[]: /uri&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[
+ ]
+
+[
+ ]: /uri
+.
+&lt;p&gt;[
+]&lt;/p&gt;
+&lt;p&gt;[
+]: /uri&lt;/p&gt;
+</code></pre>
+<p>A <a href=\\"@\\">collapsed reference link</a>
+consists of a [link label] that [matches] a
+[link reference definition] elsewhere in the
+document, followed by the string <code>[]</code>.
+The contents of the link label are parsed as inlines,
+which are used as the link's text.  The link's URI and title are
+provided by the matching reference link definition.  Thus,
+<code>[foo][]</code> is equivalent to <code>[foo][foo]</code>.</p>
+<pre><code class=\\"language-example\\">[foo][]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[*foo* bar][]
+
+[*foo* bar]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The link labels are case-insensitive:</p>
+<pre><code class=\\"language-example\\">[Foo][]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;Foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>As with full reference links, spaces, tabs, or line endings are not
+allowed between the two sets of brackets:</p>
+<pre><code class=\\"language-example\\">[foo] 
+[]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;
+[]&lt;/p&gt;
+</code></pre>
+<p>A <a href=\\"@\\">shortcut reference link</a>
+consists of a [link label] that [matches] a
+[link reference definition] elsewhere in the
+document and is not followed by <code>[]</code> or a link label.
+The contents of the link label are parsed as inlines,
+which are used as the link's text.  The link's URI and title
+are provided by the matching link reference definition.
+Thus, <code>[foo]</code> is equivalent to <code>[foo][]</code>.</p>
+<pre><code class=\\"language-example\\">[foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[*foo* bar]
+
+[*foo* bar]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[[*foo* bar]]
+
+[*foo* bar]: /url &quot;title&quot;
+.
+&lt;p&gt;[&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;&lt;em&gt;foo&lt;/em&gt; bar&lt;/a&gt;]&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[[bar [foo]
+
+[foo]: /url
+.
+&lt;p&gt;[[bar &lt;a href=&quot;/url&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>The link labels are case-insensitive:</p>
+<pre><code class=\\"language-example\\">[Foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;Foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>A space after the link text should be preserved:</p>
+<pre><code class=\\"language-example\\">[foo] bar
+
+[foo]: /url
+.
+&lt;p&gt;&lt;a href=&quot;/url&quot;&gt;foo&lt;/a&gt; bar&lt;/p&gt;
+</code></pre>
+<p>If you just want bracketed text, you can backslash-escape the
+opening bracket to avoid links:</p>
+<pre><code class=\\"language-example\\">\\\\[foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;[foo]&lt;/p&gt;
+</code></pre>
+<p>Note that this is a link, because a link label ends with the first
+following closing bracket:</p>
+<pre><code class=\\"language-example\\">[foo*]: /url
+
+*[foo*]
+.
+&lt;p&gt;*&lt;a href=&quot;/url&quot;&gt;foo*&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Full and collapsed references take precedence over shortcut
+references:</p>
+<pre><code class=\\"language-example\\">[foo][bar]
+
+[foo]: /url1
+[bar]: /url2
+.
+&lt;p&gt;&lt;a href=&quot;/url2&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo][]
+
+[foo]: /url1
+.
+&lt;p&gt;&lt;a href=&quot;/url1&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Inline links also take precedence:</p>
+<pre><code class=\\"language-example\\">[foo]()
+
+[foo]: /url1
+.
+&lt;p&gt;&lt;a href=&quot;&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">[foo](not a link)
+
+[foo]: /url1
+.
+&lt;p&gt;&lt;a href=&quot;/url1&quot;&gt;foo&lt;/a&gt;(not a link)&lt;/p&gt;
+</code></pre>
+<p>In the following case <code>[bar][baz]</code> is parsed as a reference,
+<code>[foo]</code> as normal text:</p>
+<pre><code class=\\"language-example\\">[foo][bar][baz]
+
+[baz]: /url
+.
+&lt;p&gt;[foo]&lt;a href=&quot;/url&quot;&gt;bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Here, though, <code>[foo][bar]</code> is parsed as a reference, since
+<code>[bar]</code> is defined:</p>
+<pre><code class=\\"language-example\\">[foo][bar][baz]
+
+[baz]: /url1
+[bar]: /url2
+.
+&lt;p&gt;&lt;a href=&quot;/url2&quot;&gt;foo&lt;/a&gt;&lt;a href=&quot;/url1&quot;&gt;baz&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Here <code>[foo]</code> is not parsed as a shortcut reference, because it
+is followed by a link label (even though <code>[bar]</code> is not defined):</p>
+<pre><code class=\\"language-example\\">[foo][bar][baz]
+
+[baz]: /url1
+[foo]: /url2
+.
+&lt;p&gt;[foo]&lt;a href=&quot;/url1&quot;&gt;bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<h2>Images</h2>
+<p>Syntax for images is like the syntax for links, with one
+difference. Instead of [link text], we have an
+<a href=\\"@\\">image description</a>.  The rules for this are the
+same as for [link text], except that (a) an
+image description starts with <code>![</code> rather than <code>[</code>, and
+(b) an image description may contain links.
+An image description has inline elements
+as its contents.  When an image is rendered to HTML,
+this is standardly used as the image's <code>alt</code> attribute.</p>
+<pre><code class=\\"language-example\\">![foo](/url &quot;title&quot;)
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo *bar*]
+
+[foo *bar*]: train.jpg &quot;train &amp; tracks&quot;
+.
+&lt;p&gt;&lt;img src=&quot;train.jpg&quot; alt=&quot;foo bar&quot; title=&quot;train &amp;amp; tracks&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo ![bar](/url)](/url2)
+.
+&lt;p&gt;&lt;img src=&quot;/url2&quot; alt=&quot;foo bar&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo [bar](/url)](/url2)
+.
+&lt;p&gt;&lt;img src=&quot;/url2&quot; alt=&quot;foo bar&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>Though this spec is concerned with parsing, not rendering, it is
+recommended that in rendering to HTML, only the plain string content
+of the [image description] be used.  Note that in
+the above example, the alt attribute's value is <code>foo bar</code>, not <code>foo [bar](/url)</code> or <code>foo &lt;a href=&quot;/url&quot;&gt;bar&lt;/a&gt;</code>.  Only the plain string
+content is rendered, without formatting.</p>
+<pre><code class=\\"language-example\\">![foo *bar*][]
+
+[foo *bar*]: train.jpg &quot;train &amp; tracks&quot;
+.
+&lt;p&gt;&lt;img src=&quot;train.jpg&quot; alt=&quot;foo bar&quot; title=&quot;train &amp;amp; tracks&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo *bar*][foobar]
+
+[FOOBAR]: train.jpg &quot;train &amp; tracks&quot;
+.
+&lt;p&gt;&lt;img src=&quot;train.jpg&quot; alt=&quot;foo bar&quot; title=&quot;train &amp;amp; tracks&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo](train.jpg)
+.
+&lt;p&gt;&lt;img src=&quot;train.jpg&quot; alt=&quot;foo&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">My ![foo bar](/path/to/train.jpg  &quot;title&quot;   )
+.
+&lt;p&gt;My &lt;img src=&quot;/path/to/train.jpg&quot; alt=&quot;foo bar&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo](&lt;url&gt;)
+.
+&lt;p&gt;&lt;img src=&quot;url&quot; alt=&quot;foo&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![](/url)
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>Reference-style:</p>
+<pre><code class=\\"language-example\\">![foo][bar]
+
+[bar]: /url
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![foo][bar]
+
+[BAR]: /url
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>Collapsed:</p>
+<pre><code class=\\"language-example\\">![foo][]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![*foo* bar][]
+
+[*foo* bar]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo bar&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>The labels are case-insensitive:</p>
+<pre><code class=\\"language-example\\">![Foo][]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;Foo&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>As with reference links, spaces, tabs, and line endings, are not allowed
+between the two sets of brackets:</p>
+<pre><code class=\\"language-example\\">![foo] 
+[]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo&quot; title=&quot;title&quot; /&gt;
+[]&lt;/p&gt;
+</code></pre>
+<p>Shortcut:</p>
+<pre><code class=\\"language-example\\">![foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">![*foo* bar]
+
+[*foo* bar]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;foo bar&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that link labels cannot contain unescaped brackets:</p>
+<pre><code class=\\"language-example\\">![[foo]]
+
+[[foo]]: /url &quot;title&quot;
+.
+&lt;p&gt;![[foo]]&lt;/p&gt;
+&lt;p&gt;[[foo]]: /url &amp;quot;title&amp;quot;&lt;/p&gt;
+</code></pre>
+<p>The link labels are case-insensitive:</p>
+<pre><code class=\\"language-example\\">![Foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;&lt;img src=&quot;/url&quot; alt=&quot;Foo&quot; title=&quot;title&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>If you just want a literal <code>!</code> followed by bracketed text, you can
+backslash-escape the opening <code>[</code>:</p>
+<pre><code class=\\"language-example\\">!\\\\[foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;![foo]&lt;/p&gt;
+</code></pre>
+<p>If you want a link after a literal <code>!</code>, backslash-escape the
+<code>!</code>:</p>
+<pre><code class=\\"language-example\\">\\\\![foo]
+
+[foo]: /url &quot;title&quot;
+.
+&lt;p&gt;!&lt;a href=&quot;/url&quot; title=&quot;title&quot;&gt;foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<h2>Autolinks</h2>
+<p><a href=\\"@\\">Autolink</a>s are absolute URIs and email addresses inside
+<code>&lt;</code> and <code>&gt;</code>. They are parsed as links, with the URL or email address
+as the link label.</p>
+<p>A <a href=\\"@\\">URI autolink</a> consists of <code>&lt;</code>, followed by an
+[absolute URI] followed by <code>&gt;</code>.  It is parsed as
+a link to the URI, with the URI as the link's label.</p>
+<p>An <a href=\\"@\\">absolute URI</a>,
+for these purposes, consists of a [scheme] followed by a colon (<code>:</code>)
+followed by zero or more characters other than [ASCII control
+characters][ASCII control character], [space], <code>&lt;</code>, and <code>&gt;</code>.
+If the URI includes these characters, they must be percent-encoded
+(e.g. <code>%20</code> for a space).</p>
+<p>For purposes of this spec, a <a href=\\"@\\">scheme</a> is any sequence
+of 2--32 characters beginning with an ASCII letter and followed
+by any combination of ASCII letters, digits, or the symbols plus
+(&quot;+&quot;), period (&quot;.&quot;), or hyphen (&quot;-&quot;).</p>
+<p>Here are some valid autolinks:</p>
+<pre><code class=\\"language-example\\">&lt;http://foo.bar.baz&gt;
+.
+&lt;p&gt;&lt;a href=&quot;http://foo.bar.baz&quot;&gt;http://foo.bar.baz&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean&gt;
+.
+&lt;p&gt;&lt;a href=&quot;https://foo.bar.baz/test?q=hello&amp;amp;id=22&amp;amp;boolean&quot;&gt;https://foo.bar.baz/test?q=hello&amp;amp;id=22&amp;amp;boolean&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;irc://foo.bar:2233/baz&gt;
+.
+&lt;p&gt;&lt;a href=&quot;irc://foo.bar:2233/baz&quot;&gt;irc://foo.bar:2233/baz&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Uppercase is also fine:</p>
+<pre><code class=\\"language-example\\">&lt;MAILTO:FOO@BAR.BAZ&gt;
+.
+&lt;p&gt;&lt;a href=&quot;MAILTO:FOO@BAR.BAZ&quot;&gt;MAILTO:FOO@BAR.BAZ&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Note that many strings that count as [absolute URIs] for
+purposes of this spec are not valid URIs, because their
+schemes are not registered or because of other problems
+with their syntax:</p>
+<pre><code class=\\"language-example\\">&lt;a+b+c:d&gt;
+.
+&lt;p&gt;&lt;a href=&quot;a+b+c:d&quot;&gt;a+b+c:d&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;made-up-scheme://foo,bar&gt;
+.
+&lt;p&gt;&lt;a href=&quot;made-up-scheme://foo,bar&quot;&gt;made-up-scheme://foo,bar&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;https://../&gt;
+.
+&lt;p&gt;&lt;a href=&quot;https://../&quot;&gt;https://../&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;localhost:5001/foo&gt;
+.
+&lt;p&gt;&lt;a href=&quot;localhost:5001/foo&quot;&gt;localhost:5001/foo&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Spaces are not allowed in autolinks:</p>
+<pre><code class=\\"language-example\\">&lt;https://foo.bar/baz bim&gt;
+.
+&lt;p&gt;&amp;lt;https://foo.bar/baz bim&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Backslash-escapes do not work inside autolinks:</p>
+<pre><code class=\\"language-example\\">&lt;https://example.com/\\\\[\\\\&gt;
+.
+&lt;p&gt;&lt;a href=&quot;https://example.com/%5C%5B%5C&quot;&gt;https://example.com/\\\\[\\\\&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>An <a href=\\"@\\">email autolink</a>
+consists of <code>&lt;</code>, followed by an [email address],
+followed by <code>&gt;</code>.  The link's label is the email address,
+and the URL is <code>mailto:</code> followed by the email address.</p>
+<p>An <a href=\\"@\\">email address</a>,
+for these purposes, is anything that matches
+the <a href=\\"https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email)\\">non-normative regex from the HTML5
+spec</a>:</p>
+<pre><code>/^[a-zA-Z0-9.!#$%&amp;'*+/=?^_\`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
+(?:\\\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+</code></pre>
+<p>Examples of email autolinks:</p>
+<pre><code class=\\"language-example\\">&lt;foo@bar.example.com&gt;
+.
+&lt;p&gt;&lt;a href=&quot;mailto:foo@bar.example.com&quot;&gt;foo@bar.example.com&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;foo+special@Bar.baz-bar0.com&gt;
+.
+&lt;p&gt;&lt;a href=&quot;mailto:foo+special@Bar.baz-bar0.com&quot;&gt;foo+special@Bar.baz-bar0.com&lt;/a&gt;&lt;/p&gt;
+</code></pre>
+<p>Backslash-escapes do not work inside email autolinks:</p>
+<pre><code class=\\"language-example\\">&lt;foo\\\\+@bar.example.com&gt;
+.
+&lt;p&gt;&amp;lt;foo+@bar.example.com&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>These are not autolinks:</p>
+<pre><code class=\\"language-example\\">&lt;&gt;
+.
+&lt;p&gt;&amp;lt;&amp;gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt; https://foo.bar &gt;
+.
+&lt;p&gt;&amp;lt; https://foo.bar &amp;gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;m:abc&gt;
+.
+&lt;p&gt;&amp;lt;m:abc&amp;gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;foo.bar.baz&gt;
+.
+&lt;p&gt;&amp;lt;foo.bar.baz&amp;gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">https://example.com
+.
+&lt;p&gt;https://example.com&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo@bar.example.com
+.
+&lt;p&gt;foo@bar.example.com&lt;/p&gt;
+</code></pre>
+<h2>Raw HTML</h2>
+<p>Text between <code>&lt;</code> and <code>&gt;</code> that looks like an HTML tag is parsed as a
+raw HTML tag and will be rendered in HTML without escaping.
+Tag and attribute names are not limited to current HTML tags,
+so custom tags (and even, say, DocBook tags) may be used.</p>
+<p>Here is the grammar for tags:</p>
+<p>A <a href=\\"@\\">tag name</a> consists of an ASCII letter
+followed by zero or more ASCII letters, digits, or
+hyphens (<code>-</code>).</p>
+<p>An <a href=\\"@\\">attribute</a> consists of spaces, tabs, and up to one line ending,
+an [attribute name], and an optional
+[attribute value specification].</p>
+<p>An <a href=\\"@\\">attribute name</a>
+consists of an ASCII letter, <code>_</code>, or <code>:</code>, followed by zero or more ASCII
+letters, digits, <code>_</code>, <code>.</code>, <code>:</code>, or <code>-</code>.  (Note:  This is the XML
+specification restricted to ASCII.  HTML5 is laxer.)</p>
+<p>An <a href=\\"@\\">attribute value specification</a>
+consists of optional spaces, tabs, and up to one line ending,
+a <code>=</code> character, optional spaces, tabs, and up to one line ending,
+and an [attribute value].</p>
+<p>An <a href=\\"@\\">attribute value</a>
+consists of an [unquoted attribute value],
+a [single-quoted attribute value], or a [double-quoted attribute value].</p>
+<p>An <a href=\\"@\\">unquoted attribute value</a>
+is a nonempty string of characters not
+including spaces, tabs, line endings, <code>&quot;</code>, <code>'</code>, <code>=</code>, <code>&lt;</code>, <code>&gt;</code>, or <code>\`</code>.</p>
+<p>A <a href=\\"@\\">single-quoted attribute value</a>
+consists of <code>'</code>, zero or more
+characters not including <code>'</code>, and a final <code>'</code>.</p>
+<p>A <a href=\\"@\\">double-quoted attribute value</a>
+consists of <code>&quot;</code>, zero or more
+characters not including <code>&quot;</code>, and a final <code>&quot;</code>.</p>
+<p>An <a href=\\"@\\">open tag</a> consists of a <code>&lt;</code> character, a [tag name],
+zero or more [attributes], optional spaces, tabs, and up to one line ending,
+an optional <code>/</code> character, and a <code>&gt;</code> character.</p>
+<p>A <a href=\\"@\\">closing tag</a> consists of the string <code>&lt;/</code>, a
+[tag name], optional spaces, tabs, and up to one line ending, and the character
+<code>&gt;</code>.</p>
+<p>An <a href=\\"@\\">HTML comment</a> consists of <code>&lt;!--&gt;</code>, <code>&lt;!---&gt;</code>, or  <code>&lt;!--</code>, a string of
+characters not including the string <code>--&gt;</code>, and <code>--&gt;</code> (see the
+<a href=\\"https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state\\">HTML spec</a>).</p>
+<p>A <a href=\\"@\\">processing instruction</a>
+consists of the string <code>&lt;?</code>, a string
+of characters not including the string <code>?&gt;</code>, and the string
+<code>?&gt;</code>.</p>
+<p>A <a href=\\"@\\">declaration</a> consists of the string <code>&lt;!</code>, an ASCII letter, zero or more
+characters not including the character <code>&gt;</code>, and the character <code>&gt;</code>.</p>
+<p>A <a href=\\"@\\">CDATA section</a> consists of
+the string <code>&lt;![CDATA[</code>, a string of characters not including the string
+<code>]]&gt;</code>, and the string <code>]]&gt;</code>.</p>
+<p>An <a href=\\"@\\">HTML tag</a> consists of an [open tag], a [closing tag],
+an [HTML comment], a [processing instruction], a [declaration],
+or a [CDATA section].</p>
+<p>Here are some simple open tags:</p>
+<pre><code class=\\"language-example\\">&lt;a&gt;&lt;bab&gt;&lt;c2c&gt;
+.
+&lt;p&gt;&lt;a&gt;&lt;bab&gt;&lt;c2c&gt;&lt;/p&gt;
+</code></pre>
+<p>Empty elements:</p>
+<pre><code class=\\"language-example\\">&lt;a/&gt;&lt;b2/&gt;
+.
+&lt;p&gt;&lt;a/&gt;&lt;b2/&gt;&lt;/p&gt;
+</code></pre>
+<p>Whitespace is allowed:</p>
+<pre><code class=\\"language-example\\">&lt;a  /&gt;&lt;b2
+data=&quot;foo&quot; &gt;
+.
+&lt;p&gt;&lt;a  /&gt;&lt;b2
+data=&quot;foo&quot; &gt;&lt;/p&gt;
+</code></pre>
+<p>With attributes:</p>
+<pre><code class=\\"language-example\\">&lt;a foo=&quot;bar&quot; bam = 'baz &lt;em&gt;&quot;&lt;/em&gt;'
+_boolean zoop:33=zoop:33 /&gt;
+.
+&lt;p&gt;&lt;a foo=&quot;bar&quot; bam = 'baz &lt;em&gt;&quot;&lt;/em&gt;'
+_boolean zoop:33=zoop:33 /&gt;&lt;/p&gt;
+</code></pre>
+<p>Custom tag names can be used:</p>
+<pre><code class=\\"language-example\\">Foo &lt;responsive-image src=&quot;foo.jpg&quot; /&gt;
+.
+&lt;p&gt;Foo &lt;responsive-image src=&quot;foo.jpg&quot; /&gt;&lt;/p&gt;
+</code></pre>
+<p>Illegal tag names, not parsed as HTML:</p>
+<pre><code class=\\"language-example\\">&lt;33&gt; &lt;__&gt;
+.
+&lt;p&gt;&amp;lt;33&amp;gt; &amp;lt;__&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Illegal attribute names:</p>
+<pre><code class=\\"language-example\\">&lt;a h*#ref=&quot;hi&quot;&gt;
+.
+&lt;p&gt;&amp;lt;a h*#ref=&amp;quot;hi&amp;quot;&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Illegal attribute values:</p>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;
+.
+&lt;p&gt;&amp;lt;a href=&amp;quot;hi'&amp;gt; &amp;lt;a href=hi'&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Illegal whitespace:</p>
+<pre><code class=\\"language-example\\">&lt; a&gt;&lt;
+foo&gt;&lt;bar/ &gt;
+&lt;foo bar=baz
+bim!bop /&gt;
+.
+&lt;p&gt;&amp;lt; a&amp;gt;&amp;lt;
+foo&amp;gt;&amp;lt;bar/ &amp;gt;
+&amp;lt;foo bar=baz
+bim!bop /&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Missing whitespace:</p>
+<pre><code class=\\"language-example\\">&lt;a href='bar'title=title&gt;
+.
+&lt;p&gt;&amp;lt;a href='bar'title=title&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Closing tags:</p>
+<pre><code class=\\"language-example\\">&lt;/a&gt;&lt;/foo &gt;
+.
+&lt;p&gt;&lt;/a&gt;&lt;/foo &gt;&lt;/p&gt;
+</code></pre>
+<p>Illegal attributes in closing tag:</p>
+<pre><code class=\\"language-example\\">&lt;/a href=&quot;foo&quot;&gt;
+.
+&lt;p&gt;&amp;lt;/a href=&amp;quot;foo&amp;quot;&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Comments:</p>
+<pre><code class=\\"language-example\\">foo &lt;!-- this is a --
+comment - with hyphens --&gt;
+.
+&lt;p&gt;foo &lt;!-- this is a --
+comment - with hyphens --&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo &lt;!--&gt; foo --&gt;
+
+foo &lt;!---&gt; foo --&gt;
+.
+&lt;p&gt;foo &lt;!--&gt; foo --&amp;gt;&lt;/p&gt;
+&lt;p&gt;foo &lt;!---&gt; foo --&amp;gt;&lt;/p&gt;
+</code></pre>
+<p>Processing instructions:</p>
+<pre><code class=\\"language-example\\">foo &lt;?php echo $a; ?&gt;
+.
+&lt;p&gt;foo &lt;?php echo $a; ?&gt;&lt;/p&gt;
+</code></pre>
+<p>Declarations:</p>
+<pre><code class=\\"language-example\\">foo &lt;!ELEMENT br EMPTY&gt;
+.
+&lt;p&gt;foo &lt;!ELEMENT br EMPTY&gt;&lt;/p&gt;
+</code></pre>
+<p>CDATA sections:</p>
+<pre><code class=\\"language-example\\">foo &lt;![CDATA[&gt;&amp;&lt;]]&gt;
+.
+&lt;p&gt;foo &lt;![CDATA[&gt;&amp;&lt;]]&gt;&lt;/p&gt;
+</code></pre>
+<p>Entity and numeric character references are preserved in HTML
+attributes:</p>
+<pre><code class=\\"language-example\\">foo &lt;a href=&quot;&amp;ouml;&quot;&gt;
+.
+&lt;p&gt;foo &lt;a href=&quot;&amp;ouml;&quot;&gt;&lt;/p&gt;
+</code></pre>
+<p>Backslash escapes do not work in HTML attributes:</p>
+<pre><code class=\\"language-example\\">foo &lt;a href=&quot;\\\\*&quot;&gt;
+.
+&lt;p&gt;foo &lt;a href=&quot;\\\\*&quot;&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;\\\\&quot;&quot;&gt;
+.
+&lt;p&gt;&amp;lt;a href=&amp;quot;&amp;quot;&amp;quot;&amp;gt;&lt;/p&gt;
+</code></pre>
+<h2>Hard line breaks</h2>
+<p>A line ending (not in a code span or HTML tag) that is preceded
+by two or more spaces and does not occur at the end of a block
+is parsed as a <a href=\\"@\\">hard line break</a> (rendered
+in HTML as a <code>&lt;br /&gt;</code> tag):</p>
+<pre><code class=\\"language-example\\">foo  
+baz
+.
+&lt;p&gt;foo&lt;br /&gt;
+baz&lt;/p&gt;
+</code></pre>
+<p>For a more visible alternative, a backslash before the
+[line ending] may be used instead of two or more spaces:</p>
+<pre><code class=\\"language-example\\">foo\\\\
+baz
+.
+&lt;p&gt;foo&lt;br /&gt;
+baz&lt;/p&gt;
+</code></pre>
+<p>More than two spaces can be used:</p>
+<pre><code class=\\"language-example\\">foo       
+baz
+.
+&lt;p&gt;foo&lt;br /&gt;
+baz&lt;/p&gt;
+</code></pre>
+<p>Leading spaces at the beginning of the next line are ignored:</p>
+<pre><code class=\\"language-example\\">foo  
+     bar
+.
+&lt;p&gt;foo&lt;br /&gt;
+bar&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo\\\\
+     bar
+.
+&lt;p&gt;foo&lt;br /&gt;
+bar&lt;/p&gt;
+</code></pre>
+<p>Hard line breaks can occur inside emphasis, links, and other constructs
+that allow inline content:</p>
+<pre><code class=\\"language-example\\">*foo  
+bar*
+.
+&lt;p&gt;&lt;em&gt;foo&lt;br /&gt;
+bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">*foo\\\\
+bar*
+.
+&lt;p&gt;&lt;em&gt;foo&lt;br /&gt;
+bar&lt;/em&gt;&lt;/p&gt;
+</code></pre>
+<p>Hard line breaks do not occur inside code spans</p>
+<pre><code class=\\"language-example\\">\`code  
+span\`
+.
+&lt;p&gt;&lt;code&gt;code   span&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">\`code\\\\
+span\`
+.
+&lt;p&gt;&lt;code&gt;code\\\\ span&lt;/code&gt;&lt;/p&gt;
+</code></pre>
+<p>or HTML tags:</p>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;foo  
+bar&quot;&gt;
+.
+&lt;p&gt;&lt;a href=&quot;foo  
+bar&quot;&gt;&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">&lt;a href=&quot;foo\\\\
+bar&quot;&gt;
+.
+&lt;p&gt;&lt;a href=&quot;foo\\\\
+bar&quot;&gt;&lt;/p&gt;
+</code></pre>
+<p>Hard line breaks are for separating inline content within a block.
+Neither syntax for hard line breaks works at the end of a paragraph or
+other block element:</p>
+<pre><code class=\\"language-example\\">foo\\\\
+.
+&lt;p&gt;foo\\\\&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">foo  
+.
+&lt;p&gt;foo&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">### foo\\\\
+.
+&lt;h3&gt;foo\\\\&lt;/h3&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">### foo  
+.
+&lt;h3&gt;foo&lt;/h3&gt;
+</code></pre>
+<h2>Soft line breaks</h2>
+<p>A regular line ending (not in a code span or HTML tag) that is not
+preceded by two or more spaces or a backslash is parsed as a
+<a href=\\"@\\">softbreak</a>.  (A soft line break may be rendered in HTML either as a
+[line ending] or as a space. The result will be the same in
+browsers. In the examples here, a [line ending] will be used.)</p>
+<pre><code class=\\"language-example\\">foo
+baz
+.
+&lt;p&gt;foo
+baz&lt;/p&gt;
+</code></pre>
+<p>Spaces at the end of the line and beginning of the next line are
+removed:</p>
+<pre><code class=\\"language-example\\">foo 
+ baz
+.
+&lt;p&gt;foo
+baz&lt;/p&gt;
+</code></pre>
+<p>A conforming parser may render a soft line break in HTML either as a
+line ending or as a space.</p>
+<p>A renderer may also provide an option to render soft line breaks
+as hard line breaks.</p>
+<h2>Textual content</h2>
+<p>Any characters not given an interpretation by the above rules will
+be parsed as plain textual content.</p>
+<pre><code class=\\"language-example\\">hello $.;'there
+.
+&lt;p&gt;hello $.;'there&lt;/p&gt;
+</code></pre>
+<pre><code class=\\"language-example\\">Foo χρῆν
+.
+&lt;p&gt;Foo χρῆν&lt;/p&gt;
+</code></pre>
+<p>Internal spaces are preserved verbatim:</p>
+<pre><code class=\\"language-example\\">Multiple     spaces
+.
+&lt;p&gt;Multiple     spaces&lt;/p&gt;
+</code></pre>
+<p>&lt;!-- END TESTS --&gt;</p>
+<h1>Appendix: A parsing strategy</h1>
+<p>In this appendix we describe some features of the parsing strategy
+used in the CommonMark reference implementations.</p>
+<h2>Overview</h2>
+<p>Parsing has two phases:</p>
+<ol>
+<li>
+<p>In the first phase, lines of input are consumed and the block
+structure of the document---its division into paragraphs, block quotes,
+list items, and so on---is constructed.  Text is assigned to these
+blocks but not parsed. Link reference definitions are parsed and a
+map of links is constructed.</p>
+</li>
+<li>
+<p>In the second phase, the raw text contents of paragraphs and headings
+are parsed into sequences of Markdown inline elements (strings,
+code spans, links, emphasis, and so on), using the map of link
+references constructed in phase 1.</p>
+</li>
+</ol>
+<p>At each point in processing, the document is represented as a tree of
+<strong>blocks</strong>.  The root of the tree is a <code>document</code> block.  The <code>document</code>
+may have any number of other blocks as <strong>children</strong>.  These children
+may, in turn, have other blocks as children.  The last child of a block
+is normally considered <strong>open</strong>, meaning that subsequent lines of input
+can alter its contents.  (Blocks that are not open are <strong>closed</strong>.)
+Here, for example, is a possible document tree, with the open blocks
+marked by arrows:</p>
+<pre><code class=\\"language-tree\\">-&gt; document
+  -&gt; block_quote
+       paragraph
+         &quot;Lorem ipsum dolor\\\\nsit amet.&quot;
+    -&gt; list (type=bullet tight=true bullet_char=-)
+         list_item
+           paragraph
+             &quot;Qui *quodsi iracundia*&quot;
+      -&gt; list_item
+        -&gt; paragraph
+             &quot;aliquando id&quot;
+</code></pre>
+<h2>Phase 1: block structure</h2>
+<p>Each line that is processed has an effect on this tree.  The line is
+analyzed and, depending on its contents, the document may be altered
+in one or more of the following ways:</p>
+<ol>
+<li>One or more open blocks may be closed.</li>
+<li>One or more new blocks may be created as children of the
+last open block.</li>
+<li>Text may be added to the last (deepest) open block remaining
+on the tree.</li>
+</ol>
+<p>Once a line has been incorporated into the tree in this way,
+it can be discarded, so input can be read in a stream.</p>
+<p>For each line, we follow this procedure:</p>
+<ol>
+<li>
+<p>First we iterate through the open blocks, starting with the
+root document, and descending through last children down to the last
+open block.  Each block imposes a condition that the line must satisfy
+if the block is to remain open.  For example, a block quote requires a
+<code>&gt;</code> character.  A paragraph requires a non-blank line.
+In this phase we may match all or just some of the open
+blocks.  But we cannot close unmatched blocks yet, because we may have a
+[lazy continuation line].</p>
+</li>
+<li>
+<p>Next, after consuming the continuation markers for existing
+blocks, we look for new block starts (e.g. <code>&gt;</code> for a block quote).
+If we encounter a new block start, we close any blocks unmatched
+in step 1 before creating the new block as a child of the last
+matched container block.</p>
+</li>
+<li>
+<p>Finally, we look at the remainder of the line (after block
+markers like <code>&gt;</code>, list markers, and indentation have been consumed).
+This is text that can be incorporated into the last open
+block (a paragraph, code block, heading, or raw HTML).</p>
+</li>
+</ol>
+<p>Setext headings are formed when we see a line of a paragraph
+that is a [setext heading underline].</p>
+<p>Reference link definitions are detected when a paragraph is closed;
+the accumulated text lines are parsed to see if they begin with
+one or more reference link definitions.  Any remainder becomes a
+normal paragraph.</p>
+<p>We can see how this works by considering how the tree above is
+generated by four lines of Markdown:</p>
+<pre><code class=\\"language-markdown\\">&gt; Lorem ipsum dolor
+sit amet.
+&gt; - Qui *quodsi iracundia*
+&gt; - aliquando id
+</code></pre>
+<p>At the outset, our document model is just</p>
+<pre><code class=\\"language-tree\\">-&gt; document
+</code></pre>
+<p>The first line of our text,</p>
+<pre><code class=\\"language-markdown\\">&gt; Lorem ipsum dolor
+</code></pre>
+<p>causes a <code>block_quote</code> block to be created as a child of our
+open <code>document</code> block, and a <code>paragraph</code> block as a child of
+the <code>block_quote</code>.  Then the text is added to the last open
+block, the <code>paragraph</code>:</p>
+<pre><code class=\\"language-tree\\">-&gt; document
+  -&gt; block_quote
+    -&gt; paragraph
+         &quot;Lorem ipsum dolor&quot;
+</code></pre>
+<p>The next line,</p>
+<pre><code class=\\"language-markdown\\">sit amet.
+</code></pre>
+<p>is a &quot;lazy continuation&quot; of the open <code>paragraph</code>, so it gets added
+to the paragraph's text:</p>
+<pre><code class=\\"language-tree\\">-&gt; document
+  -&gt; block_quote
+    -&gt; paragraph
+         &quot;Lorem ipsum dolor\\\\nsit amet.&quot;
+</code></pre>
+<p>The third line,</p>
+<pre><code class=\\"language-markdown\\">&gt; - Qui *quodsi iracundia*
+</code></pre>
+<p>causes the <code>paragraph</code> block to be closed, and a new <code>list</code> block
+opened as a child of the <code>block_quote</code>.  A <code>list_item</code> is also
+added as a child of the <code>list</code>, and a <code>paragraph</code> as a child of
+the <code>list_item</code>.  The text is then added to the new <code>paragraph</code>:</p>
+<pre><code class=\\"language-tree\\">-&gt; document
+  -&gt; block_quote
+       paragraph
+         &quot;Lorem ipsum dolor\\\\nsit amet.&quot;
+    -&gt; list (type=bullet tight=true bullet_char=-)
+      -&gt; list_item
+        -&gt; paragraph
+             &quot;Qui *quodsi iracundia*&quot;
+</code></pre>
+<p>The fourth line,</p>
+<pre><code class=\\"language-markdown\\">&gt; - aliquando id
+</code></pre>
+<p>causes the <code>list_item</code> (and its child the <code>paragraph</code>) to be closed,
+and a new <code>list_item</code> opened up as child of the <code>list</code>.  A <code>paragraph</code>
+is added as a child of the new <code>list_item</code>, to contain the text.
+We thus obtain the final tree:</p>
+<pre><code class=\\"language-tree\\">-&gt; document
+  -&gt; block_quote
+       paragraph
+         &quot;Lorem ipsum dolor\\\\nsit amet.&quot;
+    -&gt; list (type=bullet tight=true bullet_char=-)
+         list_item
+           paragraph
+             &quot;Qui *quodsi iracundia*&quot;
+      -&gt; list_item
+        -&gt; paragraph
+             &quot;aliquando id&quot;
+</code></pre>
+<h2>Phase 2: inline structure</h2>
+<p>Once all of the input has been parsed, all open blocks are closed.</p>
+<p>We then &quot;walk the tree,&quot; visiting every node, and parse raw
+string contents of paragraphs and headings as inlines.  At this
+point we have seen all the link reference definitions, so we can
+resolve reference links as we go.</p>
+<pre><code class=\\"language-tree\\">document
+  block_quote
+    paragraph
+      str &quot;Lorem ipsum dolor&quot;
+      softbreak
+      str &quot;sit amet.&quot;
+    list (type=bullet tight=true bullet_char=-)
+      list_item
+        paragraph
+          str &quot;Qui &quot;
+          emph
+            str &quot;quodsi iracundia&quot;
+      list_item
+        paragraph
+          str &quot;aliquando id&quot;
+</code></pre>
+<p>Notice how the [line ending] in the first paragraph has
+been parsed as a <code>softbreak</code>, and the asterisks in the first list item
+have become an <code>emph</code>.</p>
+<h3>An algorithm for parsing nested emphasis and links</h3>
+<p>By far the trickiest part of inline parsing is handling emphasis,
+strong emphasis, links, and images.  This is done using the following
+algorithm.</p>
+<p>When we're parsing inlines and we hit either</p>
+<ul>
+<li>a run of <code>*</code> or <code>_</code> characters, or</li>
+<li>a <code>[</code> or <code>![</code></li>
+</ul>
+<p>we insert a text node with these symbols as its literal content, and we
+add a pointer to this text node to the <a href=\\"@\\">delimiter stack</a>.</p>
+<p>The [delimiter stack] is a doubly linked list.  Each
+element contains a pointer to a text node, plus information about</p>
+<ul>
+<li>the type of delimiter (<code>[</code>, <code>![</code>, <code>*</code>, <code>_</code>)</li>
+<li>the number of delimiters,</li>
+<li>whether the delimiter is &quot;active&quot; (all are active to start), and</li>
+<li>whether the delimiter is a potential opener, a potential closer,
+or both (which depends on what sort of characters precede
+and follow the delimiters).</li>
+</ul>
+<p>When we hit a <code>]</code> character, we call the <em>look for link or image</em>
+procedure (see below).</p>
+<p>When we hit the end of the input, we call the <em>process emphasis</em>
+procedure (see below), with <code>stack_bottom</code> = NULL.</p>
+<h4><em>look for link or image</em></h4>
+<p>Starting at the top of the delimiter stack, we look backwards
+through the stack for an opening <code>[</code> or <code>![</code> delimiter.</p>
+<ul>
+<li>
+<p>If we don't find one, we return a literal text node <code>]</code>.</p>
+</li>
+<li>
+<p>If we do find one, but it's not <em>active</em>, we remove the inactive
+delimiter from the stack, and return a literal text node <code>]</code>.</p>
+</li>
+<li>
+<p>If we find one and it's active, then we parse ahead to see if
+we have an inline link/image, reference link/image, collapsed reference
+link/image, or shortcut reference link/image.</p>
+<ul>
+<li>
+<p>If we don't, then we remove the opening delimiter from the
+delimiter stack and return a literal text node <code>]</code>.</p>
+</li>
+<li>
+<p>If we do, then</p>
+<ul>
+<li>
+<p>We return a link or image node whose children are the inlines
+after the text node pointed to by the opening delimiter.</p>
+</li>
+<li>
+<p>We run <em>process emphasis</em> on these inlines, with the <code>[</code> opener
+as <code>stack_bottom</code>.</p>
+</li>
+<li>
+<p>We remove the opening delimiter.</p>
+</li>
+<li>
+<p>If we have a link (and not an image), we also set all
+<code>[</code> delimiters before the opening delimiter to <em>inactive</em>.  (This
+will prevent us from getting links within links.)</p>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h4><em>process emphasis</em></h4>
+<p>Parameter <code>stack_bottom</code> sets a lower bound to how far we
+descend in the [delimiter stack].  If it is NULL, we can
+go all the way to the bottom.  Otherwise, we stop before
+visiting <code>stack_bottom</code>.</p>
+<p>Let <code>current_position</code> point to the element on the [delimiter stack]
+just above <code>stack_bottom</code> (or the first element if <code>stack_bottom</code>
+is NULL).</p>
+<p>We keep track of the <code>openers_bottom</code> for each delimiter
+type (<code>*</code>, <code>_</code>), indexed to the length of the closing delimiter run
+(modulo 3) and to whether the closing delimiter can also be an
+opener.  Initialize this to <code>stack_bottom</code>.</p>
+<p>Then we repeat the following until we run out of potential
+closers:</p>
+<ul>
+<li>
+<p>Move <code>current_position</code> forward in the delimiter stack (if needed)
+until we find the first potential closer with delimiter <code>*</code> or <code>_</code>.
+(This will be the potential closer closest
+to the beginning of the input -- the first one in parse order.)</p>
+</li>
+<li>
+<p>Now, look back in the stack (staying above <code>stack_bottom</code> and
+the <code>openers_bottom</code> for this delimiter type) for the
+first matching potential opener (&quot;matching&quot; means same delimiter).</p>
+</li>
+<li>
+<p>If one is found:</p>
+<ul>
+<li>
+<p>Figure out whether we have emphasis or strong emphasis:
+if both closer and opener spans have length &gt;= 2, we have
+strong, otherwise regular.</p>
+</li>
+<li>
+<p>Insert an emph or strong emph node accordingly, after
+the text node corresponding to the opener.</p>
+</li>
+<li>
+<p>Remove any delimiters between the opener and closer from
+the delimiter stack.</p>
+</li>
+<li>
+<p>Remove 1 (for regular emph) or 2 (for strong emph) delimiters
+from the opening and closing text nodes.  If they become empty
+as a result, remove them and remove the corresponding element
+of the delimiter stack.  If the closing node is removed, reset
+<code>current_position</code> to the next element in the stack.</p>
+</li>
+</ul>
+</li>
+<li>
+<p>If none is found:</p>
+<ul>
+<li>
+<p>Set <code>openers_bottom</code> to the element before <code>current_position</code>.
+(We know that there are no openers for this kind of closer up to and
+including this point, so this puts a lower bound on future searches.)</p>
+</li>
+<li>
+<p>If the closer at <code>current_position</code> is not a potential opener,
+remove it from the delimiter stack (since we know it can't
+be a closer either).</p>
+</li>
+<li>
+<p>Advance <code>current_position</code> to the next element in the stack.</p>
+</li>
+</ul>
+</li>
+</ul>
+<p>After we're done, we remove all delimiters above <code>stack_bottom</code> from the
+delimiter stack.</p>
+",
+    }
+  }
+/>
+`;
+
 exports[`should never render html tags 1`] = `
 <div
   className="kbnMarkdown__body"

--- a/src/plugins/kibana_react/public/markdown/markdown.test.tsx
+++ b/src/plugins/kibana_react/public/markdown/markdown.test.tsx
@@ -8,11 +8,12 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-
+// @ts-expect-error
+import { text as specText } from 'commonmark-spec';
 import { Markdown } from './markdown';
 
-test('render', () => {
-  const component = shallow(<Markdown />);
+test('render will always match spec', () => {
+  const component = shallow(<Markdown markdown={specText} />);
   expect(component).toMatchSnapshot();
 });
 

--- a/src/plugins/kibana_react/public/markdown/markdown.test.tsx
+++ b/src/plugins/kibana_react/public/markdown/markdown.test.tsx
@@ -8,11 +8,10 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-// @ts-expect-error
 import { text as specText } from 'commonmark-spec';
 import { Markdown } from './markdown';
 
-test('render will always match spec', () => {
+test('renders consistently matches to spec', () => {
   const component = shallow(<Markdown markdown={specText} />);
   expect(component).toMatchSnapshot();
 });

--- a/typings/commonmark-spec/index.d.ts
+++ b/typings/commonmark-spec/index.d.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+declare module 'commonmark-spec' {
+  export const text: string;
+
+  export const tests: [];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14525,6 +14525,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+commonmark-spec@^0.31.2:
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/commonmark-spec/-/commonmark-spec-0.31.2.tgz#f53a6b147456fb3bf95ae5acfb915680c00f9f2b"
+  integrity sha512-vXKxmclzJPymhOJYD26G0oBjVmIcKC8p5m2DvHIq1A1btr1m0r0dT/PzRA5/nwxUbCAPedMNPEoiQE+zvuOcOw==
+
 compare-versions@3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.5.1.tgz#26e1f5cf0d48a77eced5046b9f67b6b61075a393"


### PR DESCRIPTION
## Summary

The migration that happened in PR https://github.com/elastic/kibana/pull/176478, introduced couple of bugs that were not caught at review time, especially given the existing test cases we had for the component and for the consumers did pass, which really was a false positive resulting in couple of SDH issues being raised and an emergency patch release. 

This PR aims to make it so that for any future update to markdown implementation in Kibana, we have tests that would raise an issue that might arise especially that it's quite difficult to account for every part of the markdown spec during PR reviews and even with testing manually. 

The [Markdown spec](https://github.com/commonmark/commonmark-spec) provided by the the commonmark project through the accompanying [npm package](https://www.npmjs.com/package/commonmark-spec) is being employed to help raise differences should they occur in the future.

This will also serve as a reference point for comparison for what markdown rendering output for the two existing markdown implementations in Kibana generates. it's also worth pointing out that we'd eventually want only one singular implementation, this will serve as a guide to facilitate that, especially in highlighting what changes to either implementation implies for Kibana.


### Risk Matrix

Introduces no risk

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
