### PR TITLE
Update general settings for apm config

### DIFF
--- a/x-pack/plugins/observability_solution/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/observability_solution/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -546,7 +546,7 @@ export const generalSettings: RawSettingDefinition[] = [
         'as it can lead to an explosion of transaction groups.\n' +
         'Take a look at the `transaction_name_groups` option on how to mitigate this problem by grouping URLs together.',
     }),
-    includeAgents: ['java'],
+    includeAgents: ['java', 'dotnet'],
   },
 
   {
@@ -565,6 +565,6 @@ export const generalSettings: RawSettingDefinition[] = [
         'such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`,\n' +
         'hence reducing the transaction name cardinality.',
     }),
-    includeAgents: ['java'],
+    includeAgents: ['java', 'dotnet']
   },
 ];

--- a/x-pack/plugins/observability_solution/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/observability_solution/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -565,6 +565,6 @@ export const generalSettings: RawSettingDefinition[] = [
         'such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`,\n' +
         'hence reducing the transaction name cardinality.',
     }),
-    includeAgents: ['java', 'dotnet']
+    includeAgents: ['java', 'dotnet'],
   },
 ];


### PR DESCRIPTION
## Summary

The updates the APM central config general settings to reflect that the .NET APM agent (next release) will support dynamic central configuration of `transaction_name_groups` and `use_path_as_transaction_name`.

### Checklist

Delete any items that are not applicable to this PR.

- N/A

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
