### PR TITLE
[Reporting] Fix soft disable reporting error

### DIFF
--- a/x-pack/plugins/reporting/common/errors/map_to_reporting_error.test.ts
+++ b/x-pack/plugins/reporting/common/errors/map_to_reporting_error.test.ts
@@ -11,6 +11,7 @@ import {
   BrowserUnexpectedlyClosedError,
   InvalidLayoutParametersError,
   UnknownError,
+  VisualReportingSoftDisabledError,
 } from '@kbn/reporting-common';
 import { mapToReportingError } from './map_to_reporting_error';
 import { errors } from '@kbn/screenshotting-plugin/common';
@@ -35,6 +36,33 @@ describe('mapToReportingError', () => {
     expect(mapToReportingError(new errors.FailedToSpawnBrowserError())).toBeInstanceOf(
       BrowserCouldNotLaunchError
     );
+    expect(
+      mapToReportingError(new errors.InsufficientMemoryAvailableOnCloudError())
+    ).toBeInstanceOf(VisualReportingSoftDisabledError);
+  });
+
+  test("Screenshoting errors shouldn't rely on instanceof", () => {
+    const createCustomError = (name: string) => {
+      const e = new Error('Test error msg');
+      e.name = name;
+      return e;
+    };
+
+    expect(mapToReportingError(createCustomError('InvalidLayoutParametersError'))).toBeInstanceOf(
+      InvalidLayoutParametersError
+    );
+    expect(mapToReportingError(createCustomError('BrowserClosedUnexpectedly'))).toBeInstanceOf(
+      BrowserUnexpectedlyClosedError
+    );
+    expect(mapToReportingError(createCustomError('FailedToCaptureScreenshot'))).toBeInstanceOf(
+      BrowserScreenshotError
+    );
+    expect(mapToReportingError(createCustomError('FailedToSpawnBrowserError'))).toBeInstanceOf(
+      BrowserCouldNotLaunchError
+    );
+    expect(
+      mapToReportingError(createCustomError('InsufficientMemoryAvailableOnCloudError'))
+    ).toBeInstanceOf(VisualReportingSoftDisabledError);
   });
 
   test('unknown error', () => {

--- a/x-pack/plugins/reporting/common/errors/map_to_reporting_error.ts
+++ b/x-pack/plugins/reporting/common/errors/map_to_reporting_error.ts
@@ -65,7 +65,8 @@ export function mapToReportingError(error: ExecutionError | unknown): ReportingE
     case error instanceof errors.PdfWorkerOutOfMemoryError ||
       errorName === 'PdfWorkerOutOfMemoryError':
       return new PdfWorkerOutOfMemoryError();
-    case error instanceof errors.InsufficientMemoryAvailableOnCloudError:
+    case error instanceof errors.InsufficientMemoryAvailableOnCloudError ||
+      errorName === 'InsufficientMemoryAvailableOnCloudError':
       return new VisualReportingSoftDisabledError();
   }
   return new UnknownError((error as Error)?.message);


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/179524

I think we got this regression when we moved reporting code around packages. 
I assume the `error instanceof errors.InsufficientMemoryAvailableOnCloudError` check doesn't work because the error was thrown in screenshoting plugin using its instance of `errors.InsufficientMemoryAvailableOnCloudError` but the check happens in reporting plugins using a different instance of `errors.InsufficientMemoryAvailableOnCloudError`. The fix is to check the error type by `name`, interesting that for other type of errors we already had `name` check in place 





<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->