### PR TITLE
[Infra] Add second-level navigation items to Kibana's global search

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/infra/public/plugin.ts
@@ -249,7 +249,7 @@ export class Plugin implements InfraClientPluginClass {
       hostsEnabled: boolean;
       metricsExplorerEnabled: boolean;
     }): AppDeepLink[] => {
-      const visibleIn: AppDeepLinkLocations[] = this.isServerlessEnv ? ['globalSearch'] : [];
+      const visibleIn: AppDeepLinkLocations[] = ['globalSearch'];
 
       return [
         {


### PR DESCRIPTION
Closes #176994

## Summary

This PR adds Hosts and Inventory to the global search (now not only in serverless)

![image](https://github.com/elastic/kibana/assets/14139027/1829b975-fcba-40c9-b7b2-4f03acf4d4b5)



