### PR TITLE
[DOCS] Adding a known issue for 8.13 and 8.12

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -144,6 +144,15 @@ For information about the {kib} 8.13.0 release, review the following information
 In Canvas, an empty text element incorrectly triggers a "Markdown content is required in [readOnly] mode" toast notification. For more information, refer to ({kibana-pull}179457[#179457]).
 ====
 
+[discrete]
+[[known-177938-8.13]]
+.Index templates UI incorrectly sets the `allow_auto_create` field to `false` by default.
+[%collapsible]
+====
+*Details* +
+If you are creating or editing an index template using the Index Templates form under the Index Management page, the `allow_auto_create` field is incorrectly set to `false` by default (the default value should be `undefined`). For more information, refer to ({kibana-issue}177938[#177938]).
+====
+
 [float]
 [[breaking-changes-8.13.0]]
 === Breaking changes
@@ -531,6 +540,19 @@ Security::
 == {kib} 8.12.0
 
 For information about the {kib} 8.12.0 release, review the following information.
+
+[float]
+[[known-issues-8.12.0]]
+=== Known issues
+
+[discrete]
+[[known-177938-8.12]]
+.Index templates UI incorrectly sets the `allow_auto_create` field to `false` by default.
+[%collapsible]
+====
+*Details* +
+If you are creating or editing an index template using the Index Templates form under the Index Management page, the `allow_auto_create` field is incorrectly set to `false` by default (the default value should be `undefined`). For more information, refer to ({kibana-issue}177938[#177938]).
+====
 
 [float]
 [[breaking-changes-8.12.0]]


### PR DESCRIPTION
## Summary

This PR adds a known issue to the 8.13 and 8.12 release notes regarding the `allow_auto_create` field incorrectly set to `false` in the Index Templates form.

<img width="769" alt="Screenshot 2024-04-17 at 08 14 02" src="https://github.com/elastic/kibana/assets/59341489/4bba4879-3522-4fb4-81de-8da34b8794fd">


Original issue: https://github.com/elastic/kibana/issues/177938
PR with a fix: https://github.com/elastic/kibana/pull/178321 (The PR was backported to 8.13 but unfortunately the build failed on the backport PR and we missed that. So the fix should come out in the next scheduled release, which is 8.14).


<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->