### PR TITLE
[Security Solution][Alert details] - update telemetry property to better reflect where the flyout is opened from

### DIFF
--- a/x-pack/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/index.tsx
@@ -83,7 +83,7 @@ const CaseContainerComponent: React.FC = () => {
           },
         });
         telemetry.reportDetailsFlyoutOpened({
-          tableId: TimelineId.casePage,
+          location: TimelineId.casePage,
           panel: 'right',
         });
       }

--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -122,7 +122,7 @@ const RowActionComponent = ({
         },
       });
       telemetry.reportDetailsFlyoutOpened({
-        tableId,
+        location: tableId,
         panel: 'right',
       });
     }

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/document_details/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/document_details/index.ts
@@ -11,7 +11,7 @@ import { TelemetryEventTypes } from '../../constants';
 export const DocumentDetailsFlyoutOpenedEvent: TelemetryEvent = {
   eventType: TelemetryEventTypes.DetailsFlyoutOpened,
   schema: {
-    tableId: {
+    location: {
       type: 'text',
       _meta: {
         description: 'Table ID',
@@ -31,7 +31,7 @@ export const DocumentDetailsFlyoutOpenedEvent: TelemetryEvent = {
 export const DocumentDetailsTabClickedEvent: TelemetryEvent = {
   eventType: TelemetryEventTypes.DetailsFlyoutTabClicked,
   schema: {
-    tableId: {
+    location: {
       type: 'text',
       _meta: {
         description: 'Table ID',

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/document_details/types.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/document_details/types.ts
@@ -9,12 +9,12 @@ import type { RootSchema } from '@kbn/analytics-client';
 import type { TelemetryEventTypes } from '../../constants';
 
 export interface ReportDetailsFlyoutOpenedParams {
-  tableId: string;
+  location: string;
   panel: 'left' | 'right' | 'preview';
 }
 
 export interface ReportDetailsFlyoutTabClickedParams {
-  tableId: string;
+  location: string;
   panel: 'left' | 'right';
   tabId: string;
 }

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/index.tsx
@@ -69,7 +69,7 @@ export const LeftPanel: FC<Partial<LeftPanelProps>> = memo(({ path }) => {
       },
     });
     telemetry.reportDetailsFlyoutTabClicked({
-      tableId: scopeId,
+      location: scopeId,
       panel: 'left',
       tabId,
     });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/tabs/insights_tab.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/tabs/insights_tab.tsx
@@ -117,7 +117,7 @@ export const InsightsTab: React.FC = memo(() => {
         },
       });
       telemetry.reportDetailsFlyoutTabClicked({
-        tableId: scopeId,
+        location: scopeId,
         panel: 'left',
         tabId: optionId,
       });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/alert_description.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/alert_description.tsx
@@ -59,7 +59,7 @@ export const AlertDescription: FC = () => {
       },
     });
     telemetry.reportDetailsFlyoutOpened({
-      tableId: scopeId,
+      location: scopeId,
       panel: 'preview',
     });
   }, [eventId, openPreviewPanel, indexName, scopeId, ruleId, telemetry]);

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/reason.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/reason.tsx
@@ -55,7 +55,7 @@ export const Reason: FC = () => {
       },
     });
     telemetry.reportDetailsFlyoutOpened({
-      tableId: scopeId,
+      location: scopeId,
       panel: 'preview',
     });
   }, [eventId, openPreviewPanel, indexName, scopeId, telemetry]);

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/index.tsx
@@ -65,7 +65,7 @@ export const RightPanel: FC<Partial<RightPanelProps>> = memo(({ path }) => {
     storage.set(FLYOUT_STORAGE_KEYS.RIGHT_PANEL_SELECTED_TABS, tabId);
 
     telemetry.reportDetailsFlyoutTabClicked({
-      tableId: scopeId,
+      location: scopeId,
       panel: 'right',
       tabId,
     });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/navigation.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/navigation.tsx
@@ -36,7 +36,7 @@ export const PanelNavigation: FC<PanelNavigationProps> = memo(({ flyoutIsExpanda
       },
     });
     telemetry.reportDetailsFlyoutOpened({
-      tableId: scopeId,
+      location: scopeId,
       panel: 'left',
     });
   }, [eventId, openLeftPanel, indexName, scopeId, telemetry]);


### PR DESCRIPTION
## Summary

We recently added telemetry for the expandable alert details flyout (see [this PR](https://github.com/elastic/kibana/pull/178683)). This work was merged and will be released as part of `8.14`. We just realized that there are more places where the flyout can be opened from, and some of them (like the Session Viewer) aren't tables. Therefore the `tableId` property that we were using is a little bit too restrictive.

This PR makes the smallest change to update `tableId` to `location` to be as generic as possible. 

### How to test

- add `telemetry.optIn: true` to `kibana.yaml` or `kibana.dev.yaml`
- interact with details flyout in data table (Alerts page, Host/User page, Cases Page)
- the data should be fed to staging every hour or so (see [this dashboard](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/dashboards#/view/093a84d0-dfec-11ee-8356-8b8a68fd8ef2?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-3d,to:now))))

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->