### PR TITLE
[Console] Allow persistent console to be resizable

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
@@ -38,24 +38,9 @@
     animation-duration: $euiAnimSpeedNormal;
     animation-timing-function: $euiAnimSlightResistance;
     animation-fill-mode: forwards;
-  }
-
-  &-isOpen.embeddableConsole--large {
-    animation-name: embeddableConsoleOpenPanelLarge;
-    height: $embeddableConsoleMaxHeight;
-    bottom: map-get($embeddableConsoleHeights, 'l') * -1;
-  }
-
-  &-isOpen.embeddableConsole--medium {
-    animation-name: embeddableConsoleOpenPanelMedium;
-    height: map-get($embeddableConsoleHeights, 'm');
-    bottom: map-get($embeddableConsoleHeights, 'm') * -1;
-  }
-
-  &-isOpen.embeddableConsole--small {
-    animation-name: embeddableConsoleOpenPanelSmall;
-    height: map-get($embeddableConsoleHeights, 's');
-    bottom: map-get($embeddableConsoleHeights, 's') * -1;
+    animation-name: embeddableConsoleOpenPanel;
+    height: var(--embedded-console-height);
+    bottom: var(--embedded-console-bottom);
   }
 }
 
@@ -132,34 +117,13 @@
   }
 }
 
-@keyframes embeddableConsoleOpenPanelLarge {
-  0% {
-    // Accounts for the initial height offset from the top
-    transform: translateY(calc((#{$embeddableConsoleInitialHeight} * 3) * -1));
-  }
-
-  100% {
-    transform: translateY(map-get($embeddableConsoleHeights, 'l') * -1);
-  }
-}
-
-@keyframes embeddableConsoleOpenPanelMedium {
+@keyframes embeddableConsoleOpenPanel {
   0% {
     transform: translateY(-$embeddableConsoleInitialHeight);
   }
 
   100% {
-    transform: translateY(map-get($embeddableConsoleHeights, 'm') * -1);
-  }
-}
-
-@keyframes embeddableConsoleOpenPanelSmall {
-  0% {
-    transform: translateY(-$embeddableConsoleInitialHeight);
-  }
-
-  100% {
-    transform: translateY(map-get($embeddableConsoleHeights, 's') * -1);
+    transform: translateY(var(--embedded-console-bottom));
   }
 }
 

--- a/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
@@ -65,7 +65,6 @@
 
   &--altViewButton-container {
     margin-left: auto;
-    // padding: $euiSizeS;
   }
 }
 

--- a/src/plugins/console/public/application/containers/embeddable/_variables.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_variables.scss
@@ -3,10 +3,3 @@ $embeddableConsoleText: lighten(makeHighContrastColor($euiColorLightestShade, $e
 $embeddableConsoleBorderColor: transparentize($euiColorGhost, .8);
 $embeddableConsoleInitialHeight: $euiSizeXXL;
 $embeddableConsoleMaxHeight: calc(100vh - var(--euiFixedHeadersOffset, 0));
-
-// Pixel heights ensure no blurriness caused by half pixel offsets
-$embeddableConsoleHeights: (
-  s: $euiSize * 30,
-  m: $euiSize * 50,
-  l: 100vh,
-);

--- a/src/plugins/console/public/application/containers/embeddable/console_resize_button.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_resize_button.tsx
@@ -55,6 +55,9 @@ export const EmbeddedConsoleResizeButton = ({
         setMaxConsoleHeight(newMaxConsoleHeight);
       }
       if (consoleHeight > newMaxConsoleHeight && newMaxConsoleHeight > CONSOLE_MIN_HEIGHT) {
+        // When the current console height is greater than the new max height,
+        // we resize the console to the max height. This will ensure there is not weird
+        // behavior with the drag resize.
         setConsoleHeight(newMaxConsoleHeight);
       }
     }
@@ -119,6 +122,13 @@ export const EmbeddedConsoleResizeButton = ({
     },
     [maxConsoleHeight, setConsoleHeight]
   );
+  const onResizeDoubleClick = useCallback(() => {
+    if (consoleHeight < maxConsoleHeight) {
+      setConsoleHeight(maxConsoleHeight);
+    } else {
+      setConsoleHeight(maxConsoleHeight / 2);
+    }
+  }, [consoleHeight, maxConsoleHeight, setConsoleHeight]);
 
   return (
     <EuiResizableButton
@@ -127,6 +137,7 @@ export const EmbeddedConsoleResizeButton = ({
       onMouseDown={onResizeMouseDown}
       onTouchStart={onResizeMouseDown}
       onKeyDown={onResizeKeyDown}
+      onDoubleClick={onResizeDoubleClick}
     />
   );
 };

--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -29,10 +29,9 @@ import {
   History,
   Settings,
   Storage,
-  createStorage,
   createHistory,
   createSettings,
-  setStorage,
+  getStorage,
 } from '../../../services';
 import { createUsageTracker } from '../../../services/tracker';
 import { MetricsTracker, EmbeddableConsoleDependencies } from '../../../types';
@@ -78,11 +77,7 @@ const loadDependencies = async (
 
   await loadActiveApi(core.http);
   const autocompleteInfo = getAutocompleteInfo();
-  const storage = createStorage({
-    engine: window.localStorage,
-    prefix: 'sense:',
-  });
-  setStorage(storage);
+  const storage = getStorage();
   const history = createHistory({ storage });
   const settings = createSettings({ storage });
   const objectStorageClient = localStorageObjectClient.create(storage);
@@ -107,7 +102,10 @@ const loadDependencies = async (
 };
 
 interface ConsoleWrapperProps
-  extends Omit<EmbeddableConsoleDependencies, 'setDispatch' | 'alternateView'> {
+  extends Omit<
+    EmbeddableConsoleDependencies,
+    'setDispatch' | 'alternateView' | 'setConsoleHeight' | 'getConsoleHeight'
+  > {
   onKeyDown: (this: Window, ev: WindowEventMap['keydown']) => any;
 }
 

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import useObservable from 'react-use/lib/useObservable';
 import {
@@ -17,12 +17,12 @@ import {
   EuiThemeProvider,
   EuiWindowEvent,
   keys,
+  useEuiThemeCSSVariables,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { dynamic } from '@kbn/shared-ux-utility';
 
 import {
-  EmbeddableConsoleProps,
   EmbeddableConsoleDependencies,
   EmbeddableConsoleView,
 } from '../../../types/embeddable_console';
@@ -33,6 +33,7 @@ import { setLoadFromParameter, removeLoadFromParameter } from '../../lib/load_fr
 import './_index.scss';
 
 const KBN_BODY_CONSOLE_CLASS = 'kbnBody--hasEmbeddableConsole';
+const CONSOLE_MIN_HEIGHT = 480;
 
 const landmarkHeading = i18n.translate('console.embeddableConsole.landmarkHeading', {
   defaultMessage: 'Developer console',
@@ -43,13 +44,14 @@ const ConsoleWrapper = dynamic(async () => ({
 }));
 
 export const EmbeddableConsole = ({
-  size = 'm',
   core,
   usageCollection,
   setDispatch,
   alternateView,
   isMonacoEnabled,
-}: EmbeddableConsoleProps & EmbeddableConsoleDependencies) => {
+}: EmbeddableConsoleDependencies) => {
+  const [consoleHeight, setConsoleHeight] = useState<number>(800);
+  const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
   const [consoleState, consoleDispatch] = useReducer(
     store.reducer,
     store.initialValue,
@@ -71,6 +73,12 @@ export const EmbeddableConsole = ({
     document.body.classList.add(KBN_BODY_CONSOLE_CLASS);
     return () => document.body.classList.remove(KBN_BODY_CONSOLE_CLASS);
   }, []);
+  useEffect(() => {
+    setGlobalCSSVariables({
+      '--embedded-console-height': `${consoleHeight}px`,
+      '--embedded-console-bottom': `-${consoleHeight}px`,
+    });
+  }, [consoleHeight, setGlobalCSSVariables]);
 
   const isOpen = consoleState.view !== EmbeddableConsoleView.Closed;
   const showConsole =
@@ -105,14 +113,10 @@ export const EmbeddableConsole = ({
 
   const classes = classNames('embeddableConsole', {
     'embeddableConsole-isOpen': isOpen,
-    'embeddableConsole--large': size === 'l',
-    'embeddableConsole--medium': size === 'm',
-    'embeddableConsole--small': size === 's',
     'embeddableConsole--classicChrome': chromeStyle === 'classic',
     'embeddableConsole--projectChrome': chromeStyle === 'project',
     'embeddableConsole--unknownChrome': chromeStyle === undefined,
     'embeddableConsole--fixed': true,
-    'embeddableConsole--showOnMobile': false,
   });
 
   return (

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -31,9 +31,11 @@ import * as store from '../../stores/embeddable_console';
 import { setLoadFromParameter, removeLoadFromParameter } from '../../lib/load_from';
 
 import './_index.scss';
+import { EmbeddedConsoleResizeButton } from './console_resize_button';
 
 const KBN_BODY_CONSOLE_CLASS = 'kbnBody--hasEmbeddableConsole';
-const CONSOLE_MIN_HEIGHT = 480;
+const DEFAULT_CONSOLE_HEIGHT = '600';
+const CONSOLE_HEIGHT_STORAGE_KEY = 'sense:embeddedConsoleHeight';
 
 const landmarkHeading = i18n.translate('console.embeddableConsole.landmarkHeading', {
   defaultMessage: 'Developer console',
@@ -50,8 +52,11 @@ export const EmbeddableConsole = ({
   alternateView,
   isMonacoEnabled,
 }: EmbeddableConsoleDependencies) => {
-  const [consoleHeight, setConsoleHeight] = useState<number>(800);
   const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
+  const [consoleHeight, setConsoleHeight] = useState<number>(
+    parseInt(localStorage.getItem(CONSOLE_HEIGHT_STORAGE_KEY) ?? DEFAULT_CONSOLE_HEIGHT, 10)
+  );
+
   const [consoleState, consoleDispatch] = useReducer(
     store.reducer,
     store.initialValue,
@@ -78,6 +83,7 @@ export const EmbeddableConsole = ({
       '--embedded-console-height': `${consoleHeight}px`,
       '--embedded-console-bottom': `-${consoleHeight}px`,
     });
+    localStorage.setItem(CONSOLE_HEIGHT_STORAGE_KEY, consoleHeight.toString());
   }, [consoleHeight, setGlobalCSSVariables]);
 
   const isOpen = consoleState.view !== EmbeddableConsoleView.Closed;
@@ -131,27 +137,36 @@ export const EmbeddableConsole = ({
             <h2>{landmarkHeading}</h2>
           </EuiScreenReaderOnly>
           <EuiThemeProvider colorMode={'dark'} wrapperProps={{ cloneElement: true }}>
-            <div className="embeddableConsole__controls">
-              <EuiButtonEmpty
-                color="text"
-                iconType={isOpen ? 'arrowUp' : 'arrowDown'}
-                onClick={toggleConsole}
-                className="embeddableConsole__controls--button"
-                data-test-subj="consoleEmbeddedControlBar"
-                data-telemetry-id="console-embedded-controlbar-button"
-              >
-                {i18n.translate('console.embeddableConsole.title', {
-                  defaultMessage: 'Console',
-                })}
-              </EuiButtonEmpty>
-              {alternateView && (
-                <div className="embeddableConsole__controls--altViewButton-container">
-                  <alternateView.ActivationButton
-                    activeView={showAlternateView}
-                    onClick={clickAlternateViewActivateButton}
-                  />
-                </div>
+            <div>
+              {isOpen && (
+                <EmbeddedConsoleResizeButton
+                  consoleHeight={consoleHeight}
+                  setConsoleHeight={setConsoleHeight}
+                />
               )}
+
+              <div className="embeddableConsole__controls">
+                <EuiButtonEmpty
+                  color="text"
+                  iconType={isOpen ? 'arrowUp' : 'arrowDown'}
+                  onClick={toggleConsole}
+                  className="embeddableConsole__controls--button"
+                  data-test-subj="consoleEmbeddedControlBar"
+                  data-telemetry-id="console-embedded-controlbar-button"
+                >
+                  {i18n.translate('console.embeddableConsole.title', {
+                    defaultMessage: 'Console',
+                  })}
+                </EuiButtonEmpty>
+                {alternateView && (
+                  <div className="embeddableConsole__controls--altViewButton-container">
+                    <alternateView.ActivationButton
+                      activeView={showAlternateView}
+                      onClick={clickAlternateViewActivateButton}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </EuiThemeProvider>
           {showConsole ? (

--- a/src/plugins/console/public/application/containers/embeddable/index.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/index.tsx
@@ -8,12 +8,9 @@
 
 import { dynamic } from '@kbn/shared-ux-utility';
 import React from 'react';
-import {
-  EmbeddableConsoleProps,
-  EmbeddableConsoleDependencies,
-} from '../../../types/embeddable_console';
+import { EmbeddableConsoleDependencies } from '../../../types/embeddable_console';
 
-type EmbeddableConsoleInternalProps = EmbeddableConsoleProps & EmbeddableConsoleDependencies;
+type EmbeddableConsoleInternalProps = EmbeddableConsoleDependencies;
 const Console = dynamic(async () => ({
   default: (await import('./embeddable_console')).EmbeddableConsole,
 }));

--- a/src/plugins/console/public/index.ts
+++ b/src/plugins/console/public/index.ts
@@ -17,7 +17,6 @@ export type {
   ConsoleUILocatorParams,
   ConsolePluginSetup,
   ConsolePluginStart,
-  EmbeddableConsoleProps,
   EmbeddedConsoleView,
   EmbeddedConsoleViewButtonProps,
 } from './types';

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -18,7 +18,6 @@ import {
   ConsolePluginSetup,
   ConsolePluginStart,
   ConsoleUILocatorParams,
-  EmbeddableConsoleProps,
   EmbeddedConsoleView,
 } from './types';
 import { AutocompleteInfo, setAutocompleteInfo, EmbeddableConsoleInfo } from './services';
@@ -126,9 +125,8 @@ export class ConsoleUIPlugin
       embeddedConsoleUiSetting;
 
     if (embeddedConsoleAvailable) {
-      consoleStart.EmbeddableConsole = (props: EmbeddableConsoleProps) => {
+      consoleStart.EmbeddableConsole = (_props: {}) => {
         return EmbeddableConsole({
-          ...props,
           core,
           usageCollection: deps.usageCollection,
           setDispatch: (d) => {

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -20,15 +20,28 @@ import {
   ConsoleUILocatorParams,
   EmbeddedConsoleView,
 } from './types';
-import { AutocompleteInfo, setAutocompleteInfo, EmbeddableConsoleInfo } from './services';
+import {
+  AutocompleteInfo,
+  setAutocompleteInfo,
+  EmbeddableConsoleInfo,
+  createStorage,
+  setStorage,
+} from './services';
 
 export class ConsoleUIPlugin
   implements Plugin<ConsolePluginSetup, ConsolePluginStart, AppSetupUIPluginDependencies>
 {
   private readonly autocompleteInfo = new AutocompleteInfo();
-  private _embeddableConsole: EmbeddableConsoleInfo = new EmbeddableConsoleInfo();
+  private _embeddableConsole: EmbeddableConsoleInfo;
 
-  constructor(private ctx: PluginInitializerContext) {}
+  constructor(private ctx: PluginInitializerContext) {
+    const storage = createStorage({
+      engine: window.localStorage,
+      prefix: 'sense:',
+    });
+    setStorage(storage);
+    this._embeddableConsole = new EmbeddableConsoleInfo(storage);
+  }
 
   public setup(
     { notifications, getStartServices, http }: CoreSetup,
@@ -134,6 +147,8 @@ export class ConsoleUIPlugin
           },
           alternateView: this._embeddableConsole.alternateView,
           isMonacoEnabled,
+          getConsoleHeight: this._embeddableConsole.getConsoleHeight.bind(this._embeddableConsole),
+          setConsoleHeight: this._embeddableConsole.setConsoleHeight.bind(this._embeddableConsole),
         });
       };
       consoleStart.isEmbeddedConsoleAvailable = () =>

--- a/src/plugins/console/public/services/embeddable_console.test.ts
+++ b/src/plugins/console/public/services/embeddable_console.test.ts
@@ -10,6 +10,8 @@ import { StorageMock } from './storage.mock';
 import { EmbeddableConsoleInfo } from './embeddable_console';
 
 describe('EmbeddableConsoleInfo', () => {
+  jest.useFakeTimers();
+
   let eConsole: EmbeddableConsoleInfo;
   let storage: StorageMock;
   beforeEach(() => {
@@ -65,8 +67,15 @@ describe('EmbeddableConsoleInfo', () => {
     });
   });
   describe('setConsoleHeight', () => {
-    it('stores value  in storage', () => {
+    it('stores value in storage', () => {
+      // setConsoleHeight calls are debounced
+      eConsole.setConsoleHeight('120');
+      eConsole.setConsoleHeight('110');
       eConsole.setConsoleHeight('100');
+
+      jest.runAllTimers();
+
+      expect(storage.set).toHaveBeenCalledTimes(1);
       expect(storage.set).toHaveBeenCalledWith('embeddedConsoleHeight', '100');
     });
   });

--- a/src/plugins/console/public/services/embeddable_console.test.ts
+++ b/src/plugins/console/public/services/embeddable_console.test.ts
@@ -6,12 +6,15 @@
  * Side Public License, v 1.
  */
 
+import { StorageMock } from './storage.mock';
 import { EmbeddableConsoleInfo } from './embeddable_console';
 
 describe('EmbeddableConsoleInfo', () => {
   let eConsole: EmbeddableConsoleInfo;
+  let storage: StorageMock;
   beforeEach(() => {
-    eConsole = new EmbeddableConsoleInfo();
+    storage = new StorageMock({} as unknown as Storage, 'test');
+    eConsole = new EmbeddableConsoleInfo(storage);
   });
   describe('isEmbeddedConsoleAvailable', () => {
     it('returns true if dispatch has been set', () => {
@@ -48,6 +51,23 @@ describe('EmbeddableConsoleInfo', () => {
         type: 'open',
         payload: { content: 'GET /_cat/_indices' },
       });
+    });
+  });
+  describe('getConsoleHeight', () => {
+    it('returns value in storage when found', () => {
+      storage.get.mockReturnValue('201');
+      expect(eConsole.getConsoleHeight()).toEqual('201');
+      expect(storage.get).toHaveBeenCalledWith('embeddedConsoleHeight', undefined);
+    });
+    it('returns undefined when not found', () => {
+      storage.get.mockReturnValue(undefined);
+      expect(eConsole.getConsoleHeight()).toEqual(undefined);
+    });
+  });
+  describe('setConsoleHeight', () => {
+    it('stores value  in storage', () => {
+      eConsole.setConsoleHeight('100');
+      expect(storage.set).toHaveBeenCalledWith('embeddedConsoleHeight', '100');
     });
   });
 });

--- a/src/plugins/console/public/services/embeddable_console.ts
+++ b/src/plugins/console/public/services/embeddable_console.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import type { Dispatch } from 'react';
+import { debounce } from 'lodash';
 
 import {
   EmbeddedConsoleAction as EmbeddableConsoleAction,
@@ -14,12 +15,18 @@ import {
 import { Storage } from '.';
 
 const CONSOLE_HEIGHT_KEY = 'embeddedConsoleHeight';
+const CONSOLE_HEIGHT_LOCAL_STORAGE_DEBOUNCE_WAIT_TIME = 500;
 
 export class EmbeddableConsoleInfo {
   private _dispatch: Dispatch<EmbeddableConsoleAction> | null = null;
   private _alternateView: EmbeddedConsoleView | undefined;
 
-  constructor(private readonly storage: Storage) {}
+  constructor(private readonly storage: Storage) {
+    this.setConsoleHeight = debounce(
+      this.setConsoleHeight.bind(this),
+      CONSOLE_HEIGHT_LOCAL_STORAGE_DEBOUNCE_WAIT_TIME
+    );
+  }
 
   public get alternateView(): EmbeddedConsoleView | undefined {
     return this._alternateView;

--- a/src/plugins/console/public/services/embeddable_console.ts
+++ b/src/plugins/console/public/services/embeddable_console.ts
@@ -11,10 +11,15 @@ import {
   EmbeddedConsoleAction as EmbeddableConsoleAction,
   EmbeddedConsoleView,
 } from '../types/embeddable_console';
+import { Storage } from '.';
+
+const CONSOLE_HEIGHT_KEY = 'embeddedConsoleHeight';
 
 export class EmbeddableConsoleInfo {
   private _dispatch: Dispatch<EmbeddableConsoleAction> | null = null;
   private _alternateView: EmbeddedConsoleView | undefined;
+
+  constructor(private readonly storage: Storage) {}
 
   public get alternateView(): EmbeddedConsoleView | undefined {
     return this._alternateView;
@@ -37,5 +42,13 @@ export class EmbeddableConsoleInfo {
 
   public registerAlternateView(view: EmbeddedConsoleView | null) {
     this._alternateView = view ?? undefined;
+  }
+
+  public getConsoleHeight(): string | undefined {
+    return this.storage.get(CONSOLE_HEIGHT_KEY, undefined);
+  }
+
+  public setConsoleHeight(value: string) {
+    this.storage.set(CONSOLE_HEIGHT_KEY, value);
   }
 }

--- a/src/plugins/console/public/types/embeddable_console.ts
+++ b/src/plugins/console/public/types/embeddable_console.ts
@@ -16,6 +16,8 @@ export interface EmbeddableConsoleDependencies {
   setDispatch: (dispatch: Dispatch<EmbeddedConsoleAction> | null) => void;
   alternateView?: EmbeddedConsoleView;
   isMonacoEnabled: boolean;
+  getConsoleHeight: () => string | undefined;
+  setConsoleHeight: (value: string) => void;
 }
 
 export type EmbeddedConsoleAction =

--- a/src/plugins/console/public/types/embeddable_console.ts
+++ b/src/plugins/console/public/types/embeddable_console.ts
@@ -10,16 +10,6 @@ import type { CoreStart } from '@kbn/core/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { Dispatch } from 'react';
 
-/**
- * EmbeddableConsoleProps are optional props used when rendering the embeddable developer console.
- */
-export interface EmbeddableConsoleProps {
-  /**
-   * The default height of the content area.
-   */
-  size?: 's' | 'm' | 'l';
-}
-
 export interface EmbeddableConsoleDependencies {
   core: CoreStart;
   usageCollection?: UsageCollectionStart;

--- a/src/plugins/console/public/types/plugin_dependencies.ts
+++ b/src/plugins/console/public/types/plugin_dependencies.ts
@@ -13,7 +13,7 @@ import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collectio
 import { SharePluginSetup, SharePluginStart, LocatorPublic } from '@kbn/share-plugin/public';
 
 import { ConsoleUILocatorParams } from './locator';
-import { EmbeddableConsoleProps, EmbeddedConsoleView } from './embeddable_console';
+import { EmbeddedConsoleView } from './embeddable_console';
 
 export interface AppSetupUIPluginDependencies {
   home?: HomePublicPluginSetup;
@@ -55,7 +55,7 @@ export interface ConsolePluginStart {
   /**
    * EmbeddableConsole is a functional component used to render a portable version of the dev tools console on any page in Kibana
    */
-  EmbeddableConsole?: FC<EmbeddableConsoleProps>;
+  EmbeddableConsole?: FC<{}>;
   /**
    * Register an alternate view for the Embedded Console
    *


### PR DESCRIPTION
## Summary

Updates the Persistent console to be resizable by the user using an `EuiResizableButton` at the top of the console flyout. 

- Persistent console now defaults to the maximum size for the window
- Top of console can be dragged to resize
- On resize console size is saved to local storage and used as default
- Double-clicking resize border will maximize console, or set it to 50% height if currently at the max height.

https://github.com/elastic/kibana/assets/1972968/46c8da24-56c8-4bda-82f9-f9498ec209a0





<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->