### PR TITLE
[chore] bump chromedriver to 123

### DIFF
--- a/package.json
+++ b/package.json
@@ -1555,7 +1555,7 @@
     "buildkite-test-collector": "^1.7.0",
     "callsites": "^3.1.0",
     "chance": "1.0.18",
-    "chromedriver": "^122.0.5",
+    "chromedriver": "^123.0.3",
     "clean-webpack-plugin": "^3.0.0",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13554,10 +13554,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^122.0.5:
-  version "122.0.5"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-122.0.5.tgz#7edb2bcd47f7b6afd8f44e680a77b115d5eb6040"
-  integrity sha512-5WkCY4ioJZ1Qna6KWqPSrIz1MwGh6tHW7F67XTSbZn/GaMJrpiuy6b5c1BetrddSax+NX8u4tg4l3Wy1THecLQ==
+chromedriver@^123.0.3:
+  version "123.0.3"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-123.0.3.tgz#40f9223373cbdf8f849e118507b24b0de8ecb21a"
+  integrity sha512-35IeTqDLcVR0htF9nD/Lh+g24EG088WHVKXBXiFyWq+2lelnoM0B3tKTBiUEjLng0GnELI4QyQPFK7i97Fz1fQ==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.6.7"


### PR DESCRIPTION
## Summary

Updating chromedriver to support running tests on Chrome v124