### PR TITLE
[Fleet] Fix cancel action in log level select

### DIFF
--- a/x-pack/plugins/fleet/common/settings/agent_policy_settings.ts
+++ b/x-pack/plugins/fleet/common/settings/agent_policy_settings.ts
@@ -137,12 +137,13 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     description: i18n.translate(
       'xpack.fleet.settings.agentPolicyAdvanced.agentLoggingLevelDescription',
       {
-        defaultMessage: 'Set the Agent log level. The default log level is "info".',
+        defaultMessage:
+          'Sets the log level for all the agents on the policy. The default log level is "info"',
       }
     ),
     api_field: {
       name: 'agent_logging_level',
     },
-    schema: z.nativeEnum(agentLoggingLevels),
+    schema: z.nativeEnum(agentLoggingLevels).default(agentLoggingLevels.Info),
   },
 ];

--- a/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/index.tsx
@@ -66,7 +66,7 @@ settingComponentRegistry.set(ZodFirstPartyTypeKind.ZodNativeEnum, (settingsConfi
     <SettingsFieldWrapper
       settingsConfig={settingsConfig}
       typeName={ZodFirstPartyTypeKind.ZodString}
-      renderItem={({ fieldKey, fieldValue, handleChange, coercedSchema }: any) => (
+      renderItem={({ fieldKey, fieldValue, handleChange }: any) => (
         <EuiSelect
           data-test-subj={fieldKey}
           value={fieldValue}

--- a/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/index.tsx
@@ -72,10 +72,12 @@ settingComponentRegistry.set(ZodFirstPartyTypeKind.ZodNativeEnum, (settingsConfi
           value={fieldValue}
           fullWidth
           onChange={handleChange}
-          options={Object.keys(coercedSchema.enum).map((level) => ({
-            text: level,
-            value: coercedSchema.enum[level],
-          }))}
+          options={Object.entries(settingsConfig.schema._def.innerType._def.values).map(
+            ([key, value]) => ({
+              text: key,
+              value: value as string,
+            })
+          )}
         />
       )}
     />

--- a/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/settings_field_wrapper.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/settings_field_wrapper.tsx
@@ -76,9 +76,11 @@ export const SettingsFieldWrapper: React.FC<{
       description={
         <>
           {settingsConfig.description}.{' '}
-          <EuiLink href={settingsConfig.learnMoreLink} external>
-            Learn more.
-          </EuiLink>
+          {settingsConfig.learnMoreLink && (
+            <EuiLink href={settingsConfig.learnMoreLink} external>
+              Learn more.
+            </EuiLink>
+          )}
         </>
       }
     >


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana/issues/158861
https://github.com/elastic/kibana/pull/180607 added a new log level selector in Agent Policy settings. However there were some small bugs with it. This PR addresses all of them:

- Extra dot in copy text
- A broken link was displayed - Made this link optional
- When clicking "Cancel", all the other fields on the page reset back to their original values but the log level doesn't. The reason is the no default was set for the select

### Before
![image (19)](https://github.com/elastic/kibana/assets/16084106/bc310642-5425-4413-8cfa-aff03557f2eb)

### After
![Screenshot 2024-04-17 at 10 50 04](https://github.com/elastic/kibana/assets/16084106/30fc6797-7297-496e-9ec7-209e04a44bba)


### Testing 
- Enable `hidden: false` [here](https://github.com/elastic/kibana/blob/bc9cd862f04430f4e50e7da2a11f16bc80756e9c/x-pack/plugins/fleet/common/settings/agent_policy_settings.ts#L133)
- Change the log level and then click "cancel" on the bottom of the page, it should reset back to the default value ("info" if the policy is new, the previous saved value if the policy already had this value set)
- No extra dot and link should be visible
