### PR TITLE
[8.13] [chore] bump chromedriver to 123 (#181002)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1527,7 +1527,7 @@
     "blob-polyfill": "^7.0.20220408",
     "callsites": "^3.1.0",
     "chance": "1.0.18",
-    "chromedriver": "^122.0.5",
+    "chromedriver": "^123.0.3",
     "clean-webpack-plugin": "^3.0.0",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13273,10 +13273,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^122.0.5:
-  version "122.0.5"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-122.0.5.tgz#7edb2bcd47f7b6afd8f44e680a77b115d5eb6040"
-  integrity sha512-5WkCY4ioJZ1Qna6KWqPSrIz1MwGh6tHW7F67XTSbZn/GaMJrpiuy6b5c1BetrddSax+NX8u4tg4l3Wy1THecLQ==
+chromedriver@^123.0.3:
+  version "123.0.3"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-123.0.3.tgz#40f9223373cbdf8f849e118507b24b0de8ecb21a"
+  integrity sha512-35IeTqDLcVR0htF9nD/Lh+g24EG088WHVKXBXiFyWq+2lelnoM0B3tKTBiUEjLng0GnELI4QyQPFK7i97Fz1fQ==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.6.7"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[chore] bump chromedriver to 123 (#181002)](https://github.com/elastic/kibana/pull/181002)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-04-17T09:28:37Z","message":"[chore] bump chromedriver to 123 (#181002)\n\n## Summary\r\n\r\nUpdating chromedriver to support running tests on Chrome v124","sha":"5942fb9fefcc9efd6e9cf2ba902d17cb47ef04de","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","FTR","v8.14.0","v7.17.21","v8.13.3"],"number":181002,"url":"https://github.com/elastic/kibana/pull/181002","mergeCommit":{"message":"[chore] bump chromedriver to 123 (#181002)\n\n## Summary\r\n\r\nUpdating chromedriver to support running tests on Chrome v124","sha":"5942fb9fefcc9efd6e9cf2ba902d17cb47ef04de"}},"sourceBranch":"main","suggestedTargetBranches":["7.17","8.13"],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181002","number":181002,"mergeCommit":{"message":"[chore] bump chromedriver to 123 (#181002)\n\n## Summary\r\n\r\nUpdating chromedriver to support running tests on Chrome v124","sha":"5942fb9fefcc9efd6e9cf2ba902d17cb47ef04de"}},{"branch":"7.17","label":"v7.17.21","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.13","label":"v8.13.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->