### PR TITLE
[SLOs] Group by remote cluster, display remote cluster name instead of index

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
@@ -60,6 +60,22 @@ export function GroupListView({
   if (groupBy === 'slo.indicator.type') {
     groupName = SLI_OPTIONS.find((option) => option.value === group)?.text ?? group;
   }
+  if (groupBy === '_index') {
+    // get remote cluster name from index name
+    if (groupName.includes(':.')) {
+      const [remoteClusterName] = groupName.split(':.');
+      groupName = i18n.translate('xpack.slo.group.remoteCluster', {
+        defaultMessage: 'Remote Cluster: {remoteClusterName}',
+        values: {
+          remoteClusterName,
+        },
+      });
+    } else {
+      groupName = i18n.translate('xpack.slo.group.remoteCluster', {
+        defaultMessage: 'Local Kibana',
+      });
+    }
+  }
 
   const [page, setPage] = useState(0);
   const [accordionState, setAccordionState] = useState<'open' | 'closed'>('closed');

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
@@ -71,7 +71,7 @@ export function GroupListView({
         },
       });
     } else {
-      groupName = i18n.translate('xpack.slo.group.remoteCluster', {
+      groupName = i18n.translate('xpack.slo.group.remoteCluster.localKibana', {
         defaultMessage: 'Local Kibana',
       });
     }


### PR DESCRIPTION
## Summary

Group by remote cluster, display remote cluster name instead of index !!

### After
<img width="1495" alt="image" src="https://github.com/elastic/kibana/assets/3505601/c23a5851-3daf-4ba5-91b9-0ee0aeb61ff1">


### Before
<img width="1481" alt="image" src="https://github.com/elastic/kibana/assets/3505601/ee840868-39a1-4ac8-85aa-76bcf2f50956">
