### PR TITLE
[SecuritySolution] Add auditing to Asset Criticality and Risk Engine 

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -37,6 +37,7 @@ import type { EndpointAuthz } from '../../../../../common/endpoint/types/authz';
 import { riskEngineDataClientMock } from '../../../entity_analytics/risk_engine/risk_engine_data_client.mock';
 import { riskScoreDataClientMock } from '../../../entity_analytics/risk_score/risk_score_data_client.mock';
 import { assetCriticalityDataClientMock } from '../../../entity_analytics/asset_criticality/asset_criticality_data_client.mock';
+import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
 
 export const createMockClients = () => {
   const core = coreMock.createRequestHandlerContext();
@@ -114,6 +115,7 @@ const createSecuritySolutionRequestContextMock = (
 ): jest.Mocked<SecuritySolutionApiRequestHandlerContext> => {
   const core = clients.core;
   const kibanaRequest = requestMock.create();
+  const mockAuditLogger = auditLoggerMock.create();
 
   return {
     core,
@@ -148,6 +150,7 @@ const createSecuritySolutionRequestContextMock = (
     getRiskEngineDataClient: jest.fn(() => clients.riskEngineDataClient),
     getRiskScoreDataClient: jest.fn(() => clients.riskScoreDataClient),
     getAssetCriticalityDataClient: jest.fn(() => clients.assetCriticalityDataClient),
+    getAuditLogger: jest.fn(() => mockAuditLogger),
   };
 };
 

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.test.ts
@@ -8,6 +8,7 @@
 import { loggingSystemMock, elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { AssetCriticalityDataClient } from './asset_criticality_data_client';
 import { createOrUpdateIndex } from '../utils/create_or_update_index';
+import { auditLoggerMock } from '@kbn/security-plugin/server/audit/mocks';
 
 type MockInternalEsClient = ReturnType<
   typeof elasticsearchServiceMock.createScopedClusterClient
@@ -19,12 +20,15 @@ jest.mock('../utils/create_or_update_index', () => ({
 describe('AssetCriticalityDataClient', () => {
   const esClientInternal = elasticsearchServiceMock.createScopedClusterClient().asInternalUser;
   const logger = loggingSystemMock.createLogger();
+  const mockAuditLogger = auditLoggerMock.create();
+
   describe('init', () => {
     it('ensures the index is available and up to date', async () => {
       const assetCriticalityDataClient = new AssetCriticalityDataClient({
         esClient: esClientInternal,
         logger,
         namespace: 'default',
+        auditLogger: mockAuditLogger,
       });
 
       await assetCriticalityDataClient.init();
@@ -72,6 +76,7 @@ describe('AssetCriticalityDataClient', () => {
         esClient: esClientMock,
         logger: loggerMock,
         namespace: 'default',
+        auditLogger: mockAuditLogger,
       });
     });
 

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -8,6 +8,7 @@ import type { ESFilter } from '@kbn/es-types';
 import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 import type { Logger, ElasticsearchClient } from '@kbn/core/server';
 import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
+import type { AuditLogger } from '@kbn/security-plugin-types-server';
 import type {
   AssetCriticalityCsvUploadResponse,
   AssetCriticalityUpsert,
@@ -16,9 +17,12 @@ import type { AssetCriticalityRecord } from '../../../../common/api/entity_analy
 import { createOrUpdateIndex } from '../utils/create_or_update_index';
 import { getAssetCriticalityIndex } from '../../../../common/entity_analytics/asset_criticality';
 import { assetCriticalityFieldMap } from './constants';
+import { AssetCriticalityAuditActions } from './audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../audit';
 
 interface AssetCriticalityClientOpts {
   logger: Logger;
+  auditLogger: AuditLogger | undefined;
   esClient: ElasticsearchClient;
   namespace: string;
 }
@@ -47,6 +51,16 @@ export class AssetCriticalityDataClient {
       options: {
         index: this.getIndex(),
         mappings: mappingFromFieldMap(assetCriticalityFieldMap, 'strict'),
+      },
+    });
+
+    this.options.auditLogger?.log({
+      message: 'User installed asset criticality Elasticsearch resources',
+      event: {
+        action: AssetCriticalityAuditActions.ASSET_CRITICALITY_INITIALIZE,
+        category: AUDIT_CATEGORY.DATABASE,
+        type: AUDIT_TYPE.CREATION,
+        outcome: AUDIT_OUTCOME.SUCCESS,
       },
     });
   }
@@ -83,6 +97,17 @@ export class AssetCriticalityDataClient {
       const result = await this.options.esClient.indices.exists({
         index: this.getIndex(),
       });
+
+      this.options.auditLogger?.log({
+        message: 'User checked if the asset criticality Elasticsearch resources were installed',
+        event: {
+          action: AssetCriticalityAuditActions.ASSET_CRITICALITY_INITIALIZE,
+          category: AUDIT_CATEGORY.DATABASE,
+          type: AUDIT_TYPE.ACCESS,
+          outcome: AUDIT_OUTCOME.SUCCESS,
+        },
+      });
+
       return result;
     } catch (e) {
       return false;

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/audit.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/audit.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum AssetCriticalityAuditActions {
+  ASSET_CRITICALITY_INITIALIZE = 'asset_criticality_initialize',
+  ASSET_CRITICALITY_UNASSIGN = 'asset_criticality_unassign',
+  ASSET_CRITICALITY_GET = 'asset_criticality_get',
+  ASSET_CRITICALITY_PRIVILEGE_GET = 'asset_criticality_privilege_get',
+  ASSET_CRITICALITY_STATUS_GET = 'asset_criticality_status_get',
+  ASSET_CRITICALITY_UPDATE = 'asset_criticality_update',
+  ASSET_CRITICALITY_BULK_UPDATE = 'asset_criticality_bulk_update',
+}

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/check_and_init_asset_criticality_resources.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/check_and_init_asset_criticality_resources.ts
@@ -25,6 +25,7 @@ export const checkAndInitAssetCriticalityResources = async (
   const assetCriticalityDataClient = new AssetCriticalityDataClient({
     esClient,
     logger,
+    auditLogger: securityContext.getAuditLogger(),
     namespace: securityContext.getSpaceId(),
   });
 

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/delete.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/delete.ts
@@ -17,6 +17,8 @@ import { buildRouteValidationWithZod } from '../../../../utils/build_validation/
 import { checkAndInitAssetCriticalityResources } from '../check_and_init_asset_criticality_resources';
 import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { AssetCriticalityAuditActions } from '../audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 export const assetCriticalityDeleteRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
   logger: Logger
@@ -39,12 +41,23 @@ export const assetCriticalityDeleteRoute = (
         },
       },
       async (context, request, response) => {
+        const securitySolution = await context.securitySolution;
+
+        securitySolution.getAuditLogger()?.log({
+          message: 'User attempted to un-assign asset criticality from an entity',
+          event: {
+            action: AssetCriticalityAuditActions.ASSET_CRITICALITY_UNASSIGN,
+            category: AUDIT_CATEGORY.DATABASE,
+            type: AUDIT_TYPE.DELETION,
+            outcome: AUDIT_OUTCOME.UNKNOWN,
+          },
+        });
+
         const siemResponse = buildSiemResponse(response);
         try {
           await assertAdvancedSettingsEnabled(await context.core, ENABLE_ASSET_CRITICALITY_SETTING);
           await checkAndInitAssetCriticalityResources(context, logger);
 
-          const securitySolution = await context.securitySolution;
           const assetCriticalityClient = securitySolution.getAssetCriticalityDataClient();
           await assetCriticalityClient.delete({
             idField: request.query.id_field,

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/get.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/get.ts
@@ -17,6 +17,8 @@ import { buildRouteValidationWithZod } from '../../../../utils/build_validation/
 import { AssetCriticalityRecordIdParts } from '../../../../../common/api/entity_analytics/asset_criticality';
 import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { AssetCriticalityAuditActions } from '../audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 export const assetCriticalityGetRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
   logger: Logger
@@ -54,6 +56,16 @@ export const assetCriticalityGetRoute = (
           if (!record) {
             return response.notFound();
           }
+
+          securitySolution.getAuditLogger()?.log({
+            message: 'User accessed the criticality level for an entity',
+            event: {
+              action: AssetCriticalityAuditActions.ASSET_CRITICALITY_GET,
+              category: AUDIT_CATEGORY.DATABASE,
+              type: AUDIT_TYPE.ACCESS,
+              outcome: AUDIT_OUTCOME.SUCCESS,
+            },
+          });
 
           return response.ok({ body: record });
         } catch (e) {

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/privileges.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/privileges.ts
@@ -16,6 +16,8 @@ import { checkAndInitAssetCriticalityResources } from '../check_and_init_asset_c
 import { getUserAssetCriticalityPrivileges } from '../get_user_asset_criticality_privileges';
 import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { AssetCriticalityAuditActions } from '../audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 
 export const assetCriticalityPrivilegesRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -44,6 +46,17 @@ export const assetCriticalityPrivilegesRoute = (
 
           const [_, { security }] = await getStartServices();
           const body = await getUserAssetCriticalityPrivileges(request, security);
+
+          const securitySolution = await context.securitySolution;
+          securitySolution.getAuditLogger()?.log({
+            message: 'User checked if they have the required privileges to use asset criticality',
+            event: {
+              action: AssetCriticalityAuditActions.ASSET_CRITICALITY_PRIVILEGE_GET,
+              category: AUDIT_CATEGORY.AUTHENTICATION,
+              type: AUDIT_TYPE.ACCESS,
+              outcome: AUDIT_OUTCOME.UNKNOWN,
+            },
+          });
 
           return response.ok({
             body,

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/status.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/status.ts
@@ -13,8 +13,10 @@ import {
   APP_ID,
   ENABLE_ASSET_CRITICALITY_SETTING,
 } from '../../../../../common/constants';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
 import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
+import { AssetCriticalityAuditActions } from '../audit';
 import { checkAndInitAssetCriticalityResources } from '../check_and_init_asset_criticality_resources';
 
 export const assetCriticalityStatusRoute = (
@@ -39,6 +41,17 @@ export const assetCriticalityStatusRoute = (
         const assetCriticalityClient = securitySolution.getAssetCriticalityDataClient();
 
         const result = await assetCriticalityClient.getStatus();
+
+        securitySolution.getAuditLogger()?.log({
+          message: 'User checked the status of the asset criticality service',
+          event: {
+            action: AssetCriticalityAuditActions.ASSET_CRITICALITY_STATUS_GET,
+            category: AUDIT_CATEGORY.DATABASE,
+            type: AUDIT_TYPE.ACCESS,
+            outcome: AUDIT_OUTCOME.UNKNOWN,
+          },
+        });
+
         const body: AssetCriticalityStatusResponse = {
           asset_criticality_resources_installed: result.isAssetCriticalityResourcesInstalled,
         };

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/upsert.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/upsert.ts
@@ -12,6 +12,8 @@ import { checkAndInitAssetCriticalityResources } from '../check_and_init_asset_c
 import { buildRouteValidationWithZod } from '../../../../utils/build_validation/route_validation';
 import { CreateAssetCriticalityRecord } from '../../../../../common/api/entity_analytics/asset_criticality';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { AssetCriticalityAuditActions } from '../audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 export const assetCriticalityUpsertRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
   logger: Logger
@@ -48,6 +50,16 @@ export const assetCriticalityUpsertRoute = (
           };
 
           const result = await assetCriticalityClient.upsert(assetCriticalityRecord);
+
+          securitySolution.getAuditLogger()?.log({
+            message: 'User attempted to assign the asset criticality level for an entity',
+            event: {
+              action: AssetCriticalityAuditActions.ASSET_CRITICALITY_UPDATE,
+              category: AUDIT_CATEGORY.DATABASE,
+              type: AUDIT_TYPE.CREATION,
+              outcome: AUDIT_OUTCOME.UNKNOWN,
+            },
+          });
 
           return response.ok({
             body: result,

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/audit.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/audit.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum AUDIT_TYPE {
+  CHANGE = 'change',
+  DELETION = 'deletion',
+  ACCESS = 'access',
+  CREATION = 'creation',
+}
+
+export enum AUDIT_CATEGORY {
+  AUTHENTICATION = 'authentication',
+  DATABASE = 'database',
+  WEB = 'web',
+}
+
+export enum AUDIT_OUTCOME {
+  FAILURE = 'failure',
+  SUCCESS = 'success',
+  UNKNOWN = 'unknown',
+}

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/audit.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/audit.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum RiskEngineAuditActions {
+  RISK_ENGINE_ENABLE = 'risk_engine_enable',
+  RISK_ENGINE_START = 'risk_engine_start',
+  RISK_ENGINE_DISABLE = 'risk_engine_disable',
+  RISK_ENGINE_INIT = 'risk_engine_init',
+  RISK_ENGINE_GET_LEGACY_ENGINE_STATUS_GET = 'risk_engine_get_legacy_engine_status_get',
+  RISK_ENGINE_STATUS_FOR_ALL_SPACES_GET = 'risk_engine_status_for_all_spaces_get',
+  RISK_ENGINE_STATUS_GET = 'risk_engine_status_get',
+  RISK_ENGINE_CONFIGURATION_GET = 'risk_engine_configuration_get',
+  RISK_ENGINE_DISABLE_LEGACY_ENGINE = 'risk_engine_disable_legacy_engine',
+  RISK_ENGINE_REMOVE_TASK = 'risk_engine_remove_task',
+}

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/risk_engine_data_client.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/risk_engine_data_client.test.ts
@@ -78,6 +78,7 @@ describe('RiskEngineDataClient', () => {
           esClient,
           soClient: mockSavedObjectClient,
           namespace: 'default',
+          auditLogger: undefined,
         };
         riskEngineDataClient = new RiskEngineDataClient(options);
       });

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/disable.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/disable.ts
@@ -11,6 +11,8 @@ import { RISK_ENGINE_DISABLE_URL, APP_ID } from '../../../../../common/constants
 import { TASK_MANAGER_UNAVAILABLE_ERROR } from './translations';
 import { withRiskEnginePrivilegeCheck } from '../risk_engine_privileges';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { RiskEngineAuditActions } from '../audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 
 export const riskEngineDisableRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -27,13 +29,39 @@ export const riskEngineDisableRoute = (
     .addVersion(
       { version: '1', validate: {} },
       withRiskEnginePrivilegeCheck(getStartServices, async (context, request, response) => {
-        const siemResponse = buildSiemResponse(response);
-
-        const [_, { taskManager }] = await getStartServices();
         const securitySolution = await context.securitySolution;
+
+        securitySolution.getAuditLogger()?.log({
+          message: 'User attempted to disable the risk engine.',
+          event: {
+            action: RiskEngineAuditActions.RISK_ENGINE_DISABLE,
+            category: AUDIT_CATEGORY.DATABASE,
+            type: AUDIT_TYPE.CHANGE,
+            outcome: AUDIT_OUTCOME.UNKNOWN,
+          },
+        });
+
+        const siemResponse = buildSiemResponse(response);
+        const [_, { taskManager }] = await getStartServices();
+
         const riskEngineClient = securitySolution.getRiskEngineDataClient();
 
         if (!taskManager) {
+          securitySolution.getAuditLogger()?.log({
+            message:
+              'User attempted to disable the risk engine, but the Kibana Task Manager was unavailable',
+            event: {
+              action: RiskEngineAuditActions.RISK_ENGINE_DISABLE,
+              category: AUDIT_CATEGORY.DATABASE,
+              type: AUDIT_TYPE.CHANGE,
+              outcome: AUDIT_OUTCOME.FAILURE,
+            },
+            error: {
+              message:
+                'User attempted to disable the risk engine, but the Kibana Task Manager was unavailable',
+            },
+          });
+
           return siemResponse.error({
             statusCode: 400,
             body: TASK_MANAGER_UNAVAILABLE_ERROR,

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/privileges.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/privileges.ts
@@ -8,6 +8,8 @@
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { RISK_ENGINE_PRIVILEGES_URL, APP_ID } from '../../../../../common/constants';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
+import { RiskScoreAuditActions } from '../../risk_score/audit';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
 
 import { getUserRiskEnginePrivileges } from '../risk_engine_privileges';
@@ -26,9 +28,20 @@ export const riskEnginePrivilegesRoute = (
     })
     .addVersion({ version: '1', validate: false }, async (context, request, response) => {
       const siemResponse = buildSiemResponse(response);
-
       const [_, { security }] = await getStartServices();
+      const securitySolution = await context.securitySolution;
+
       const body = await getUserRiskEnginePrivileges(request, security);
+
+      securitySolution.getAuditLogger()?.log({
+        message: 'User checked if they have the required privileges to configure the risk engine',
+        event: {
+          action: RiskScoreAuditActions.RISK_ENGINE_PRIVILEGES_GET,
+          category: AUDIT_CATEGORY.AUTHENTICATION,
+          type: AUDIT_TYPE.ACCESS,
+          outcome: AUDIT_OUTCOME.SUCCESS,
+        },
+      });
 
       try {
         return response.ok({

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/settings.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_engine/routes/settings.ts
@@ -8,7 +8,9 @@
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { RISK_ENGINE_SETTINGS_URL, APP_ID } from '../../../../../common/constants';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { RiskEngineAuditActions } from '../audit';
 
 export const riskEngineSettingsRoute = (router: EntityAnalyticsRoutesDeps['router']) => {
   router.versioned
@@ -27,6 +29,16 @@ export const riskEngineSettingsRoute = (router: EntityAnalyticsRoutesDeps['route
 
       try {
         const result = await riskEngineClient.getConfiguration();
+        securitySolution.getAuditLogger()?.log({
+          message: 'User accessed risk engine configuration information',
+          event: {
+            action: RiskEngineAuditActions.RISK_ENGINE_CONFIGURATION_GET,
+            category: AUDIT_CATEGORY.DATABASE,
+            type: AUDIT_TYPE.ACCESS,
+            outcome: AUDIT_OUTCOME.SUCCESS,
+          },
+        });
+
         if (!result) {
           throw new Error('Unable to get risk engine configuration');
         }

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/audit.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/audit.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum RiskScoreAuditActions {
+  RISK_ENGINE_INSTALL = 'risk_engine_install',
+  RISK_ENGINE_PRIVILEGES_GET = 'risk_engine_privileges_get',
+  RISK_ENGINE_MANUAL_SCORING = 'risk_engine_manual_scoring',
+  RISK_ENGINE_PREVIEW = 'risk_engine_preview',
+}

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/preview.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/preview.ts
@@ -20,6 +20,8 @@ import { assetCriticalityServiceFactory } from '../../asset_criticality';
 import { riskScoreServiceFactory } from '../risk_score_service';
 import { getRiskInputsIndex } from '../get_risk_inputs_index';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
+import { RiskScoreAuditActions } from '../audit';
+import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
 
 export const riskScorePreviewRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
@@ -103,6 +105,16 @@ export const riskScorePreviewRoute = (
             runtimeMappings,
             weights,
             alertSampleSizePerShard,
+          });
+
+          securityContext.getAuditLogger()?.log({
+            message: 'User triggered custom manual scoring',
+            event: {
+              action: RiskScoreAuditActions.RISK_ENGINE_PREVIEW,
+              category: AUDIT_CATEGORY.DATABASE,
+              type: AUDIT_TYPE.CHANGE,
+              outcome: AUDIT_OUTCOME.SUCCESS,
+            },
           });
 
           return response.ok({ body: result });

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.test.ts
@@ -59,6 +59,7 @@ describe('Risk Scoring Task', () => {
         logger: mockLogger,
         telemetry: mockTelemetry,
         entityAnalyticsConfig,
+        auditLogger: undefined,
       });
       expect(mockTaskManagerSetup.registerTaskDefinitions).toHaveBeenCalled();
     });
@@ -72,6 +73,7 @@ describe('Risk Scoring Task', () => {
         logger: mockLogger,
         telemetry: mockTelemetry,
         entityAnalyticsConfig,
+        auditLogger: undefined,
       });
       expect(mockTaskManagerSetup.registerTaskDefinitions).not.toHaveBeenCalled();
     });

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/tasks/risk_scoring_task.ts
@@ -14,6 +14,7 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+import type { AuditLogger } from '@kbn/security-plugin-types-server';
 import {
   type AfterKeys,
   type IdentifierType,
@@ -56,6 +57,7 @@ export const registerRiskScoringTask = ({
   getStartServices,
   kibanaVersion,
   logger,
+  auditLogger,
   taskManager,
   telemetry,
   entityAnalyticsConfig,
@@ -63,6 +65,7 @@ export const registerRiskScoringTask = ({
   getStartServices: EntityAnalyticsRoutesDeps['getStartServices'];
   kibanaVersion: string;
   logger: Logger;
+  auditLogger: AuditLogger | undefined;
   taskManager: TaskManagerSetupContract | undefined;
   telemetry: AnalyticsServiceSetup;
   entityAnalyticsConfig: EntityAnalyticsConfig;
@@ -80,6 +83,7 @@ export const registerRiskScoringTask = ({
       const assetCriticalityDataClient = new AssetCriticalityDataClient({
         esClient,
         logger,
+        auditLogger,
         namespace,
       });
 
@@ -94,6 +98,7 @@ export const registerRiskScoringTask = ({
         esClient,
         namespace,
         soClient,
+        auditLogger,
       });
       const riskScoreDataClient = new RiskScoreDataClient({
         logger,
@@ -101,6 +106,7 @@ export const registerRiskScoringTask = ({
         esClient,
         namespace,
         soClient,
+        auditLogger,
       });
 
       return riskScoreServiceFactory({

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -211,6 +211,7 @@ export class Plugin implements ISecuritySolutionPlugin {
         getStartServices: core.getStartServices,
         kibanaVersion: pluginContext.env.packageInfo.version,
         logger: this.logger,
+        auditLogger: plugins.security?.audit.withoutRequest,
         taskManager: plugins.taskManager,
         telemetry: core.analytics,
         entityAnalyticsConfig: config.entityAnalytics,

--- a/x-pack/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/plugins/security_solution/server/request_context_factory.ts
@@ -77,6 +77,8 @@ export class RequestContextFactory implements IRequestContextFactory {
       kibanaBranch: options.kibanaBranch,
     });
 
+    const getAuditLogger = () => security?.audit.asScoped(request);
+
     // List of endpoint authz for the current request's user. Will be initialized the first
     // time it is requested (see `getEndpointAuthz()` below)
     let endpointAuthz: Immutable<EndpointAuthz>;
@@ -106,6 +108,8 @@ export class RequestContextFactory implements IRequestContextFactory {
       getRuleDataService: () => ruleRegistry.ruleDataService,
 
       getRacClient: startPlugins.ruleRegistry.getRacClientWithRequest,
+
+      getAuditLogger,
 
       getDetectionEngineHealthClient: memoize(() =>
         ruleMonitoringService.createDetectionEngineHealthClient({
@@ -141,6 +145,7 @@ export class RequestContextFactory implements IRequestContextFactory {
             esClient: coreContext.elasticsearch.client.asCurrentUser,
             soClient: coreContext.savedObjects.client,
             namespace: getSpaceId(),
+            auditLogger: getAuditLogger(),
           })
       ),
       getRiskScoreDataClient: memoize(

--- a/x-pack/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/plugins/security_solution/server/request_context_factory.ts
@@ -164,6 +164,7 @@ export class RequestContextFactory implements IRequestContextFactory {
             logger: options.logger,
             esClient: coreContext.elasticsearch.client.asCurrentUser,
             namespace: getSpaceId(),
+            auditLogger: getAuditLogger(),
           })
       ),
     };

--- a/x-pack/plugins/security_solution/server/types.ts
+++ b/x-pack/plugins/security_solution/server/types.ts
@@ -19,6 +19,7 @@ import type { ExceptionListClient, ListsApiRequestHandlerContext } from '@kbn/li
 import type { AlertsClient, IRuleDataService } from '@kbn/rule-registry-plugin/server';
 
 import type { Readable } from 'stream';
+import type { AuditLogger } from '@kbn/security-plugin-types-server';
 import type { Immutable } from '../common/endpoint/types';
 import { AppClient } from './client';
 import type { ConfigType } from './config';
@@ -46,6 +47,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getDetectionEngineHealthClient: () => IDetectionEngineHealthClient;
   getRuleExecutionLog: () => IRuleExecutionLogForRoutes;
   getRacClient: (req: KibanaRequest) => Promise<AlertsClient>;
+  getAuditLogger: () => AuditLogger | undefined;
   getExceptionListClient: () => ExceptionListClient | null;
   getInternalFleetServices: () => EndpointInternalFleetServicesInterface;
   getRiskEngineDataClient: () => RiskEngineDataClient;

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -198,6 +198,7 @@
     "@kbn/core-chrome-browser",
     "@kbn/shared-ux-chrome-navigation",
     "@kbn/core-ui-settings-browser-mocks",
-    "@kbn/management-plugin"
+    "@kbn/management-plugin",
+    "@kbn/security-plugin-types-server"
   ]
 }


### PR DESCRIPTION
## Summary

Add auditing to Asset Criticality and Risk Engine as specified in the EPIC ticket.


All telemetry is sent from data clients and route files. To do that, I had to update some extra files to make sure the routes and data clients had access to the audit logger. 



### How to test
1. Deploy branch to cloud
2. Send cloud deployment logs to another deployment
3. Enable `xpack.security.audit.enabled: true` for kibana
4. Use the risk engine on the deployment
5. On the logs deployment, verify if the audit logs are arriving
   * Open explore
    * Set the data view `elastic-cloud-logs-*`
    * Search for the actions `event.action: action_name`





