### PR TITLE
[BK] Adjust buildkite pipeline definition settings post migration

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ES_SERVERLESS_IMAGE: latest
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-      allow_rebuilds: false
+      allow_rebuilds: true
       branch_configuration: main
       default_branch: main
       repository: elastic/kibana
@@ -35,7 +35,7 @@ spec:
         trigger_mode: none
         build_tags: false
         prefix_pull_request_fork_branch_names: false
-        skip_pull_request_builds_for_existing_commits: true
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -21,7 +21,7 @@ spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-      allow_rebuilds: false
+      allow_rebuilds: true
       branch_configuration: main 8.13 7.17
       default_branch: main
       repository: elastic/kibana
@@ -34,7 +34,7 @@ spec:
         trigger_mode: none
         build_tags: false
         prefix_pull_request_fork_branch_names: false
-        skip_pull_request_builds_for_existing_commits: true
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: BUILD_AND_READ
@@ -81,7 +81,7 @@ spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-      allow_rebuilds: false
+      allow_rebuilds: true
       branch_configuration: main 8.13 7.17
       default_branch: main
       repository: elastic/kibana
@@ -94,7 +94,7 @@ spec:
         trigger_mode: none
         build_tags: false
         prefix_pull_request_fork_branch_names: false
-        skip_pull_request_builds_for_existing_commits: true
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: BUILD_AND_READ
@@ -128,7 +128,7 @@ spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-      allow_rebuilds: false
+      allow_rebuilds: true
       branch_configuration: main 8.13 7.17
       default_branch: main
       repository: elastic/kibana
@@ -141,7 +141,7 @@ spec:
         trigger_mode: none
         build_tags: false
         prefix_pull_request_fork_branch_names: false
-        skip_pull_request_builds_for_existing_commits: true
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/kibana-flaky.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-flaky.yml
@@ -18,17 +18,18 @@ spec:
       name: kibana / flaky-test-suite-runner
       description: ':warning: Trigger a new build here: https://ci-stats.kibana.dev/trigger_flaky_test_runner :warning:'
     spec:
-      allow_rebuilds: false
+      allow_rebuilds: true
       default_branch: refs/pull/INSERT_PR_NUMBER/head
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/flaky_tests/pipeline.sh
       skip_intermediate_builds: false
       provider_settings:
+        build_branches: true
         build_pull_requests: false
         publish_commit_status: false
         trigger_mode: none
         prefix_pull_request_fork_branch_names: false
-        skip_pull_request_builds_for_existing_commits: true
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
@@ -21,7 +21,7 @@ spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-unsupported-ftrs-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-      allow_rebuilds: false
+      allow_rebuilds: true
       branch_configuration: main 8.13 7.17
       default_branch: main
       repository: elastic/kibana
@@ -34,7 +34,7 @@ spec:
         trigger_mode: none
         build_tags: false
         prefix_pull_request_fork_branch_names: false
-        skip_pull_request_builds_for_existing_commits: true
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: BUILD_AND_READ


### PR DESCRIPTION
## Summary
Some defaults/generated-settings weren't aligned with what we had previously for these pipelines (from #180346 and #180403). This PR adjusts them manually to where they were.