### PR TITLE
fix(slo): handle eventual consistency of delete slo data

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/observability/slos/delete_slo.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/slos/delete_slo.ts
@@ -80,8 +80,7 @@ export default function ({ getService }: FtrProviderContext) {
       await cleanup({ esClient, logger });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/180982
-    describe.skip('non partition by SLO', () => {
+    describe('non partition by SLO', () => {
       it('deletes the SLO definition, transforms, ingest pipeline and data', async () => {
         const createdSlo = await sloApi.create({
           name: 'my custom name',
@@ -114,18 +113,17 @@ export default function ({ getService }: FtrProviderContext) {
         });
         expect(savedObject.total).to.eql(1);
         expect(savedObject.saved_objects[0].attributes.id).to.eql(sloId);
+        const sloRevision = savedObject.saved_objects[0].attributes.revision ?? 1;
 
         // Transforms
-        const sloTransformId = getSLOTransformId(sloId, 1);
-        const sloSummaryTransformId = getSLOSummaryTransformId(sloId, 1);
+        const sloTransformId = getSLOTransformId(sloId, sloRevision);
+        const sloSummaryTransformId = getSLOSummaryTransformId(sloId, sloRevision);
         await transform.api.waitForTransformToExist(sloTransformId);
         await transform.api.waitForTransformToExist(sloSummaryTransformId);
 
         // Ingest pipeline
-        const sloRevision = 1;
         const pipelineResponse = await fetchSloSummaryPipeline(esClient, sloId, sloRevision);
-        const expectedPipeline = `.slo-observability.summary.pipeline-${sloId}-${sloRevision}`;
-        expect(pipelineResponse[expectedPipeline]).not.to.be(undefined);
+        expect(pipelineResponse[getSLOSummaryPipelineId(sloId, sloRevision)]).not.to.be(undefined);
 
         // RollUp and Summary data
         const sloRollupData = await sloApi.waitForSloData({
@@ -154,19 +152,26 @@ export default function ({ getService }: FtrProviderContext) {
         await transform.api.getTransform(sloTransformId, 404);
         await transform.api.getTransform(sloSummaryTransformId, 404);
 
-        // Roll up and summary data
-        await retry.tryForTime(60 * 1000, async () => {
-          const sloRollupDataAfterDeletion = await sloApi.getSloData({
-            sloId,
-            indexName: SLO_DESTINATION_INDEX_PATTERN,
-          });
+        await retry.waitForWithTimeout('SLO summary data is deleted', 60 * 1000, async () => {
           const sloSummaryDataAfterDeletion = await sloApi.getSloData({
             sloId,
             indexName: SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
           });
+          if (sloSummaryDataAfterDeletion.hits.hits.length > 0) {
+            throw new Error('SLO summary data not deleted yet');
+          }
+          return true;
+        });
 
-          expect(sloRollupDataAfterDeletion.hits.hits.length).to.be(0);
-          expect(sloSummaryDataAfterDeletion.hits.hits.length).to.be(0);
+        await retry.waitForWithTimeout('SLO rollup data is deleted', 60 * 1000, async () => {
+          const sloRollupDataAfterDeletion = await sloApi.getSloData({
+            sloId,
+            indexName: SLO_DESTINATION_INDEX_PATTERN,
+          });
+          if (sloRollupDataAfterDeletion.hits.hits.length > 0) {
+            throw new Error('SLO rollup data not deleted yet');
+          }
+          return true;
         });
       });
     });


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/180982

## Summary

When we delete an SLO, the summary data delete operation waits for its completion, but the sli data delete opration is done in background. Therefore, we need to assert on its eventual deletion by retrying for awhile.