### PR TITLE
[Security Solution][Serverless] Fix browser title updater

### DIFF
--- a/x-pack/plugins/security_solution/public/common/links/use_find_app_links_by_path.test.ts
+++ b/x-pack/plugins/security_solution/public/common/links/use_find_app_links_by_path.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { ExternalPageName } from '@kbn/security-solution-navigation';
 import { renderHook } from '@testing-library/react-hooks';
 import { APP_PATH, SecurityPageName } from '../../../common';
 import { useFindAppLinksByPath } from './use_find_app_links_by_path';
@@ -30,6 +31,10 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('useFindAppLinksByPath', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns null when navLinks is undefined', () => {
     const { result } = renderHook(() => useFindAppLinksByPath(undefined));
     expect(result.current).toBe(null);
@@ -79,5 +84,24 @@ describe('useFindAppLinksByPath', () => {
     mockedUseLocation.mockReturnValue({ pathname: '/users-risk' });
     const { result } = renderHook(() => useFindAppLinksByPath([usersNavItem, usersRiskNavItem]));
     expect(result.current).toBe(usersRiskNavItem);
+  });
+
+  it('should call getAppUrl using security internal security appId', () => {
+    const navItem = { id: SecurityPageName.users, title: 'Test User page' };
+    mockedUseLocation.mockReturnValue({ pathname: '/users' });
+    const { result } = renderHook(() => useFindAppLinksByPath([navItem]));
+    expect(result.current).toBe(navItem);
+    expect(mockedGetAppUrl).toHaveBeenCalledWith({
+      appId: 'securitySolutionUI',
+      deepLinkId: 'users',
+    });
+  });
+
+  it('should call getAppUrl using security external appId', () => {
+    const navItem = { id: ExternalPageName.osquery, title: 'Test Osquery external page' };
+    mockedUseLocation.mockReturnValue({ pathname: '/osquery' });
+    const { result } = renderHook(() => useFindAppLinksByPath([navItem]));
+    expect(result.current).toBe(navItem);
+    expect(mockedGetAppUrl).toHaveBeenCalledWith({ appId: 'osquery', deepLinkId: '' });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/links/use_find_app_links_by_path.ts
+++ b/x-pack/plugins/security_solution/public/common/links/use_find_app_links_by_path.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { getNavigationPropsFromId } from '@kbn/security-solution-navigation';
 import { useCallback, useMemo } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
 import { APP_PATH } from '../../../common';
@@ -23,7 +24,8 @@ export const useFindAppLinksByPath = (navLinks: NavigationLink[] | undefined) =>
 
   const isCurrentPathItem = useCallback(
     (navItem: NavigationLink) => {
-      const appUrl = getAppUrl({ deepLinkId: navItem.id });
+      const { appId, deepLinkId } = getNavigationPropsFromId(navItem.id);
+      const appUrl = getAppUrl({ appId, deepLinkId });
       return !!matchPath(`${basePath}${APP_PATH}${pathname}`, { path: appUrl, strict: false });
     },
     [basePath, getAppUrl, pathname]


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/181060

Fixes a bug on the Browser title generation from navigation links

### Issue

External links (Discover, Osquery) were not processed properly and they were being compared using the Security base path (/app/security) in the `matchPath`, causing the first external link in the list, Osquery, to be displayed instead of the correct ones.

### Screenshots

Before:

<img width="961" alt="before" src="https://github.com/elastic/kibana/assets/17747913/3836d956-3a04-443a-8659-6b038a8f0bf4">


After:

<img width="961" alt="after" src="https://github.com/elastic/kibana/assets/17747913/dfb39139-7cc5-459a-a5de-bc77576ce542">




<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->