### PR TITLE
[Serverless] Increasing metrics reset interval to 2 minutes

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -139,6 +139,7 @@ uiSettings:
 # Task Manager
 xpack.task_manager.allow_reading_invalid_state: false
 xpack.task_manager.request_timeouts.update_by_query: 60000
+xpack.task_manager.metrics_reset_interval: 120000
 
 # Reporting feature
 xpack.screenshotting.enabled: false


### PR DESCRIPTION
Increasing the metric reset interval for the `/api/task_manager/metrics` API to 2 minutes from 30 seconds. We believe 30 seconds is too aggressive based on data from the overview cluster that shows metrics being collected anywhere from 10 seconds (the expected interval) to 2 minutes.