### PR TITLE
[Console] update ux for opening/closing alternate view

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/console_notebooks.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/console_notebooks.ts
@@ -28,8 +28,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleNotebooksButton();
       await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleNotebooksToBeOpen();
 
-      // Click the Notebooks button again to switch to the dev console
-      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleNotebooksButton();
+      // Click the Console Bar button again to switch to the dev console
+      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
       await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeOpen();
       await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleNotebooksToBeClosed();
 
@@ -45,7 +45,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleNotebooksToBeOpen();
 
       // Close the console
-      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
+      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleNotebooksButton();
       await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleNotebooksToBeClosed();
       await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
     });


### PR DESCRIPTION
## Summary

Updated the behavior on how to close and switch between the persistent console alternate view to improve the UX and be more intuitive after testing with design and product.

The new behavior is:
- Clicking the Alt view button when the console is open will close the console.
- Clicking the console bar when the Alt view is open will switch to the console view.