### PR TITLE
[Security Solution] [Alerts table] Fix rule preview cell rendering

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
@@ -5,11 +5,22 @@
  * 2.0.
  */
 
-import type React from 'react';
+import React from 'react';
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
+import { TableId } from '@kbn/securitysolution-data-table';
 import type { CellValueElementProps } from '../../../../../common/types';
+import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { RenderCellValue } from '../../../../detections/configurations/security_solution_detections';
 
 export const PreviewRenderCellValue: React.FC<
   EuiDataGridCellValueElementProps & CellValueElementProps
-> = (props) => RenderCellValue({ ...props, asPlainText: true });
+> = (props) => {
+  return (
+    <RenderCellValue
+      {...props}
+      asPlainText={true}
+      scopeId={SourcererScopeName.detections}
+      tableId={TableId.rulePreview}
+    />
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
+++ b/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
@@ -51,7 +51,7 @@ export const RenderCellValue: React.FC<EuiDataGridCellProps['cellContext']> = me
       rowRenderers,
       isDetails,
       isExpandable,
-      isDraggable,
+      isDraggable = false,
       isExpanded,
       colIndex,
       eventId,


### PR DESCRIPTION
## Summary

Fixes the rule preview cell rendering, as the RenderCellValue is not a function that returns a component any more, but a component itself. A type cast caused this to be missed on the initial pr I believe. Also defaults isDraggable to false, as only timeline cells will have this value set to true, and this will allow all tables that use the cell renderer like the cases page to behave as before, without having to override this default value. 
Rule Preview:
![image](https://github.com/elastic/kibana/assets/56408403/a4ade8f3-ec8e-463d-8f48-a994442ce51d)
Cases page:
<img width="1184" alt="image" src="https://github.com/elastic/kibana/assets/56408403/faa4f126-908a-43f9-92a1-039e909c9af9">


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




