### PR TITLE
[MKI][EDR Workflows] Switch from placeholder explore to edr workflows tests

### DIFF
--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
@@ -3,7 +3,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: bk-kibana-serverless-secsol-defend-workflows
-  description: "[MKI] Executes Cypress tests for the Defend Workflows team"
+  description: "[MKI] Executes Cypress tests for the EDR Workflows team"
 spec:
   type: buildkite-pipeline
   owner: 'group:security-engineering-productivity'
@@ -12,11 +12,11 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: "Kibana / Serverless / Security Solution Quality Gate / Defend Workflows"
-      description: "[MKI] Executes Cypress tests for the Defend Workflows team"
+      name: "Kibana / Serverless / Security Solution Quality Gate / EDR Workflows"
+      description: "[MKI] Executes Cypress tests for the EDR Workflows team"
     spec:
       repository: elastic/kibana
-      pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
+      pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_edr_workflows.yml
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
@@ -3,7 +3,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: bk-kibana-serverless-secsol-defend-workflows
-  description: "[MKI] Executes Cypress tests for the EDR Workflows team"
+  description: "[MKI] Executes Cypress tests for the Defend Workflows team"
 spec:
   type: buildkite-pipeline
   owner: 'group:security-engineering-productivity'
@@ -12,11 +12,11 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: "Kibana / Serverless / Security Solution Quality Gate / EDR Workflows"
-      description: "[MKI] Executes Cypress tests for the EDR Workflows team"
+      name: "Kibana / Serverless / Security Solution Quality Gate / Defend Workflows"
+      description: "[MKI] Executes Cypress tests for the Defend Workflows team"
     spec:
       repository: elastic/kibana
-      pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_edr_workflows.yml
+      pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
@@ -33,4 +33,4 @@ steps:
   - command: "echo 'Running the defend worklows tests in this step"
     depends_on: build_image
     key: test_defend_workflows
-    label: 'Serverless MKI QA EDR Workflows - Security Solution Cypress Tests'
+    label: 'Serverless MKI QA Defend Workflows - Security Solution Cypress Tests'

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_edr_workflows.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_security_solution_edr_workflows.yml
@@ -33,4 +33,4 @@ steps:
   - command: "echo 'Running the defend worklows tests in this step"
     depends_on: build_image
     key: test_defend_workflows
-    label: 'Serverless MKI QA Defend Workflows - Security Solution Cypress Tests'
+    label: 'Serverless MKI QA EDR Workflows - Security Solution Cypress Tests'


### PR DESCRIPTION
We need to update the current quality gate configuration for the EDR Workflows team. It's using a placeholder called `mki_security_solution_explore` , and we want to replace it with the actual target EDR Workflows configuration.

This is a prerequisite for https://github.com/elastic/kibana/pull/181080