### PR TITLE
[Search] [Playground] fix code formatting

### DIFF
--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
@@ -10,7 +10,7 @@ from openai import OpenAI
 
 
 es_client = Elasticsearch(
-  http://my-local-cloud-instance,
+  \\"http://my-local-cloud-instance\\",
   api_key=os.environ[\\"ES_API_KEY\\"]
 )
       
@@ -19,16 +19,7 @@ openai_client = OpenAI(
   api_key=os.environ[\\"OPENAI_API_KEY\\"],
 )
 
-def get_elasticsearch_results(query):
-  es_query = {}
-
-  result = es.search(index=\\"index1,index2\\", query=es_query, size=10)
-  return result[\\"hits\\"][\\"hits\\"]
-
-def create_openai_prompt(question, results):
-
-  context = \\"\\"
-  index_source_fields = {
+index_source_fields = {
   \\"index1\\": [
     \\"field1\\"
   ],
@@ -36,11 +27,22 @@ def create_openai_prompt(question, results):
     \\"field2\\"
   ]
 }
+
+def get_elasticsearch_results(query):
+  es_query = {
+  \\"query\\": {},
+  \\"size\\": 10
+}
+
+  result = es.search(index=\\"index1,index2\\", body=es_query)
+  return result[\\"hits\\"][\\"hits\\"]
+
+def create_openai_prompt(question, results):
+  context = \\"\\"
   for hit in results:
     source_field = index_source_fields.get(hit[\\"_index\\"])[0]
     hit_context = hit[\\"_source\\"][source_field]
-    context += f\\"{hit_context}
-\\"
+    context += f\\"{hit_context}\\\\n\\"
 
   prompt = f\\"\\"\\"
   Instructions:
@@ -64,25 +66,21 @@ def create_openai_prompt(question, results):
 
 def generate_openai_completion(user_prompt):
   response = openai_client.chat.completions.create(
-    model=\\"Your-new-model\\",
+    model=\\"gpt-3.5-turbo\\",
     messages=[
-        {\\"role\\": \\"system\\", \\"content\\": \\"You are an assistant for question-answering tasks.\\"},
-        {\\"role\\": \\"user\\", \\"content\\": user_prompt},
+      {\\"role\\": \\"system\\", \\"content\\": \\"You are an assistant for question-answering tasks.\\"},
+      {\\"role\\": \\"user\\", \\"content\\": user_prompt},
     ]
   )
 
   return response.choices[0].message.content
 
 if __name__ == \\"__main__\\":
-    question = \\"my question\\"
-
-    elasticsearch_results = get_elasticsearch_results(question)
-
-    context_prompt = create_openai_prompt(question, elasticsearch_results)
-
-    openai_completion = generate_openai_completion(context_prompt)
-
-    print(openai_completion)
+  question = \\"my question\\"
+  elasticsearch_results = get_elasticsearch_results(question)
+  context_prompt = create_openai_prompt(question, elasticsearch_results)
+  openai_completion = generate_openai_completion(context_prompt)
+  print(openai_completion)
 
 "
 `;

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
@@ -29,7 +29,7 @@ index_source_fields = {
 }
 
 def get_elasticsearch_results(query):
-  es_query =   {
+  es_query = {
     \\"query\\": {},
     \\"size\\": 10
   }

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
@@ -29,10 +29,10 @@ index_source_fields = {
 }
 
 def get_elasticsearch_results(query):
-  es_query = {
-  \\"query\\": {},
-  \\"size\\": 10
-}
+  es_query =   {
+    \\"query\\": {},
+    \\"size\\": 10
+  }
 
   result = es.search(index=\\"index1,index2\\", body=es_query)
   return result[\\"hits\\"][\\"hits\\"]

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
@@ -20,7 +20,7 @@ es_client = Elasticsearch(
       
 
 def build_query(query):
-  return   {
+  return {
     \\"query\\": {}
   }
 

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
@@ -13,9 +13,8 @@ from langchain_core.prompts import format_document
 from langchain.prompts.prompt import PromptTemplate
 import os
 
-
 es_client = Elasticsearch(
-  http://my-local-cloud-instance,
+  \\"http://my-local-cloud-instance\\",
   api_key=os.environ[\\"ES_API_KEY\\"]
 )
       
@@ -25,18 +24,26 @@ def build_query(query):
   \\"query\\": {}
 }
 
+index_source_fields = {
+  \\"index1\\": [
+    \\"field1\\"
+  ],
+  \\"index2\\": [
+    \\"field2\\"
+  ]
+}
+
 retriever = ElasticsearchRetriever(
-  index_name=\\"{formValues.indices.join(',')}\\",
+  index_name=\\"index1,index2\\",
   body_func=build_query,
-  content_field=\\"text\\",
+  content_field=index_source_fields,
   es_client=es_client
 )
 
-model = ChatOpenAI(openai_api_key=os.environ[\\"OPENAI_API_KEY\\"], model_name=\\"Your-new-model\\")
-
+model = ChatOpenAI(openai_api_key=os.environ[\\"OPENAI_API_KEY\\"], model_name=\\"gpt-3.5-turbo\\")
 
 ANSWER_PROMPT = ChatPromptTemplate.from_template(
-    f\\"\\"\\"
+  f\\"\\"\\"
   Instructions:
   
   - Your prompt

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
@@ -20,9 +20,9 @@ es_client = Elasticsearch(
       
 
 def build_query(query):
-  return {
-  \\"query\\": {}
-}
+  return   {
+    \\"query\\": {}
+  }
 
 index_source_fields = {
   \\"index1\\": [

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
@@ -9,16 +9,7 @@ import { EuiCodeBlock } from '@elastic/eui';
 import React from 'react';
 import { ChatForm } from '../../../types';
 import { Prompt } from '../../../../common/prompt';
-
-const getESQuery = (query: any) => {
-  try {
-    return JSON.stringify(query, null, 2).replace('"${query}"', 'f"${query}"');
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Error parsing ES query', e);
-    return '{}';
-  }
-};
+import { getESQuery } from './utils';
 
 export const PY_LANG_CLIENT = (formValues: ChatForm, clientDetails: string) => (
   <EuiCodeBlock language="py" isCopyable overflowHeight="100%">
@@ -35,22 +26,23 @@ openai_client = OpenAI(
   api_key=os.environ["OPENAI_API_KEY"],
 )
 
-def get_elasticsearch_results(query):
-  es_query = ${getESQuery(formValues.elasticsearch_query.query)}
+index_source_fields = ${JSON.stringify(formValues.source_fields, null, 2)}
 
-  result = es.search(index="${formValues.indices.join(',')}", query=es_query, size=${
-      formValues.doc_size
-    })
+def get_elasticsearch_results(query):
+  es_query = ${getESQuery({
+    ...formValues.elasticsearch_query,
+    size: formValues.doc_size,
+  })}
+
+  result = es.search(index="${formValues.indices.join(',')}", body=es_query)
   return result["hits"]["hits"]
 
 def create_openai_prompt(question, results):
-
   context = ""
-  index_source_fields = ${JSON.stringify(formValues.source_fields, null, 2)}
   for hit in results:
     source_field = index_source_fields.get(hit["_index"])[0]
     hit_context = hit["_source"][source_field]
-    context += f"{hit_context}\n"
+    context += f"{hit_context}\\n"
 
   prompt = f"""${Prompt(formValues.prompt, {
     context: true,
@@ -62,25 +54,21 @@ def create_openai_prompt(question, results):
 
 def generate_openai_completion(user_prompt):
   response = openai_client.chat.completions.create(
-    model="${formValues.summarization_model}",
+    model="gpt-3.5-turbo",
     messages=[
-        {"role": "system", "content": "You are an assistant for question-answering tasks."},
-        {"role": "user", "content": user_prompt},
+      {"role": "system", "content": "You are an assistant for question-answering tasks."},
+      {"role": "user", "content": user_prompt},
     ]
   )
 
   return response.choices[0].message.content
 
 if __name__ == "__main__":
-    question = "my question"
-
-    elasticsearch_results = get_elasticsearch_results(question)
-
-    context_prompt = create_openai_prompt(question, elasticsearch_results)
-
-    openai_completion = generate_openai_completion(context_prompt)
-
-    print(openai_completion)
+  question = "my question"
+  elasticsearch_results = get_elasticsearch_results(question)
+  context_prompt = create_openai_prompt(question, elasticsearch_results)
+  openai_completion = generate_openai_completion(context_prompt)
+  print(openai_completion)
 
 `}
   </EuiCodeBlock>

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const getESQuery = (query: any) => {
+  try {
+    return JSON.stringify(query, null, 2)
+      .replace('"{query}"', 'query')
+      .split('\n')
+      .map((line) => `  ${line}`)
+      .join('\n');
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Error parsing ES query', e);
+    return '{}';
+  }
+};

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
@@ -11,7 +11,8 @@ export const getESQuery = (query: any) => {
       .replace('"{query}"', 'query')
       .split('\n')
       .map((line) => `  ${line}`)
-      .join('\n');
+      .join('\n')
+      .trim();
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error('Error parsing ES query', e);

--- a/x-pack/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
+++ b/x-pack/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
@@ -35,7 +35,7 @@ export const ES_CLIENT_DETAILS = (cloud: CloudSetup | undefined) => {
   if (cloud) {
     return `
 es_client = Elasticsearch(
-  ${cloud.elasticsearchUrl},
+  "${cloud.elasticsearchUrl}",
   api_key=os.environ["ES_API_KEY"]
 )
       `;
@@ -91,8 +91,8 @@ export const ViewCodeFlyout: React.FC<ViewCodeFlyoutProps> = ({ onClose }) => {
               <EuiFlexItem>
                 <EuiSelect
                   options={[
-                    { value: 'py-es-client', text: 'Python Elasticsearch Client' },
-                    { value: 'lc-py', text: 'LangChain Python' },
+                    { value: 'py-es-client', text: 'Python Elasticsearch Client with OpenAI' },
+                    { value: 'lc-py', text: 'LangChain Python with OpenAI' },
                   ]}
                   onChange={(e) => setSelectedLanguage(e.target.value)}
                   value={selectedLanguage}


### PR DESCRIPTION
Fixing the code formatting in the view code section. Also labelling the examples as OpenAI as we now introduced more model options (Azure and Bedrock + more) which we dont have support for yet in view_code. 

In future these code examples will be moved to notebooks in elasticsearch-labs so they can inherit the formatting / automated test coverage / updates and no longer managed in strings. 

![image](https://github.com/elastic/kibana/assets/49480/67865378-61c5-4b40-9985-fbc419f82578)
 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->