### PR TITLE
[Search] Remove beta callouts from sync rules

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
@@ -24,8 +24,6 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { BetaBadge } from '../../../../../shared/beta/beta_badge';
-
 import { docLinks } from '../../../../../shared/doc_links';
 
 import { ConnectorViewLogic } from '../../../connector_detail/connector_view_logic';
@@ -80,9 +78,6 @@ export const ConnectorSyncRules: React.FC = () => {
                     </h2>
                   </EuiTitle>
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <BetaBadge />
-                </EuiFlexItem>
               </EuiFlexGroup>
               <EuiSpacer />
               <EuiText size="s">
@@ -97,7 +92,7 @@ export const ConnectorSyncRules: React.FC = () => {
                   })}
                 </p>
                 <p>
-                  <EuiLink href={docLinks.syncRules} external>
+                  <EuiLink href={docLinks.syncRules} external target="_blank">
                     {i18n.translate(
                       'xpack.enterpriseSearch.index.connector.syncRules.syncRulesLabel',
                       {
@@ -191,7 +186,7 @@ export const ConnectorSyncRules: React.FC = () => {
                       )}
                     </p>
                     <p>
-                      <EuiLink external href={docLinks.syncRulesAdvanced}>
+                      <EuiLink external href={docLinks.syncRulesAdvanced} target="_blank">
                         {i18n.translate(
                           'xpack.enterpriseSearch.content.index.connector.syncRules.advancedFiltersLinkTitle',
                           {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/edit_sync_rules_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/edit_sync_rules_flyout.tsx
@@ -25,8 +25,6 @@ import { i18n } from '@kbn/i18n';
 
 import { FilteringValidation } from '@kbn/search-connectors';
 
-import { BetaCallOut } from '../../../../../shared/beta/beta_callout';
-
 import { AdvancedSyncRules } from './advanced_sync_rules';
 import { EditSyncRulesTab } from './edit_sync_rules_tab';
 import { SyncRulesTable } from './editable_basic_rules_table';
@@ -105,16 +103,6 @@ export const EditSyncRulesFlyout: React.FC<EditFilteringFlyoutProps> = ({
             )}
           </h2>
         </EuiTitle>
-        <EuiSpacer />
-        <BetaCallOut
-          description={i18n.translate(
-            'xpack.enterpriseSearch.content.index.connector.syncRules.flyout.betaDescription',
-            {
-              defaultMessage:
-                'Sync rules is a beta feature. Beta features are subject to change and are not covered by the support SLA of general release (GA) features. Elastic plans to promote this feature to GA in a future release.',
-            }
-          )}
-        />
         <EuiSpacer />
         <EuiText size="s">
           {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/editable_basic_rules_table.tsx
@@ -80,7 +80,7 @@ export const SyncRulesTable: React.FC = () => {
         values: { indexName },
       })}
       <EuiSpacer />
-      <EuiLink href={docLinks.syncRules} external>
+      <EuiLink href={docLinks.syncRules} external target="_blank">
         {i18n.translate('xpack.enterpriseSearch.content.index.connector.syncRules.link', {
           defaultMessage: 'Learn more about customizing your sync rules.',
         })}


### PR DESCRIPTION
## Summary

Promote Sync Rules to GA, by removing the beta callout and labels.
Also fixes a few links that didn't set up as external.

<img width="1254" alt="Screenshot 2024-04-18 at 16 17 22" src="https://github.com/elastic/kibana/assets/1410658/d7c44504-dcfa-47f6-af7d-21b6b8fdc312">
<img width="669" alt="Screenshot 2024-04-18 at 16 17 27" src="https://github.com/elastic/kibana/assets/1410658/b9dcfaab-8b10-4e78-af11-ec665c076d70">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed





<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->