### PR TITLE
[Security Solution] [AI Insights] Enable LangSmith tracing in cloud deployments

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant-common/impl/llm/actions_client_llm.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/llm/actions_client_llm.ts
@@ -5,13 +5,14 @@
  * 2.0.
  */
 
-import { v4 as uuidv4 } from 'uuid';
-import { KibanaRequest, Logger } from '@kbn/core/server';
 import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import { KibanaRequest, Logger } from '@kbn/core/server';
 import { LLM } from '@langchain/core/language_models/llms';
 import { get } from 'lodash/fp';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getMessageContentAndRole } from './helpers';
+import { TraceOptions } from './types';
 
 const LLM_TYPE = 'ActionsClientLlm';
 
@@ -27,6 +28,7 @@ interface ActionsClientLlmParams {
   model?: string;
   temperature?: number;
   traceId?: string;
+  traceOptions?: TraceOptions;
 }
 
 export class ActionsClientLlm extends LLM {
@@ -52,8 +54,11 @@ export class ActionsClientLlm extends LLM {
     model,
     request,
     temperature,
+    traceOptions,
   }: ActionsClientLlmParams) {
-    super({});
+    super({
+      callbacks: [...(traceOptions?.tracers ?? [])],
+    });
 
     this.#actions = actions;
     this.#connectorId = connectorId;

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/llm/types.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/llm/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
 import {
   ChatCompletionContentPart,
   ChatCompletionCreateParamsNonStreaming,
@@ -37,4 +38,13 @@ export interface InvokeAIActionParamsSchema {
   temperature?: ChatCompletionCreateParamsNonStreaming['temperature'];
   functions?: ChatCompletionCreateParamsNonStreaming['functions'];
   signal?: AbortSignal;
+}
+
+export interface TraceOptions {
+  evaluationId?: string;
+  exampleId?: string;
+  projectName?: string;
+  runName?: string;
+  tags?: string[];
+  tracers?: LangChainTracer[];
 }

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/insights/alerts/post_alerts_insights_route.gen.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/insights/alerts/post_alerts_insights_route.gen.ts
@@ -56,6 +56,8 @@ export const AlertsInsightsPostRequestBody = z.object({
   anonymizationFields: z.array(AnonymizationFieldResponse),
   connectorId: z.string(),
   actionTypeId: z.string(),
+  langSmithProject: z.string().optional(),
+  langSmithApiKey: z.string().optional(),
   model: z.string().optional(),
   replacements: Replacements.optional(),
   size: z.number(),

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/insights/alerts/post_alerts_insights_route.schema.yaml
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/insights/alerts/post_alerts_insights_route.schema.yaml
@@ -73,6 +73,10 @@ paths:
                   type: string
                 actionTypeId:
                   type: string
+                langSmithProject:
+                  type: string
+                langSmithApiKey:
+                  type: string
                 model:
                   type: string
                 replacements:

--- a/x-pack/plugins/security_solution/public/ai_insights/use_insights/index.tsx
+++ b/x-pack/plugins/security_solution/public/ai_insights/use_insights/index.tsx
@@ -16,6 +16,7 @@ import {
   AlertsInsightsPostResponse,
   ELASTIC_AI_ASSISTANT_INTERNAL_API_VERSION,
 } from '@kbn/elastic-assistant-common';
+import { isEmpty } from 'lodash/fp';
 import moment from 'moment';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useLocalStorage, useSessionStorage } from 'react-use';
@@ -60,7 +61,7 @@ export const useInsights = ({
   const [isLoading, setIsLoading] = useState(false);
 
   // get alerts index pattern and allow lists from the assistant context:
-  const { alertsIndexPattern, knowledgeBase } = useAssistantContext();
+  const { alertsIndexPattern, knowledgeBase, traceOptions } = useAssistantContext();
 
   const { data: anonymizationFields } = useFetchAnonymizationFields();
 
@@ -116,6 +117,12 @@ export const useInsights = ({
       alertsIndexPattern: alertsIndexPattern ?? '',
       anonymizationFields: anonymizationFields?.data ?? [],
       connectorId: connectorId ?? '',
+      langSmithProject: isEmpty(traceOptions?.langSmithProject)
+        ? undefined
+        : traceOptions?.langSmithProject,
+      langSmithApiKey: isEmpty(traceOptions?.langSmithApiKey)
+        ? undefined
+        : traceOptions?.langSmithApiKey,
       size: knowledgeBase.latestAlerts,
       replacements: {}, // no need to re-use replacements in the current implementation
       subAction: 'invokeAI', // non-streaming
@@ -227,6 +234,8 @@ export const useInsights = ({
     setLocalStorageGenerationIntervals,
     setSessionStorageCachedInsights,
     toasts,
+    traceOptions?.langSmithApiKey,
+    traceOptions?.langSmithProject,
   ]);
 
   return {


### PR DESCRIPTION
## [Security Solution] [AI Insights] Enable LangSmith tracing in cloud deployments

### Summary

This PR enables LangSmith tracing for the [AI Insights](https://github.com/elastic/kibana/pull/180611) feature in cloud deployments.

LangSmith project names and API keys are specified using the same UI and patterns introduced by @spong in <https://github.com/elastic/kibana/pull/180227>

### Details

To enable LangSmith tracing in cloud deployments, configure the following `xpack.securitySolution.enableExperimental` feature flags:

```
xpack.securitySolution.enableExperimental: ['assistantModelEvaluation', 'assistantAlertsInsights']
```

- The `assistantModelEvaluation` feature flag enables the `Evaluation` settings category in the assistant. The LangSmith project name and API key are configured here
- The `assistantAlertsInsights` feature flag enables the AI Insights feature, which is off by default at the time of this writing

After enabling the feature flags above:

1) Click the `AI Assistant` button anywhere in the Security Solution to launch the assistant

2) Click the settings gear in the assistant

3) Click the `Evaluation` settings category

4) Click `Show Trace Options (for internal use only)`

5) Specify a `LangSmith Project` and `LangSmith API Key` per the screenshot below:

![langsmith_settings](https://github.com/elastic/kibana/assets/4459398/896c8155-3a06-4381-becf-b846b5aba426)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->