### PR TITLE
fix(NA): do not change default encoding when using vfs to copy files

### DIFF
--- a/packages/kbn-plugin-generator/src/render_template.ts
+++ b/packages/kbn-plugin-generator/src/render_template.ts
@@ -79,6 +79,7 @@ export async function renderTemplates({
       buffer: true,
       nodir: true,
       cwd: Path.resolve(__dirname, '../template'),
+      encoding: false,
     }),
 
     // exclude files from the template based on selected options, patterns

--- a/packages/kbn-plugin-helpers/src/tasks/brotli_compress_bundles.ts
+++ b/packages/kbn-plugin-helpers/src/tasks/brotli_compress_bundles.ts
@@ -34,7 +34,7 @@ export async function brotliCompressBundles({ buildDir, log, plugin }: TaskConte
   try {
     await del(['**/*.br'], { cwd: compressDir });
     await asyncPipeline(
-      vfs.src(['**/*.{js,css}'], { cwd: compressDir }),
+      vfs.src(['**/*.{js,css}'], { cwd: compressDir, encoding: false }),
       gulpBrotli({
         params: {
           [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,

--- a/packages/kbn-plugin-helpers/src/tasks/write_public_assets.ts
+++ b/packages/kbn-plugin-helpers/src/tasks/write_public_assets.ts
@@ -28,6 +28,7 @@ export async function writePublicAssets({ log, plugin, sourceDir, buildDir }: Ta
       base: sourceDir,
       buffer: true,
       allowEmpty: true,
+      encoding: false,
     }),
     vfs.dest(buildDir)
   );

--- a/packages/kbn-plugin-helpers/src/tasks/write_server_files.ts
+++ b/packages/kbn-plugin-helpers/src/tasks/write_server_files.ts
@@ -53,6 +53,7 @@ export async function writeServerFiles({
           '**/*.{test,test.mocks,mock,mocks}.*',
         ],
         allowEmpty: true,
+        encoding: false,
       }
     ),
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/180067

When we upgraded into vinyl-fs@4.0.0 there was a missing breaking change into their changelog related to encodings that was only added last february. Because of that we missed a couple places where file encondings were being changed from the default ones and in some cases corrupting those files. 

This PR fixes those problems.

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->