### PR TITLE
[Security Solution][Alert details] - use expandable flyout within Session Viewer

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/hooks/use_detail_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/hooks/use_detail_panel.test.tsx
@@ -12,7 +12,6 @@ import { timelineActions } from '../../../store';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { TimelineId, TimelineTabs } from '../../../../../common/types/timeline';
-import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
 import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
 import { TestProviders } from '../../../../common/mock';
 
@@ -69,205 +68,20 @@ describe('useDetailPanel', () => {
       await waitForNextUpdate();
 
       expect(result.current.openEventDetailsPanel).toBeDefined();
-      expect(result.current.openHostDetailsPanel).toBeDefined();
-      expect(result.current.openNetworkDetailsPanel).toBeDefined();
-      expect(result.current.openUserDetailsPanel).toBeDefined();
-      expect(result.current.handleOnDetailsPanelClosed).toBeDefined();
       expect(result.current.shouldShowDetailsPanel).toBe(false);
       expect(result.current.DetailsPanel).toBeNull();
     });
   });
 
-  describe('open event details', () => {
-    const testEventId = '123';
-    test('should fire redux action to open event details panel', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
+  test('should fire redux action to open event details panel', async () => {
+    await act(async () => {
+      const { result, waitForNextUpdate } = renderUseDetailPanel();
+      await waitForNextUpdate();
 
-        result.current?.openEventDetailsPanel(testEventId);
+      result.current?.openEventDetailsPanel('123');
 
-        expect(mockDispatch).toHaveBeenCalled();
-        expect(timelineActions.toggleDetailPanel).toHaveBeenCalled();
-      });
-    });
-
-    test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        result.current?.openEventDetailsPanel(testEventId, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-      });
-    });
-
-    test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
-      // Test that the onClose ref is properly updated
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        const secondMockOnClose = jest.fn();
-        result.current?.openEventDetailsPanel(testEventId, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-
-        result.current?.openEventDetailsPanel(testEventId, secondMockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(secondMockOnClose).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('open host details', () => {
-    const hostName = 'my-host';
-    test('should fire redux action to open host details panel', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        result.current?.openHostDetailsPanel(hostName);
-
-        expect(mockDispatch).toHaveBeenCalled();
-        expect(timelineActions.toggleDetailPanel).toHaveBeenCalled();
-      });
-    });
-
-    test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        result.current?.openHostDetailsPanel(hostName, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-      });
-    });
-
-    test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
-      // Test that the onClose ref is properly updated
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        const secondMockOnClose = jest.fn();
-        result.current?.openHostDetailsPanel(hostName, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-
-        result.current?.openEventDetailsPanel(hostName, secondMockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(secondMockOnClose).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('open network details', () => {
-    const ip = '1.2.3.4';
-    const flowTarget = FlowTargetSourceDest.source;
-    test('should fire redux action to open host details panel', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        result.current?.openNetworkDetailsPanel(ip, flowTarget);
-
-        expect(mockDispatch).toHaveBeenCalled();
-        expect(timelineActions.toggleDetailPanel).toHaveBeenCalled();
-      });
-    });
-
-    test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        result.current?.openNetworkDetailsPanel(ip, flowTarget, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-      });
-    });
-
-    test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
-      // Test that the onClose ref is properly updated
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        const secondMockOnClose = jest.fn();
-        result.current?.openNetworkDetailsPanel(ip, flowTarget, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-
-        result.current?.openNetworkDetailsPanel(ip, flowTarget, secondMockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(secondMockOnClose).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('open user details', () => {
-    const userName = 'IAmBatman';
-    test('should fire redux action to open host details panel', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        result.current?.openUserDetailsPanel(userName);
-
-        expect(mockDispatch).toHaveBeenCalled();
-        expect(timelineActions.toggleDetailPanel).toHaveBeenCalled();
-      });
-    });
-
-    test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        result.current?.openUserDetailsPanel(userName, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-      });
-    });
-
-    test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
-      // Test that the onClose ref is properly updated
-      await act(async () => {
-        const { result, waitForNextUpdate } = renderUseDetailPanel();
-        await waitForNextUpdate();
-
-        const mockOnClose = jest.fn();
-        const secondMockOnClose = jest.fn();
-        result.current?.openUserDetailsPanel(userName, mockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(mockOnClose).toHaveBeenCalled();
-
-        result.current?.openUserDetailsPanel(userName, secondMockOnClose);
-        result.current?.handleOnDetailsPanelClosed();
-
-        expect(secondMockOnClose).toHaveBeenCalled();
-      });
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(timelineActions.toggleDetailPanel).toHaveBeenCalled();
     });
   });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/hooks/use_detail_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/hooks/use_detail_panel.test.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { renderHook, act } from '@testing-library/react-hooks';
+import React from 'react';
 import type { UseDetailPanelConfig } from './use_detail_panel';
 import { useDetailPanel } from './use_detail_panel';
 import { timelineActions } from '../../../store';
@@ -12,6 +13,8 @@ import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { TimelineId, TimelineTabs } from '../../../../../common/types/timeline';
 import { FlowTargetSourceDest } from '../../../../../common/search_strategy';
+import { ExpandableFlyoutProvider } from '@kbn/expandable-flyout';
+import { TestProviders } from '../../../../common/mock';
 
 const mockDispatch = jest.fn();
 jest.mock('../../../../common/lib/kibana');
@@ -52,11 +55,17 @@ describe('useDetailPanel', () => {
     (useDeepEqualSelector as jest.Mock).mockClear();
   });
 
+  const wrapper = ({ children }: { children: React.ReactChild }) => (
+    <TestProviders>
+      <ExpandableFlyoutProvider>{children}</ExpandableFlyoutProvider>
+    </TestProviders>
+  );
+  const renderUseDetailPanel = (props = defaultProps) =>
+    renderHook(() => useDetailPanel(props), { wrapper });
+
   test('should return open fns (event, host, network, user), handleOnDetailsPanelClosed fn, shouldShowDetailsPanel, and the DetailsPanel component', async () => {
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => {
-        return useDetailPanel(defaultProps);
-      });
+      const { result, waitForNextUpdate } = renderUseDetailPanel();
       await waitForNextUpdate();
 
       expect(result.current.openEventDetailsPanel).toBeDefined();
@@ -73,9 +82,7 @@ describe('useDetailPanel', () => {
     const testEventId = '123';
     test('should fire redux action to open event details panel', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         result.current?.openEventDetailsPanel(testEventId);
@@ -87,9 +94,7 @@ describe('useDetailPanel', () => {
 
     test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -103,9 +108,7 @@ describe('useDetailPanel', () => {
     test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
       // Test that the onClose ref is properly updated
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -127,9 +130,7 @@ describe('useDetailPanel', () => {
     const hostName = 'my-host';
     test('should fire redux action to open host details panel', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         result.current?.openHostDetailsPanel(hostName);
@@ -141,9 +142,7 @@ describe('useDetailPanel', () => {
 
     test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -157,9 +156,7 @@ describe('useDetailPanel', () => {
     test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
       // Test that the onClose ref is properly updated
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -182,9 +179,7 @@ describe('useDetailPanel', () => {
     const flowTarget = FlowTargetSourceDest.source;
     test('should fire redux action to open host details panel', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         result.current?.openNetworkDetailsPanel(ip, flowTarget);
@@ -196,9 +191,7 @@ describe('useDetailPanel', () => {
 
     test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -212,9 +205,7 @@ describe('useDetailPanel', () => {
     test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
       // Test that the onClose ref is properly updated
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -236,9 +227,7 @@ describe('useDetailPanel', () => {
     const userName = 'IAmBatman';
     test('should fire redux action to open host details panel', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         result.current?.openUserDetailsPanel(userName);
@@ -250,9 +239,7 @@ describe('useDetailPanel', () => {
 
     test('should call provided onClose callback provided to openEventDetailsPanel fn', async () => {
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -266,9 +253,7 @@ describe('useDetailPanel', () => {
     test('should call the last onClose callback provided to openEventDetailsPanel fn', async () => {
       // Test that the onClose ref is properly updated
       await act(async () => {
-        const { result, waitForNextUpdate } = renderHook(() => {
-          return useDetailPanel(defaultProps);
-        });
+        const { result, waitForNextUpdate } = renderUseDetailPanel();
         await waitForNextUpdate();
 
         const mockOnClose = jest.fn();
@@ -298,9 +283,7 @@ describe('useDetailPanel', () => {
     };
 
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => {
-        return useDetailPanel(updatedProps);
-      });
+      const { result, waitForNextUpdate } = renderUseDetailPanel(updatedProps);
       await waitForNextUpdate();
 
       expect(result.current.DetailsPanel).toMatchInlineSnapshot(`

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/hooks/use_detail_panel.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/hooks/use_detail_panel.tsx
@@ -11,12 +11,9 @@ import type { EntityType } from '@kbn/timelines-plugin/common';
 import { dataTableSelectors } from '@kbn/securitysolution-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
-import { UserPanelKey } from '../../../../flyout/entity_details/user_right';
-import { HostPanelKey } from '../../../../flyout/entity_details/host_right';
 import { useKibana } from '../../../../common/lib/kibana';
 import type { ExpandedDetailType } from '../../../../../common/types';
 import { getScopedActions, isInTableScope, isTimelineScope } from '../../../../helpers';
-import type { FlowTargetSourceDest } from '../../../../../common/search_strategy';
 import { timelineSelectors } from '../../../store';
 import { useSourcererDataView } from '../../../../common/containers/sourcerer';
 import type { SourcererScopeName } from '../../../../common/store/sourcerer/model';
@@ -36,14 +33,6 @@ export interface UseDetailPanelConfig {
 }
 export interface UseDetailPanelReturn {
   openEventDetailsPanel: (eventId?: string, onClose?: () => void) => void;
-  openHostDetailsPanel: (hostName: string, onClose?: () => void) => void;
-  openNetworkDetailsPanel: (
-    ip: string,
-    flowTarget: FlowTargetSourceDest,
-    onClose?: () => void
-  ) => void;
-  openUserDetailsPanel: (userName: string, onClose?: () => void) => void;
-  handleOnDetailsPanelClosed: () => void;
   DetailsPanel: JSX.Element | null;
   shouldShowDetailsPanel: boolean;
 }
@@ -135,57 +124,8 @@ export const useDetailPanel = ({
     [isSecurityFlyoutEnabled, openFlyout, eventDetailsIndex, scopeId, telemetry, loadDetailsPanel]
   );
 
-  const openHostDetailsPanel = useCallback(
-    (hostName: string, onClose?: () => void) => {
-      if (isSecurityFlyoutEnabled) {
-        openFlyout({
-          right: {
-            id: HostPanelKey,
-            params: {
-              hostName,
-              scopeId,
-            },
-          },
-        });
-      } else {
-        loadDetailsPanel({ panelView: 'hostDetail', params: { hostName } });
-        onPanelClose.current = onClose ?? noopPanelClose;
-      }
-    },
-    [isSecurityFlyoutEnabled, loadDetailsPanel, openFlyout, scopeId]
-  );
-
-  const openNetworkDetailsPanel = useCallback(
-    (ip: string, flowTarget: FlowTargetSourceDest, onClose?: () => void) => {
-      loadDetailsPanel({ panelView: 'networkDetail', params: { ip, flowTarget } });
-      onPanelClose.current = onClose ?? noopPanelClose;
-    },
-    [loadDetailsPanel]
-  );
-
-  const openUserDetailsPanel = useCallback(
-    (userName: string, onClose?: () => void) => {
-      if (isSecurityFlyoutEnabled) {
-        openFlyout({
-          right: {
-            id: UserPanelKey,
-            params: {
-              userName,
-              scopeId,
-            },
-          },
-        });
-      } else {
-        loadDetailsPanel({ panelView: 'userDetail', params: { userName } });
-        onPanelClose.current = onClose ?? noopPanelClose;
-      }
-    },
-    [isSecurityFlyoutEnabled, loadDetailsPanel, openFlyout, scopeId]
-  );
-
   const handleOnDetailsPanelClosed = useCallback(() => {
     if (isSecurityFlyoutEnabled) return;
-
     if (onPanelClose.current) onPanelClose.current();
     if (scopedActions) {
       dispatch(scopedActions.toggleDetailPanel({ tabType, id: scopeId }));
@@ -219,10 +159,6 @@ export const useDetailPanel = ({
 
   return {
     openEventDetailsPanel,
-    openHostDetailsPanel,
-    openNetworkDetailsPanel,
-    openUserDetailsPanel,
-    handleOnDetailsPanelClosed,
     shouldShowDetailsPanel,
     DetailsPanel,
   };


### PR DESCRIPTION
## Summary

We introduced the expandable flyout for alert details a while ago. For some reason we missed a usage of the flyout in the Session Viewer. This PR fixes that. Session View is now using the expandable flyout when the advanced settings is enabled (which it is by default).

### How to test

If you want to easily generate and visualize data in the Session Viewer:
- generate data using the script (for example `yarn test:generate -n http://elastic:changeme@localhost:9200 -k http://elastic:changeme@localhost:5601 --anc 10 --related 10 --relAlerts 10`)
- comment out [this line](https://github.com/elastic/kibana/blob/main/x-pack/plugins/session_view/public/components/process_tree/hooks.ts#L244)
- comment out [these lines](https://github.com/elastic/kibana/blob/main/x-pack/plugins/session_view/server/routes/process_events_route.ts#L115-L132)

https://github.com/elastic/kibana/assets/17276605/92fcd346-939e-48ff-8214-86500b9f044d

https://github.com/elastic/security-team/issues/9211
https://github.com/elastic/kibana/issues/180131
Part of https://github.com/elastic/security-team/issues/7464

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->