### PR TITLE
[EDR Workflows][chore] Fix `load_agent_policies` script for cloud and serverless

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_policy_generator/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_policy_generator/index.ts
@@ -56,6 +56,8 @@ const agentPolicyGenerator: RunFn = async ({ flags, log }) => {
     url: flags.kibana as string,
     username: flags.username as string,
     password: flags.password as string,
+    noCertForSsl: true,
+    log,
   });
 
   const totalPoliciesCount = flags.count as unknown as number;

--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_policy_generator/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_policy_generator/index.ts
@@ -38,13 +38,15 @@ export const cli = () => {
           kibana: 'http://127.0.0.1:5601',
           username: 'elastic',
           password: 'changeme',
+          apikey: undefined,
         },
         help: `
-        --count               Number of agent policies to create. Default: 10
-        --concurrency         Number of concurrent agent policies can be created. Default: 10
-        --kibana              The URL to kibana including credentials. Default: http://127.0.0.1:5601
-        --username            The username to use for authentication. Default: elastic
-        --password            The password to use for authentication. Default: changeme
+        --count            Number of agent policies to create. Default: 10
+        --concurrency      Number of concurrent agent policies can be created. Default: 10
+        --kibana           The URL to kibana including credentials. Default: http://127.0.0.1:5601
+        --username         The username to use for authentication for local or cloud environment. Default: elastic
+        --password         The password to use for authentication for local or cloud environment. Default: changeme
+        --apikey           API key for authenticating for Serverless environment. Default: -
       `,
       },
     }
@@ -56,6 +58,7 @@ const agentPolicyGenerator: RunFn = async ({ flags, log }) => {
     url: flags.kibana as string,
     username: flags.username as string,
     password: flags.password as string,
+    apiKey: flags.apikey as string,
     noCertForSsl: true,
     log,
   });


### PR DESCRIPTION
## Summary

For the script `x-pack/plugins/security_solution/scripts/endpoint/load_agent_policies.js`:
- fixes the `self-signed certificate in certificate chain` error when using with cloud environment (by simply *not* using certificate)
- adds a new option called `apikey` which makes it possible to use with serverless environment