### PR TITLE
[ResponseOps] Fix for flaky task state validation jest integration test

### DIFF
--- a/x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts
@@ -258,8 +258,7 @@ describe('task state validation', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/164032
-  describe.skip('allow_reading_invalid_state: false', () => {
+  describe('allow_reading_invalid_state: false', () => {
     const taskIdsToRemove: string[] = [];
     let esServer: TestElasticsearchUtils;
     let kibanaServer: TestKibanaUtils;
@@ -327,9 +326,11 @@ describe('task state validation', () => {
       taskIdsToRemove.push(id);
 
       await retry(async () => {
-        expect(logSpy.mock.calls[0][0]).toBe(
-          `Task (fooType/${id}) has a validation error: [foo]: expected value of type [string] but got [boolean]`
-        );
+        const calls = logSpy.mock.calls as string[][];
+        const expected =
+          /^Task \(fooType\/.*\) has a validation error: \[foo\]: expected value of type \[string\] but got \[boolean\]/;
+        const found = calls.map((arr) => arr[0]).find((message) => message.match(expected) != null);
+        expect(found).toMatch(expected);
         expect(updateSpy).toHaveBeenCalledWith(
           expect.arrayContaining([expect.objectContaining({ id, taskType: 'fooType' })]),
           { validate: false }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/164032#

## Summary

This PR unskips a flaky test caused by a race condition with a  TM health status log. We use a regex to find the log we care about instead of just comparing the first log to the expected message. 


### To verify

- Run the following command to run the test, and verify that it passes
```
node scripts/jest_integration.js x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts
```