### PR TITLE
[skip on serverless] x-pack/test_serverless/functional/test_suites/co…

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/index_management/data_streams.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index_management/data_streams.ts
@@ -20,6 +20,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const TEST_DS_NAME = 'test-ds-1';
 
   describe('Data Streams', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/181242
+    this.tags(['failsOnMKI']);
     before(async () => {
       log.debug('Creating required data stream');
       try {


### PR DESCRIPTION
…mmon/management/index_management/data_streams.ts

See issue for details: https://github.com/elastic/kibana/issues/181242

## Failing on Serverless

File last modified in: https://github.com/elastic/kibana/pull/173408

## Error message
Error: expected 'Error updating data retention: \'Request for uri [/_data_stream/test-ds-1/_lifecycle] with method [DELETE] exists but is not available when running in serverless mode\'' to contain 'Data retention disabled'
    at Assertion.assert (expect.js:100:11)
    at Assertion.contain (expect.js:442:10)
    at Context. (data_streams.ts:137:54)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.apply (wrap_function.js:73:16)
