### PR TITLE
[Detection Engine][Telemetry] Adds basic suppression telemetry

### DIFF
--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -10161,15 +10161,6 @@
             "description": "Non-default value of setting."
           }
         },
-        "observability:logsExplorer:allowedDataViews": {
-          "type": "array",
-          "items": {
-            "type": "keyword",
-            "_meta": {
-              "description": "Non-default value of setting."
-            }
-          }
-        },
         "observability:aiAssistantLogsIndexPattern": {
           "type": "keyword",
           "_meta": {
@@ -10186,6 +10177,15 @@
           "type": "boolean",
           "_meta": {
             "description": "Non-default value of setting."
+          }
+        },
+        "observability:logsExplorer:allowedDataViews": {
+          "type": "array",
+          "items": {
+            "type": "keyword",
+            "_meta": {
+              "description": "Non-default value of setting."
+            }
           }
         },
         "banners:placement": {

--- a/x-pack/plugins/security_solution/server/usage/collector.ts
+++ b/x-pack/plugins/security_solution/server/usage/collector.ts
@@ -78,6 +78,30 @@ export const registerCollector: RegisterCollector = ({
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
                 },
               },
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of query rules with suppression enabled' },
+              },
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of query rules with suppression enabled and missing field strategy set to suppress',
+                },
+              },
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description: 'Number of query rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of query rules with suppression enabled during a selected time period',
+                },
+              },
             },
             threshold: {
               enabled: {
@@ -121,6 +145,31 @@ export const registerCollector: RegisterCollector = ({
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
                 },
               },
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of threshold rules with suppression enabled' },
+              },
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of threshold rules with suppression enabled and missing field strategy set to suppress',
+                },
+              },
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of threshold rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of threshold rules with suppression enabled during a selected time period',
+                },
+              },
             },
             eql: {
               enabled: { type: 'long', _meta: { description: 'Number of eql rules enabled' } },
@@ -154,6 +203,30 @@ export const registerCollector: RegisterCollector = ({
                 _meta: {
                   description:
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
+                },
+              },
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of eql rules with suppression enabled' },
+              },
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of eql rules with suppression enabled and missing field strategy set to suppress',
+                },
+              },
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description: 'Number of eql rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of eql rules with suppression enabled during a selected time period',
                 },
               },
             },
@@ -242,6 +315,31 @@ export const registerCollector: RegisterCollector = ({
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
                 },
               },
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of threat match rules with suppression enabled' },
+              },
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of threat match rules with suppression enabled and missing field strategy set to suppress',
+                },
+              },
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of threat match rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of threat match rules with suppression enabled during a selected time period',
+                },
+              },
             },
             new_terms: {
               enabled: {
@@ -283,6 +381,31 @@ export const registerCollector: RegisterCollector = ({
                 _meta: {
                   description:
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
+                },
+              },
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of new terms rules with suppression enabled' },
+              },
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of new terms rules with suppression enabled and missing field strategy set to suppress',
+                },
+              },
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of new terms rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of new terms rules with suppression enabled during a selected time period',
                 },
               },
             },
@@ -366,6 +489,31 @@ export const registerCollector: RegisterCollector = ({
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
                 },
               },
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of prebuilt rules with suppression enabled' },
+              },
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of prebuilt rules with suppression enabled and missing field strategy set to suppress',
+                },
+              },
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of prebuilt rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of prebuilt rules with suppression enabled during a selected time period',
+                },
+              },
             },
             custom_total: {
               enabled: { type: 'long', _meta: { description: 'Number of custom rules enabled' } },
@@ -400,6 +548,30 @@ export const registerCollector: RegisterCollector = ({
                   description:
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
                 },
+              },
+            },
+            suppression_enabled: {
+              type: 'long',
+              _meta: { description: 'Number of custom rules with suppression enabled' },
+            },
+            suppression_enabled_missing_fields_suppress: {
+              type: 'long',
+              _meta: {
+                description:
+                  'Number of custom rules with suppression enabled and missing field strategy set to suppress',
+              },
+            },
+            suppression_enabled_per_rule_execution: {
+              type: 'long',
+              _meta: {
+                description: 'Number of custom rules with suppression enabled per rule execution',
+              },
+            },
+            suppression_enabled_per_timeperiod: {
+              type: 'long',
+              _meta: {
+                description:
+                  'Number of custom rules with suppression enabled during a selected time period',
               },
             },
           },

--- a/x-pack/plugins/security_solution/server/usage/collector.ts
+++ b/x-pack/plugins/security_solution/server/usage/collector.ts
@@ -549,29 +549,29 @@ export const registerCollector: RegisterCollector = ({
                     'Number of rules using the legacy investigation fields type introduced only in 8.10 ESS',
                 },
               },
-            },
-            suppression_enabled: {
-              type: 'long',
-              _meta: { description: 'Number of custom rules with suppression enabled' },
-            },
-            suppression_enabled_missing_fields_suppress: {
-              type: 'long',
-              _meta: {
-                description:
-                  'Number of custom rules with suppression enabled and missing field strategy set to suppress',
+              suppression_enabled: {
+                type: 'long',
+                _meta: { description: 'Number of custom rules with suppression enabled' },
               },
-            },
-            suppression_enabled_per_rule_execution: {
-              type: 'long',
-              _meta: {
-                description: 'Number of custom rules with suppression enabled per rule execution',
+              suppression_enabled_missing_fields_suppress: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of custom rules with suppression enabled and missing field strategy set to suppress',
+                },
               },
-            },
-            suppression_enabled_per_timeperiod: {
-              type: 'long',
-              _meta: {
-                description:
-                  'Number of custom rules with suppression enabled during a selected time period',
+              suppression_enabled_per_rule_execution: {
+                type: 'long',
+                _meta: {
+                  description: 'Number of custom rules with suppression enabled per rule execution',
+                },
+              },
+              suppression_enabled_per_timeperiod: {
+                type: 'long',
+                _meta: {
+                  description:
+                    'Number of custom rules with suppression enabled during a selected time period',
+                },
               },
             },
           },

--- a/x-pack/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/rules/get_initial_usage.ts
@@ -27,6 +27,10 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
+    suppression_enabled_per_rule_execution: 0,
+    suppression_enabled_per_timeperiod: 0,
+    suppression_enabled_missing_fields_suppress: 0,
   },
   threshold: {
     enabled: 0,
@@ -38,6 +42,7 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
   },
   eql: {
     enabled: 0,
@@ -49,6 +54,10 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
+    suppression_enabled_per_rule_execution: 0,
+    suppression_enabled_per_timeperiod: 0,
+    suppression_enabled_missing_fields_suppress: 0,
   },
   machine_learning: {
     enabled: 0,
@@ -71,6 +80,10 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
+    suppression_enabled_per_rule_execution: 0,
+    suppression_enabled_per_timeperiod: 0,
+    suppression_enabled_missing_fields_suppress: 0,
   },
   new_terms: {
     enabled: 0,
@@ -82,6 +95,10 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
+    suppression_enabled_per_rule_execution: 0,
+    suppression_enabled_per_timeperiod: 0,
+    suppression_enabled_missing_fields_suppress: 0,
   },
   esql: {
     enabled: 0,
@@ -104,6 +121,10 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
+    suppression_enabled_per_rule_execution: 0,
+    suppression_enabled_per_timeperiod: 0,
+    suppression_enabled_missing_fields_suppress: 0,
   },
   custom_total: {
     enabled: 0,
@@ -115,6 +136,10 @@ export const getInitialRulesUsage = (): RulesTypeUsage => ({
     notifications_enabled: 0,
     notifications_disabled: 0,
     legacy_investigation_fields: 0,
+    suppression_enabled: 0,
+    suppression_enabled_per_rule_execution: 0,
+    suppression_enabled_per_timeperiod: 0,
+    suppression_enabled_missing_fields_suppress: 0,
   },
 });
 

--- a/x-pack/plugins/security_solution/server/usage/detections/rules/transform_utils/get_rule_object_correlations.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/rules/transform_utils/get_rule_object_correlations.ts
@@ -8,6 +8,7 @@
 import type { SavedObjectsFindResult } from '@kbn/core/server';
 import type { RuleMetric } from '../types';
 import type { RuleSearchResult } from '../../../types';
+import { getSuppressionUsage } from '../usage_utils/get_suppression_usage';
 
 export interface RuleObjectCorrelationsOptions {
   ruleResults: Array<SavedObjectsFindResult<RuleSearchResult>>;
@@ -41,6 +42,12 @@ export const getRuleObjectCorrelations = ({
       attributes.actions.length > 0 &&
       attributes.muteAll !== true;
 
+    const {
+      hasAlertSuppressionPerExecution,
+      hasAlertSuppressionPerPeriod,
+      hasAlertSuppressionMissingFieldsStrategySuppress,
+    } = getSuppressionUsage(attributes);
+
     return {
       rule_name: attributes.name,
       rule_id: attributes.params.ruleId,
@@ -56,6 +63,10 @@ export const getRuleObjectCorrelations = ({
       has_legacy_notification: hasLegacyNotification,
       has_notification: hasNotification,
       has_legacy_investigation_field: Array.isArray(attributes.params.investigationFields),
+      has_alert_suppression_per_execution: hasAlertSuppressionPerExecution,
+      has_alert_suppression_per_period: hasAlertSuppressionPerPeriod,
+      has_alert_suppression_missing_fields_strategy_suppress:
+        hasAlertSuppressionMissingFieldsStrategySuppress,
     };
   });
 };

--- a/x-pack/plugins/security_solution/server/usage/detections/rules/types.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/rules/types.ts
@@ -15,6 +15,10 @@ export interface FeatureTypeUsage {
   notifications_enabled: number;
   notifications_disabled: number;
   legacy_investigation_fields: number;
+  suppression_enabled?: number;
+  suppression_enabled_per_rule_execution?: number;
+  suppression_enabled_per_timeperiod?: number;
+  suppression_enabled_missing_fields_suppress?: number;
 }
 
 export interface RulesTypeUsage {
@@ -49,6 +53,9 @@ export interface RuleMetric {
   has_legacy_notification: boolean;
   has_notification: boolean;
   has_legacy_investigation_field: boolean;
+  has_alert_suppression_per_execution: boolean;
+  has_alert_suppression_per_period: boolean;
+  has_alert_suppression_missing_fields_strategy_suppress: boolean;
 }
 
 /**

--- a/x-pack/plugins/security_solution/server/usage/detections/rules/update_usage.test.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/rules/update_usage.test.ts
@@ -18,6 +18,9 @@ interface StubRuleOptions {
   hasLegacyNotification: boolean;
   hasNotification: boolean;
   hasLegacyInvestigationField: boolean;
+  hasAlertSuppressionPerExecution: boolean;
+  hasAlertSuppressionPerPeriod: boolean;
+  hasAlertSuppressionMissingFieldsStrategySuppress: boolean;
 }
 
 const createStubRule = ({
@@ -29,6 +32,9 @@ const createStubRule = ({
   hasLegacyNotification,
   hasNotification,
   hasLegacyInvestigationField,
+  hasAlertSuppressionPerExecution,
+  hasAlertSuppressionPerPeriod,
+  hasAlertSuppressionMissingFieldsStrategySuppress,
 }: StubRuleOptions): RuleMetric => ({
   rule_name: 'rule-name',
   rule_id: 'id-123',
@@ -43,6 +49,10 @@ const createStubRule = ({
   has_legacy_notification: hasLegacyNotification,
   has_notification: hasNotification,
   has_legacy_investigation_field: hasLegacyInvestigationField,
+  has_alert_suppression_per_execution: hasAlertSuppressionPerExecution,
+  has_alert_suppression_per_period: hasAlertSuppressionPerPeriod,
+  has_alert_suppression_missing_fields_strategy_suppress:
+    hasAlertSuppressionMissingFieldsStrategySuppress,
 });
 
 describe('Detections Usage and Metrics', () => {
@@ -57,6 +67,9 @@ describe('Detections Usage and Metrics', () => {
         hasLegacyNotification: false,
         hasNotification: false,
         hasLegacyInvestigationField: false,
+        hasAlertSuppressionPerExecution: false,
+        hasAlertSuppressionPerPeriod: false,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
       });
       const usage = updateRuleUsage(stubRule, getInitialRulesUsage());
 
@@ -72,6 +85,10 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 0,
+          suppression_enabled: 0,
+          suppression_enabled_missing_fields_suppress: 0,
+          suppression_enabled_per_rule_execution: 0,
+          suppression_enabled_per_timeperiod: 0,
         },
         eql: {
           alerts: 1,
@@ -83,6 +100,10 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 0,
+          suppression_enabled: 0,
+          suppression_enabled_missing_fields_suppress: 0,
+          suppression_enabled_per_rule_execution: 0,
+          suppression_enabled_per_timeperiod: 0,
         },
       });
     });
@@ -97,6 +118,9 @@ describe('Detections Usage and Metrics', () => {
         hasLegacyNotification: false,
         hasNotification: false,
         hasLegacyInvestigationField: false,
+        hasAlertSuppressionPerExecution: true,
+        hasAlertSuppressionPerPeriod: false,
+        hasAlertSuppressionMissingFieldsStrategySuppress: true,
       });
       const stubQueryRuleOne = createStubRule({
         ruleType: 'query',
@@ -107,6 +131,9 @@ describe('Detections Usage and Metrics', () => {
         hasLegacyNotification: false,
         hasNotification: false,
         hasLegacyInvestigationField: true,
+        hasAlertSuppressionPerExecution: false,
+        hasAlertSuppressionPerPeriod: true,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
       });
       const stubQueryRuleTwo = createStubRule({
         ruleType: 'query',
@@ -117,6 +144,9 @@ describe('Detections Usage and Metrics', () => {
         hasLegacyNotification: false,
         hasNotification: false,
         hasLegacyInvestigationField: false,
+        hasAlertSuppressionPerExecution: true,
+        hasAlertSuppressionPerPeriod: false,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
       });
       const stubMachineLearningOne = createStubRule({
         ruleType: 'machine_learning',
@@ -127,6 +157,9 @@ describe('Detections Usage and Metrics', () => {
         hasLegacyNotification: false,
         hasNotification: false,
         hasLegacyInvestigationField: false,
+        hasAlertSuppressionPerExecution: false,
+        hasAlertSuppressionPerPeriod: false,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
       });
       const stubMachineLearningTwo = createStubRule({
         ruleType: 'machine_learning',
@@ -137,6 +170,9 @@ describe('Detections Usage and Metrics', () => {
         hasLegacyNotification: false,
         hasNotification: false,
         hasLegacyInvestigationField: false,
+        hasAlertSuppressionPerExecution: false,
+        hasAlertSuppressionPerPeriod: false,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
       });
 
       let usage = updateRuleUsage(stubEqlRule, getInitialRulesUsage());
@@ -157,6 +193,10 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 0,
+          suppression_enabled: 2,
+          suppression_enabled_missing_fields_suppress: 1,
+          suppression_enabled_per_rule_execution: 1,
+          suppression_enabled_per_timeperiod: 1,
         },
         elastic_total: {
           alerts: 28,
@@ -168,6 +208,10 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 1,
+          suppression_enabled: 0,
+          suppression_enabled_missing_fields_suppress: 0,
+          suppression_enabled_per_rule_execution: 0,
+          suppression_enabled_per_timeperiod: 0,
         },
         eql: {
           alerts: 1,
@@ -179,6 +223,10 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 0,
+          suppression_enabled: 1,
+          suppression_enabled_missing_fields_suppress: 1,
+          suppression_enabled_per_rule_execution: 0,
+          suppression_enabled_per_timeperiod: 1,
         },
         machine_learning: {
           alerts: 22,
@@ -190,6 +238,10 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 0,
+          suppression_enabled: 0,
+          suppression_enabled_missing_fields_suppress: 0,
+          suppression_enabled_per_rule_execution: 0,
+          suppression_enabled_per_timeperiod: 0,
         },
         query: {
           alerts: 10,
@@ -201,64 +253,68 @@ describe('Detections Usage and Metrics', () => {
           notifications_enabled: 0,
           notifications_disabled: 0,
           legacy_investigation_fields: 1,
+          suppression_enabled: 1,
+          suppression_enabled_missing_fields_suppress: 0,
+          suppression_enabled_per_rule_execution: 1,
+          suppression_enabled_per_timeperiod: 0,
         },
       });
     });
 
     describe('table tests of "ruleType", "enabled", "elasticRule", "legacyNotification", and "hasLegacyInvestigationField"', () => {
       test.each`
-        ruleType              | enabled  | hasLegacyNotification | hasNotification | expectedLegacyNotificationsEnabled | expectedLegacyNotificationsDisabled | expectedNotificationsEnabled | expectedNotificationsDisabled | hasLegacyInvestigationField
-        ${'eql'}              | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'eql'}              | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'eql'}              | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'eql'}              | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'eql'}              | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'eql'}              | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'eql'}              | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
-        ${'query'}            | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'query'}            | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'query'}            | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'query'}            | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'query'}            | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'query'}            | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'query'}            | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
-        ${'threshold'}        | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'threshold'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'threshold'}        | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'threshold'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'threshold'}        | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'threshold'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'threshold'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
-        ${'machine_learning'} | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'machine_learning'} | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'machine_learning'} | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'machine_learning'} | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'machine_learning'} | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'machine_learning'} | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'machine_learning'} | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
-        ${'threat_match'}     | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'threat_match'}     | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'threat_match'}     | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'threat_match'}     | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'threat_match'}     | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'threat_match'}     | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'threat_match'}     | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
-        ${'new_terms'}        | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'new_terms'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'new_terms'}        | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'new_terms'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'new_terms'}        | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'new_terms'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'new_terms'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
-        ${'esql'}             | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'esql'}             | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'esql'}             | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}
-        ${'esql'}             | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}
-        ${'esql'}             | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}
-        ${'esql'}             | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}
-        ${'esql'}             | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}
+        ruleType              | enabled  | hasLegacyNotification | hasNotification | expectedLegacyNotificationsEnabled | expectedLegacyNotificationsDisabled | expectedNotificationsEnabled | expectedNotificationsDisabled | hasLegacyInvestigationField | hasAlertSuppressionPerExecution | hasAlertSuppressionPerPeriod | hasAlertSuppressionMissingFieldsStrategySuppress
+        ${'eql'}              | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'eql'}              | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${false}
+        ${'eql'}              | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${false}                        | ${true}                      | ${true}
+        ${'eql'}              | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${true}                         | ${false}                     | ${false}
+        ${'eql'}              | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${true}                         | ${false}                     | ${true}
+        ${'eql'}              | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'eql'}              | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
+        ${'query'}            | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'query'}            | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${true}                         | ${false}                     | ${false}
+        ${'query'}            | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${true}                         | ${false}                     | ${true}
+        ${'query'}            | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${false}
+        ${'query'}            | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${true}
+        ${'query'}            | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'query'}            | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
+        ${'threshold'}        | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'threshold'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${true}                         | ${false}                     | ${false}
+        ${'threshold'}        | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${true}                         | ${false}                     | ${true}
+        ${'threshold'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${false}
+        ${'threshold'}        | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${true}
+        ${'threshold'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'threshold'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'machine_learning'} | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
+        ${'threat_match'}     | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'threat_match'}     | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${true}                         | ${false}                     | ${false}
+        ${'threat_match'}     | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${true}                         | ${false}                     | ${true}
+        ${'threat_match'}     | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${false}
+        ${'threat_match'}     | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${true}
+        ${'threat_match'}     | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'threat_match'}     | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
+        ${'new_terms'}        | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'new_terms'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${true}                         | ${false}                     | ${false}
+        ${'new_terms'}        | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${true}                         | ${false}                     | ${true}
+        ${'new_terms'}        | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${false}
+        ${'new_terms'}        | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${true}                      | ${true}
+        ${'new_terms'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'new_terms'}        | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${true}  | ${true}               | ${false}        | ${1}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${false} | ${false}              | ${true}         | ${0}                               | ${0}                                | ${0}                         | ${1}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${true}  | ${false}              | ${true}         | ${0}                               | ${0}                                | ${1}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${false} | ${true}               | ${false}        | ${0}                               | ${1}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${0}                        | ${false}                        | ${false}                     | ${false}
+        ${'esql'}             | ${false} | ${false}              | ${false}        | ${0}                               | ${0}                                | ${0}                         | ${0}                          | ${1}                        | ${false}                        | ${false}                     | ${false}
       `(
-        'expect { "ruleType": $ruleType, "enabled": $enabled, "hasLegacyNotification": $hasLegacyNotification, "hasNotification": $hasNotification, hasLegacyInvestigationField: $hasLegacyInvestigationField } to equal { legacy_notifications_enabled: $expectedLegacyNotificationsEnabled, legacy_notifications_disabled: $expectedLegacyNotificationsDisabled, notifications_enabled: $expectedNotificationsEnabled, notifications_disabled, $expectedNotificationsDisabled, hasLegacyInvestigationField: $hasLegacyInvestigationField }',
+        'expect { "ruleType": $ruleType, "enabled": $enabled, "hasLegacyNotification": $hasLegacyNotification, "hasNotification": $hasNotification, hasLegacyInvestigationField: $hasLegacyInvestigationField } to equal { legacy_notifications_enabled: $expectedLegacyNotificationsEnabled, legacy_notifications_disabled: $expectedLegacyNotificationsDisabled, notifications_enabled: $expectedNotificationsEnabled, notifications_disabled, $expectedNotificationsDisabled, hasLegacyInvestigationField: $hasLegacyInvestigationField hasAlertSuppressionPerExecution: $hasAlertSuppressionPerExecution, hasAlertSuppressionPerPeriod: $hasAlertSuppressionPerPeriod, hasAlertSuppressionMissingFieldsStrategySuppress: $hasAlertSuppressionMissingFieldsStrategySuppress }',
         ({
           ruleType,
           enabled,
@@ -269,6 +325,9 @@ describe('Detections Usage and Metrics', () => {
           expectedNotificationsEnabled,
           expectedNotificationsDisabled,
           hasLegacyInvestigationField,
+          hasAlertSuppressionPerExecution,
+          hasAlertSuppressionPerPeriod,
+          hasAlertSuppressionMissingFieldsStrategySuppress,
         }) => {
           const rule1 = createStubRule({
             ruleType,
@@ -279,6 +338,9 @@ describe('Detections Usage and Metrics', () => {
             alertCount: 0,
             caseCount: 0,
             hasLegacyInvestigationField,
+            hasAlertSuppressionPerExecution,
+            hasAlertSuppressionPerPeriod,
+            hasAlertSuppressionMissingFieldsStrategySuppress,
           });
           const usage = updateRuleUsage(rule1, getInitialRulesUsage()) as ReturnType<
             typeof updateRuleUsage
@@ -303,6 +365,9 @@ describe('Detections Usage and Metrics', () => {
             alertCount: 0,
             caseCount: 0,
             hasLegacyInvestigationField,
+            hasAlertSuppressionPerExecution,
+            hasAlertSuppressionPerPeriod,
+            hasAlertSuppressionMissingFieldsStrategySuppress,
           });
           const usageAddedByOne = updateRuleUsage(rule2, usage) as ReturnType<
             typeof updateRuleUsage

--- a/x-pack/plugins/security_solution/server/usage/detections/rules/usage_utils/get_suppression_usage.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/rules/usage_utils/get_suppression_usage.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RuleSearchResult } from '../../../types';
+
+export const getSuppressionUsage = (
+  ruleAttributes: RuleSearchResult
+): {
+  hasAlertSuppressionPerExecution: boolean;
+  hasAlertSuppressionPerPeriod: boolean;
+  hasAlertSuppressionMissingFieldsStrategySuppress: boolean;
+} => {
+  switch (ruleAttributes.params.type) {
+    case 'threshold':
+      return {
+        hasAlertSuppressionPerExecution: false,
+        hasAlertSuppressionPerPeriod: ruleAttributes.params.alertSuppression != null,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
+      };
+    case 'query':
+    case 'saved_query':
+    case 'new_terms':
+    case 'threat_match':
+    case 'eql':
+      return {
+        hasAlertSuppressionPerExecution:
+          ruleAttributes.params.alertSuppression != null &&
+          ruleAttributes.params.alertSuppression.duration == null,
+        hasAlertSuppressionPerPeriod:
+          ruleAttributes.params.alertSuppression != null &&
+          ruleAttributes.params.alertSuppression.duration != null,
+        hasAlertSuppressionMissingFieldsStrategySuppress:
+          ruleAttributes.params.alertSuppression != null &&
+          ruleAttributes.params.alertSuppression.missingFieldsStrategy != null &&
+          ruleAttributes.params.alertSuppression.missingFieldsStrategy === 'suppress',
+      };
+    default:
+      return {
+        hasAlertSuppressionPerExecution: false,
+        hasAlertSuppressionPerPeriod: false,
+        hasAlertSuppressionMissingFieldsStrategySuppress: false,
+      };
+  }
+};

--- a/x-pack/plugins/security_solution/server/usage/detections/rules/usage_utils/update_query_usage.ts
+++ b/x-pack/plugins/security_solution/server/usage/detections/rules/usage_utils/update_query_usage.ts
@@ -47,5 +47,20 @@ export const updateQueryUsage = ({
     legacy_investigation_fields: detectionRuleMetric.has_legacy_investigation_field
       ? usage[ruleType].legacy_investigation_fields + 1
       : usage[ruleType].legacy_investigation_fields,
+    suppression_enabled:
+      detectionRuleMetric.has_alert_suppression_per_execution ||
+      detectionRuleMetric.has_alert_suppression_per_period
+        ? (usage[ruleType].suppression_enabled || 0) + 1
+        : usage[ruleType].suppression_enabled,
+    suppression_enabled_missing_fields_suppress:
+      detectionRuleMetric.has_alert_suppression_missing_fields_strategy_suppress
+        ? (usage[ruleType].suppression_enabled_missing_fields_suppress || 0) + 1
+        : usage[ruleType].suppression_enabled_missing_fields_suppress,
+    suppression_enabled_per_rule_execution: detectionRuleMetric.has_alert_suppression_per_execution
+      ? (usage[ruleType].suppression_enabled_per_timeperiod || 0) + 1
+      : usage[ruleType].suppression_enabled_per_timeperiod,
+    suppression_enabled_per_timeperiod: detectionRuleMetric.has_alert_suppression_per_period
+      ? (usage[ruleType].suppression_enabled_per_timeperiod || 0) + 1
+      : usage[ruleType].suppression_enabled_per_timeperiod,
   };
 };

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -11243,6 +11243,30 @@
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
                           }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of query rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of query rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of query rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of query rules with suppression enabled during a selected time period"
+                          }
                         }
                       }
                     },
@@ -11301,6 +11325,30 @@
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
                           }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threshold rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threshold rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threshold rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threshold rules with suppression enabled during a selected time period"
+                          }
                         }
                       }
                     },
@@ -11358,6 +11406,30 @@
                           "type": "long",
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
+                          }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of eql rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of eql rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of eql rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of eql rules with suppression enabled during a selected time period"
                           }
                         }
                       }
@@ -11475,6 +11547,30 @@
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
                           }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threat match rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threat match rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threat match rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of threat match rules with suppression enabled during a selected time period"
+                          }
                         }
                       }
                     },
@@ -11532,6 +11628,30 @@
                           "type": "long",
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
+                          }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of new terms rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of new terms rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of new terms rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of new terms rules with suppression enabled during a selected time period"
                           }
                         }
                       }
@@ -11649,6 +11769,30 @@
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
                           }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of prebuilt rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of prebuilt rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of prebuilt rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of prebuilt rules with suppression enabled during a selected time period"
+                          }
                         }
                       }
                     },
@@ -11706,6 +11850,30 @@
                           "type": "long",
                           "_meta": {
                             "description": "Number of rules using the legacy investigation fields type introduced only in 8.10 ESS"
+                          }
+                        },
+                        "suppression_enabled": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of custom rules with suppression enabled"
+                          }
+                        },
+                        "suppression_enabled_missing_fields_suppress": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of custom rules with suppression enabled and missing field strategy set to suppress"
+                          }
+                        },
+                        "suppression_enabled_per_rule_execution": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of custom rules with suppression enabled per rule execution"
+                          }
+                        },
+                        "suppression_enabled_per_timeperiod": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Number of custom rules with suppression enabled during a selected time period"
                           }
                         }
                       }


### PR DESCRIPTION
## Summary

Adds some basic alert suppression telemetry around to answer:

- Is telemetry enabled?
- When enabled, is it enabled per rule execution?
- When enabled, is it enabled per time period?
- When enabled, is missing field strategy set to suppress?