### PR TITLE
[Synthetics] Fix externally-controlled format string

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/public/utils/api_service/api_service.ts
+++ b/x-pack/plugins/observability_solution/synthetics/public/utils/api_service/api_service.ts
@@ -50,9 +50,8 @@ class ApiService {
       } else {
         // eslint-disable-next-line no-console
         console.error(
-          `API ${apiUrl} is not returning expected response, ${formatErrors(
-            decoded.left
-          )} for response`,
+          `API $s is not returning expected response, ${formatErrors(decoded.left)} for response`,
+          apiUrl,
           response
         );
       }


### PR DESCRIPTION
## Summary

Close https://github.com/elastic/kibana/issues/177702

use a %s specifier  to fix security issue. The %s logs the output as string

<!--ONMERGE {"backportTargets":["8.13","8.14"]} ONMERGE-->