### PR TITLE
[ES|QL] Fixes comments bugs in Discover and Data Visualizer

### DIFF
--- a/packages/kbn-esql-utils/index.ts
+++ b/packages/kbn-esql-utils/index.ts
@@ -15,6 +15,7 @@ export {
   getIndexForESQLQuery,
   getInitialESQLQuery,
   getESQLWithSafeLimit,
+  appendToESQLQuery,
   TextBasedLanguages,
 } from './src';
 

--- a/packages/kbn-esql-utils/src/index.ts
+++ b/packages/kbn-esql-utils/src/index.ts
@@ -16,3 +16,4 @@ export {
   getLimitFromESQLQuery,
   removeDropCommandsFromESQLQuery,
 } from './utils/query_parsing_helpers';
+export { appendToESQLQuery } from './utils/append_to_query';

--- a/packages/kbn-esql-utils/src/utils/append_to_query.test.ts
+++ b/packages/kbn-esql-utils/src/utils/append_to_query.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { appendToESQLQuery } from './append_to_query';
+
+describe('getESQLWithSafeLimit()', () => {
+  it('append the text on a new line after the query', () => {
+    expect(appendToESQLQuery('from logstash-* // meow', '| stats var = avg(woof)')).toBe(
+      `from logstash-* // meow
+| stats var = avg(woof)`
+    );
+  });
+
+  it('append the text on a new line after the query for text with variables', () => {
+    const limit = 10;
+    expect(appendToESQLQuery('from logstash-*', `| limit ${limit}`)).toBe(
+      `from logstash-*
+| limit 10`
+    );
+  });
+});

--- a/packages/kbn-esql-utils/src/utils/append_to_query.test.ts
+++ b/packages/kbn-esql-utils/src/utils/append_to_query.test.ts
@@ -7,7 +7,7 @@
  */
 import { appendToESQLQuery } from './append_to_query';
 
-describe('getESQLWithSafeLimit()', () => {
+describe('appendToESQLQuery', () => {
   it('append the text on a new line after the query', () => {
     expect(appendToESQLQuery('from logstash-* // meow', '| stats var = avg(woof)')).toBe(
       `from logstash-* // meow

--- a/packages/kbn-esql-utils/src/utils/append_to_query.ts
+++ b/packages/kbn-esql-utils/src/utils/append_to_query.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// Append in a new line the appended text to take care of the case where the user adds a comment at the end of the query
+// in these cases a base query such as "from index // comment" will result in errors or wrong data if we don't append in a new line
+export function appendToESQLQuery(baseESQLQuery: string, appendedText: string): string {
+  return `${baseESQLQuery}\n${appendedText}`;
+}

--- a/packages/kbn-esql-utils/src/utils/get_esql_with_safe_limit.test.ts
+++ b/packages/kbn-esql-utils/src/utils/get_esql_with_safe_limit.test.ts
@@ -17,15 +17,15 @@ describe('getESQLWithSafeLimit()', () => {
   });
 
   it('should add the limit', () => {
-    expect(getESQLWithSafeLimit(' from logs', LIMIT)).toBe('from logs | LIMIT 10000');
+    expect(getESQLWithSafeLimit(' from logs', LIMIT)).toBe('from logs \n| LIMIT 10000');
     expect(getESQLWithSafeLimit('FROM logs* | LIMIT 5', LIMIT)).toBe(
-      'FROM logs* | LIMIT 10000| LIMIT 5'
+      'FROM logs* \n| LIMIT 10000| LIMIT 5'
     );
     expect(getESQLWithSafeLimit('FROM logs* | SORT @timestamp | LIMIT 5', LIMIT)).toBe(
-      'FROM logs* |SORT @timestamp | LIMIT 10000| LIMIT 5'
+      'FROM logs* |SORT @timestamp \n| LIMIT 10000| LIMIT 5'
     );
     expect(getESQLWithSafeLimit('from logs* | STATS MIN(a) BY b', LIMIT)).toBe(
-      'from logs* | LIMIT 10000| STATS MIN(a) BY b'
+      'from logs* \n| LIMIT 10000| STATS MIN(a) BY b'
     );
   });
 });

--- a/packages/kbn-esql-utils/src/utils/get_esql_with_safe_limit.ts
+++ b/packages/kbn-esql-utils/src/utils/get_esql_with_safe_limit.ts
@@ -26,7 +26,7 @@ export function getESQLWithSafeLimit(esql: string, limit: number): string {
   return parts
     .map((part, i) => {
       if (i === index) {
-        return `${part.trim()} | LIMIT ${limit}`;
+        return `${part.trim()} \n| LIMIT ${limit}`;
       }
       return part;
     })

--- a/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.test.ts
+++ b/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.test.ts
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
 import type { DataViewField } from '@kbn/data-views-plugin/common';
 import { buildSearchFilter, fetchAndCalculateFieldStats } from './field_stats_utils_text_based';
 
@@ -74,11 +73,10 @@ describe('fieldStatsUtilsTextBased', function () {
           "totalDocuments": 4,
         }
       `);
-
       expect(searchHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           query:
-            'from logs* | limit 1000| WHERE `message` IS NOT NULL\n    | STATS `message_terms` = count(`message`) BY `message`\n    | SORT `message_terms` DESC\n    | LIMIT 10',
+            'from logs* | limit 1000\n| WHERE `message` IS NOT NULL\n    | STATS `message_terms` = count(`message`) BY `message`\n    | SORT `message_terms` DESC\n    | LIMIT 10',
         })
       );
     });
@@ -121,7 +119,7 @@ describe('fieldStatsUtilsTextBased', function () {
       expect(searchHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           query:
-            'from logs* | limit 1000| WHERE `message` IS NOT NULL\n    | KEEP `message`\n    | LIMIT 100',
+            'from logs* | limit 1000\n| WHERE `message` IS NOT NULL\n    | KEEP `message`\n    | LIMIT 100',
         })
       );
     });

--- a/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.ts
+++ b/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ESQLSearchReponse } from '@kbn/es-types';
+import { appendToESQLQuery } from '@kbn/esql-utils';
 import type { DataViewField } from '@kbn/data-views-plugin/common';
 import type { FieldStatsResponse } from '../../types';
 import {
@@ -74,14 +75,15 @@ export async function getStringTopValues(
   size = DEFAULT_TOP_VALUES_SIZE
 ): Promise<FieldStatsResponse<string | boolean>> {
   const { searchHandler, field, esqlBaseQuery } = params;
-  const esqlQuery =
-    esqlBaseQuery +
-    `| WHERE ${getSafeESQLFieldName(field.name)} IS NOT NULL
-    | STATS ${getSafeESQLFieldName(`${field.name}_terms`)} = count(${getSafeESQLFieldName(
-      field.name
-    )}) BY ${getSafeESQLFieldName(field.name)}
-    | SORT ${getSafeESQLFieldName(`${field.name}_terms`)} DESC
-    | LIMIT ${size}`;
+  const safeEsqlFieldName = getSafeESQLFieldName(field.name);
+  const safeEsqlFieldNameTerms = getSafeESQLFieldName(`${field.name}_terms`);
+  const esqlQuery = appendToESQLQuery(
+    esqlBaseQuery,
+    `| WHERE ${safeEsqlFieldName} IS NOT NULL
+    | STATS ${safeEsqlFieldNameTerms} = count(${safeEsqlFieldName}) BY ${safeEsqlFieldName}
+    | SORT ${safeEsqlFieldNameTerms} DESC
+    | LIMIT ${size}`
+  );
 
   const result = await searchHandler({ query: esqlQuery });
   const values = result?.values as Array<[number, string]>;
@@ -111,11 +113,13 @@ export async function getSimpleTextExamples(
   params: FetchAndCalculateFieldStatsParams
 ): Promise<FieldStatsResponse<string | boolean>> {
   const { searchHandler, field, esqlBaseQuery } = params;
-  const esqlQuery =
-    esqlBaseQuery +
-    `| WHERE ${getSafeESQLFieldName(field.name)} IS NOT NULL
-    | KEEP ${getSafeESQLFieldName(field.name)}
-    | LIMIT ${SIMPLE_EXAMPLES_FETCH_SIZE}`;
+  const safeEsqlFieldName = getSafeESQLFieldName(field.name);
+  const esqlQuery = appendToESQLQuery(
+    esqlBaseQuery,
+    `| WHERE ${safeEsqlFieldName} IS NOT NULL
+    | KEEP ${safeEsqlFieldName}
+    | LIMIT ${SIMPLE_EXAMPLES_FETCH_SIZE}`
+  );
 
   const result = await searchHandler({ query: esqlQuery });
   const values = ((result?.values as Array<[string | string[]]>) || []).map((value) =>

--- a/src/plugins/unified_histogram/public/services/lens_vis_service.attributes.test.ts
+++ b/src/plugins/unified_histogram/public/services/lens_vis_service.attributes.test.ts
@@ -763,7 +763,8 @@ describe('LensVisService attributes', () => {
 
   it('should use the correct histogram query when no suggestion passed', async () => {
     const histogramQuery = {
-      esql: 'from logstash-* | limit 10 | EVAL timestamp=DATE_TRUNC(10 minute, @timestamp) | stats results = count(*) by timestamp | rename timestamp as `@timestamp every 10 minute`',
+      esql: `from logstash-* | limit 10
+| EVAL timestamp=DATE_TRUNC(10 minute, @timestamp) | stats results = count(*) by timestamp | rename timestamp as \`@timestamp every 10 minute\``,
     };
     const lensVis = await getLensVisMock({
       filters,

--- a/src/plugins/unified_histogram/public/services/lens_vis_service.suggestions.test.ts
+++ b/src/plugins/unified_histogram/public/services/lens_vis_service.suggestions.test.ts
@@ -120,7 +120,8 @@ describe('LensVisService suggestions', () => {
     expect(lensVis.currentSuggestionContext?.suggestion).toBeDefined();
 
     const histogramQuery = {
-      esql: 'from the-data-view | limit 100 | EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp | rename timestamp as `@timestamp every 30 minute`',
+      esql: `from the-data-view | limit 100
+| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp | rename timestamp as \`@timestamp every 30 minute\``,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);
@@ -157,7 +158,8 @@ describe('LensVisService suggestions', () => {
     expect(lensVis.currentSuggestionContext?.suggestion).toBeDefined();
 
     const histogramQuery = {
-      esql: 'from the-data-view | limit 100 | EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp | rename timestamp as `@timestamp every 30 minute`',
+      esql: `from the-data-view | limit 100
+| EVAL timestamp=DATE_TRUNC(30 minute, @timestamp) | stats results = count(*) by timestamp | rename timestamp as \`@timestamp every 30 minute\``,
     };
 
     expect(lensVis.visContext?.attributes.state.query).toStrictEqual(histogramQuery);

--- a/src/plugins/unified_histogram/public/services/lens_vis_service.ts
+++ b/src/plugins/unified_histogram/public/services/lens_vis_service.ts
@@ -8,7 +8,7 @@
 
 import { BehaviorSubject, distinctUntilChanged, map, Observable } from 'rxjs';
 import { isEqual } from 'lodash';
-import { removeDropCommandsFromESQLQuery } from '@kbn/esql-utils';
+import { removeDropCommandsFromESQLQuery, appendToESQLQuery } from '@kbn/esql-utils';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type {
   CountIndexPatternColumn,
@@ -513,8 +513,10 @@ export class LensVisService {
     const queryInterval = interval ?? computeInterval(timeRange, this.services.data);
     const language = getAggregateQueryMode(query);
     const safeQuery = removeDropCommandsFromESQLQuery(query[language]);
-    return `${safeQuery}
-    | EVAL timestamp=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by timestamp | rename timestamp as \`${dataView.timeFieldName} every ${queryInterval}\``;
+    return appendToESQLQuery(
+      safeQuery,
+      `| EVAL timestamp=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by timestamp | rename timestamp as \`${dataView.timeFieldName} every ${queryInterval}\``
+    );
   };
 
   private getAllSuggestions = ({ queryParams }: { queryParams: QueryParams }): Suggestion[] => {

--- a/src/plugins/unified_histogram/public/services/lens_vis_service.ts
+++ b/src/plugins/unified_histogram/public/services/lens_vis_service.ts
@@ -513,7 +513,8 @@ export class LensVisService {
     const queryInterval = interval ?? computeInterval(timeRange, this.services.data);
     const language = getAggregateQueryMode(query);
     const safeQuery = removeDropCommandsFromESQLQuery(query[language]);
-    return `${safeQuery} | EVAL timestamp=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by timestamp | rename timestamp as \`${dataView.timeFieldName} every ${queryInterval}\``;
+    return `${safeQuery}
+    | EVAL timestamp=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by timestamp | rename timestamp as \`${dataView.timeFieldName} every ${queryInterval}\``;
   };
 
   private getAllSuggestions = ({ queryParams }: { queryParams: QueryParams }): Suggestion[] => {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_boolean_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_boolean_field_stats.ts
@@ -9,7 +9,7 @@ import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import pLimit from 'p-limit';
-import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import { isFulfilled, isRejected } from '../../../common/util/promise_all_settled_utils';
@@ -35,16 +35,19 @@ export const getESQLBooleanFieldStats = async ({
   const booleanFields = columns
     .filter((f) => f.secondaryType === 'boolean')
     .map((field) => {
-      const query = `| STATS ${getSafeESQLName(`${field.name}_terms`)} = count(${getSafeESQLName(
-        field.name
-      )}) BY ${getSafeESQLName(field.name)}
-        | LIMIT 3`;
+      const query = appendToESQLQuery(
+        esqlBaseQuery,
+        `| STATS ${getSafeESQLName(`${field.name}_terms`)} = count(${getSafeESQLName(
+          field.name
+        )}) BY ${getSafeESQLName(field.name)}
+        | LIMIT 3`
+      );
 
       return {
         field,
         request: {
           params: {
-            query: esqlBaseQuery + query,
+            query,
             ...(filter ? { filter } : {}),
             version: ESQL_LATEST_VERSION,
           },

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_count_and_cardinality.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_count_and_cardinality.ts
@@ -9,7 +9,7 @@ import pLimit from 'p-limit';
 import { chunk } from 'lodash';
 import { isDefined } from '@kbn/ml-is-defined';
 import type { ESQLSearchReponse } from '@kbn/es-types';
-import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { i18n } from '@kbn/i18n';
@@ -100,8 +100,10 @@ const getESQLOverallStatsInChunk = async ({
 
     let countQuery = fieldsToFetch.length > 0 ? '| STATS ' : '';
     countQuery += fieldsToFetch.map((field) => field.query).join(',');
-
-    const query = esqlBaseQueryWithLimit + (evalQuery ? ' | EVAL ' + evalQuery : '') + countQuery;
+    const query = appendToESQLQuery(
+      esqlBaseQueryWithLimit,
+      (evalQuery ? ' | EVAL ' + evalQuery : '') + countQuery
+    );
 
     const request = {
       params: {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_date_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_date_field_stats.ts
@@ -8,7 +8,7 @@
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
-import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import type { DateFieldStats, FieldStatsError } from '../../../../../common/types/field_stats';
@@ -37,9 +37,10 @@ export const getESQLDateFieldStats = async ({
 
   if (dateFields.length > 0) {
     const dateStatsQuery = ' | STATS ' + dateFields.map(({ query }) => query).join(',');
+    const query = appendToESQLQuery(esqlBaseQuery, dateStatsQuery);
     const request = {
       params: {
-        query: esqlBaseQuery + dateStatsQuery,
+        query,
         ...(filter ? { filter } : {}),
         version: ESQL_LATEST_VERSION,
       },

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_numeric_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_numeric_field_stats.ts
@@ -8,7 +8,7 @@
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
-import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import { chunk } from 'lodash';
 import pLimit from 'p-limit';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
@@ -66,9 +66,10 @@ const getESQLNumericFieldStatsInChunk = async ({
   if (numericFields.length > 0) {
     const numericStatsQuery = '| STATS ' + numericFields.map(({ query }) => query).join(',');
 
+    const query = appendToESQLQuery(esqlBaseQuery, numericStatsQuery);
     const request = {
       params: {
-        query: esqlBaseQuery + numericStatsQuery,
+        query,
         ...(filter ? { filter } : {}),
         version: ESQL_LATEST_VERSION,
       },


### PR DESCRIPTION
## Summary

Closes  https://github.com/elastic/kibana/issues/181276

Fixes the histogram and the field statistics problem when the user adds a comment at the end of the query. The fix is simple, starting the code we are adding on a new line.

<img width="1679" alt="Screenshot 2024-04-22 at 12 31 53 PM" src="https://github.com/elastic/kibana/assets/17003240/7d0dbe2c-9205-489c-a646-7e7509602c81">


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->