### PR TITLE
[Cases] Add missing alerts table dependency to Cases plugin

### DIFF
--- a/x-pack/plugins/cases/kibana.jsonc
+++ b/x-pack/plugins/cases/kibana.jsonc
@@ -20,6 +20,7 @@
       "licensing",
       "features",
       "triggersActionsUi",
+      "fieldFormats",
       "management",
       "security",
       "notifications",


### PR DESCRIPTION
## Summary

Adds the missing `fieldFormats` dependency needed by the alerts table to the Cases plugin.

Fixes #181301

## To verify

1. Create a stack rule that fires alerts from `Stack Management > Rules` (i.e. ElasticSearch Query)
2. Assign a Case action to that rule
3. Wait for alerts to be created
4. Navigate to `Stack Management > Cases` and open the automatically created case
5. In the case detail page, navigate to the `Alerts` tab
6. Verify that the alerts table renders correctly

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->