### PR TITLE
[ML] AIOps: Fixes query string for the change point detection metric charts

### DIFF
--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_context.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_context.tsx
@@ -247,6 +247,10 @@ export const ChangePointDetectionContextProvider: FC = ({ children }) => {
       if (globalFilters) {
         filterManager?.addFilters(globalFilters);
       }
+      return () => {
+        filterManager?.removeAll();
+        queryString.clearQuery();
+      };
     },
     [requestParamsFromUrl.filters, requestParamsFromUrl.query, filterManager, queryString]
   );

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_context.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_context.tsx
@@ -132,7 +132,7 @@ export const ChangePointDetectionContextProvider: FC = ({ children }) => {
   const {
     uiSettings,
     data: {
-      query: { filterManager },
+      query: { filterManager, queryString },
     },
   } = useAiopsAppContext();
 
@@ -241,11 +241,14 @@ export const ChangePointDetectionContextProvider: FC = ({ children }) => {
       if (requestParamsFromUrl.filters) {
         filterManager.setFilters(requestParamsFromUrl.filters);
       }
+      if (requestParamsFromUrl.query) {
+        queryString.setQuery(requestParamsFromUrl.query);
+      }
       if (globalFilters) {
         filterManager?.addFilters(globalFilters);
       }
     },
-    [requestParamsFromUrl.filters, filterManager]
+    [requestParamsFromUrl.filters, requestParamsFromUrl.query, filterManager, queryString]
   );
 
   const combinedQuery = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/179814

Query string from the Unified Search query bar was applying to the change point agg request, but wasn't in sync with the query service to correctly render the chart preview. With the PR the query string is synchronized and metric charts are rendered correctly. 


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->