### PR TITLE
[FTR] Update search_profiler api tests to use api keys

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/search_profiler/search_profiler.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/search_profiler/search_profiler.ts
@@ -8,14 +8,24 @@
 import expect from '@kbn/expect';
 
 import { FtrProviderContext } from '../../../ftr_provider_context';
+import { RoleCredentials } from '../../../../shared/services';
 
 const API_BASE_PATH = '/api/searchprofiler';
 
 export default function ({ getService }: FtrProviderContext) {
-  const supertest = getService('supertest');
   const svlCommonApi = getService('svlCommonApi');
+  const svlUserManager = getService('svlUserManager');
+  let roleAuthc: RoleCredentials;
+  const supertestWithoutAuth = getService('supertestWithoutAuth') as any;
 
   describe('Profile', () => {
+    before(async () => {
+      roleAuthc = await svlUserManager.createApiKeyForRole('admin');
+    });
+    after(async () => {
+      await svlUserManager.invalidateApiKeyForRole(roleAuthc);
+    });
+
     it('should return profile results for a valid index', async () => {
       const payload = {
         index: '_all',
@@ -26,10 +36,11 @@ export default function ({ getService }: FtrProviderContext) {
         },
       };
 
-      const { body } = await supertest
+      const { body } = await supertestWithoutAuth
         .post(`${API_BASE_PATH}/profile`)
         .set(svlCommonApi.getInternalRequestHeader())
         .set('Content-Type', 'application/json;charset=UTF-8')
+        .set(roleAuthc.apiKeyHeader)
         .send(payload)
         .expect(200);
 
@@ -46,10 +57,11 @@ export default function ({ getService }: FtrProviderContext) {
         },
       };
 
-      const { body } = await supertest
+      const { body } = await supertestWithoutAuth
         .post(`${API_BASE_PATH}/profile`)
         .set(svlCommonApi.getInternalRequestHeader())
         .set('Content-Type', 'application/json;charset=UTF-8')
+        .set(roleAuthc.apiKeyHeader)
         .send(payloadWithInvalidIndex)
         .expect(404);
 


### PR DESCRIPTION
## Summary

Update common serverless search_profiler API test to use API keys

Contributes to: https://github.com/elastic/kibana/issues/180834
