### PR TITLE
[EDR Workflow] Fix policy details FTRs

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -400,8 +400,18 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await (await testSubjects.find('policyDetailsBackLink')).click();
         await testSubjects.existOrFail('endpointIntegrationPolicyForm');
       });
-      it.skip('should not show host isolation exceptions card because no entries', async () => {
-        await testSubjects.missingOrFail('hostIsolationExceptions-fleet-integration-card');
+      it('should show host isolation exceptions card and link should go back to policy', async () => {
+        await testSubjects.existOrFail('hostIsolationExceptions-fleet-integration-card');
+        const hostIsolationExceptionsCard = await testSubjects.find(
+          'hostIsolationExceptions-fleet-integration-card'
+        );
+        await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(
+          hostIsolationExceptionsCard
+        );
+        await (await testSubjects.find('hostIsolationExceptions-link-to-exceptions')).click();
+        await testSubjects.existOrFail('policyDetailsPage');
+        await (await testSubjects.find('policyDetailsBackLink')).click();
+        await testSubjects.existOrFail('endpointIntegrationPolicyForm');
       });
     });
   });

--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -375,31 +375,27 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         );
       });
 
-      // Failing: See https://github.com/elastic/kibana/issues/138776
-      it.skip('should show trusted apps card and link should go back to policy', async () => {
+      it('should show trusted apps card and link should go back to policy', async () => {
         await testSubjects.existOrFail('trustedApps-fleet-integration-card');
         await (await testSubjects.find('trustedApps-link-to-exceptions')).click();
-        await (await testSubjects.find('confirmModalConfirmButton')).click(); // Fleet show a confirm modal on unsaved changes
         await testSubjects.existOrFail('policyDetailsPage');
         await (await testSubjects.find('policyDetailsBackLink')).click();
         await testSubjects.existOrFail('endpointIntegrationPolicyForm');
       });
-      it.skip('should show event filters card and link should go back to policy', async () => {
+      it('should show event filters card and link should go back to policy', async () => {
         await testSubjects.existOrFail('eventFilters-fleet-integration-card');
         const eventFiltersCard = await testSubjects.find('eventFilters-fleet-integration-card');
         await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(eventFiltersCard);
         await (await testSubjects.find('eventFilters-link-to-exceptions')).click();
-        await (await testSubjects.find('confirmModalConfirmButton')).click(); // Fleet show a confirm modal on unsaved changes
         await testSubjects.existOrFail('policyDetailsPage');
         await (await testSubjects.find('policyDetailsBackLink')).click();
         await testSubjects.existOrFail('endpointIntegrationPolicyForm');
       });
-      it.skip('should show blocklists card and link should go back to policy', async () => {
+      it('should show blocklists card and link should go back to policy', async () => {
         await testSubjects.existOrFail('blocklists-fleet-integration-card');
         const blocklistsCard = await testSubjects.find('blocklists-fleet-integration-card');
         await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(blocklistsCard);
         await (await testSubjects.find('blocklists-link-to-exceptions')).click();
-        await (await testSubjects.find('confirmModalConfirmButton')).click(); // Fleet show a confirm modal on unsaved changes
         await testSubjects.existOrFail('policyDetailsPage');
         await (await testSubjects.find('policyDetailsBackLink')).click();
         await testSubjects.existOrFail('endpointIntegrationPolicyForm');

--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -375,44 +375,22 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         );
       });
 
-      it('should show trusted apps card and link should go back to policy', async () => {
-        await testSubjects.existOrFail('trustedApps-fleet-integration-card');
-        await (await testSubjects.find('trustedApps-link-to-exceptions')).click();
-        await testSubjects.existOrFail('policyDetailsPage');
-        await (await testSubjects.find('policyDetailsBackLink')).click();
-        await testSubjects.existOrFail('endpointIntegrationPolicyForm');
-      });
-      it('should show event filters card and link should go back to policy', async () => {
-        await testSubjects.existOrFail('eventFilters-fleet-integration-card');
-        const eventFiltersCard = await testSubjects.find('eventFilters-fleet-integration-card');
-        await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(eventFiltersCard);
-        await (await testSubjects.find('eventFilters-link-to-exceptions')).click();
-        await testSubjects.existOrFail('policyDetailsPage');
-        await (await testSubjects.find('policyDetailsBackLink')).click();
-        await testSubjects.existOrFail('endpointIntegrationPolicyForm');
-      });
-      it('should show blocklists card and link should go back to policy', async () => {
-        await testSubjects.existOrFail('blocklists-fleet-integration-card');
-        const blocklistsCard = await testSubjects.find('blocklists-fleet-integration-card');
-        await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(blocklistsCard);
-        await (await testSubjects.find('blocklists-link-to-exceptions')).click();
-        await testSubjects.existOrFail('policyDetailsPage');
-        await (await testSubjects.find('policyDetailsBackLink')).click();
-        await testSubjects.existOrFail('endpointIntegrationPolicyForm');
-      });
-      it('should show host isolation exceptions card and link should go back to policy', async () => {
-        await testSubjects.existOrFail('hostIsolationExceptions-fleet-integration-card');
-        const hostIsolationExceptionsCard = await testSubjects.find(
-          'hostIsolationExceptions-fleet-integration-card'
-        );
-        await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(
-          hostIsolationExceptionsCard
-        );
-        await (await testSubjects.find('hostIsolationExceptions-link-to-exceptions')).click();
-        await testSubjects.existOrFail('policyDetailsPage');
-        await (await testSubjects.find('policyDetailsBackLink')).click();
-        await testSubjects.existOrFail('endpointIntegrationPolicyForm');
-      });
+      ['trustedApps', 'eventFilters', 'blocklists', 'hostIsolationExceptions'].forEach(
+        (cardName) => {
+          it(`should show ${cardName} card and link should go back to policy`, async () => {
+            await testSubjects.existOrFail(`${cardName}-fleet-integration-card`);
+
+            const card = await testSubjects.find(`${cardName}-fleet-integration-card`);
+            await pageObjects.ingestManagerCreatePackagePolicy.scrollToCenterOfWindow(card);
+            await (await testSubjects.find(`${cardName}-link-to-exceptions`)).click();
+
+            await testSubjects.existOrFail('policyDetailsPage');
+
+            await (await testSubjects.find('policyDetailsBackLink')).click();
+            await testSubjects.existOrFail('endpointIntegrationPolicyForm');
+          });
+        }
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR unskips some skipped Policy Details functional tests. They were not flaky, they failed due to changed behaviour: no confirmation modal is shown to the user when leaving Policy Details editor, if no changes were made. (I think this is the related PR: https://github.com/elastic/kibana/pull/147470)

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->