### PR TITLE
[FTR] Update scripts_tests API tests to use API keys

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/scripts_tests/languages.js
+++ b/x-pack/test_serverless/api_integration/test_suites/common/scripts_tests/languages.js
@@ -11,16 +11,25 @@ import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { SCRIPT_LANGUAGES_ROUTE_LATEST_VERSION } from '@kbn/data-plugin/common/constants';
 
 export default function ({ getService }) {
-  const supertest = getService('supertest');
   const svlCommonApi = getService('svlCommonApi');
+  const svlUserManager = getService('svlUserManager');
+  let roleAuthc;
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('Script Languages API', function getLanguages() {
+    before(async () => {
+      roleAuthc = await svlUserManager.createApiKeyForRole('admin');
+    });
+    after(async () => {
+      await svlUserManager.invalidateApiKeyForRole(roleAuthc);
+    });
     it('should return 200 with an array of languages', () =>
-      supertest
+      supertestWithoutAuth
         .get('/internal/scripts/languages')
         .set(ELASTIC_HTTP_VERSION_HEADER, SCRIPT_LANGUAGES_ROUTE_LATEST_VERSION)
         // TODO: API requests in Serverless require internal request headers
         .set(svlCommonApi.getInternalRequestHeader())
+        .set(roleAuthc.apiKeyHeader)
         .expect(200)
         .then((response) => {
           expect(response.body).to.be.an('array');
@@ -28,11 +37,12 @@ export default function ({ getService }) {
 
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip('should only return langs enabled for inline scripting', () =>
-      supertest
+      supertestWithoutAuth
         .get('/internal/scripts/languages')
         .set(ELASTIC_HTTP_VERSION_HEADER, SCRIPT_LANGUAGES_ROUTE_LATEST_VERSION)
         // TODO: API requests in Serverless require internal request headers
         .set(svlCommonApi.getInternalRequestHeader())
+        .set(roleAuthc.apiKeyHeader)
         .expect(200)
         .then((response) => {
           expect(response.body).to.contain('expression');


### PR DESCRIPTION
## Summary

Update common serverless scripts_tests API tests to use API keys

Contributes to: https://github.com/elastic/kibana/issues/180834
