### PR TITLE
[Serverless] Use new `monitoring` config

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -151,8 +151,8 @@ xpack.reporting.statefulSettings.enabled: false
 
 # Disabled Observability plugins
 xpack.ux.enabled: false
-xpack.monitoring.enabled: false
 xpack.legacy_uptime.enabled: false
+monitoring.enabled: false
 monitoring.ui.enabled: false
 
 ## Enable uiSettings validations


### PR DESCRIPTION
## Summary

While troubleshooting something else, I noticed we are logging this deprecation message on every Kibana start:

```
Setting "xpack.monitoring" has been replaced by "monitoring". However, both keys are present. Ignoring "xpack.monitoring"
```

Let's comply with the suggestion of using `monitoring` instead of `xpack.monitoring`

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
