### PR TITLE
[Lens] Fix datatable actions when first row is empty

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/datatable/expression.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/datatable/expression.test.tsx
@@ -8,8 +8,8 @@ import { createMockExecutionContext } from '@kbn/expressions-plugin/common/mocks
 import type { DatatableProps } from '../../../common/expressions';
 import type { FormatFactory } from '../../../common/types';
 import { getDatatable } from '../../../common/expressions';
-import { getColumnCellValueActions } from './expression';
-import type { Datatable } from '@kbn/expressions-plugin/common';
+import { getColumnCellValueActions, getColumnsFilterable } from './expression';
+import type { Datatable, IInterpreterRenderHandlers } from '@kbn/expressions-plugin/common';
 import { LensCellValueAction } from '../../types';
 
 const cellValueAction: LensCellValueAction = {
@@ -120,6 +120,57 @@ describe('datatable_expression', () => {
       const config = sampleArgs();
       const result = await getColumnCellValueActions(config, undefined);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getColumnsFilterable', () => {
+    it('should return no data if an empty table is passed', async () => {
+      const { data } = sampleArgs();
+      data.rows = [];
+      const hasCompatibleActions = jest.fn();
+      expect(
+        await getColumnsFilterable(data, {
+          hasCompatibleActions,
+        } as unknown as IInterpreterRenderHandlers)
+      ).toBeUndefined();
+      expect(hasCompatibleActions).not.toHaveBeenCalled();
+    });
+
+    it('should call the handler for each column', async () => {
+      const { data } = sampleArgs();
+      const hasCompatibleActions = jest.fn().mockResolvedValue(true);
+      expect(
+        await getColumnsFilterable(data, {
+          hasCompatibleActions,
+        } as unknown as IInterpreterRenderHandlers)
+      ).toEqual([true, true, true]);
+      expect(hasCompatibleActions).toHaveBeenCalledTimes(data.columns.length);
+    });
+
+    it('should call the handler for each column with table coords of data values', async () => {
+      const { data } = sampleArgs();
+      data.rows = [
+        { a: null, b: null, c: null },
+        { a: 'shoes', b: 1588024800000, c: 3 },
+      ];
+      const hasCompatibleActions = jest.fn().mockResolvedValue(true);
+      expect(
+        await getColumnsFilterable(data, {
+          hasCompatibleActions,
+        } as unknown as IInterpreterRenderHandlers)
+      ).toEqual([true, true, true]);
+      expect(hasCompatibleActions).toHaveBeenCalledTimes(data.columns.length);
+      for (const id of data.columns.map((_, i) => i + 1)) {
+        expect(hasCompatibleActions).toHaveBeenNthCalledWith(
+          id,
+          expect.objectContaining({
+            name: 'filter',
+            data: expect.objectContaining({
+              data: [expect.objectContaining({ row: 1 })],
+            }),
+          })
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes a bug that affects cell actions when the first column row is empty in a Lens datatable.
The check for the action was checking only the first row, while now it tries to find the first row with some values.

<img width="838" alt="Screenshot 2024-04-22 at 18 11 00" src="https://github.com/elastic/kibana/assets/924948/09f38bbe-e0de-4f3e-8188-7e5e9fbfe81f">
<img width="858" alt="Screenshot 2024-04-22 at 18 10 54" src="https://github.com/elastic/kibana/assets/924948/cba5584b-d0a5-4351-9db2-1c952c418249">

This shouldn't have any particular performance impact, but it's worth testing to be sure about it.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
