### PR TITLE
[Embeddable rebuild] ML anomaly swim lane embeddable: ensures dashboard reset works correctly

### DIFF
--- a/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/initialize_swim_lane_controls.ts
+++ b/x-pack/plugins/ml/public/embeddables/anomaly_swimlane/initialize_swim_lane_controls.ts
@@ -60,10 +60,10 @@ export const initializeSwimLaneControls = (
   };
 
   const swimLaneComparators: StateComparators<AnomalySwimLaneControlsState> = {
-    jobIds: [jobIds, jobIds.next, fastIsEqual],
-    swimlaneType: [swimlaneType, swimlaneType.next],
-    viewBy: [viewBy, viewBy.next],
-    perPage: [perPage, perPage.next],
+    jobIds: [jobIds, (arg) => jobIds.next(arg), fastIsEqual],
+    swimlaneType: [swimlaneType, (arg) => swimlaneType.next(arg)],
+    viewBy: [viewBy, (arg) => viewBy.next(arg)],
+    perPage: [perPage, (arg) => perPage.next(arg)],
   };
 
   return {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/181210
The reset functionality was not reverting the embeddable values. This PR ensures the embeddable values are reset on dashboard reset.

Comparators require the `next` functionality to be wrapped in a function in order to maintain `this` being defined.
The problem is that BehaviourSubjects are class instances, and if you pass in the next method like `[someSubject$, someSubject$.next]` you lose the this context.

NOTE: This needs the `8.14.1` label when it's available

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->