### PR TITLE
[Console] disable autosave when loadFrom is used

### DIFF
--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -222,7 +222,12 @@ function EditorUI({ initialTextValue, setEditorInstance }: EditorProps) {
     autocompleteInfo.retrieve(settingsService, settingsService.getAutocomplete());
 
     const unsubscribeResizer = subscribeResizeChecker(editorRef.current!, editor);
-    setupAutosave();
+    if (!initialQueryParams.load_from) {
+      // Don't setup autosaving editor content when we pre-load content
+      // This prevents losing the user's current console content when
+      // `loadFrom` query param is used for a console session
+      setupAutosave();
+    }
 
     return () => {
       unsubscribeResizer();

--- a/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/use_set_initial_value.ts
@@ -30,7 +30,7 @@ interface SetInitialValueParams {
 /**
  * Util function for reading the load_from parameter from the current url.
  */
-const readLoadFromParam = () => {
+export const readLoadFromParam = () => {
   const [, queryString] = (window.location.hash || window.location.search || '').split('?');
 
   const queryParams = parse(queryString || '', { sort: false }) as Required<QueryParams>;

--- a/src/plugins/console/public/application/containers/editor/monaco/use_setup_autosave.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/use_setup_autosave.ts
@@ -8,6 +8,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useSaveCurrentTextObject } from '../../../hooks';
+import { readLoadFromParam } from './use_set_initial_value';
 
 interface SetupAutosaveParams {
   /** The current input value in the Console editor. */
@@ -37,6 +38,12 @@ export const useSetupAutosave = (params: SetupAutosaveParams) => {
 
     if (timerRef.current) {
       clearTimeout(timerRef.current);
+    }
+
+    const loadFromParam = readLoadFromParam();
+    if (loadFromParam) {
+      // If we pre-loaded content we want to skip saving the state of the editor
+      return;
     }
     timerRef.current = window.setTimeout(saveCurrentState, saveDelay);
 


### PR DESCRIPTION
## Summary

Updated the editor to disable the autosave functionality when the editor is pre-loaded with content using the loadFrom query parameter. This is to ensure we do not overwrite a user's console content when they update code that was pre-loaded in the dev console.

This behavior was always possible, but is more likely to happen now as we use the Persistent Console with "Try in Console" buttons throughout Kibana.

If you're a developer who uses the console as a scratchpad opening the console with `loadFrom` and losing all your previous state is a very annoying user experience.