### PR TITLE
[SLOs] support filters in grouped view on slo overview list

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/slo_list.tsx
@@ -124,6 +124,7 @@ export function SloList() {
           kqlQuery={kqlQuery}
           sort={state.sort.by}
           direction={state.sort.direction}
+          filters={filters}
         />
       )}
     </EuiFlexGroup>

--- a/x-pack/plugins/observability_solution/slo/server/services/find_slo_groups.ts
+++ b/x-pack/plugins/observability_solution/slo/server/services/find_slo_groups.ts
@@ -73,6 +73,7 @@ export class FindSLOGroups {
             getElasticsearchQueryOrThrow(kqlQuery),
             ...(parsedFilters.filter ?? []),
           ],
+          must_not: [...(parsedFilters.must_not ?? [])],
         },
       },
       body: {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/181311

Supports unified search filters when using the group by option on the SLO overview page.

### Testing
1. Create a few SLOs
2. Group the SLOs by status
3. Create a unified search filter for `slo.name` that matches a single SLO
4. Observe that the results are filtered appropriately
5. Negate that unified search filter
6. Observe that the results are filtered appropriately 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->