### PR TITLE
Use permanent cache for translation files on production

### DIFF
--- a/packages/core/i18n/core-i18n-server-internal/index.ts
+++ b/packages/core/i18n/core-i18n-server-internal/index.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export type { I18nConfigType } from './src';
+export type { I18nConfigType, InternalI18nServicePreboot } from './src';
 export { config, I18nService } from './src';

--- a/packages/core/i18n/core-i18n-server-internal/src/i18n_service.test.ts
+++ b/packages/core/i18n/core-i18n-server-internal/src/i18n_service.test.ts
@@ -37,12 +37,13 @@ describe('I18nService', () => {
   let configService: ReturnType<typeof configServiceMock.create>;
   let httpPreboot: ReturnType<typeof httpServiceMock.createInternalPrebootContract>;
   let httpSetup: ReturnType<typeof httpServiceMock.createInternalSetupContract>;
+  let coreContext: ReturnType<typeof mockCoreContext.create>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     configService = getConfigService();
 
-    const coreContext = mockCoreContext.create({ configService });
+    coreContext = mockCoreContext.create({ configService });
     service = new I18nService(coreContext);
 
     httpPreboot = httpServiceMock.createInternalPrebootContract();
@@ -73,13 +74,15 @@ describe('I18nService', () => {
       expect(initTranslationsMock).toHaveBeenCalledWith('en', translationFiles);
     });
 
-    it('calls `registerRoutesMock` with the correct parameters', async () => {
+    it('calls `registerRoutes` with the correct parameters', async () => {
       await service.preboot({ pluginPaths: [], http: httpPreboot });
 
       expect(registerRoutesMock).toHaveBeenCalledTimes(1);
       expect(registerRoutesMock).toHaveBeenCalledWith({
         locale: 'en',
         router: expect.any(Object),
+        isDist: coreContext.env.packageInfo.dist,
+        translationHash: expect.any(String),
       });
     });
   });
@@ -114,13 +117,15 @@ describe('I18nService', () => {
       expect(initTranslationsMock).toHaveBeenCalledWith('en', translationFiles);
     });
 
-    it('calls `registerRoutesMock` with the correct parameters', async () => {
+    it('calls `registerRoutes` with the correct parameters', async () => {
       await service.setup({ pluginPaths: [], http: httpSetup });
 
       expect(registerRoutesMock).toHaveBeenCalledTimes(1);
       expect(registerRoutesMock).toHaveBeenCalledWith({
         locale: 'en',
         router: expect.any(Object),
+        isDist: coreContext.env.packageInfo.dist,
+        translationHash: expect.any(String),
       });
     });
 

--- a/packages/core/i18n/core-i18n-server-internal/src/index.ts
+++ b/packages/core/i18n/core-i18n-server-internal/src/index.ts
@@ -9,3 +9,4 @@
 export { config } from './i18n_config';
 export type { I18nConfigType } from './i18n_config';
 export { I18nService } from './i18n_service';
+export type { InternalI18nServicePreboot } from './i18n_service';

--- a/packages/core/i18n/core-i18n-server-internal/src/routes/index.ts
+++ b/packages/core/i18n/core-i18n-server-internal/src/routes/index.ts
@@ -9,6 +9,16 @@
 import type { IRouter } from '@kbn/core-http-server';
 import { registerTranslationsRoute } from './translations';
 
-export const registerRoutes = ({ router, locale }: { router: IRouter; locale: string }) => {
-  registerTranslationsRoute(router, locale);
+export const registerRoutes = ({
+  router,
+  locale,
+  isDist,
+  translationHash,
+}: {
+  router: IRouter;
+  locale: string;
+  isDist: boolean;
+  translationHash: string;
+}) => {
+  registerTranslationsRoute({ router, locale, isDist, translationHash });
 };

--- a/packages/core/i18n/core-i18n-server-internal/src/routes/translations.test.ts
+++ b/packages/core/i18n/core-i18n-server-internal/src/routes/translations.test.ts
@@ -12,7 +12,12 @@ import { registerTranslationsRoute } from './translations';
 describe('registerTranslationsRoute', () => {
   test('registers route with expected options', () => {
     const router = mockRouter.create();
-    registerTranslationsRoute(router, 'en');
+    registerTranslationsRoute({
+      router,
+      locale: 'en',
+      isDist: true,
+      translationHash: 'XXX',
+    });
     expect(router.get).toHaveBeenCalledTimes(1);
     expect(router.get).toHaveBeenNthCalledWith(
       1,

--- a/packages/core/i18n/core-i18n-server-internal/src/routes/translations.test.ts
+++ b/packages/core/i18n/core-i18n-server-internal/src/routes/translations.test.ts
@@ -16,12 +16,23 @@ describe('registerTranslationsRoute', () => {
       router,
       locale: 'en',
       isDist: true,
-      translationHash: 'XXX',
+      translationHash: 'XXXX',
     });
-    expect(router.get).toHaveBeenCalledTimes(1);
+    expect(router.get).toHaveBeenCalledTimes(2);
     expect(router.get).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ options: { access: 'public', authRequired: false } }),
+      expect.objectContaining({
+        path: '/translations/{locale}.json',
+        options: { access: 'public', authRequired: false },
+      }),
+      expect.any(Function)
+    );
+    expect(router.get).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: '/translations/XXXX/{locale}.json',
+        options: { access: 'public', authRequired: false },
+      }),
       expect.any(Function)
     );
   });

--- a/packages/core/i18n/core-i18n-server-mocks/src/i18n_service.mock.ts
+++ b/packages/core/i18n/core-i18n-server-mocks/src/i18n_service.mock.ts
@@ -7,17 +7,29 @@
  */
 
 import type { PublicMethodsOf } from '@kbn/utility-types';
-import type { I18nService } from '@kbn/core-i18n-server-internal';
+import type { I18nService, InternalI18nServicePreboot } from '@kbn/core-i18n-server-internal';
 import type { I18nServiceSetup } from '@kbn/core-i18n-server';
 
 const createSetupContractMock = () => {
   const mock: jest.Mocked<I18nServiceSetup> = {
     getLocale: jest.fn(),
     getTranslationFiles: jest.fn(),
+    getTranslationHash: jest.fn(),
   };
 
   mock.getLocale.mockReturnValue('en');
   mock.getTranslationFiles.mockReturnValue([]);
+  mock.getTranslationHash.mockReturnValue('MOCK_HASH');
+
+  return mock;
+};
+
+const createInternalPrebootMock = () => {
+  const mock: jest.Mocked<InternalI18nServicePreboot> = {
+    getTranslationHash: jest.fn(),
+  };
+
+  mock.getTranslationHash.mockReturnValue('MOCK_HASH');
 
   return mock;
 };
@@ -38,4 +50,5 @@ const createMock = () => {
 export const i18nServiceMock = {
   create: createMock,
   createSetupContract: createSetupContractMock,
+  createInternalPrebootContract: createInternalPrebootMock,
 };

--- a/packages/core/i18n/core-i18n-server/src/types.ts
+++ b/packages/core/i18n/core-i18n-server/src/types.ts
@@ -19,4 +19,9 @@ export interface I18nServiceSetup {
    * Return the absolute paths to translation files currently in use.
    */
   getTranslationFiles(): string[];
+
+  /**
+   * Returns the hash generated from the current translations.
+   */
+  getTranslationHash(): string;
 }

--- a/packages/core/rendering/core-rendering-server-internal/src/__snapshots__/rendering_service.test.ts.snap
+++ b/packages/core/rendering/core-rendering-server-internal/src/__snapshots__/rendering_service.test.ts.snap
@@ -37,7 +37,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -117,7 +117,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -193,7 +193,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -273,7 +273,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -349,7 +349,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -425,7 +425,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -505,7 +505,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -581,7 +581,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -662,7 +662,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -742,7 +742,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -823,7 +823,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -908,7 +908,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -984,7 +984,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -1065,7 +1065,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -1150,7 +1150,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {
@@ -1231,7 +1231,7 @@ Object {
     ],
   },
   "i18n": Object {
-    "translationsUrl": "/mock-server-basepath/translations/en.json",
+    "translationsUrl": "/mock-server-basepath/translations/MOCK_HASH/en.json",
   },
   "legacyMetadata": Object {
     "globalUiSettings": Object {

--- a/packages/core/rendering/core-rendering-server-internal/src/test_helpers/params.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/test_helpers/params.ts
@@ -12,6 +12,7 @@ import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 import { statusServiceMock } from '@kbn/core-status-server-mocks';
 import { customBrandingServiceMock } from '@kbn/core-custom-branding-server-mocks';
 import { userSettingsServiceMock } from '@kbn/core-user-settings-server-mocks';
+import { i18nServiceMock } from '@kbn/core-i18n-server-mocks';
 
 const context = mockCoreContext.create();
 const httpPreboot = httpServiceMock.createInternalPrebootContract();
@@ -33,6 +34,7 @@ export const mockRenderingServiceParams = context;
 export const mockRenderingPrebootDeps = {
   http: httpPreboot,
   uiPlugins: createUiPlugins(),
+  i18n: i18nServiceMock.createInternalPrebootContract(),
 };
 export const mockRenderingSetupDeps = {
   elasticsearch,
@@ -41,4 +43,5 @@ export const mockRenderingSetupDeps = {
   customBranding,
   status,
   userSettings,
+  i18n: i18nServiceMock.createSetupContract(),
 };

--- a/packages/core/rendering/core-rendering-server-internal/src/types.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/types.ts
@@ -22,6 +22,8 @@ import type { UiPlugins } from '@kbn/core-plugins-base-server-internal';
 import type { InternalCustomBrandingSetup } from '@kbn/core-custom-branding-server-internal';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import type { InternalUserSettingsServiceSetup } from '@kbn/core-user-settings-server-internal';
+import type { I18nServiceSetup } from '@kbn/core-i18n-server';
+import type { InternalI18nServicePreboot } from '@kbn/core-i18n-server-internal';
 
 /** @internal */
 export interface RenderingMetadata {
@@ -42,6 +44,7 @@ export interface RenderingMetadata {
 export interface RenderingPrebootDeps {
   http: InternalHttpServicePreboot;
   uiPlugins: UiPlugins;
+  i18n: InternalI18nServicePreboot;
 }
 
 /** @internal */
@@ -52,6 +55,7 @@ export interface RenderingSetupDeps {
   uiPlugins: UiPlugins;
   customBranding: InternalCustomBrandingSetup;
   userSettings: InternalUserSettingsServiceSetup;
+  i18n: I18nServiceSetup;
 }
 
 /** @internal */

--- a/packages/core/rendering/core-rendering-server-internal/tsconfig.json
+++ b/packages/core/rendering/core-rendering-server-internal/tsconfig.json
@@ -41,6 +41,8 @@
     "@kbn/core-user-settings-server-internal",
     "@kbn/core-logging-common-internal",
     "@kbn/core-logging-server-internal",
+    "@kbn/core-i18n-server",
+    "@kbn/core-i18n-server-internal",
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/rendering/core-rendering-server-internal/tsconfig.json
+++ b/packages/core/rendering/core-rendering-server-internal/tsconfig.json
@@ -43,6 +43,7 @@
     "@kbn/core-logging-server-internal",
     "@kbn/core-i18n-server",
     "@kbn/core-i18n-server-internal",
+    "@kbn/core-i18n-server-mocks",
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/root/core-root-server-internal/src/server.ts
+++ b/packages/core/root/core-root-server-internal/src/server.ts
@@ -192,7 +192,7 @@ export class Server {
       const httpPreboot = await this.http.preboot({ context: contextServicePreboot });
 
       // setup i18n prior to any other service, to have translations ready
-      await this.i18n.preboot({ http: httpPreboot, pluginPaths });
+      const i18nPreboot = await this.i18n.preboot({ http: httpPreboot, pluginPaths });
 
       this.capabilities.preboot({ http: httpPreboot });
 
@@ -200,7 +200,11 @@ export class Server {
 
       await this.status.preboot({ http: httpPreboot });
 
-      const renderingPreboot = await this.rendering.preboot({ http: httpPreboot, uiPlugins });
+      const renderingPreboot = await this.rendering.preboot({
+        http: httpPreboot,
+        uiPlugins,
+        i18n: i18nPreboot,
+      });
 
       const httpResourcesPreboot = this.httpResources.preboot({
         http: httpPreboot,
@@ -324,6 +328,7 @@ export class Server {
       uiPlugins,
       customBranding: customBrandingSetup,
       userSettings: userSettingsServiceSetup,
+      i18n: i18nServiceSetup,
     });
 
     const httpResourcesSetup = this.httpResources.setup({

--- a/test/api_integration/apis/core/translations.ts
+++ b/test/api_integration/apis/core/translations.ts
@@ -18,8 +18,11 @@ export default function ({ getService }: FtrProviderContext) {
         expect(response.body.locale).to.eql('en');
 
         expect(response.header).to.have.property('content-type', 'application/json; charset=utf-8');
-        expect(response.header).to.have.property('cache-control', 'must-revalidate');
-        expect(response.header).to.have.property('etag');
+        expect(response.header).to.have.property(
+          'cache-control',
+          'public, max-age=31536000, immutable'
+        );
+        expect(response.header).not.to.have.property('etag');
       });
     });
 

--- a/test/server_integration/http/platform/cache.ts
+++ b/test/server_integration/http/platform/cache.ts
@@ -22,7 +22,7 @@ export default function ({ getService }: FtrProviderContext) {
     it('allows translation bundles to be cached', async () => {
       await supertest
         .get('/translations/en.json')
-        .expect('Cache-Control', 'must-revalidate')
+        .expect('Cache-Control', 'public, max-age=31536000, immutable')
         .expect(200);
     });
 

--- a/x-pack/test_serverless/api_integration/test_suites/common/core/translations.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/core/translations.ts
@@ -17,8 +17,11 @@ export default function ({ getService }: FtrProviderContext) {
         expect(response.body.locale).to.eql('en');
 
         expect(response.header).to.have.property('content-type', 'application/json; charset=utf-8');
-        expect(response.header).to.have.property('cache-control', 'must-revalidate');
-        expect(response.header).to.have.property('etag');
+        expect(response.header).to.have.property(
+          'cache-control',
+          'public, max-age=31536000, immutable'
+        );
+        expect(response.header).not.to.have.property('etag');
       });
     });
 


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/83409

Use a permanent cache (`public, max-age=365d, immutable`) for translation files when in production (`dist`), similar to what we're doing for static assets. 

Translation files cache busting is a little tricky, because it doesn't only depend on the version (enabling or disabling a custom plugin can change the translations while not changing the build hash), so we're using a custom hash generated from the content of the current translation file (which was already used to generate the `etag` header previously).


