### PR TITLE
[ES|QL] Improve validation for some ES|QL scenarios

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/definitions/builtin.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/builtin.ts
@@ -47,9 +47,11 @@ function createComparisonDefinition(
   {
     name,
     description,
+    extraSignatures = [],
   }: {
     name: string;
     description: string;
+    extraSignatures?: FunctionDefinition['signatures'];
   },
   validate?: FunctionDefinition['validate']
 ): FunctionDefinition {
@@ -82,6 +84,14 @@ function createComparisonDefinition(
         ],
         returnType: 'boolean',
       },
+      {
+        params: [
+          { name: 'left', type: 'ip' },
+          { name: 'right', type: 'ip' },
+        ],
+        returnType: 'boolean',
+      },
+      ...extraSignatures,
     ],
   };
 }
@@ -180,6 +190,15 @@ export const builtinFunctions: FunctionDefinition[] = [
       description: i18n.translate('kbn-esql-validation-autocomplete.esql.definition.equalToDoc', {
         defaultMessage: 'Equal to',
       }),
+      extraSignatures: [
+        {
+          params: [
+            { name: 'left', type: 'boolean' },
+            { name: 'right', type: 'boolean' },
+          ],
+          returnType: 'boolean',
+        },
+      ],
     },
     {
       name: '!=',
@@ -189,6 +208,15 @@ export const builtinFunctions: FunctionDefinition[] = [
           defaultMessage: 'Not equal to',
         }
       ),
+      extraSignatures: [
+        {
+          params: [
+            { name: 'left', type: 'boolean' },
+            { name: 'right', type: 'boolean' },
+          ],
+          returnType: 'boolean',
+        },
+      ],
     },
     {
       name: '<',

--- a/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -380,7 +380,9 @@ export function isEqualType(
   if (arg.type === 'function') {
     if (isSupportedFunction(arg.name, parentCommand).supported) {
       const fnDef = buildFunctionLookup().get(arg.name)!;
-      return fnDef.signatures.some((signature) => argType === signature.returnType);
+      return fnDef.signatures.some(
+        (signature) => signature.returnType === 'any' || argType === signature.returnType
+      );
     }
   }
   if (arg.type === 'timeInterval') {

--- a/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -397,7 +397,8 @@ export function isEqualType(
       return false;
     }
     const wrappedTypes = Array.isArray(validHit.type) ? validHit.type : [validHit.type];
-    return wrappedTypes.some((ct) => argType === ct);
+    // if final type is of type any make it pass for now
+    return wrappedTypes.some((ct) => ct === 'any' || argType === ct);
   }
 }
 

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -12441,6 +12441,11 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval round(case(false, 0, 1))",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval 1 anno",
       "error": [
         "EVAL does not support [date_period] in expression [1 anno]"

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -2985,12 +2985,12 @@
       "warning": []
     },
     {
-      "query": "row var = to_ip(\"a\") > to_ip(\"a\")",
+      "query": "row var = to_ip(\"127.0.0.1\") > to_ip(\"127.0.0.1\")",
       "error": [],
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") > to_datetime(\"2020-10-1\")",
+      "query": "row var = now() > now()",
       "error": [],
       "warning": []
     },
@@ -3032,12 +3032,12 @@
       "warning": []
     },
     {
-      "query": "row var = to_ip(\"a\") >= to_ip(\"a\")",
+      "query": "row var = to_ip(\"127.0.0.1\") >= to_ip(\"127.0.0.1\")",
       "error": [],
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") >= to_datetime(\"2020-10-1\")",
+      "query": "row var = now() >= now()",
       "error": [],
       "warning": []
     },
@@ -3079,12 +3079,12 @@
       "warning": []
     },
     {
-      "query": "row var = to_ip(\"a\") < to_ip(\"a\")",
+      "query": "row var = to_ip(\"127.0.0.1\") < to_ip(\"127.0.0.1\")",
       "error": [],
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") < to_datetime(\"2020-10-1\")",
+      "query": "row var = now() < now()",
       "error": [],
       "warning": []
     },
@@ -3126,12 +3126,12 @@
       "warning": []
     },
     {
-      "query": "row var = to_ip(\"a\") <= to_ip(\"a\")",
+      "query": "row var = to_ip(\"127.0.0.1\") <= to_ip(\"127.0.0.1\")",
       "error": [],
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") <= to_datetime(\"2020-10-1\")",
+      "query": "row var = now() <= now()",
       "error": [],
       "warning": []
     },
@@ -3173,12 +3173,12 @@
       "warning": []
     },
     {
-      "query": "row var = to_ip(\"a\") == to_ip(\"a\")",
+      "query": "row var = to_ip(\"127.0.0.1\") == to_ip(\"127.0.0.1\")",
       "error": [],
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") == to_datetime(\"2020-10-1\")",
+      "query": "row var = now() == now()",
       "error": [],
       "warning": []
     },
@@ -3217,12 +3217,12 @@
       "warning": []
     },
     {
-      "query": "row var = to_ip(\"a\") != to_ip(\"a\")",
+      "query": "row var = to_ip(\"127.0.0.1\") != to_ip(\"127.0.0.1\")",
       "error": [],
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") != to_datetime(\"2020-10-1\")",
+      "query": "row var = now() != now()",
       "error": [],
       "warning": []
     },
@@ -3242,7 +3242,7 @@
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") + to_datetime(\"2020-10-1\")",
+      "query": "row var = now() + now()",
       "error": [],
       "warning": []
     },
@@ -3257,7 +3257,7 @@
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") - to_datetime(\"2020-10-1\")",
+      "query": "row var = now() - now()",
       "error": [],
       "warning": []
     },
@@ -3272,10 +3272,10 @@
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") * to_datetime(\"2020-10-1\")",
+      "query": "row var = now() * now()",
       "error": [
-        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
-        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+        "Argument of [*] must be [number], found value [now()] type [date]",
+        "Argument of [*] must be [number], found value [now()] type [date]"
       ],
       "warning": []
     },
@@ -3290,10 +3290,10 @@
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") / to_datetime(\"2020-10-1\")",
+      "query": "row var = now() / now()",
       "error": [
-        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
-        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+        "Argument of [/] must be [number], found value [now()] type [date]",
+        "Argument of [/] must be [number], found value [now()] type [date]"
       ],
       "warning": []
     },
@@ -3308,10 +3308,10 @@
       "warning": []
     },
     {
-      "query": "row var = to_datetime(\"2020-10-1\") % to_datetime(\"2020-10-1\")",
+      "query": "row var = now() % now()",
       "error": [
-        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
-        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+        "Argument of [%] must be [number], found value [now()] type [date]",
+        "Argument of [%] must be [number], found value [now()] type [date]"
       ],
       "warning": []
     },
@@ -12058,7 +12058,7 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval to_datetime(\"2020-10-1\") + to_datetime(\"2020-10-1\")",
+      "query": "from a_index | eval now() + now()",
       "error": [],
       "warning": []
     },
@@ -12078,7 +12078,7 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval to_datetime(\"2020-10-1\") - to_datetime(\"2020-10-1\")",
+      "query": "from a_index | eval now() - now()",
       "error": [],
       "warning": []
     },
@@ -12098,10 +12098,10 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval to_datetime(\"2020-10-1\") * to_datetime(\"2020-10-1\")",
+      "query": "from a_index | eval now() * now()",
       "error": [
-        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
-        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+        "Argument of [*] must be [number], found value [now()] type [date]",
+        "Argument of [*] must be [number], found value [now()] type [date]"
       ],
       "warning": []
     },
@@ -12121,10 +12121,10 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval to_datetime(\"2020-10-1\") / to_datetime(\"2020-10-1\")",
+      "query": "from a_index | eval now() / now()",
       "error": [
-        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
-        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+        "Argument of [/] must be [number], found value [now()] type [date]",
+        "Argument of [/] must be [number], found value [now()] type [date]"
       ],
       "warning": []
     },
@@ -12144,10 +12144,10 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval to_datetime(\"2020-10-1\") % to_datetime(\"2020-10-1\")",
+      "query": "from a_index | eval now() % now()",
       "error": [
-        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
-        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+        "Argument of [%] must be [number], found value [now()] type [date]",
+        "Argument of [%] must be [number], found value [now()] type [date]"
       ],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -12441,6 +12441,11 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval result = case(false, 0, 1) | stats var0 = sum(result)",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval round(case(false, 0, 1))",
       "error": [],
       "warning": []
@@ -15378,6 +15383,16 @@
     },
     {
       "query": "FROM index | STATS AVG(numberField) by round(numberField) + 1 | EVAL `round(numberField) + 1` / 2",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats sum(case(false, 0, 1))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = sum( case(false, 0, 1))",
       "error": [],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -2985,6 +2985,24 @@
       "warning": []
     },
     {
+      "query": "row var = to_ip(\"a\") > to_ip(\"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") > to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = false > false",
+      "error": [
+        "Argument of [>] must be [number], found value [false] type [boolean]",
+        "Argument of [>] must be [number], found value [false] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = 5 >= 0",
       "error": [],
       "warning": []
@@ -3010,6 +3028,24 @@
       "query": "row var = \"a\" >= 0",
       "error": [
         "Argument of [>=] must be [number], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = to_ip(\"a\") >= to_ip(\"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") >= to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = false >= false",
+      "error": [
+        "Argument of [>=] must be [number], found value [false] type [boolean]",
+        "Argument of [>=] must be [number], found value [false] type [boolean]"
       ],
       "warning": []
     },
@@ -3043,6 +3079,24 @@
       "warning": []
     },
     {
+      "query": "row var = to_ip(\"a\") < to_ip(\"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") < to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = false < false",
+      "error": [
+        "Argument of [<] must be [number], found value [false] type [boolean]",
+        "Argument of [<] must be [number], found value [false] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = 5 <= 0",
       "error": [],
       "warning": []
@@ -3068,6 +3122,24 @@
       "query": "row var = \"a\" <= 0",
       "error": [
         "Argument of [<=] must be [number], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = to_ip(\"a\") <= to_ip(\"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") <= to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = false <= false",
+      "error": [
+        "Argument of [<=] must be [number], found value [false] type [boolean]",
+        "Argument of [<=] must be [number], found value [false] type [boolean]"
       ],
       "warning": []
     },
@@ -3101,12 +3173,76 @@
       "warning": []
     },
     {
+      "query": "row var = to_ip(\"a\") == to_ip(\"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") == to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = false == false",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = 5 != 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = NOT 5 != 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = (numberField != 0)",
+      "error": [
+        "Unknown column [numberField]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = (NOT (5 != 0))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = \"a\" != 0",
+      "error": [
+        "Argument of [!=] must be [number], found value [\"a\"] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "row var = to_ip(\"a\") != to_ip(\"a\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") != to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = false != false",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "row var = 1 + 1",
       "error": [],
       "warning": []
     },
     {
       "query": "row var = (5 + 1)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") + to_datetime(\"2020-10-1\")",
       "error": [],
       "warning": []
     },
@@ -3121,6 +3257,11 @@
       "warning": []
     },
     {
+      "query": "row var = to_datetime(\"2020-10-1\") - to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "row var = 1 * 1",
       "error": [],
       "warning": []
@@ -3128,6 +3269,14 @@
     {
       "query": "row var = (5 * 1)",
       "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") * to_datetime(\"2020-10-1\")",
+      "error": [
+        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
+        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+      ],
       "warning": []
     },
     {
@@ -3141,6 +3290,14 @@
       "warning": []
     },
     {
+      "query": "row var = to_datetime(\"2020-10-1\") / to_datetime(\"2020-10-1\")",
+      "error": [
+        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
+        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = 1 % 1",
       "error": [],
       "warning": []
@@ -3148,6 +3305,14 @@
     {
       "query": "row var = (5 % 1)",
       "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = to_datetime(\"2020-10-1\") % to_datetime(\"2020-10-1\")",
+      "error": [
+        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
+        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+      ],
       "warning": []
     },
     {
@@ -5158,10 +5323,38 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval stringField > 0",
+      "query": "from a_index | where stringField > 0",
       "error": [
         "Argument of [>] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField > stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField > numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateField > dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where booleanField > booleanField",
+      "error": [
+        "Argument of [>] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [>] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where ipField > ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -5190,10 +5383,38 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval stringField >= 0",
+      "query": "from a_index | where stringField >= 0",
       "error": [
         "Argument of [>=] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField >= stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField >= numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateField >= dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where booleanField >= booleanField",
+      "error": [
+        "Argument of [>=] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [>=] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where ipField >= ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -5222,10 +5443,38 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval stringField < 0",
+      "query": "from a_index | where stringField < 0",
       "error": [
         "Argument of [<] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField < stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField < numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateField < dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where booleanField < booleanField",
+      "error": [
+        "Argument of [<] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [<] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where ipField < ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -5254,10 +5503,38 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval stringField <= 0",
+      "query": "from a_index | where stringField <= 0",
       "error": [
         "Argument of [<=] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField <= stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField <= numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateField <= dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where booleanField <= booleanField",
+      "error": [
+        "Argument of [<=] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [<=] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where ipField <= ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -5286,10 +5563,92 @@
       "warning": []
     },
     {
-      "query": "from a_index | eval stringField == 0",
+      "query": "from a_index | where stringField == 0",
       "error": [
         "Argument of [==] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField == stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField == numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateField == dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where booleanField == booleanField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where ipField == ipField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField != 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where NOT numberField != 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where (numberField != 0)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where (NOT (numberField != 0))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where 1 != 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField != 0",
+      "error": [
+        "Argument of [!=] must be [number], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where stringField != stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where numberField != numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateField != dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where booleanField != booleanField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where ipField != ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -11419,6 +11778,34 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval stringField > stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval numberField > numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval dateField > dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval booleanField > booleanField",
+      "error": [
+        "Argument of [>] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [>] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval ipField > ipField",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval numberField >= 0",
       "error": [],
       "warning": []
@@ -11448,6 +11835,34 @@
       "error": [
         "Argument of [>=] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval stringField >= stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval numberField >= numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval dateField >= dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval booleanField >= booleanField",
+      "error": [
+        "Argument of [>=] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [>=] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval ipField >= ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -11483,6 +11898,34 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval stringField < stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval numberField < numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval dateField < dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval booleanField < booleanField",
+      "error": [
+        "Argument of [<] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [<] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval ipField < ipField",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval numberField <= 0",
       "error": [],
       "warning": []
@@ -11512,6 +11955,34 @@
       "error": [
         "Argument of [<=] must be [number], found value [stringField] type [string]"
       ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval stringField <= stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval numberField <= numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval dateField <= dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval booleanField <= booleanField",
+      "error": [
+        "Argument of [<=] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [<=] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval ipField <= ipField",
+      "error": [],
       "warning": []
     },
     {
@@ -11547,6 +12018,31 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval stringField == stringField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval numberField == numberField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval dateField == dateField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval booleanField == booleanField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval ipField == ipField",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval numberField + 1",
       "error": [],
       "warning": []
@@ -11558,6 +12054,11 @@
     },
     {
       "query": "from a_index | eval 1 + 1",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval to_datetime(\"2020-10-1\") + to_datetime(\"2020-10-1\")",
       "error": [],
       "warning": []
     },
@@ -11577,6 +12078,11 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval to_datetime(\"2020-10-1\") - to_datetime(\"2020-10-1\")",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval numberField * 1",
       "error": [],
       "warning": []
@@ -11589,6 +12095,14 @@
     {
       "query": "from a_index | eval 1 * 1",
       "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval to_datetime(\"2020-10-1\") * to_datetime(\"2020-10-1\")",
+      "error": [
+        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
+        "Argument of [*] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+      ],
       "warning": []
     },
     {
@@ -11607,6 +12121,14 @@
       "warning": []
     },
     {
+      "query": "from a_index | eval to_datetime(\"2020-10-1\") / to_datetime(\"2020-10-1\")",
+      "error": [
+        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
+        "Argument of [/] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+      ],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval numberField % 1",
       "error": [],
       "warning": []
@@ -11619,6 +12141,14 @@
     {
       "query": "from a_index | eval 1 % 1",
       "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval to_datetime(\"2020-10-1\") % to_datetime(\"2020-10-1\")",
+      "error": [
+        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]",
+        "Argument of [%] must be [number], found value [to_datetime(\"2020-10-1\")] type [date]"
+      ],
       "warning": []
     },
     {
@@ -11897,6 +12427,16 @@
     },
     {
       "query": "from a_index | eval mv_sort([\"a\", \"b\"], \"DESC\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval result = case(false, 0, 1), round(result)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval result = case(false, 0, 1) | stats sum(result)",
       "error": [],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -1804,6 +1804,7 @@ describe('validation logic', () => {
         `from a_index | eval result = case(false, 0, 1) | stats sum(result)`,
         []
       );
+      testErrorsAndWarnings(`from a_index | eval round(case(false, 0, 1))`, []);
 
       describe('date math', () => {
         testErrorsAndWarnings('from a_index | eval 1 anno', [

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -664,11 +664,8 @@ describe('validation logic', () => {
         testErrorsAndWarnings(`row var = "a" ${op} 0`, [
           `Argument of [${op}] must be [number], found value ["a"] type [string]`,
         ]);
-        testErrorsAndWarnings(`row var = to_ip("a") ${op} to_ip("a")`, []);
-        testErrorsAndWarnings(
-          `row var = to_datetime("2020-10-1") ${op} to_datetime("2020-10-1")`,
-          []
-        );
+        testErrorsAndWarnings(`row var = to_ip("127.0.0.1") ${op} to_ip("127.0.0.1")`, []);
+        testErrorsAndWarnings(`row var = now() ${op} now()`, []);
         testErrorsAndWarnings(
           `row var = false ${op} false`,
           ['==', '!='].includes(op)
@@ -683,12 +680,12 @@ describe('validation logic', () => {
         testErrorsAndWarnings(`row var = 1 ${op} 1`, []);
         testErrorsAndWarnings(`row var = (5 ${op} 1)`, []);
         testErrorsAndWarnings(
-          `row var = to_datetime("2020-10-1") ${op} to_datetime("2020-10-1")`,
+          `row var = now() ${op} now()`,
           ['+', '-'].includes(op)
             ? []
             : [
-                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
-                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
+                `Argument of [${op}] must be [number], found value [now()] type [date]`,
+                `Argument of [${op}] must be [number], found value [now()] type [date]`,
               ]
         );
       }
@@ -1694,12 +1691,12 @@ describe('validation logic', () => {
         testErrorsAndWarnings(`from a_index | eval (numberField ${op} 1)`, []);
         testErrorsAndWarnings(`from a_index | eval 1 ${op} 1`, []);
         testErrorsAndWarnings(
-          `from a_index | eval to_datetime("2020-10-1") ${op} to_datetime("2020-10-1")`,
+          `from a_index | eval now() ${op} now()`,
           ['+', '-'].includes(op)
             ? []
             : [
-                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
-                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
+                `Argument of [${op}] must be [number], found value [now()] type [date]`,
+                `Argument of [${op}] must be [number], found value [now()] type [date]`,
               ]
         );
       }

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -656,7 +656,7 @@ describe('validation logic', () => {
           }
         }
       }
-      for (const op of ['>', '>=', '<', '<=', '==']) {
+      for (const op of ['>', '>=', '<', '<=', '==', '!=']) {
         testErrorsAndWarnings(`row var = 5 ${op} 0`, []);
         testErrorsAndWarnings(`row var = NOT 5 ${op} 0`, []);
         testErrorsAndWarnings(`row var = (numberField ${op} 0)`, ['Unknown column [numberField]']);
@@ -664,10 +664,33 @@ describe('validation logic', () => {
         testErrorsAndWarnings(`row var = "a" ${op} 0`, [
           `Argument of [${op}] must be [number], found value ["a"] type [string]`,
         ]);
+        testErrorsAndWarnings(`row var = to_ip("a") ${op} to_ip("a")`, []);
+        testErrorsAndWarnings(
+          `row var = to_datetime("2020-10-1") ${op} to_datetime("2020-10-1")`,
+          []
+        );
+        testErrorsAndWarnings(
+          `row var = false ${op} false`,
+          ['==', '!='].includes(op)
+            ? []
+            : [
+                `Argument of [${op}] must be [number], found value [false] type [boolean]`,
+                `Argument of [${op}] must be [number], found value [false] type [boolean]`,
+              ]
+        );
       }
       for (const op of ['+', '-', '*', '/', '%']) {
         testErrorsAndWarnings(`row var = 1 ${op} 1`, []);
         testErrorsAndWarnings(`row var = (5 ${op} 1)`, []);
+        testErrorsAndWarnings(
+          `row var = to_datetime("2020-10-1") ${op} to_datetime("2020-10-1")`,
+          ['+', '-'].includes(op)
+            ? []
+            : [
+                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
+                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
+              ]
+        );
       }
 
       for (const op of ['like', 'rlike']) {
@@ -1064,15 +1087,26 @@ describe('validation logic', () => {
         testErrorsAndWarnings(`from a_index | where ${nValue} > 0`, []);
         testErrorsAndWarnings(`from a_index | where NOT ${nValue} > 0`, []);
       }
-      for (const op of ['>', '>=', '<', '<=', '==']) {
+      for (const op of ['>', '>=', '<', '<=', '==', '!=']) {
         testErrorsAndWarnings(`from a_index | where numberField ${op} 0`, []);
         testErrorsAndWarnings(`from a_index | where NOT numberField ${op} 0`, []);
         testErrorsAndWarnings(`from a_index | where (numberField ${op} 0)`, []);
         testErrorsAndWarnings(`from a_index | where (NOT (numberField ${op} 0))`, []);
         testErrorsAndWarnings(`from a_index | where 1 ${op} 0`, []);
-        testErrorsAndWarnings(`from a_index | eval stringField ${op} 0`, [
+        testErrorsAndWarnings(`from a_index | where stringField ${op} 0`, [
           `Argument of [${op}] must be [number], found value [stringField] type [string]`,
         ]);
+        for (const type of ['string', 'number', 'date', 'boolean', 'ip']) {
+          testErrorsAndWarnings(
+            `from a_index | where ${type}Field ${op} ${type}Field`,
+            type !== 'boolean' || ['==', '!='].includes(op)
+              ? []
+              : [
+                  `Argument of [${op}] must be [number], found value [${type}Field] type [${type}]`,
+                  `Argument of [${op}] must be [number], found value [${type}Field] type [${type}]`,
+                ]
+          );
+        }
       }
 
       for (const nesting of NESTED_DEPTHS) {
@@ -1643,11 +1677,31 @@ describe('validation logic', () => {
         testErrorsAndWarnings(`from a_index | eval stringField ${op} 0`, [
           `Argument of [${op}] must be [number], found value [stringField] type [string]`,
         ]);
+        for (const type of ['string', 'number', 'date', 'boolean', 'ip']) {
+          testErrorsAndWarnings(
+            `from a_index | eval ${type}Field ${op} ${type}Field`,
+            type !== 'boolean' || ['==', '!='].includes(op)
+              ? []
+              : [
+                  `Argument of [${op}] must be [number], found value [${type}Field] type [${type}]`,
+                  `Argument of [${op}] must be [number], found value [${type}Field] type [${type}]`,
+                ]
+          );
+        }
       }
       for (const op of ['+', '-', '*', '/', '%']) {
         testErrorsAndWarnings(`from a_index | eval numberField ${op} 1`, []);
         testErrorsAndWarnings(`from a_index | eval (numberField ${op} 1)`, []);
         testErrorsAndWarnings(`from a_index | eval 1 ${op} 1`, []);
+        testErrorsAndWarnings(
+          `from a_index | eval to_datetime("2020-10-1") ${op} to_datetime("2020-10-1")`,
+          ['+', '-'].includes(op)
+            ? []
+            : [
+                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
+                `Argument of [${op}] must be [number], found value [to_datetime("2020-10-1")] type [date]`,
+              ]
+        );
       }
       for (const divideByZeroExpr of ['1/0', 'var = 1/0', '1 + 1/0']) {
         testErrorsAndWarnings(
@@ -1744,6 +1798,12 @@ describe('validation logic', () => {
 
       testErrorsAndWarnings(`from a_index | eval mv_sort(["a", "b"], "ASC")`, []);
       testErrorsAndWarnings(`from a_index | eval mv_sort(["a", "b"], "DESC")`, []);
+
+      testErrorsAndWarnings(`from a_index | eval result = case(false, 0, 1), round(result)`, []);
+      testErrorsAndWarnings(
+        `from a_index | eval result = case(false, 0, 1) | stats sum(result)`,
+        []
+      );
 
       describe('date math', () => {
         testErrorsAndWarnings('from a_index | eval 1 anno', [

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -1801,6 +1801,10 @@ describe('validation logic', () => {
         `from a_index | eval result = case(false, 0, 1) | stats sum(result)`,
         []
       );
+      testErrorsAndWarnings(
+        `from a_index | eval result = case(false, 0, 1) | stats var0 = sum(result)`,
+        []
+      );
       testErrorsAndWarnings(`from a_index | eval round(case(false, 0, 1))`, []);
 
       describe('date math', () => {
@@ -2309,6 +2313,9 @@ describe('validation logic', () => {
         `FROM index | STATS AVG(numberField) by round(numberField) + 1 | EVAL \`round(numberField) + 1\` / 2`,
         []
       );
+
+      testErrorsAndWarnings(`from a_index | stats sum(case(false, 0, 1))`, []);
+      testErrorsAndWarnings(`from a_index | stats var0 = sum( case(false, 0, 1))`, []);
     });
 
     describe('sort', () => {


### PR DESCRIPTION
## Summary

Fixes some issues with specific types in ES|QL query validation:
* comparator operators now support `ip` type too
* `==` and `!=` support `boolean` type now
* column/variable/returnType of `any` type will skip strict type validation

<img width="534" alt="Screenshot 2024-04-23 at 10 00 10" src="https://github.com/elastic/kibana/assets/924948/81fb0cfa-d7e8-4cff-b834-efcaedbec14e">
<img width="547" alt="Screenshot 2024-04-23 at 09 53 12" src="https://github.com/elastic/kibana/assets/924948/c1badb21-8a92-44cf-9532-576087a8383d">
<img width="484" alt="Screenshot 2024-04-23 at 09 52 58" src="https://github.com/elastic/kibana/assets/924948/4e142260-1053-4a6b-a85e-3397e7a0256a">
<img width="508" alt="Screenshot 2024-04-23 at 09 52 53" src="https://github.com/elastic/kibana/assets/924948/3e729f4e-fc34-43ad-b4ea-a4a558fe66c2">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->