### PR TITLE
[Cases] Fix failing test: `useCreateCaseModal `

### DIFF
--- a/x-pack/plugins/cases/public/components/use_create_case_modal/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/index.test.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { render, act as reactAct } from '@testing-library/react';
 
 import { useKibana } from '../../common/lib/kibana';
 import type { UseCreateCaseModalProps, UseCreateCaseModalReturnedValues } from '.';
@@ -19,94 +18,87 @@ jest.mock('../../common/lib/kibana');
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 const onCaseCreated = jest.fn();
 
-// FLAKY: https://github.com/elastic/kibana/issues/174205
-describe.skip('useCreateCaseModal', () => {
-  let navigateToApp: jest.Mock;
+for (let i = 0; i <= 300; i = i + 1) {
+  describe('useCreateCaseModal', () => {
+    let navigateToApp: jest.Mock;
 
-  beforeEach(() => {
-    navigateToApp = jest.fn();
-    useKibanaMock().services.application.navigateToApp = navigateToApp;
-  });
+    beforeEach(() => {
+      navigateToApp = jest.fn();
+      useKibanaMock().services.application.navigateToApp = navigateToApp;
+    });
 
-  it('init', async () => {
-    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-      () => useCreateCaseModal({ onCaseCreated }),
-      {
+    it('init', async () => {
+      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+        () => useCreateCaseModal({ onCaseCreated }),
+        {
+          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+        }
+      );
+
+      expect(result.current.isModalOpen).toBe(false);
+    });
+
+    it('opens the modal', async () => {
+      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+        () => useCreateCaseModal({ onCaseCreated }),
+        {
+          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+        }
+      );
+
+      act(() => {
+        result.current.openModal();
+      });
+
+      expect(result.current.isModalOpen).toBe(true);
+    });
+
+    it('closes the modal', async () => {
+      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+        () => useCreateCaseModal({ onCaseCreated }),
+        {
+          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+        }
+      );
+
+      act(() => {
+        result.current.openModal();
+        result.current.closeModal();
+      });
+
+      expect(result.current.isModalOpen).toBe(false);
+    });
+
+    it('returns a memoized value', async () => {
+      const { result, rerender } = renderHook<
+        UseCreateCaseModalProps,
+        UseCreateCaseModalReturnedValues
+      >(() => useCreateCaseModal({ onCaseCreated }), {
         wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-      }
-    );
+      });
 
-    expect(result.current.isModalOpen).toBe(false);
+      const result1 = result.current;
+      act(() => rerender());
+      const result2 = result.current;
+
+      expect(Object.is(result1, result2)).toBe(true);
+    });
+
+    it('closes the modal when creating a case', async () => {
+      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+        () => useCreateCaseModal({ onCaseCreated }),
+        {
+          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+        }
+      );
+
+      act(() => {
+        result.current.openModal();
+        result.current.modal.props.onSuccess({ id: 'case-id' });
+      });
+
+      expect(result.current.isModalOpen).toBe(false);
+      expect(onCaseCreated).toHaveBeenCalledWith({ id: 'case-id' });
+    });
   });
-
-  it('opens the modal', async () => {
-    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-      () => useCreateCaseModal({ onCaseCreated }),
-      {
-        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-      }
-    );
-
-    act(() => {
-      result.current.openModal();
-    });
-
-    expect(result.current.isModalOpen).toBe(true);
-  });
-
-  it('closes the modal', async () => {
-    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-      () => useCreateCaseModal({ onCaseCreated }),
-      {
-        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-      }
-    );
-
-    act(() => {
-      result.current.openModal();
-      result.current.closeModal();
-    });
-
-    expect(result.current.isModalOpen).toBe(false);
-  });
-
-  it('returns a memoized value', async () => {
-    const { result, rerender } = renderHook<
-      UseCreateCaseModalProps,
-      UseCreateCaseModalReturnedValues
-    >(() => useCreateCaseModal({ onCaseCreated }), {
-      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-    });
-
-    const result1 = result.current;
-    act(() => rerender());
-    const result2 = result.current;
-
-    expect(Object.is(result1, result2)).toBe(true);
-  });
-
-  it('closes the modal when creating a case', async () => {
-    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-      () => useCreateCaseModal({ onCaseCreated }),
-      {
-        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-      }
-    );
-
-    act(() => {
-      result.current.openModal();
-    });
-
-    await reactAct(async () => {
-      const modal = result.current.modal;
-      render(<TestProviders>{modal}</TestProviders>);
-    });
-
-    act(() => {
-      result.current.modal.props.onSuccess({ id: 'case-id' });
-    });
-
-    expect(result.current.isModalOpen).toBe(false);
-    expect(onCaseCreated).toHaveBeenCalledWith({ id: 'case-id' });
-  });
-});
+}

--- a/x-pack/plugins/cases/public/components/use_create_case_modal/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_create_case_modal/index.test.tsx
@@ -18,87 +18,85 @@ jest.mock('../../common/lib/kibana');
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 const onCaseCreated = jest.fn();
 
-for (let i = 0; i <= 300; i = i + 1) {
-  describe('useCreateCaseModal', () => {
-    let navigateToApp: jest.Mock;
+describe('useCreateCaseModal', () => {
+  let navigateToApp: jest.Mock;
 
-    beforeEach(() => {
-      navigateToApp = jest.fn();
-      useKibanaMock().services.application.navigateToApp = navigateToApp;
-    });
-
-    it('init', async () => {
-      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-        () => useCreateCaseModal({ onCaseCreated }),
-        {
-          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-        }
-      );
-
-      expect(result.current.isModalOpen).toBe(false);
-    });
-
-    it('opens the modal', async () => {
-      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-        () => useCreateCaseModal({ onCaseCreated }),
-        {
-          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-        }
-      );
-
-      act(() => {
-        result.current.openModal();
-      });
-
-      expect(result.current.isModalOpen).toBe(true);
-    });
-
-    it('closes the modal', async () => {
-      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-        () => useCreateCaseModal({ onCaseCreated }),
-        {
-          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-        }
-      );
-
-      act(() => {
-        result.current.openModal();
-        result.current.closeModal();
-      });
-
-      expect(result.current.isModalOpen).toBe(false);
-    });
-
-    it('returns a memoized value', async () => {
-      const { result, rerender } = renderHook<
-        UseCreateCaseModalProps,
-        UseCreateCaseModalReturnedValues
-      >(() => useCreateCaseModal({ onCaseCreated }), {
-        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-      });
-
-      const result1 = result.current;
-      act(() => rerender());
-      const result2 = result.current;
-
-      expect(Object.is(result1, result2)).toBe(true);
-    });
-
-    it('closes the modal when creating a case', async () => {
-      const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
-        () => useCreateCaseModal({ onCaseCreated }),
-        {
-          wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
-        }
-      );
-
-      act(() => {
-        result.current.openModal();
-        result.current.modal.props.onSuccess({ id: 'case-id' });
-      });
-
-      expect(result.current.isModalOpen).toBe(false);
-      expect(onCaseCreated).toHaveBeenCalledWith({ id: 'case-id' });
-    });
+  beforeEach(() => {
+    navigateToApp = jest.fn();
+    useKibanaMock().services.application.navigateToApp = navigateToApp;
   });
-}
+
+  it('init', async () => {
+    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+      () => useCreateCaseModal({ onCaseCreated }),
+      {
+        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+      }
+    );
+
+    expect(result.current.isModalOpen).toBe(false);
+  });
+
+  it('opens the modal', async () => {
+    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+      () => useCreateCaseModal({ onCaseCreated }),
+      {
+        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.openModal();
+    });
+
+    expect(result.current.isModalOpen).toBe(true);
+  });
+
+  it('closes the modal', async () => {
+    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+      () => useCreateCaseModal({ onCaseCreated }),
+      {
+        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.openModal();
+      result.current.closeModal();
+    });
+
+    expect(result.current.isModalOpen).toBe(false);
+  });
+
+  it('returns a memoized value', async () => {
+    const { result, rerender } = renderHook<
+      UseCreateCaseModalProps,
+      UseCreateCaseModalReturnedValues
+    >(() => useCreateCaseModal({ onCaseCreated }), {
+      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    });
+
+    const result1 = result.current;
+    act(() => rerender());
+    const result2 = result.current;
+
+    expect(Object.is(result1, result2)).toBe(true);
+  });
+
+  it('closes the modal when creating a case', async () => {
+    const { result } = renderHook<UseCreateCaseModalProps, UseCreateCaseModalReturnedValues>(
+      () => useCreateCaseModal({ onCaseCreated }),
+      {
+        wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+      }
+    );
+
+    act(() => {
+      result.current.openModal();
+      result.current.modal.props.onSuccess({ id: 'case-id' });
+    });
+
+    expect(result.current.isModalOpen).toBe(false);
+    expect(onCaseCreated).toHaveBeenCalledWith({ id: 'case-id' });
+  });
+});


### PR DESCRIPTION
Fixes #174205

## Summary

The failing test was rendering the opened modal and not doing anything with it. I removed that block and the execution time locally went from 200+ ms to around 4.