### PR TITLE
cater for both cloud_defend.block_action_enabled and block_action_enabled in d4c metering

### DIFF
--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.ts
@@ -85,7 +85,17 @@ export const getAggregationByCloudSecuritySolution = (
     return {
       asset_count_groups: {
         terms: {
-          field: 'cloud_defend.block_action_enabled',
+          script: {
+            source: `
+              if (doc.containsKey('cloud_defend.block_action_enabled') && !doc['cloud_defend.block_action_enabled'].empty) {
+                return doc['cloud_defend.block_action_enabled'].value;
+              } else if (doc.containsKey('block_action_enabled') && !doc['block_action_enabled'].empty) {
+                return doc['block_action_enabled'].value;
+              } else {
+                return 'none';  // Default value
+              }
+            `,
+          },
         },
         aggs: {
           unique_assets: {


### PR DESCRIPTION
An example of how we could fix:
- https://github.com/elastic/security-team/issues/8525

This fix won't be needed if the issue is fixed on the `cloud_defend` side, but if for some reason we need to fix it on the metering side, this is one option