### PR TITLE
Make saved objects import/export APIs public and clarify docs

### DIFF
--- a/docs/api/saved-objects/export.asciidoc
+++ b/docs/api/saved-objects/export.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Export objects</titleabbrev>
 ++++
 
-experimental[] Retrieve sets of saved objects that you want to import into {kib}.
+Retrieve sets of saved objects that you want to import into {kib}. Exported files should not be edited before being imported as this could to lead to unexpected behaviour 
+or upgrade failures in future versions.
 
 [NOTE]
 ====

--- a/docs/api/saved-objects/import.asciidoc
+++ b/docs/api/saved-objects/import.asciidoc
@@ -4,7 +4,8 @@
 <titleabbrev>Import objects</titleabbrev>
 ++++
 
-experimental[] Create sets of {kib} saved objects from a file created by the export API.
+Create sets of {kib} saved objects from a file created by the export API. Files should not be edited before being imported as this could to lead to unexpected behaviour 
+or upgrade failures in future versions.
 
 [NOTE]
 ====
@@ -66,7 +67,8 @@ NOTE: This option cannot be used with the `createNewCopies` option.
 The request body must include the multipart/form-data type.
 
 `file`::
-  A file exported using the export API.
+  A file exported using the export API. Exported files should not be edited before being imported as this could to lead to unexpected behaviour 
+  or upgrade failures in future versions.
 +
 NOTE: The <<savedObjects-maxImportExportSize, `savedObjects.maxImportExportSize`>> configuration setting
 limits the number of saved objects which may be included in this file. Similarly, the


### PR DESCRIPTION
## Summary

This removes the `experimental[]`/"tech preview" label from the saved objects import/export APIs to mark this public/stable. I also tried to clarify that the files being imported should not be edited as we have seen this leading to unexpected things breaking in Kibana and upgrade failures. Any suggestions for making this text clearer?

## Release notes
The saved objects import and export APIs are now marked as stable public APIs.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
