### PR TITLE
Unskip for pipelines other than mki.

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/index_management/data_streams.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index_management/data_streams.ts
@@ -19,8 +19,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
   const TEST_DS_NAME = 'test-ds-1';
 
-  // FAILING: https://github.com/elastic/kibana/issues/181242
-  describe.skip('Data Streams', function () {
+  describe('Data Streams', function () {
     // failsOnMKI, see https://github.com/elastic/kibana/issues/181242
     this.tags(['failsOnMKI']);
     before(async () => {


### PR DESCRIPTION
## Summary

Until it's unblocked on stateless, we still need protection on statefull.

Resolves: https://github.com/elastic/kibana/issues/181242
