### PR TITLE
[Cases] fix property actions flaky tests

### DIFF
--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.test.tsx
@@ -17,84 +17,87 @@ import {
 } from '../../../common/mock';
 import { AlertPropertyActions } from './alert_property_actions';
 
-// FLAKY: https://github.com/elastic/kibana/issues/174667
-describe.skip('AlertPropertyActions', () => {
-  let appMock: AppMockRenderer;
+for (let i = 0; i < 200; i++) {
+  describe('AlertPropertyActions', () => {
+    let appMock: AppMockRenderer;
 
-  const props = {
-    isLoading: false,
-    totalAlerts: 1,
-    onDelete: jest.fn(),
-  };
+    const props = {
+      isLoading: false,
+      totalAlerts: 1,
+      onDelete: jest.fn(),
+    };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    appMock = createAppMockRenderer();
-  });
+    beforeEach(() => {
+      jest.clearAllMocks();
+      appMock = createAppMockRenderer();
+    });
 
-  it('renders the correct number of actions', async () => {
-    appMock.render(<AlertPropertyActions {...props} />);
+    it('renders correctly', async () => {
+      appMock.render(<AlertPropertyActions {...props} />);
 
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    });
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-    await waitForEuiPopoverOpen();
+    it('renders the correct number of actions', async () => {
+      appMock.render(<AlertPropertyActions {...props} />);
 
-    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
-      1
-    );
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    expect(
-      await screen.findByTestId('property-actions-user-action-minusInCircle')
-    ).toBeInTheDocument();
-  });
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      await waitForEuiPopoverOpen();
 
-  it('renders the modal info correctly for multiple alert', async () => {
-    appMock.render(<AlertPropertyActions {...props} totalAlerts={2} />);
+      expect(
+        (await screen.findByTestId('property-actions-user-action-group')).children.length
+      ).toBe(1);
+    });
 
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    it('renders the modal info correctly for multiple alert', async () => {
+      appMock.render(<AlertPropertyActions {...props} totalAlerts={2} />);
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-    await waitForEuiPopoverOpen();
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-minusInCircle'));
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      await waitForEuiPopoverOpen();
 
-    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+      userEvent.click(await screen.findByTestId('property-actions-user-action-minusInCircle'));
 
-    expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent('Remove alerts');
-    expect(await screen.findByText('Remove')).toBeInTheDocument();
-  });
+      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
 
-  it('remove alerts correctly', async () => {
-    appMock.render(<AlertPropertyActions {...props} />);
+      expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent('Remove alerts');
+      expect(await screen.findByText('Remove')).toBeInTheDocument();
+    });
 
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    it('remove alerts correctly', async () => {
+      appMock.render(<AlertPropertyActions {...props} />);
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-    await waitForEuiPopoverOpen();
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-minusInCircle'));
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      await waitForEuiPopoverOpen();
 
-    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+      userEvent.click(await screen.findByTestId('property-actions-user-action-minusInCircle'));
 
-    userEvent.click(await screen.findByText('Remove'));
+      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(props.onDelete).toHaveBeenCalled();
+      userEvent.click(await screen.findByText('Remove'));
+
+      await waitFor(() => {
+        expect(props.onDelete).toHaveBeenCalled();
+      });
+    });
+
+    it('does not show the property actions without delete permissions', () => {
+      appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
+      appMock.render(<AlertPropertyActions {...props} />);
+
+      expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+    });
+
+    it('does show the property actions with only delete permissions', async () => {
+      appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
+      appMock.render(<AlertPropertyActions {...props} />);
+
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
     });
   });
-
-  it('does not show the property actions without delete permissions', async () => {
-    appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
-    appMock.render(<AlertPropertyActions {...props} />);
-
-    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
-  });
-
-  it('does show the property actions with only delete permissions', async () => {
-    appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
-    appMock.render(<AlertPropertyActions {...props} />);
-
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
-  });
-});
+}

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
@@ -96,14 +96,14 @@ for (let i = 0; i < 200; i++) {
       });
     });
 
-    it('does not show the property actions without delete permissions', async () => {
+    it('does not show the property actions without delete permissions', () => {
       appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
       appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
       expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
     });
 
-    it('does not show the property actions when hideDefaultActions is enabled', async () => {
+    it('does not show the property actions when hideDefaultActions is enabled', () => {
       appMock.render(<RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />);
 
       expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Fixes #174384
Fixes #174667

First test fails always, as it takes more than `100 ms`. 
However adding a first test as just rendering the component, seems to reduce the time of same test from `100ms` to `75ms`.

<details><summary>Before</summary>

![image](https://github.com/elastic/kibana/assets/117571355/4dc46d90-4528-4ae5-9446-25a893b1e854)

![image](https://github.com/elastic/kibana/assets/117571355/aa465ed4-ba3b-4ad8-a71a-b81819402c34)

</details> 



<details><summary>After</summary>

![image](https://github.com/elastic/kibana/assets/117571355/cc40f358-c76f-4a92-9c58-aebbeaf10625)

![image](https://github.com/elastic/kibana/assets/117571355/b3b23462-eed6-44a4-8c2a-e5b19172958a)


</details> 

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
