### PR TITLE
[Profiling] Adding "estimated value" label on sample columns

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/public/components/frame_information_window/apm_transactions.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/frame_information_window/apm_transactions.tsx
@@ -88,12 +88,13 @@ function EstimatedLabel({ label }: { label: string }) {
       })}
     >
       <>
-        {label}{' '}
-        <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+        {label} <EuiIcon size="s" color="subdued" type="questionInCircle" />
       </>
     </EuiToolTip>
   );
 }
+
+const SAMPLES_COLUMN_WIDTH = '152px';
 
 export function APMTransactions({ functionName, serviceNames }: Props) {
   const {
@@ -216,7 +217,7 @@ export function APMTransactions({ functionName, serviceNames }: Props) {
       },
       {
         field: 'serviceSamples',
-        width: '150px',
+        width: SAMPLES_COLUMN_WIDTH,
         sortable: true,
         name: (
           <EstimatedLabel
@@ -267,7 +268,7 @@ export function APMTransactions({ functionName, serviceNames }: Props) {
             })}
           />
         ),
-        width: '152px',
+        width: SAMPLES_COLUMN_WIDTH,
         render(_, { transactionSamples }) {
           if (isLoadingTransactions) {
             return '--';

--- a/x-pack/plugins/observability_solution/profiling/public/components/frame_information_window/apm_transactions.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/frame_information_window/apm_transactions.tsx
@@ -12,7 +12,9 @@ import {
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiLink,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
@@ -77,6 +79,21 @@ const findServicesAndTransactions = (
     totalItemCount: filteredItems.length,
   };
 };
+
+function EstimatedLabel({ label }: { label: string }) {
+  return (
+    <EuiToolTip
+      content={i18n.translate('xpack.profiling.functionsView.samplesColumnLabel.hint', {
+        defaultMessage: 'Estimated values',
+      })}
+    >
+      <>
+        {label}{' '}
+        <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+      </>
+    </EuiToolTip>
+  );
+}
 
 export function APMTransactions({ functionName, serviceNames }: Props) {
   const {
@@ -199,11 +216,15 @@ export function APMTransactions({ functionName, serviceNames }: Props) {
       },
       {
         field: 'serviceSamples',
-        name: i18n.translate('xpack.profiling.apmTransactions.columns.serviceSamplesName', {
-          defaultMessage: 'Service Samples',
-        }),
         width: '150px',
         sortable: true,
+        name: (
+          <EstimatedLabel
+            label={i18n.translate('xpack.profiling.apmTransactions.columns.serviceSamplesName', {
+              defaultMessage: 'Service Samples',
+            })}
+          />
+        ),
         render(_, { serviceSamples }) {
           return asNumber(serviceSamples);
         },
@@ -239,10 +260,14 @@ export function APMTransactions({ functionName, serviceNames }: Props) {
       },
       {
         field: 'transactionSamples',
-        name: i18n.translate('xpack.profiling.apmTransactions.columns.transactionSamples', {
-          defaultMessage: 'Transaction Samples',
-        }),
-        width: '150px',
+        name: (
+          <EstimatedLabel
+            label={i18n.translate('xpack.profiling.apmTransactions.columns.transactionSamples', {
+              defaultMessage: 'Transaction Samples',
+            })}
+          />
+        ),
+        width: '152px',
         render(_, { transactionSamples }) {
           if (isLoadingTransactions) {
             return '--';


### PR DESCRIPTION
The service samples and transaction samples are estimated values, so I'm adding a tooltip to make it clear for users.

<img width="883" alt="Screenshot 2024-04-23 at 15 51 44" src="https://github.com/elastic/kibana/assets/55978943/b71284ba-9104-45e5-9546-303279cb11f3">


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->