### PR TITLE
[Dashboard] Background Color Should Match When Margins are Off

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/_dashboard_container.scss
+++ b/src/plugins/dashboard/public/dashboard_container/_dashboard_container.scss
@@ -11,6 +11,10 @@
   align-items: center;
 }
 
+.dashboardViewport--defaultBg {
+  background: $euiColorEmptyShade;
+}
+
 .dshEmptyPromptParent {
   flex-grow: 1;
   display: flex;

--- a/src/plugins/dashboard/public/dashboard_container/_dashboard_container.scss
+++ b/src/plugins/dashboard/public/dashboard_container/_dashboard_container.scss
@@ -11,10 +11,6 @@
   align-items: center;
 }
 
-.dashboardViewport--defaultBg {
-  background: $euiColorEmptyShade;
-}
-
 .dshEmptyPromptParent {
   flex-grow: 1;
   display: flex;

--- a/src/plugins/dashboard/public/dashboard_container/component/viewport/_dashboard_viewport.scss
+++ b/src/plugins/dashboard/public/dashboard_container/component/viewport/_dashboard_viewport.scss
@@ -2,6 +2,9 @@
   flex: auto;
   display: flex;
   flex-direction: column;
+  &--defaultBg {
+    background: $euiColorEmptyShade;
+  }
 }
 
 .dshDashboardViewport {

--- a/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -53,6 +53,7 @@ export const DashboardViewportComponent = () => {
 
   const viewMode = dashboard.select((state) => state.explicitInput.viewMode);
   const dashboardTitle = dashboard.select((state) => state.explicitInput.title);
+  const useMargins = dashboard.select((state) => state.explicitInput.useMargins);
   const description = dashboard.select((state) => state.explicitInput.description);
   const focusedPanelId = dashboard.select((state) => state.componentState.focusedPanelId);
   const expandedPanelId = dashboard.select((state) => state.componentState.expandedPanelId);
@@ -65,7 +66,11 @@ export const DashboardViewportComponent = () => {
   });
 
   return (
-    <div className={'dshDashboardViewportWrapper'}>
+    <div
+      className={classNames('dshDashboardViewportWrapper', {
+        'dshDashboardViewportWrapper--defaultBg': !useMargins,
+      })}
+    >
       {controlGroup && viewMode !== ViewMode.PRINT ? (
         <div
           className={controlCount > 0 ? 'dshDashboardViewport-controls' : ''}

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
@@ -266,4 +266,31 @@ describe('dashboard renderer', () => {
       wrapper!.find('#superParent').getDOMNode().classList.contains('dshDashboardViewportWrapper')
     ).toBe(true);
   });
+
+  test('adds a class to apply default background color when dashboard has use margin option set to false', async () => {
+    const mockUseMarginFalseEmbeddable = {
+      ...mockDashboardContainer,
+      getInput: jest.fn().mockResolvedValue({ useMargins: false }),
+    } as unknown as DashboardContainer;
+
+    const mockUseMarginFalseFactory = {
+      create: jest.fn().mockReturnValue(mockUseMarginFalseEmbeddable),
+    } as unknown as DashboardContainerFactory;
+    pluginServices.getServices().embeddable.getEmbeddableFactory = jest
+      .fn()
+      .mockReturnValue(mockUseMarginFalseFactory);
+
+    let wrapper: ReactWrapper;
+    await act(async () => {
+      wrapper = await mountWithIntl(
+        <div id="superParent">
+          <DashboardRenderer savedObjectId="saved_object_kibanana" />
+        </div>
+      );
+    });
+
+    expect(
+      wrapper!.find('#superParent').getDOMNode().querySelector('.dashboardViewport--defaultBg')
+    ).not.toBe(null);
+  });
 });

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
@@ -32,6 +32,7 @@ describe('dashboard renderer', () => {
       render: jest.fn(),
       select: jest.fn(),
       navigateToDashboard: jest.fn().mockResolvedValue({}),
+      getInput: jest.fn().mockResolvedValue({}),
     } as unknown as DashboardContainer;
     mockDashboardFactory = {
       create: jest.fn().mockReturnValue(mockDashboardContainer),
@@ -148,6 +149,7 @@ describe('dashboard renderer', () => {
       render: jest.fn(),
       navigateToDashboard: jest.fn(),
       select: jest.fn(),
+      getInput: jest.fn().mockResolvedValue({}),
     } as unknown as DashboardContainer;
     const mockSuccessFactory = {
       create: jest.fn().mockReturnValue(mockSuccessEmbeddable),
@@ -242,6 +244,7 @@ describe('dashboard renderer', () => {
       render: jest.fn(),
       navigateToDashboard: jest.fn(),
       select: jest.fn().mockReturnValue('WhatAnExpandedPanel'),
+      getInput: jest.fn().mockResolvedValue({}),
     } as unknown as DashboardContainer;
     const mockSuccessFactory = {
       create: jest.fn().mockReturnValue(mockSuccessEmbeddable),

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.test.tsx
@@ -290,7 +290,10 @@ describe('dashboard renderer', () => {
     });
 
     expect(
-      wrapper!.find('#superParent').getDOMNode().querySelector('.dashboardViewport--defaultBg')
+      wrapper!
+        .find('#superParent')
+        .getDOMNode()
+        .classList.contains('dshDashboardViewportWrapper--defaultBg')
     ).not.toBe(null);
   });
 });

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
@@ -20,9 +20,8 @@ import React, {
 } from 'react';
 import useUnmount from 'react-use/lib/useUnmount';
 import { v4 as uuidv4 } from 'uuid';
-import { css } from '@emotion/css';
 
-import { EuiLoadingElastic, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
+import { EuiLoadingElastic, EuiLoadingSpinner } from '@elastic/eui';
 import { ErrorEmbeddable, isErrorEmbeddable } from '@kbn/embeddable-plugin/public';
 import { SavedObjectNotFound } from '@kbn/kibana-utils-plugin/common';
 
@@ -55,7 +54,6 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
   ({ savedObjectId, getCreationOptions, dashboardRedirect, showPlainSpinner, locator }, ref) => {
     const dashboardRoot = useRef(null);
     const dashboardViewport = useRef(null);
-    const { euiTheme } = useEuiTheme();
     const [loading, setLoading] = useState(true);
     const [screenshotMode, setScreenshotMode] = useState(false);
     const [dashboardContainer, setDashboardContainer] = useState<DashboardContainer>();
@@ -177,11 +175,7 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
       'dashboardViewport',
       { 'dashboardViewport--screenshotMode': screenshotMode },
       { 'dashboardViewport--loading': loading },
-      {
-        [css`
-          background: ${euiTheme.colors.emptyShade};
-        `]: !useMargins,
-      }
+      { 'dashboardViewport--defaultBg': !useMargins }
     );
 
     const loadingSpinner = showPlainSpinner ? (

--- a/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
@@ -59,17 +59,6 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
     const [dashboardContainer, setDashboardContainer] = useState<DashboardContainer>();
     const [fatalError, setFatalError] = useState<ErrorEmbeddable | undefined>();
     const [dashboardMissing, setDashboardMissing] = useState(false);
-    const [useMargins, setUseMargins] = useState(dashboardContainer?.getInput().useMargins);
-
-    useEffect(() => {
-      if (dashboardContainer?.getInput$) {
-        const s = dashboardContainer?.getInput$().subscribe((value) => {
-          setUseMargins(value.useMargins);
-        });
-
-        return () => s.unsubscribe();
-      }
-    }, [dashboardContainer]);
 
     useImperativeHandle(
       ref,
@@ -174,8 +163,7 @@ export const DashboardRenderer = forwardRef<AwaitingDashboardAPI, DashboardRende
     const viewportClasses = classNames(
       'dashboardViewport',
       { 'dashboardViewport--screenshotMode': screenshotMode },
-      { 'dashboardViewport--loading': loading },
-      { 'dashboardViewport--defaultBg': !useMargins }
+      { 'dashboardViewport--loading': loading }
     );
 
     const loadingSpinner = showPlainSpinner ? (


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/47795

This PR makes it such that when a dashboard has the margin setting disabled the dashboard background color matches the current color mode.

## Visuals

### Light mode
<img width="2560" alt="Screenshot 2024-05-10 at 12 24 10" src="https://github.com/elastic/kibana/assets/7893459/21e228c8-1e89-40c0-aa43-32b2d0e8c5bc">

### Dark mode
<img width="2560" alt="Screenshot 2024-05-10 at 12 25 06" src="https://github.com/elastic/kibana/assets/7893459/76ca1830-71f2-4993-918b-f09102e44095">


## How to verify

- Navigate to any dashboard of choice
- click on the settings menu, which should reveal the settings flyout
- notice on toggling the `use margin` and accepting the change; when the switch is enabled the gutter between margins are colored slightly darker that the panel background color in either the light or dark mode, also when the switch is in the disabled state, the panels are without any margins with it's background matching the panel color in either light or dark mode.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
<!-- 
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
 - [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->