### PR TITLE
Adding condition to remove error message when no indices are present

### DIFF
--- a/x-pack/plugins/search_playground/public/hooks/use_source_indices_field.ts
+++ b/x-pack/plugins/search_playground/public/hooks/use_source_indices_field.ts
@@ -88,6 +88,8 @@ export const useSourceIndicesFields = () => {
 
       onElasticsearchQueryChange(createQuery(defaultFields, fields));
       onSourceFieldsChange(defaultSourceFields);
+    } else {
+      setNoFieldsIndicesWarning(null);
     }
     setLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/plugins/search_playground/public/hooks/use_source_indices_fields.test.tsx
+++ b/x-pack/plugins/search_playground/public/hooks/use_source_indices_fields.test.tsx
@@ -188,4 +188,54 @@ describe.skip('useSourceIndicesFields Hook', () => {
       `);
     });
   });
+
+  it('should not provide any warning message for adding and then removing an index without any fields', async () => {
+    const querySourceFields: IndicesQuerySourceFields = {
+      missing_fields_index: {
+        elser_query_fields: [],
+        dense_vector_query_fields: [],
+        bm25_query_fields: [],
+        source_fields: [],
+      },
+    };
+
+    postMock.mockResolvedValue(querySourceFields);
+
+    const { result } = renderHook(() => useSourceIndicesFields(), { wrapper });
+    const { getValues } = formHookSpy.mock.results[0].value;
+
+    await act(async () => {
+      result.current.addIndex('missing_fields_index');
+    });
+
+    await act(async () => {
+      result.current.removeIndex('missing_fields_index');
+    });
+
+    expect(postMock).toHaveBeenCalled();
+
+    await act(async () => {
+      expect(result.current.noFieldsIndicesWarning).toBeNull();
+      expect(result.current.loading).toBe(false);
+      expect(getValues()).toMatchInlineSnapshot(`
+        Object {
+          "doc_size": 5,
+          "elasticsearch_query": Object {
+            "retriever": Object {
+              "standard": Object {
+                "query": Object {
+                  "match_all": Object {},
+                },
+              },
+            },
+          },
+          "indices": Array [],
+          "prompt": "You are an assistant for question-answering tasks.",
+          "source_fields": Object {
+            "missing_fields_index": Array [],
+          },
+        }
+      `);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Currently the `No source field` error message still display even if we removes all indices.
<img width="1241" alt="Screenshot 2024-04-23 at 2 10 41 PM" src="https://github.com/elastic/kibana/assets/150824886/5a08ba67-6440-49c3-a152-fb459b911840">

This fixes the error message to hide once we remove the index without source fields or when there is no indices.

<img width="1246" alt="Screenshot 2024-04-23 at 2 39 46 PM" src="https://github.com/elastic/kibana/assets/150824886/bd157bbc-287e-4cf2-9b6e-bbdc6e656bda">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->