### PR TITLE
[Fleet] Filter globalsearch deeplink based on authz

### DIFF
--- a/x-pack/plugins/fleet/public/deep_links.ts
+++ b/x-pack/plugins/fleet/public/deep_links.ts
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import type { AppDeepLink } from '@kbn/core/public';
 
 import type { ExperimentalFeatures } from '../common/experimental_features';
+import type { FleetAuthz } from '../common';
 
 import { FLEET_ROUTING_PATHS } from './constants/page_paths';
 
@@ -21,51 +22,59 @@ export enum FleetDeepLinkId {
   settings = 'settings',
 }
 
-export const getFleetDeepLinks: (experimentalFeatures: ExperimentalFeatures) => AppDeepLink[] = (
-  experimentalFeatures
-) => [
-  {
-    id: FleetDeepLinkId.agents,
-    title: i18n.translate('xpack.fleet.deepLinks.agents.title', { defaultMessage: 'Agents' }),
-    path: FLEET_ROUTING_PATHS.agents,
-  },
-  {
-    id: FleetDeepLinkId.policies,
-    title: i18n.translate('xpack.fleet.deepLinks.policies.title', {
-      defaultMessage: 'Agent policies',
-    }),
-    path: FLEET_ROUTING_PATHS.policies,
-  },
-  {
-    id: FleetDeepLinkId.enrollmentTokens,
-    title: i18n.translate('xpack.fleet.deepLinks.enrollmentTokens.title', {
-      defaultMessage: 'Enrollment tokens',
-    }),
-    path: FLEET_ROUTING_PATHS.enrollment_tokens,
-  },
-  ...(experimentalFeatures.agentTamperProtectionEnabled
-    ? [
-        {
-          id: FleetDeepLinkId.uninstallTokens,
-          title: i18n.translate('xpack.fleet.deepLinks.uninstallTokens.title', {
-            defaultMessage: 'Uninstall tokens',
-          }),
-          path: FLEET_ROUTING_PATHS.uninstall_tokens,
-        },
-      ]
-    : []),
-  {
-    id: FleetDeepLinkId.dataStreams,
-    title: i18n.translate('xpack.fleet.deepLinks.dataStreams.title', {
-      defaultMessage: 'Data streams',
-    }),
-    path: FLEET_ROUTING_PATHS.data_streams,
-  },
-  {
-    id: FleetDeepLinkId.settings,
-    title: i18n.translate('xpack.fleet.deepLinks.settings.title', {
-      defaultMessage: 'Settings',
-    }),
-    path: FLEET_ROUTING_PATHS.settings,
-  },
-];
+export const getFleetDeepLinks: (
+  experimentalFeatures: ExperimentalFeatures,
+  authz?: FleetAuthz
+) => AppDeepLink[] = (experimentalFeatures, authz) => {
+  return [
+    {
+      id: FleetDeepLinkId.agents,
+      title: i18n.translate('xpack.fleet.deepLinks.agents.title', { defaultMessage: 'Agents' }),
+      path: FLEET_ROUTING_PATHS.agents,
+      visibleIn: !authz?.fleet.readAgents ? [] : ['globalSearch'],
+    },
+    {
+      id: FleetDeepLinkId.policies,
+      title: i18n.translate('xpack.fleet.deepLinks.policies.title', {
+        defaultMessage: 'Agent policies',
+      }),
+      path: FLEET_ROUTING_PATHS.policies,
+      visibleIn: !authz?.fleet.readAgentPolicies ? [] : ['globalSearch'],
+    },
+    {
+      id: FleetDeepLinkId.enrollmentTokens,
+      title: i18n.translate('xpack.fleet.deepLinks.enrollmentTokens.title', {
+        defaultMessage: 'Enrollment tokens',
+      }),
+      path: FLEET_ROUTING_PATHS.enrollment_tokens,
+      visibleIn: !authz?.fleet.allAgents ? [] : ['globalSearch'],
+    },
+    ...((experimentalFeatures.agentTamperProtectionEnabled
+      ? [
+          {
+            id: FleetDeepLinkId.uninstallTokens,
+            title: i18n.translate('xpack.fleet.deepLinks.uninstallTokens.title', {
+              defaultMessage: 'Uninstall tokens',
+            }),
+            path: FLEET_ROUTING_PATHS.uninstall_tokens,
+            visibleIn: !authz?.fleet.allAgents ? [] : ['globalSearch'],
+          },
+        ]
+      : []) as AppDeepLink[]),
+    {
+      id: FleetDeepLinkId.dataStreams,
+      title: i18n.translate('xpack.fleet.deepLinks.dataStreams.title', {
+        defaultMessage: 'Data streams',
+      }),
+      path: FLEET_ROUTING_PATHS.data_streams,
+    },
+    {
+      id: FleetDeepLinkId.settings,
+      title: i18n.translate('xpack.fleet.deepLinks.settings.title', {
+        defaultMessage: 'Settings',
+      }),
+      path: FLEET_ROUTING_PATHS.settings,
+      visibleIn: !authz?.fleet.readSettings ? [] : ['globalSearch'],
+    },
+  ];
+};


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/181225

Filter Fleet visible global search deeplink based on authz to avoid showing page the user cannot access.

## How to manually test

Create a user with limited fleet permissions and check the user only see the relevant `Fleet - *` when searching for Fleet

<img width="894" alt="Screenshot 2024-04-23 at 3 58 56 PM" src="https://github.com/elastic/kibana/assets/1336873/ebc53a48-61b3-4ecc-8603-18992daeacda">

## Tests

`getFleetDeepLinks` could be unit tested but not sure of the value this will add


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->