### PR TITLE
Fix `maps` plugin async route registration

### DIFF
--- a/x-pack/plugins/maps/server/data_indexing/indexing_routes.ts
+++ b/x-pack/plugins/maps/server/data_indexing/indexing_routes.ts
@@ -26,11 +26,11 @@ import { getMatchingIndexes } from './get_indexes_matching_pattern';
 export function initIndexingRoutes({
   router,
   logger,
-  dataPlugin,
+  getDataPlugin,
 }: {
   router: IRouter<DataRequestHandlerContext>;
   logger: Logger;
-  dataPlugin: DataPluginStart;
+  getDataPlugin: () => Promise<DataPluginStart>;
   securityPlugin?: SecurityPluginStart;
 }) {
   router.versioned
@@ -58,6 +58,7 @@ export function initIndexingRoutes({
       async (context, request, response) => {
         const coreContext = await context.core;
         const { index, mappings } = request.body;
+        const dataPlugin = await getDataPlugin();
         const indexPatternsService = await dataPlugin.indexPatterns.dataViewsServiceFactory(
           coreContext.savedObjects.client,
           coreContext.elasticsearch.client.asCurrentUser,

--- a/x-pack/plugins/maps/server/mvt/mvt_routes.ts
+++ b/x-pack/plugins/maps/server/mvt/mvt_routes.ts
@@ -27,11 +27,11 @@ const CACHE_TIMEOUT_SECONDS = 60 * 60;
 export function initMVTRoutes({
   router,
   logger,
-  core,
+  getCore,
 }: {
   router: IRouter<DataRequestHandlerContext>;
   logger: Logger;
-  core: CoreStart;
+  getCore: () => Promise<CoreStart>;
 }) {
   router.versioned
     .get({
@@ -93,7 +93,7 @@ export function initMVTRoutes({
           abortController: makeAbortController(request),
           body: tileRequest.body,
           context,
-          core,
+          core: await getCore(),
           executionContext: makeExecutionContext({
             type: 'server',
             name: APP_ID,
@@ -173,7 +173,7 @@ export function initMVTRoutes({
           abortController: makeAbortController(request),
           body: tileRequest.body,
           context,
-          core,
+          core: await getCore(),
           executionContext: makeExecutionContext({
             type: 'server',
             name: APP_ID,

--- a/x-pack/plugins/maps/server/plugin.ts
+++ b/x-pack/plugins/maps/server/plugin.ts
@@ -145,7 +145,7 @@ export class MapsPlugin implements Plugin {
     );
   }
 
-  setup(core: CoreSetup, plugins: SetupDeps) {
+  setup(core: CoreSetup<StartDeps>, plugins: SetupDeps) {
     const getFilterMigrations = plugins.data.query.filterManager.getAllMigrations.bind(
       plugins.data.query.filterManager
     );


### PR DESCRIPTION
## Summary

Async registration is bad, especially when promise rejections are not caught. 

The PR adapts the routes registration to be synchronous