### PR TITLE
[ES|QL] Multiline query in expanded mode shows undefined for line number

### DIFF
--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.styles.ts
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.styles.ts
@@ -12,7 +12,7 @@ export const EDITOR_INITIAL_HEIGHT_EXPANDED = 140;
 export const EDITOR_MIN_HEIGHT = 40;
 export const EDITOR_MAX_HEIGHT = 400;
 
-export const textBasedLanguagedEditorStyles = (
+export const textBasedLanguageEditorStyles = (
   euiTheme: EuiThemeComputed,
   isCompactFocused: boolean,
   editorHeight: number,

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -43,7 +43,7 @@ import {
 import { CodeEditor, CodeEditorProps } from '@kbn/code-editor';
 
 import {
-  textBasedLanguagedEditorStyles as textBasedLanguageEditorStyles,
+  textBasedLanguageEditorStyles,
   EDITOR_INITIAL_HEIGHT,
   EDITOR_INITIAL_HEIGHT_EXPANDED,
   EDITOR_MAX_HEIGHT,

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -43,7 +43,7 @@ import {
 import { CodeEditor, CodeEditorProps } from '@kbn/code-editor';
 
 import {
-  textBasedLanguagedEditorStyles,
+  textBasedLanguagedEditorStyles as textBasedLanguageEditorStyles,
   EDITOR_INITIAL_HEIGHT,
   EDITOR_INITIAL_HEIGHT_EXPANDED,
   EDITOR_MAX_HEIGHT,
@@ -189,7 +189,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     kibana.services;
   const timeZone = core?.uiSettings?.get('dateFormat:tz');
   const [code, setCode] = useState<string>(queryString ?? '');
-  const [codeOneLiner, setCodeOneLiner] = useState('');
+  const [codeOneLiner, setCodeOneLiner] = useState<string | null>(null);
   // To make server side errors less "sticky", register the state of the code when submitting
   const [codeWhenSubmitted, setCodeStateOnSubmission] = useState(code);
   const [editorHeight, setEditorHeight] = useState(
@@ -273,7 +273,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     });
   });
 
-  const styles = textBasedLanguagedEditorStyles(
+  const styles = textBasedLanguageEditorStyles(
     euiTheme,
     isCompactFocused,
     editorHeight,
@@ -342,34 +342,24 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     updateLinesFromModel = false;
     clickedOutside = true;
     if (editor1.current) {
-      const editorElement = editor1.current.getDomNode();
-      if (editorElement) {
-        editorElement.style.height = `${EDITOR_INITIAL_HEIGHT}px`;
-        const contentWidth = Number(editorElement?.style.width.replace('px', ''));
-        calculateVisibleCode(contentWidth, true);
-        editor1.current.layout({ width: contentWidth, height: EDITOR_INITIAL_HEIGHT });
-      }
+      const contentWidth = editor1.current.getLayoutInfo().width;
+      calculateVisibleCode(contentWidth, true);
+      editor1.current.layout({ width: contentWidth, height: EDITOR_INITIAL_HEIGHT });
     }
   };
 
   const updateHeight = useCallback((editor: monaco.editor.IStandaloneCodeEditor) => {
-    if (lines === 1 || clickedOutside || initialRender) return;
-    const editorElement = editor.getDomNode();
+    if (clickedOutside || initialRender) return;
     const contentHeight = Math.min(MAX_COMPACT_VIEW_LENGTH, editor.getContentHeight());
-
-    if (editorElement) {
-      editorElement.style.height = `${contentHeight}px`;
-    }
-    const contentWidth = Number(editorElement?.style.width.replace('px', ''));
-    editor.layout({ width: contentWidth, height: contentHeight });
     setEditorHeight(contentHeight);
+    editor.layout({ width: editor.getLayoutInfo().width, height: contentHeight });
   }, []);
 
   const onEditorFocus = useCallback(() => {
     setIsCompactFocused(true);
     setIsCodeEditorExpandedFocused(true);
     setShowLineNumbers(true);
-    setCodeOneLiner('');
+    setCodeOneLiner(null);
     clickedOutside = false;
     initialRender = false;
     updateLinesFromModel = true;
@@ -598,13 +588,9 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
 
   useEffect(() => {
     if (editor1.current && !isCompactFocused) {
-      const editorElement = editor1.current.getDomNode();
-      if (editorElement) {
-        const contentWidth = Number(editorElement?.style.width.replace('px', ''));
-        if (code !== queryString) {
-          setCode(queryString);
-          calculateVisibleCode(contentWidth);
-        }
+      if (code !== queryString) {
+        setCode(queryString);
+        calculateVisibleCode(editor1.current.getLayoutInfo().width);
       }
     }
   }, [calculateVisibleCode, code, isCompactFocused, queryString]);
@@ -944,9 +930,14 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
                           monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
                           onQuerySubmit
                         );
+
                         if (!isCodeEditorExpanded) {
                           editor.onDidContentSizeChange((e) => {
-                            updateHeight(editor);
+                            // @ts-expect-error the property _oldContentHeight exists on the event object received but
+                            // is not available on the type definition
+                            if (e.contentHeight !== e._oldContentHeight) {
+                              updateHeight(editor);
+                            }
                           });
                         }
                       }}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/kibana/issues/180570

Thanks to @drewdaemon for the preliminary investigation to the root cause of the issue, see https://github.com/elastic/kibana/issues/180570#issuecomment-2059590022. Building off of this, I noticed there's actually a first render pass where the code editor renders just fine, but for some reason it renders again ~causing~ which in turn causes the issue to happen see 

<img width="1728" alt="Screenshot 2024-04-24 at 01 48 18" src="https://github.com/elastic/kibana/assets/7893459/cc575b48-ef18-4920-9a40-14b53ed71e2d">

From the image above we see that the editor has it's line numbers rendered appropriately but then there's another render triggered which causes the issue, we'll notice that the dynamic overlay instance in the image above have their property of `_shouldRender` marked as false, this is because a render already happened see line 97 from the same image where said dynamic overlay is marked as rendered;
 
<img width="450" alt="Screenshot 2024-04-24 at 09 09 51" src="https://github.com/elastic/kibana/assets/7893459/c82e5c61-da34-417c-92b0-0eddde84b37f">

See [here](https://github.com/microsoft/vscode/blob/a3944f74adb303047355e8c7d4b401bfba4e1a0d/src/vs/editor/common/viewEventHandler.ts#L30-L32) for the definition of `onDidRender`. This then makes it such that for the next render pass the render result isn't available. 

My assumption is that because we are updating the layout value of the editor, on every model change without actually taking into consideration the state of the editor it causes the editor to go out of sync, see 

<img width="413" alt="Screenshot 2024-04-24 at 09 31 45" src="https://github.com/elastic/kibana/assets/7893459/ed1b94e2-d894-493e-a378-6dc0fcffd684">

To counteract this, this PR introduces a guard that only updates the editor height when the event received actually has a diff in `contentHeight` property. Alongside this computation of the editor height is now inferred by reading values provided by the editor itself and not the DOM element of the editor.


## Visuals

https://github.com/elastic/kibana/assets/7893459/26bb60ad-9ea1-41fe-854a-5c8a7be2e29d



<!--### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->