### PR TITLE
Reorder the list of options

### DIFF
--- a/docs/management/field-formatters/string-formatter.asciidoc
+++ b/docs/management/field-formatters/string-formatter.asciidoc
@@ -8,13 +8,13 @@ Supported transformations include:
 
 * Convert to title case
 
+* Base64 decode
+
+* URL param decode
+
 * Apply the short dots transformation, which replaces the content before the `.` character with the first character of
 the content. For example:
 
 [horizontal]
 *Original*:: *Becomes*
 `com.organizations.project.ClassName`:: `c.o.p.ClassName`
-
-* Base64 decode
-
-* URL param decode


### PR DESCRIPTION
Otherwise the last 2 options are part of the example table which looks weird.

## Summary

The doc switches from:

<img width="1002" alt="Capture d’écran 2024-04-24 à 14 34 27" src="https://github.com/dadoonet/kibana/assets/274222/33270db7-f676-4e6d-aa9f-900cebbece6a">

To:

<img width="1002" alt="Capture d’écran 2024-04-24 à 14 37 21" src="https://github.com/dadoonet/kibana/assets/274222/4a26fd78-5c57-427b-8fdf-f76b0c8b9b94">
