### PR TITLE
[8.14] [SecuritySolutions] Fix entity analytics UI issues on dark mode (#181431)

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/components/file_picker_step.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/components/file_picker_step.tsx
@@ -136,7 +136,7 @@ export const AssetCriticalityFilePickerStep: React.FC<AssetCriticalityFilePicker
           <EuiCodeBlock
             language="csv"
             css={css`
-              background-color: ${euiTheme.colors.ghost};
+              background-color: ${euiTheme.colors.emptyShade};
             `}
             paddingSize="s"
             lineNumbers

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/shared/components/entity_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/shared/components/entity_table/columns.tsx
@@ -7,7 +7,7 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { euiLightVars } from '@kbn/ui-theme';
+import { euiThemeVars } from '@kbn/ui-theme';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { DefaultFieldRenderer } from '../../../../../timelines/components/field_renderers/field_renderers';
 import { getEmptyTagValue } from '../../../../../common/components/empty_value';
@@ -32,8 +32,8 @@ export const getEntityTableColumns = <T extends BasicEntityData>(
       <span
         data-test-subj="entity-table-label"
         css={css`
-          font-weight: ${euiLightVars.euiFontWeightMedium};
-          color: ${euiLightVars.euiTitleColor};
+          font-weight: ${euiThemeVars.euiFontWeightMedium};
+          color: ${euiThemeVars.euiTitleColor};
         `}
       >
         {label ?? field}

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/new_user_detail/columns.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/new_user_detail/columns.tsx
@@ -7,7 +7,7 @@
 
 import { css } from '@emotion/react';
 import React from 'react';
-import { euiLightVars } from '@kbn/ui-theme';
+import { euiThemeVars } from '@kbn/ui-theme';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { SourcererScopeName } from '../../../../common/store/sourcerer/model';
 import { DefaultFieldRenderer } from '../../field_renderers/field_renderers';
@@ -21,8 +21,8 @@ const fieldColumn: EuiBasicTableColumn<ManagedUserTable> = {
   render: (label: string, { field }) => (
     <span
       css={css`
-        font-weight: ${euiLightVars.euiFontWeightMedium};
-        color: ${euiLightVars.euiTitleColor};
+        font-weight: ${euiThemeVars.euiFontWeightMedium};
+        color: ${euiThemeVars.euiTitleColor};
       `}
     >
       {label ?? field}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[SecuritySolutions] Fix entity analytics UI issues on dark mode (#181431)](https://github.com/elastic/kibana/pull/181431)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2024-04-24T12:59:48Z","message":"[SecuritySolutions] Fix entity analytics UI issues on dark mode (#181431)\n\n## Summary\r\n\r\nWe were using the wrong colour variables in a couple of places.\r\nThese changes only impact the dark mode UI.\r\n\r\n\r\nFixed pages:\r\n\r\n![Screenshot 2024-04-23 at 14 55\r\n20](https://github.com/elastic/kibana/assets/1490444/4b330c43-559d-4542-ab6b-46e98b69ce19)\r\n\r\n![Screenshot 2024-04-23 at 14 36\r\n12](https://github.com/elastic/kibana/assets/1490444/0b47b893-e9f2-4a54-b7c6-d055f2bb91a6)\r\n\r\n.","sha":"58562c95656d37ad458d204f1e1810c63b7b2456","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: SecuritySolution","Team:Entity Analytics","v8.14.0","v8.15.0"],"number":181431,"url":"https://github.com/elastic/kibana/pull/181431","mergeCommit":{"message":"[SecuritySolutions] Fix entity analytics UI issues on dark mode (#181431)\n\n## Summary\r\n\r\nWe were using the wrong colour variables in a couple of places.\r\nThese changes only impact the dark mode UI.\r\n\r\n\r\nFixed pages:\r\n\r\n![Screenshot 2024-04-23 at 14 55\r\n20](https://github.com/elastic/kibana/assets/1490444/4b330c43-559d-4542-ab6b-46e98b69ce19)\r\n\r\n![Screenshot 2024-04-23 at 14 36\r\n12](https://github.com/elastic/kibana/assets/1490444/0b47b893-e9f2-4a54-b7c6-d055f2bb91a6)\r\n\r\n.","sha":"58562c95656d37ad458d204f1e1810c63b7b2456"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181431","number":181431,"mergeCommit":{"message":"[SecuritySolutions] Fix entity analytics UI issues on dark mode (#181431)\n\n## Summary\r\n\r\nWe were using the wrong colour variables in a couple of places.\r\nThese changes only impact the dark mode UI.\r\n\r\n\r\nFixed pages:\r\n\r\n![Screenshot 2024-04-23 at 14 55\r\n20](https://github.com/elastic/kibana/assets/1490444/4b330c43-559d-4542-ab6b-46e98b69ce19)\r\n\r\n![Screenshot 2024-04-23 at 14 36\r\n12](https://github.com/elastic/kibana/assets/1490444/0b47b893-e9f2-4a54-b7c6-d055f2bb91a6)\r\n\r\n.","sha":"58562c95656d37ad458d204f1e1810c63b7b2456"}}]}] BACKPORT-->