### PR TITLE
Adjust esClient parameters to prevent flaky behaviors

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -65,7 +65,7 @@ describe('migration actions', () => {
   beforeAll(async () => {
     esServer = await startES();
     // we don't need a long timeout for testing purposes
-    client = esServer.es.getClient().child({ ...MIGRATION_CLIENT_OPTIONS, requestTimeout: 5500 });
+    client = esServer.es.getClient().child({ ...MIGRATION_CLIENT_OPTIONS, requestTimeout: 10_000 });
     esCapabilities = elasticsearchServiceMock.createCapabilities();
 
     // Create test fixture data:
@@ -390,8 +390,7 @@ describe('migration actions', () => {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/152677
-  describe.skip('waitForIndexStatus', () => {
+  describe('waitForIndexStatus', () => {
     afterEach(async () => {
       try {
         await client.indices.delete({ index: 'red_then_yellow_index' });

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -1308,7 +1308,7 @@ describe('migration actions', () => {
         query: { match_all: {} },
         batchSize: 1, // small batch size so we don't exceed the maxResponseSize
         searchAfter: undefined,
-        maxResponseSizeBytes: 1000, // set a small size to force the error
+        maxResponseSizeBytes: 5000, // make sure long ids don't cause es_response_too_large
       });
       const rightResponse = await readWithPitTask();
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1348,8 +1348,7 @@ export const runActionTestSuite = ({
       );
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/167288
-    it.skip('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
+    it('returns a left es_response_too_large error when a read batch exceeds the maxResponseSize', async () => {
       const openPitTask = openPit({ client, index: 'existing_index_with_docs' });
       const pitResponse = (await openPitTask()) as Either.Right<OpenPitResponse>;
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -1359,7 +1359,7 @@ export const runActionTestSuite = ({
         query: { match_all: {} },
         batchSize: 1, // small batch size so we don't exceed the maxResponseSize
         searchAfter: undefined,
-        maxResponseSizeBytes: 1000, // set a small size to force the error
+        maxResponseSizeBytes: 5000, // make sure long ids don't cause es_response_too_large
       });
       const rightResponse = await readWithPitTask();
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/152677

It seems that CI eventually times out whilst creating SO indices for testing purposes.
The PR aims at preventing this by increasing that timeout from `5.5s` to `10s`.


Last 4 CI failures report the exact same `Request timed out` error:

<img width="1037" alt="image" src="https://github.com/elastic/kibana/assets/25349407/8b4856f7-d667-4e95-b623-a085ab756e84">

---

Fixes https://github.com/elastic/kibana/issues/167288

The PIT ids are much longer on stateless ES. This causes issues with some our tests, which were checking response sizes.
PR https://github.com/elastic/kibana/pull/180261 attempted at fixing it, but the parameters were not properly adjusted, because the tests first do a valid request, followed by an invalid one.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->