### PR TITLE
[Security Solution][PoC] use `preference` property in network flow queries

### DIFF
--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_countries/index.test.ts
@@ -12,8 +12,10 @@ import {
   mockSearchStrategyResponse,
   formattedSearchStrategyResponse,
 } from './__mocks__';
+import { httpServerMock } from '@kbn/core/server/mocks';
 
 describe('networkTopCountries search strategy', () => {
+  const requestMock = httpServerMock.createKibanaRequest();
   const buildTopCountriesQuery = jest.spyOn(buildQuery, 'buildTopCountriesQuery');
 
   afterEach(() => {
@@ -22,7 +24,7 @@ describe('networkTopCountries search strategy', () => {
 
   describe('buildDsl', () => {
     test('should build dsl query', () => {
-      networkTopCountries.buildDsl(mockOptions);
+      networkTopCountries.buildDsl(mockOptions, { request: requestMock });
       expect(buildTopCountriesQuery).toHaveBeenCalledWith(mockOptions);
     });
   });

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/index.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/index.test.ts
@@ -15,6 +15,7 @@ import {
   mockCountStrategyResponse,
   formattedCountStrategyResponse,
 } from './__mocks__';
+import { httpServerMock } from '@kbn/core/server/mocks';
 
 describe('Network TopNFlow search strategy', () => {
   describe('networkTopNFlow', () => {
@@ -25,8 +26,9 @@ describe('Network TopNFlow search strategy', () => {
     });
 
     describe('buildDsl', () => {
+      const requestMock = httpServerMock.createKibanaRequest();
       test('should build dsl query', () => {
-        networkTopNFlow.buildDsl(mockOptions);
+        networkTopNFlow.buildDsl(mockOptions, { request: requestMock });
         expect(buildTopNFlowQuery).toHaveBeenCalledWith(mockOptions);
       });
     });
@@ -47,8 +49,9 @@ describe('Network TopNFlow search strategy', () => {
     });
 
     describe('buildDsl', () => {
+      const requestMock = httpServerMock.createKibanaRequest();
       test('should build dsl query', () => {
-        networkTopNFlowCount.buildDsl(mockCountOptions);
+        networkTopNFlowCount.buildDsl(mockCountOptions, { request: requestMock });
         expect(buildTopNFlowCountQuery).toHaveBeenCalledWith(mockCountOptions);
       });
     });

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/index.ts
@@ -9,6 +9,7 @@ import { getOr } from 'lodash/fp';
 
 import type { IEsSearchResponse } from '@kbn/data-plugin/common';
 
+import type { KibanaRequest } from '@kbn/core/server';
 import { DEFAULT_MAX_TABLE_QUERY_SIZE } from '../../../../../../common/constants';
 import type {
   NetworkTopNFlowStrategyResponse,
@@ -24,34 +25,47 @@ import { getTopNFlowEdges } from './helpers';
 import { buildTopNFlowQuery, buildTopNFlowCountQuery } from './query.top_n_flow_network.dsl';
 
 export const networkTopNFlow: SecuritySolutionFactory<NetworkQueries.topNFlow> = {
-  buildDsl: (options) => {
+  buildDsl: (options, { request }) => {
     if (options.pagination && options.pagination.querySize >= DEFAULT_MAX_TABLE_QUERY_SIZE) {
       throw new Error(`No query size above ${DEFAULT_MAX_TABLE_QUERY_SIZE}`);
     }
-    return buildTopNFlowQuery(options);
+    return buildTopNFlowQuery(options, { preference: getPreference(request) });
   },
   parse: async (
     options,
-    response: IEsSearchResponse<unknown>
+    response: IEsSearchResponse<unknown>,
+    deps
   ): Promise<NetworkTopNFlowStrategyResponse> => {
     const { cursorStart, querySize } = options.pagination;
     const networkTopNFlowEdges: NetworkTopNFlowEdges[] = getTopNFlowEdges(response, options);
     const edges = networkTopNFlowEdges.splice(cursorStart, querySize - cursorStart);
 
-    const inspect = { dsl: [inspectStringifyObject(buildTopNFlowQuery(options))] };
+    const inspect = { dsl: [inspectStringifyObject(deps?.searchRequestParams)] };
     return { ...response, inspect, edges };
   },
 };
 
 export const networkTopNFlowCount: SecuritySolutionFactory<NetworkQueries.topNFlowCount> = {
-  buildDsl: (options) => buildTopNFlowCountQuery(options),
+  buildDsl: (options, { request }) =>
+    buildTopNFlowCountQuery(options, { preference: getPreference(request) }),
   parse: async (
-    options,
-    response: IEsSearchResponse<unknown>
+    _options,
+    response: IEsSearchResponse<unknown>,
+    deps
   ): Promise<NetworkTopNFlowCountStrategyResponse> => {
     const totalCount = getOr(0, 'rawResponse.aggregations.top_n_flow_count.value', response);
 
-    const inspect = { dsl: [inspectStringifyObject(buildTopNFlowCountQuery(options))] };
+    const inspect = { dsl: [inspectStringifyObject(deps?.searchRequestParams)] };
     return { ...response, inspect, totalCount };
   },
+};
+
+/**
+ * Generates the preference parameter with the authorization header,
+ * which is used as session id for the preference cache.
+ * The preference parameter should never start with `_` as it is reserved for internal use.
+ **/
+const getPreference = (request: KibanaRequest) => {
+  const authHeaderKey = request.headers.authorization;
+  return `session:${Array.isArray(authHeaderKey) ? authHeaderKey.join() : authHeaderKey}`;
 };

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network.dsl.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/network/top_n_flow/query.top_n_flow_network.dsl.ts
@@ -30,15 +30,18 @@ interface AggregationsAggregationWithFieldsContainer extends AggregationsAggrega
   };
 }
 
-export const buildTopNFlowQuery = ({
-  defaultIndex,
-  filterQuery,
-  flowTarget,
-  sort,
-  pagination,
-  timerange,
-  ip,
-}: NetworkTopNFlowRequestOptions): ISearchRequestParams => {
+export const buildTopNFlowQuery = (
+  {
+    defaultIndex,
+    filterQuery,
+    flowTarget,
+    sort,
+    pagination,
+    timerange,
+    ip,
+  }: NetworkTopNFlowRequestOptions,
+  extraParams?: Partial<ISearchRequestParams>
+): ISearchRequestParams => {
   const querySize = pagination?.querySize ?? 10;
   const query = getQuery({ filterQuery, flowTarget, timerange, ip });
 
@@ -59,17 +62,15 @@ export const buildTopNFlowQuery = ({
       size: 0,
     },
     track_total_hits: false,
+    ...extraParams,
   };
   return dslQuery;
 };
 
-export const buildTopNFlowCountQuery = ({
-  defaultIndex,
-  filterQuery,
-  flowTarget,
-  timerange,
-  ip,
-}: NetworkTopNFlowCountRequestOptions): ISearchRequestParams => {
+export const buildTopNFlowCountQuery = (
+  { defaultIndex, filterQuery, flowTarget, timerange, ip }: NetworkTopNFlowCountRequestOptions,
+  extraParams?: Partial<ISearchRequestParams>
+): ISearchRequestParams => {
   const query = getQuery({ filterQuery, flowTarget, timerange, ip });
   const dslQuery = {
     allow_no_indices: true,
@@ -82,6 +83,7 @@ export const buildTopNFlowCountQuery = ({
       size: 0,
     },
     track_total_hits: false,
+    ...extraParams,
   };
   return dslQuery;
 };

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
@@ -20,7 +20,10 @@ import type {
 import type { EndpointAppContext } from '../../../endpoint/types';
 
 export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
-  buildDsl: (options: StrategyRequestType<T>) => ISearchRequestParams;
+  buildDsl: (
+    options: StrategyRequestType<T>,
+    deps: { request: KibanaRequest }
+  ) => ISearchRequestParams;
   parse: (
     options: StrategyRequestType<T>,
     response: IEsSearchResponse,
@@ -29,6 +32,7 @@ export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
       savedObjectsClient: SavedObjectsClientContract;
       endpointContext: EndpointAppContext;
       request: KibanaRequest;
+      searchRequestParams: ISearchRequestParams;
       spaceId?: string;
       ruleDataClient?: IRuleDataClient | null;
     }

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -31,8 +31,8 @@ export const securitySolutionSearchStrategyProvider = (
 
       const queryFactory = securitySolutionFactory[parsedRequest.factoryQueryType];
 
-      const dsl = queryFactory.buildDsl(parsedRequest);
-      return es.search({ ...request, params: dsl }, options, deps).pipe(
+      const searchRequestParams = queryFactory.buildDsl(parsedRequest, { request: deps.request });
+      return es.search({ ...request, params: searchRequestParams }, options, deps).pipe(
         map((response) => {
           return {
             ...response,
@@ -47,6 +47,7 @@ export const securitySolutionSearchStrategyProvider = (
             savedObjectsClient: deps.savedObjectsClient,
             endpointContext,
             request: deps.request,
+            searchRequestParams,
             spaceId: getSpaceId && getSpaceId(deps.request),
             ruleDataClient,
           })


### PR DESCRIPTION
## Summary

follow up of: https://github.com/elastic/kibana/issues/178372

Added the `preference` property to expensive network queries to use ES node caching. 
Testing the `authorization` header as a session identifier for preference.

> [!WARNING]  
> This PoC is not meant to be merged, the goal is to test the performance impact against the QA project environment.
