### PR TITLE
[Fleet] allow fleet-server agent upgrade to newer than fleet-server

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.test.tsx
@@ -334,6 +334,43 @@ describe('AgentUpgradeAgentModal', () => {
         expect(el).not.toBeDisabled();
       });
     });
+
+    it('should enable submit button for a single fleet-server when version is greater than maxFleetServerVersion', async () => {
+      mockSendGetAgentsAvailableVersions.mockClear();
+      mockSendGetAgentsAvailableVersions.mockResolvedValue({
+        data: {
+          items: ['8.10.4', '8.10.2', '8.9.0', '8.8.0'],
+        },
+      });
+      mockSendAllFleetServerAgents.mockResolvedValue({
+        allFleetServerAgents: [
+          { id: 'fleet-server', local_metadata: { elastic: { agent: { version: '8.9.0' } } } },
+        ] as any,
+      });
+
+      const { utils } = renderAgentUpgradeAgentModal({
+        agents: [
+          {
+            id: 'fleet-server',
+            local_metadata: {
+              elastic: {
+                agent: { version: '8.9.0', upgradeable: true },
+              },
+              host: { hostname: 'host00001' },
+            },
+          },
+        ] as any,
+        agentCount: 1,
+      });
+
+      await waitFor(() => {
+        const container = utils.getByTestId('agentUpgradeModal.VersionCombobox');
+        const input = within(container).getByRole<HTMLInputElement>('combobox');
+        expect(input?.value).toEqual('8.10.2');
+        const el = utils.getByTestId('confirmModalConfirmButton');
+        expect(el).toBeEnabled();
+      });
+    });
   });
 
   describe('restart upgrade', () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -287,6 +287,9 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
   const { startDatetime, onChangeStartDateTime, initialDatetime, minTime, maxTime } =
     useScheduleDateTime();
 
+  const isSingleAgentFleetServer =
+    isSingleAgent && fleetServerAgents.map((agent) => agent.id).includes(agents[0].id);
+
   const isSubmitButtonDisabled = useMemo(
     () =>
       isSubmitting ||
@@ -294,6 +297,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       !selectedVersion[0].value ||
       (isSingleAgent && !isAgentUpgradeableToVersion(agents[0], selectedVersion[0].value)) ||
       (isSingleAgent &&
+        !isSingleAgentFleetServer &&
         !isAgentVersionLessThanFleetServer(selectedVersion[0].value, fleetServerAgents)),
     [
       agents,
@@ -303,6 +307,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       isUpdating,
       selectedVersion,
       updatingAgents,
+      isSingleAgentFleetServer,
     ]
   );
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/181394

Allow upgrade fleet-server even if fleet-server version is older than the upgrade version.
See testing steps in the linked issue.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->