### PR TITLE
[build/serverless] Do not use spot instances

### DIFF
--- a/.buildkite/pipelines/artifacts_container_image.yml
+++ b/.buildkite/pipelines/artifacts_container_image.yml
@@ -2,7 +2,7 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/docker_image.sh
     label: Build serverless container images
     agents:
-      queue: n2-16-spot
+      queue: c2-16
     timeout_in_minutes: 60
     retry:
       automatic:

--- a/.buildkite/pipelines/artifacts_container_image.yml
+++ b/.buildkite/pipelines/artifacts_container_image.yml
@@ -4,7 +4,3 @@ steps:
     agents:
       queue: c2-16
     timeout_in_minutes: 60
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3


### PR DESCRIPTION
This build step doesn't support retries, if the docker image has already been uploaded once it exits early.  We want to rule out spot preemptions as a cause of failure.