### PR TITLE
[ML] Adds ML feature privileges tooltip

### DIFF
--- a/x-pack/plugins/ml/server/plugin.ts
+++ b/x-pack/plugins/ml/server/plugin.ts
@@ -135,7 +135,7 @@ export class MlServerPlugin
       catalogue: [PLUGIN_ID, `${PLUGIN_ID}_file_data_visualizer`],
       privilegesTooltip: i18n.translate('xpack.ml.featureRegistry.privilegesTooltip', {
         defaultMessage:
-          'Granting the All feature privilege will also grant the role All feature privileges to certain types of Kibana saved objects, namely index patterns, dashboards, saved searches and visualizations as well as machine learning job, trained model and module saved objects.',
+          'Granting All or Read feature privilege for Machine Learning will also grant the equivalent feature privileges to certain types of Kibana saved objects, namely index patterns, dashboards, saved searches and visualizations as well as machine learning job, trained model and module saved objects.',
       }),
       management: {
         insightsAndAlerting: ['jobsListLink', 'triggersActions'],

--- a/x-pack/plugins/ml/server/plugin.ts
+++ b/x-pack/plugins/ml/server/plugin.ts
@@ -133,6 +133,10 @@ export class MlServerPlugin
       category: DEFAULT_APP_CATEGORIES.kibana,
       app: [PLUGIN_ID, 'kibana'],
       catalogue: [PLUGIN_ID, `${PLUGIN_ID}_file_data_visualizer`],
+      privilegesTooltip: i18n.translate('xpack.ml.featureRegistry.privilegesTooltip', {
+        defaultMessage:
+          'Granting the All feature privilege will also grant the role All feature privileges to certain types of Kibana saved objects, namely index patterns, dashboards, saved searches and visualizations as well as machine learning job, trained model and module saved objects.',
+      }),
       management: {
         insightsAndAlerting: ['jobsListLink', 'triggersActions'],
       },


### PR DESCRIPTION
Adds a tooltip to the machine learning feature to inform users that an ML all privilege also grants some additional saved object privileges.

![image](https://github.com/elastic/kibana/assets/22172091/73023a51-91b9-4eb9-8889-5d9d9fad1be7)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->