### PR TITLE
[MGMTEX] Fix action data override when adding a second action

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -639,7 +639,9 @@ export const ActionForm = ({
             // TODO: fix in https://github.com/elastic/kibana/issues/155993
             // actionTypes with subtypes need to be updated in case they switched to a
             // subtype that is not the default one
-            actions[0].actionTypeId = savedAction.actionTypeId;
+            activeActionItem.indices.forEach((index: number) => {
+              actions[index].actionTypeId = savedAction.actionTypeId;
+            });
             connectors.push(savedAction);
             const indicesToUpdate = activeActionItem.indices || [];
             indicesToUpdate.forEach((index: number) => setActionIdByIndex(savedAction.id, index));

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -340,5 +340,53 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       await discardNewRuleCreation();
     });
+
+    it('should do no type override when adding a second action', async () => {
+      // create a new rule
+      const ruleName = generateUniqueKey();
+      await rules.common.defineIndexThresholdAlert(ruleName);
+
+      // add server log action
+      await testSubjects.click('.server-log-alerting-ActionTypeSelectOption');
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="Serverlog#xyz"]'
+        )
+      ).to.eql(true);
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="webhook-test"]'
+        )
+      ).to.eql(false);
+
+      // click on add new action
+      await testSubjects.click('addAlertActionButton');
+      await find.existsByCssSelector('[data-test-subj="Serverlog#xyz"]');
+
+      // create webhook connector
+      await testSubjects.click('.webhook-alerting-ActionTypeSelectOption');
+      await testSubjects.click('createActionConnectorButton-1');
+      await testSubjects.setValue('nameInput', 'webhook-test');
+      await testSubjects.setValue('webhookUrlText', 'https://test.test');
+      await testSubjects.setValue('webhookUserInput', 'fakeuser');
+      await testSubjects.setValue('webhookPasswordInput', 'fakepassword');
+      await testSubjects.click('saveActionButtonModal');
+
+      // checking the new one first to avoid flakiness. If the value is checked before the new one is added
+      // it might return a false positive
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="webhook-test"]'
+        )
+      ).to.eql(true);
+      // If it was overridden, the value would change to be empty
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="Serverlog#xyz"]'
+        )
+      ).to.eql(true);
+
+      await deleteConnectorByName('webhook-test');
+    });
   });
 };

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -341,7 +341,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await discardNewRuleCreation();
     });
 
-    it('should do no type override when adding a second action', async () => {
+    it('should not do a type override when adding a second action', async () => {
       // create a new rule
       const ruleName = generateUniqueKey();
       await rules.common.defineIndexThresholdAlert(ruleName);


### PR DESCRIPTION
## Summary

We were overwriting the `actionTypeId` of the first action in the "create connector" callback. The value assigned was the `actionTypeId` of the newly created action, meaning that we would have converted the first action to be the same as the second one. This fix changes the `actionTypeId` not for the first option but for all current `activeActionItem.indices`. 

Previously, we did add that override to fix a bug related to the slack connector https://github.com/elastic/kibana/issues/155722. Its test should cover us from breaking it back again. I did test it manually just in case and it seems to be working still. Feel free to test it too.

Also, if you are wondering why `activeActionItems.indices` is an array of numbers. The user might be using the same connector in more than one action and then delete the connector. In case this happens, and the user clicks on "edit rule", they will be able to restore both actions by just creating the connector once. In order to be able to restore all affected actions, their index is being stored as a number[]. More info here https://github.com/elastic/kibana/pull/86838 

Closes https://github.com/elastic/kibana/issues/181407

## Release Note
Fixes bug that would change the action type of the first action linked to a new rule. This happened when creating a connector inline after adding a second action to the rule.

<!--ONMERGE {"backportTargets":["8.13","8.14"]} ONMERGE-->