### PR TITLE
[Fleet] Fix managed agent policy preconfiguration update

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -40,6 +40,7 @@ export interface NewAgentPolicy {
   is_protected?: boolean;
   overrides?: { [key: string]: any } | null;
   advanced_settings?: { [key: string]: any } | null;
+  keep_monitoring_alive?: boolean | null;
 }
 
 // SO definition for this type is declared in server/types/interfaces
@@ -53,7 +54,6 @@ export interface AgentPolicy extends Omit<NewAgentPolicy, 'id'> {
   revision: number;
   agents?: number;
   is_protected: boolean;
-  keep_monitoring_alive?: boolean;
 }
 
 export interface FullAgentPolicyInputStream {

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -167,7 +167,8 @@ export async function ensurePreconfiguredPackagesAndPolicies(
       );
 
       if (!created) {
-        if (!policy?.is_managed) return { created, policy };
+        if (!policy) return { created, policy };
+        if (!policy.is_managed && !preconfiguredAgentPolicy.is_managed) return { created, policy };
         const { hasChanged, fields } = comparePreconfiguredPolicyToCurrent(
           preconfiguredAgentPolicy,
           policy


### PR DESCRIPTION
## Summary


Managed agent policy defined in the kibana config should be updated, if there is a change in the kibana config. It seems if the saved object for that agent policy is out-of-sync and do not have the `is_managed` attribute correctly set we never update them. (This is causing some bug like with the `keep_monitoring_alive` flag added in 8.12).

That PR fix that by using the policy defined in the config and not the SO as source of truth.


## Tests 

### Automated

I added unit test to the preconfiguration service

### Manual 

You can start kibana locally with the following config
```
xpack.fleet.agentPolicies:
  - name: Test policy
    description: TEST
    id: test-policy
    is_default: false
    is_default_fleet_server: false
    package_policies: []
```

Than update it to add `is_managed` and `keep_monitoring_alive` and verify your policy contains these fields
```
xpack.fleet.agentPolicies:
  - name: Test policy
    description: TEST
    id: test-policy
    is_default: false
    is_managed: true
    is_default_fleet_server: false
    package_policies: []
    keep_monitoring_alive: true
```



## Questions

Should we add a release note for that?

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->