### PR TITLE
[Logs Explorer] Remove beta icon from esql link

### DIFF
--- a/x-pack/plugins/observability_solution/logs_explorer/public/components/data_source_selector/sub_components/selector_footer.tsx
+++ b/x-pack/plugins/observability_solution/logs_explorer/public/components/data_source_selector/sub_components/selector_footer.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import {
-  EuiBetaBadge,
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -58,22 +57,7 @@ export const ESQLButton = (props: DiscoverEsqlUrlProps) => {
 
   return (
     <EuiFlexItem grow={false}>
-      <EuiButton
-        {...linkProps}
-        iconType={() => (
-          <EuiBetaBadge
-            label="ESQL Beta"
-            color="hollow"
-            iconType="beaker"
-            size="s"
-            alignment="middle"
-          />
-        )}
-        iconSide="right"
-        color="success"
-        size="s"
-        data-test-subj="esqlLink"
-      >
+      <EuiButton {...linkProps} color="success" size="s" data-test-subj="esqlLink">
         {tryEsql}
       </EuiButton>
     </EuiFlexItem>


### PR DESCRIPTION
## 📓 Summary

Removes the beta icon from the ESQL link available in the DataSourceSelector

<img width="531" alt="Screenshot 2024-04-25 at 10 30 20" src="https://github.com/elastic/kibana/assets/34506779/219f1057-42b5-49e6-b4c0-9b9689d196cf">


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->