### PR TITLE
[8.13] [Search] Move Attach Index to top (#181446)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -83,271 +83,247 @@ export const ConnectorConfiguration: React.FC = () => {
       <EuiFlexGroup>
         <EuiFlexItem grow={2}>
           <EuiPanel hasShadow={false} hasBorder>
-            <EuiSteps
-              steps={[
-                {
-                  children: connector.index_name ? (
-                    <ApiKeyConfig
-                      indexName={connector.index_name}
-                      hasApiKey={!!connector.api_key_id}
-                      isNative={false}
-                    />
-                  ) : (
-                    i18n.translate(
-                      'xpack.enterpriseSearch.content.connectorDetail.configuration.apiKey.noApiKeyLabel',
-                      {
-                        defaultMessage:
-                          'Before you can generate an API key, you need to attach an index. Scroll to the bottom of this page for instructions.',
-                      }
-                    )
-                  ),
-                  status: hasApiKey ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.generateApiKey.title',
+            {
+              <>
+                <EuiSpacer />
+                <AttachIndexBox connector={connector} />
+              </>
+            }
+            {connector.index_name && (
+              <>
+                <EuiSpacer />
+                <EuiSteps
+                  steps={[
                     {
-                      defaultMessage: 'Generate an API key',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: (
-                    <>
-                      <EuiSpacer />
-                      <EuiText size="s">
-                        <FormattedMessage
-                          id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.description.thirdParagraph"
-                          defaultMessage="In this step, you will need to clone or fork the elastic/connectors repository, and copy the API key and connector ID values to the config.yml file. Here's an {exampleLink}."
-                          values={{
-                            exampleLink: (
-                              <EuiLink
-                                href="https://github.com/elastic/connectors-python/blob/main/config.yml.example"
-                                target="_blank"
-                                external
-                              >
-                                {i18n.translate(
-                                  'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.configurationFileLink',
-                                  { defaultMessage: 'example config file' }
-                                )}
-                              </EuiLink>
-                            ),
-                          }}
+                      children: (
+                        <ApiKeyConfig
+                          indexName={connector.index_name}
+                          hasApiKey={!!connector.api_key_id}
+                          isNative={false}
                         />
-                      </EuiText>
-                      <EuiSpacer />
-                      <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" isCopyable>
-                        {getConnectorTemplate({
-                          apiKeyData,
-                          connectorData: {
-                            id: connector.id,
-                            service_type: connector.service_type,
-                          },
-                          host: cloudContext.elasticsearchUrl,
-                        })}
-                      </EuiCodeBlock>
-                      <EuiSpacer />
-                      <EuiText size="s">
-                        <FormattedMessage
-                          id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.description.fourthParagraph"
-                          defaultMessage="Because this connector is self-managed, you need to deploy the connector service on your own infrastructure. You can build from source or use Docker. Refer to the {link} for your deployment options."
-                          values={{
-                            link: (
-                              <EuiLink
-                                href={docLinks.connectorsClientDeploy}
-                                target="_blank"
-                                external
-                              >
-                                {i18n.translate(
-                                  'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.deploymentModeLink',
-                                  { defaultMessage: 'documentation' }
-                                )}
-                              </EuiLink>
-                            ),
-                          }}
-                        />
-                      </EuiText>
-                    </>
-                  ),
-                  status:
-                    !connector.status || connector.status === ConnectorStatus.CREATED
-                      ? 'incomplete'
-                      : 'complete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.deployConnector.title',
+                      ),
+                      status: hasApiKey ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.generateApiKey.title',
+                        {
+                          defaultMessage: 'Generate an API key',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
                     {
-                      defaultMessage: 'Set up and deploy connector',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: (
-                    <ConnectorConfigurationComponent
-                      connector={connector}
-                      hasPlatinumLicense={hasPlatinumLicense}
-                      isLoading={updateConnectorConfigurationStatus === Status.LOADING}
-                      saveConfig={(configuration) =>
-                        updateConnectorConfiguration({
-                          configuration,
-                          connectorId: connector.id,
-                        })
-                      }
-                      subscriptionLink={docLinks.licenseManagement}
-                      stackManagementLink={http.basePath.prepend(
-                        '/app/management/stack/license_management'
-                      )}
-                    >
-                      {!connector.status || connector.status === ConnectorStatus.CREATED ? (
-                        <EuiCallOut
-                          title={i18n.translate(
-                            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.waitingForConnectorTitle',
-                            {
-                              defaultMessage: 'Waiting for your connector',
-                            }
+                      children: (
+                        <>
+                          <EuiSpacer />
+                          <EuiText size="s">
+                            <FormattedMessage
+                              id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.description.thirdParagraph"
+                              defaultMessage="In this step, you will need to clone or fork the elastic/connectors repository, and copy the API key and connector ID values to the config.yml file. Here's an {exampleLink}."
+                              values={{
+                                exampleLink: (
+                                  <EuiLink
+                                    data-test-subj="entSearchContent-connector-configuration-exampleConfigFileLink"
+                                    data-telemetry-id="entSearchContent-connector-configuration-exampleConfigFileLink"
+                                    href="https://github.com/elastic/connectors-python/blob/main/config.yml.example"
+                                    target="_blank"
+                                    external
+                                  >
+                                    {i18n.translate(
+                                      'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.configurationFileLink',
+                                      { defaultMessage: 'example config file' }
+                                    )}
+                                  </EuiLink>
+                                ),
+                              }}
+                            />
+                          </EuiText>
+                          <EuiSpacer />
+                          <EuiCodeBlock fontSize="m" paddingSize="m" color="dark" isCopyable>
+                            {getConnectorTemplate({
+                              apiKeyData,
+                              connectorData: {
+                                id: connector.id,
+                                service_type: connector.service_type,
+                              },
+                              host: cloudContext.elasticsearchUrl,
+                            })}
+                          </EuiCodeBlock>
+                          <EuiSpacer />
+                          <EuiText size="s">
+                            <FormattedMessage
+                              id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.description.fourthParagraph"
+                              defaultMessage="Because this connector is self-managed, you need to deploy the connector service on your own infrastructure. You can build from source or use Docker. Refer to the {link} for your deployment options."
+                              values={{
+                                link: (
+                                  <EuiLink
+                                    data-test-subj="entSearchContent-connector-configuration-deploymentModeLink"
+                                    data-telemetry-id="entSearchContent-connector-configuration-deploymentModeLink"
+                                    href={docLinks.connectorsClientDeploy}
+                                    target="_blank"
+                                    external
+                                  >
+                                    {i18n.translate(
+                                      'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.deploymentModeLink',
+                                      { defaultMessage: 'documentation' }
+                                    )}
+                                  </EuiLink>
+                                ),
+                              }}
+                            />
+                          </EuiText>
+                        </>
+                      ),
+                      status:
+                        !connector.status || connector.status === ConnectorStatus.CREATED
+                          ? 'incomplete'
+                          : 'complete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.deployConnector.title',
+                        {
+                          defaultMessage: 'Set up and deploy connector',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
+                    {
+                      children: (
+                        <ConnectorConfigurationComponent
+                          connector={connector}
+                          hasPlatinumLicense={hasPlatinumLicense}
+                          isLoading={updateConnectorConfigurationStatus === Status.LOADING}
+                          saveConfig={(configuration) =>
+                            updateConnectorConfiguration({
+                              configuration,
+                              connectorId: connector.id,
+                            })
+                          }
+                          subscriptionLink={docLinks.licenseManagement}
+                          stackManagementLink={http.basePath.prepend(
+                            '/app/management/stack/license_management'
                           )}
-                          iconType="iInCircle"
                         >
-                          {i18n.translate(
-                            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.waitingForConnectorText',
-                            {
-                              defaultMessage:
-                                'Your connector has not connected to Search. Troubleshoot your configuration and refresh the page.',
-                            }
-                          )}
-                          <EuiSpacer size="s" />
-                          <EuiButton
-                            disabled={!index}
-                            data-telemetry-id="entSearchContent-connector-configuration-recheckNow"
-                            iconType="refresh"
-                            onClick={() => fetchConnector({ connectorId: connector.id })}
-                            isLoading={isLoading}
-                          >
-                            {i18n.translate(
-                              'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.waitingForConnector.button.label',
-                              {
-                                defaultMessage: 'Recheck now',
-                              }
-                            )}
-                          </EuiButton>
-                        </EuiCallOut>
-                      ) : (
-                        <EuiCallOut
-                          iconType="check"
-                          color="success"
-                          title={i18n.translate(
-                            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.connectorConnected',
-                            {
-                              defaultMessage:
-                                'Your connector {name} has connected to Search successfully.',
-                              values: { name: connector.name },
-                            }
-                          )}
-                        />
-                      )}
-                    </ConnectorConfigurationComponent>
-                  ),
-                  status:
-                    connector.status === ConnectorStatus.CONNECTED ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.enhance.title',
-                    {
-                      defaultMessage: 'Configure your connector',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: (
-                    <EuiFlexGroup direction="column">
-                      {!connector.index_name && (
-                        <EuiFlexItem>
-                          <EuiCallOut
-                            iconType="iInCircle"
-                            color="danger"
-                            title={i18n.translate(
-                              'xpack.enterpriseSearch.content.connectors.configuration.connectorNoIndexCallOut.title',
-                              {
-                                defaultMessage: 'Connector has no attached index',
-                              }
-                            )}
-                          >
-                            <EuiSpacer size="s" />
-                            <EuiText size="s">
+                          {!connector.status || connector.status === ConnectorStatus.CREATED ? (
+                            <EuiCallOut
+                              title={i18n.translate(
+                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.waitingForConnectorTitle',
+                                {
+                                  defaultMessage: 'Waiting for your connector',
+                                }
+                              )}
+                              iconType="iInCircle"
+                            >
                               {i18n.translate(
-                                'xpack.enterpriseSearch.content.connectors.configuration.connectorNoIndexCallOut.description',
+                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.waitingForConnectorText',
                                 {
                                   defaultMessage:
-                                    "You won't be able to start syncing content until your connector is attached to an index.",
+                                    'Your connector has not connected to Search. Troubleshoot your configuration and refresh the page.',
+                                }
+                              )}
+                              <EuiSpacer size="s" />
+                              <EuiButton
+                                disabled={!index}
+                                data-test-subj="entSearchContent-connector-configuration-recheckNow"
+                                data-telemetry-id="entSearchContent-connector-configuration-recheckNow"
+                                iconType="refresh"
+                                onClick={() => fetchConnector({ connectorId: connector.id })}
+                                isLoading={isLoading}
+                              >
+                                {i18n.translate(
+                                  'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.waitingForConnector.button.label',
+                                  {
+                                    defaultMessage: 'Recheck now',
+                                  }
+                                )}
+                              </EuiButton>
+                            </EuiCallOut>
+                          ) : (
+                            <EuiCallOut
+                              iconType="check"
+                              color="success"
+                              title={i18n.translate(
+                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.connectorConnected',
+                                {
+                                  defaultMessage:
+                                    'Your connector {name} has connected to Search successfully.',
+                                  values: { name: connector.name },
+                                }
+                              )}
+                            />
+                          )}
+                        </ConnectorConfigurationComponent>
+                      ),
+                      status:
+                        connector.status === ConnectorStatus.CONNECTED ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.enhance.title',
+                        {
+                          defaultMessage: 'Configure your connector',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
+                    {
+                      children: (
+                        <EuiFlexGroup direction="column">
+                          <EuiFlexItem>
+                            <EuiText size="s">
+                              {i18n.translate(
+                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.scheduleSync.description',
+                                {
+                                  defaultMessage:
+                                    'Finalize your connector by triggering a one-time sync, or setting a recurring sync to keep your data source in sync over time',
                                 }
                               )}
                             </EuiText>
-                            <EuiSpacer />
-                          </EuiCallOut>
-                        </EuiFlexItem>
-                      )}
-                      <EuiFlexItem>
-                        <EuiText size="s">
-                          {i18n.translate(
-                            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.scheduleSync.description',
-                            {
-                              defaultMessage:
-                                'Finalize your connector by triggering a one-time sync, or setting a recurring sync to keep your data source in sync over time',
-                            }
-                          )}
-                        </EuiText>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <EuiFlexGroup responsive={false}>
-                          <EuiFlexItem grow={false}>
-                            <EuiButtonTo
-                              data-test-subj="entSearchContent-connector-configuration-setScheduleAndSync"
-                              data-telemetry-id="entSearchContent-connector-configuration-setScheduleAndSync"
-                              isDisabled={
-                                (connector?.is_native && !!errorConnectingMessage) ||
-                                [
-                                  ConnectorStatus.NEEDS_CONFIGURATION,
-                                  ConnectorStatus.CREATED,
-                                ].includes(connector?.status) ||
-                                !connector?.index_name
-                              }
-                              to={`${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
-                                connectorId: connector.id,
-                                tabId: ConnectorDetailTabId.SCHEDULING,
-                              })}`}
-                            >
-                              {i18n.translate(
-                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.schedule.button.label',
-                                {
-                                  defaultMessage: 'Set schedule and sync',
-                                }
-                              )}
-                            </EuiButtonTo>
                           </EuiFlexItem>
-                          <EuiFlexItem grow={false}>
-                            <SyncsContextMenu />
+                          <EuiFlexItem>
+                            <EuiFlexGroup responsive={false}>
+                              <EuiFlexItem grow={false}>
+                                <EuiButtonTo
+                                  data-test-subj="entSearchContent-connector-configuration-setScheduleAndSync"
+                                  data-telemetry-id="entSearchContent-connector-configuration-setScheduleAndSync"
+                                  isDisabled={
+                                    (connector?.is_native && !!errorConnectingMessage) ||
+                                    [
+                                      ConnectorStatus.NEEDS_CONFIGURATION,
+                                      ConnectorStatus.CREATED,
+                                    ].includes(connector?.status) ||
+                                    !connector?.index_name
+                                  }
+                                  to={`${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+                                    connectorId: connector.id,
+                                    tabId: ConnectorDetailTabId.SCHEDULING,
+                                  })}`}
+                                >
+                                  {i18n.translate(
+                                    'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.schedule.button.label',
+                                    {
+                                      defaultMessage: 'Set schedule and sync',
+                                    }
+                                  )}
+                                </EuiButtonTo>
+                              </EuiFlexItem>
+                              <EuiFlexItem grow={false}>
+                                <SyncsContextMenu />
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
                           </EuiFlexItem>
                         </EuiFlexGroup>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  ),
-                  status: connector.scheduling.full.enabled ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.schedule.title',
-                    {
-                      defaultMessage: 'Sync your data',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-              ]}
-            />
+                      ),
+                      status: connector.scheduling.full.enabled ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.connector_detail.configurationConnector.steps.schedule.title',
+                        {
+                          defaultMessage: 'Sync your data',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
+                  ]}
+                />
+              </>
+            )}
           </EuiPanel>
-          {
-            <>
-              <EuiSpacer />
-              <AttachIndexBox connector={connector} />
-            </>
-          }
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <EuiFlexGroup direction="column">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -139,106 +139,111 @@ export const NativeConnectorConfiguration: React.FC = () => {
                 <EuiSpacer />
               </>
             )}
-            <EuiSteps
-              steps={[
-                {
-                  children: <ResearchConfiguration nativeConnector={nativeConnector} />,
-                  status: hasResearched ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.researchConfigurationTitle',
+            {
+              <>
+                <EuiSpacer />
+                <AttachIndexBox connector={connector} />
+              </>
+            }
+            {connector.index_name && (
+              <>
+                <EuiSpacer />
+                <EuiSteps
+                  steps={[
                     {
-                      defaultMessage: 'Research configuration requirements',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: (
-                    <NativeConnectorConfigurationConfig
-                      connector={connector}
-                      nativeConnector={nativeConnector}
-                      status={connector.status}
-                    />
-                  ),
-                  status: hasConfigured ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.configurationTitle',
+                      children: <ResearchConfiguration nativeConnector={nativeConnector} />,
+                      status: hasResearched ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.researchConfigurationTitle',
+                        {
+                          defaultMessage: 'Research configuration requirements',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
                     {
-                      defaultMessage: 'Configuration',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: (
-                    <ApiKeyConfig
-                      indexName={connector.index_name || ''}
-                      hasApiKey={hasApiKey}
-                      isNative
-                    />
-                  ),
-                  status: hasApiKey ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
+                      children: (
+                        <NativeConnectorConfigurationConfig
+                          connector={connector}
+                          nativeConnector={nativeConnector}
+                          status={connector.status}
+                        />
+                      ),
+                      status: hasConfigured ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.configurationTitle',
+                        {
+                          defaultMessage: 'Configuration',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
                     {
-                      defaultMessage: 'Manage API key',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
-                  children: (
-                    <EuiFlexGroup direction="column">
-                      <EuiFlexItem>
-                        <EuiText size="s">
-                          <FormattedMessage
-                            id="xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnectorAdvancedConfiguration.description"
-                            defaultMessage="Finalize your connector by triggering a one time sync, or setting a recurring sync schedule."
-                          />
-                        </EuiText>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <EuiFlexGroup responsive={false}>
-                          <EuiFlexItem grow={false}>
-                            <EuiButtonTo
-                              to={`${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
-                                connectorId: connector.id,
-                                tabId: ConnectorDetailTabId.SCHEDULING,
-                              })}`}
-                            >
-                              {i18n.translate(
-                                'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnectorAdvancedConfiguration.schedulingButtonLabel',
-                                {
-                                  defaultMessage: 'Set schedule and sync',
-                                }
-                              )}
-                            </EuiButtonTo>
+                      children: (
+                        <ApiKeyConfig
+                          indexName={connector.index_name || ''}
+                          hasApiKey={hasApiKey}
+                          isNative
+                        />
+                      ),
+                      status: hasApiKey ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
+                        {
+                          defaultMessage: 'Manage API key',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
+                    {
+                      children: (
+                        <EuiFlexGroup direction="column">
+                          <EuiFlexItem>
+                            <EuiText size="s">
+                              <FormattedMessage
+                                id="xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnectorAdvancedConfiguration.description"
+                                defaultMessage="Finalize your connector by triggering a one time sync, or setting a recurring sync schedule."
+                              />
+                            </EuiText>
                           </EuiFlexItem>
-                          <EuiFlexItem grow={false}>
-                            <SyncsContextMenu />
+                          <EuiFlexItem>
+                            <EuiFlexGroup responsive={false}>
+                              <EuiFlexItem grow={false}>
+                                <EuiButtonTo
+                                  to={`${generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+                                    connectorId: connector.id,
+                                    tabId: ConnectorDetailTabId.SCHEDULING,
+                                  })}`}
+                                >
+                                  {i18n.translate(
+                                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnectorAdvancedConfiguration.schedulingButtonLabel',
+                                    {
+                                      defaultMessage: 'Set schedule and sync',
+                                    }
+                                  )}
+                                </EuiButtonTo>
+                              </EuiFlexItem>
+                              <EuiFlexItem grow={false}>
+                                <SyncsContextMenu />
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
                           </EuiFlexItem>
                         </EuiFlexGroup>
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  ),
-                  status: hasConfiguredAdvanced ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.advancedConfigurationTitle',
-                    {
-                      defaultMessage: 'Sync your data',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-              ]}
-            />
+                      ),
+                      status: hasConfiguredAdvanced ? 'complete' : 'incomplete',
+                      title: i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.advancedConfigurationTitle',
+                        {
+                          defaultMessage: 'Sync your data',
+                        }
+                      ),
+                      titleSize: 'xs',
+                    },
+                  ]}
+                />
+              </>
+            )}
           </EuiPanel>
-          {
-            <>
-              <EuiSpacer />
-              <AttachIndexBox connector={connector} />
-            </>
-          }
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <EuiFlexGroup direction="column">


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Search] Move Attach Index to top (#181446)](https://github.com/elastic/kibana/pull/181446)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2024-04-24T09:35:36Z","message":"[Search] Move Attach Index to top (#181446)\n\n## Summary\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/1410658/de571e71-88c1-4576-94ee-55763ba8af98\r\n\r\n<img width=\"873\" alt=\"Screenshot 2024-04-23 at 16 27 52\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/bbc4fb1c-6dd5-49f2-bd52-9d47c41b0be8\">\r\n\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"9d5abba33898de51b41d3b9397db05e66b13f16b","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.14.0","v8.15.0"],"number":181446,"url":"https://github.com/elastic/kibana/pull/181446","mergeCommit":{"message":"[Search] Move Attach Index to top (#181446)\n\n## Summary\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/1410658/de571e71-88c1-4576-94ee-55763ba8af98\r\n\r\n<img width=\"873\" alt=\"Screenshot 2024-04-23 at 16 27 52\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/bbc4fb1c-6dd5-49f2-bd52-9d47c41b0be8\">\r\n\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"9d5abba33898de51b41d3b9397db05e66b13f16b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/181533","number":181533,"state":"MERGED","mergeCommit":{"sha":"b36b0ddd2d6cefc2bb8c7f3f596915e49ba1d8e1","message":"[8.14] [Search] Move Attach Index to top (#181446) (#181533)\n\n# Backport\r\n\r\nThis will backport the following commits from `main` to `8.14`:\r\n- [[Search] Move Attach Index to top\r\n(#181446)](https://github.com/elastic/kibana/pull/181446)\r\n\r\n<!--- Backport version: 9.4.3 -->\r\n\r\n### Questions ?\r\nPlease refer to the [Backport tool\r\ndocumentation](https://github.com/sqren/backport)\r\n\r\n<!--BACKPORT [{\"author\":{\"name\":\"Efe Gürkan\r\nYALAMAN\",\"email\":\"efeguerkan.yalaman@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-04-24T09:35:36Z\",\"message\":\"[Search]\r\nMove Attach Index to top (#181446)\\n\\n##\r\nSummary\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/elastic/kibana/assets/1410658/de571e71-88c1-4576-94ee-55763ba8af98\\r\\n\\r\\n<img\r\nwidth=\\\"873\\\" alt=\\\"Screenshot 2024-04-23 at 16 27\r\n52\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/1410658/bbc4fb1c-6dd5-49f2-bd52-9d47c41b0be8\\\">\\r\\n\\r\\n\\r\\n\\r\\n###\r\nChecklist\\r\\n\\r\\nDelete any items that are not applicable to this\r\nPR.\\r\\n\\r\\n- [ ] Any text added follows [EUI's\r\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\r\nuses\\r\\nsentence case text and includes\r\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\r\n[\r\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\r\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\r\nor\r\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\r\nupdated or added to match the most common scenarios\\r\\n- [ ] [Flaky\r\nTest\\r\\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)\r\nwas\\r\\nused on any tests changed\\r\\n- [ ] Any UI touched in this PR is\r\nusable by keyboard only (learn more\\r\\nabout [keyboard\r\naccessibility](https://webaim.org/techniques/keyboard/))\\r\\n- [ ] Any UI\r\ntouched in this PR does not create any new axe failures\\r\\n(run axe in\r\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\r\n[ ] If a plugin configuration key changed, check if it needs to\r\nbe\\r\\nallowlisted in the cloud and added to the\r\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\r\n[ ] This renders correctly on smaller devices using a\r\nresponsive\\r\\nlayout. (You can test this [in\r\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\r\n[ ] This was checked for\r\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\",\"sha\":\"9d5abba33898de51b41d3b9397db05e66b13f16b\",\"branchLabelMapping\":{\"^v8.15.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:EnterpriseSearch\",\"v8.14.0\",\"v8.15.0\"],\"title\":\"[Search]\r\nMove Attach Index to\r\ntop\",\"number\":181446,\"url\":\"https://github.com/elastic/kibana/pull/181446\",\"mergeCommit\":{\"message\":\"[Search]\r\nMove Attach Index to top (#181446)\\n\\n##\r\nSummary\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/elastic/kibana/assets/1410658/de571e71-88c1-4576-94ee-55763ba8af98\\r\\n\\r\\n<img\r\nwidth=\\\"873\\\" alt=\\\"Screenshot 2024-04-23 at 16 27\r\n52\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/1410658/bbc4fb1c-6dd5-49f2-bd52-9d47c41b0be8\\\">\\r\\n\\r\\n\\r\\n\\r\\n###\r\nChecklist\\r\\n\\r\\nDelete any items that are not applicable to this\r\nPR.\\r\\n\\r\\n- [ ] Any text added follows [EUI's\r\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\r\nuses\\r\\nsentence case text and includes\r\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\r\n[\r\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\r\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\r\nor\r\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\r\nupdated or added to match the most common scenarios\\r\\n- [ ] [Flaky\r\nTest\\r\\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)\r\nwas\\r\\nused on any tests changed\\r\\n- [ ] Any UI touched in this PR is\r\nusable by keyboard only (learn more\\r\\nabout [keyboard\r\naccessibility](https://webaim.org/techniques/keyboard/))\\r\\n- [ ] Any UI\r\ntouched in this PR does not create any new axe failures\\r\\n(run axe in\r\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\r\n[ ] If a plugin configuration key changed, check if it needs to\r\nbe\\r\\nallowlisted in the cloud and added to the\r\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\r\n[ ] This renders correctly on smaller devices using a\r\nresponsive\\r\\nlayout. (You can test this [in\r\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\r\n[ ] This was checked for\r\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\",\"sha\":\"9d5abba33898de51b41d3b9397db05e66b13f16b\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.14\"],\"targetPullRequestStates\":[{\"branch\":\"8.14\",\"label\":\"v8.14.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.15.0\",\"branchLabelMappingKey\":\"^v8.15.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/181446\",\"number\":181446,\"mergeCommit\":{\"message\":\"[Search]\r\nMove Attach Index to top (#181446)\\n\\n##\r\nSummary\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/elastic/kibana/assets/1410658/de571e71-88c1-4576-94ee-55763ba8af98\\r\\n\\r\\n<img\r\nwidth=\\\"873\\\" alt=\\\"Screenshot 2024-04-23 at 16 27\r\n52\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/1410658/bbc4fb1c-6dd5-49f2-bd52-9d47c41b0be8\\\">\\r\\n\\r\\n\\r\\n\\r\\n###\r\nChecklist\\r\\n\\r\\nDelete any items that are not applicable to this\r\nPR.\\r\\n\\r\\n- [ ] Any text added follows [EUI's\r\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\r\nuses\\r\\nsentence case text and includes\r\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\r\n[\r\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\r\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\r\nor\r\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\r\nupdated or added to match the most common scenarios\\r\\n- [ ] [Flaky\r\nTest\\r\\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)\r\nwas\\r\\nused on any tests changed\\r\\n- [ ] Any UI touched in this PR is\r\nusable by keyboard only (learn more\\r\\nabout [keyboard\r\naccessibility](https://webaim.org/techniques/keyboard/))\\r\\n- [ ] Any UI\r\ntouched in this PR does not create any new axe failures\\r\\n(run axe in\r\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\r\n[ ] If a plugin configuration key changed, check if it needs to\r\nbe\\r\\nallowlisted in the cloud and added to the\r\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\r\n[ ] This renders correctly on smaller devices using a\r\nresponsive\\r\\nlayout. (You can test this [in\r\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\r\n[ ] This was checked for\r\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\",\"sha\":\"9d5abba33898de51b41d3b9397db05e66b13f16b\"}}]}]\r\nBACKPORT-->\r\n\r\nCo-authored-by: Efe Gürkan YALAMAN <efeguerkan.yalaman@elastic.co>"}},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181446","number":181446,"mergeCommit":{"message":"[Search] Move Attach Index to top (#181446)\n\n## Summary\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/1410658/de571e71-88c1-4576-94ee-55763ba8af98\r\n\r\n<img width=\"873\" alt=\"Screenshot 2024-04-23 at 16 27 52\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/bbc4fb1c-6dd5-49f2-bd52-9d47c41b0be8\">\r\n\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"9d5abba33898de51b41d3b9397db05e66b13f16b"}}]}] BACKPORT-->