### PR TITLE
[Alert details page][Log threshold] Fix alert number annotation on the history chart 

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
@@ -335,7 +335,7 @@ const CriterionPreviewChart: React.FC<ChartProps> = ({
           />
           <Settings
             baseTheme={chartTheme.baseTheme}
-            theme={{ chartMargins: { top: 40 } }}
+            theme={{ chartMargins: { top: 35 } }}
             locale={i18n.getLocale()}
           />
           <Tooltip {...tooltipProps} />

--- a/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/criterion_preview_chart.tsx
@@ -333,7 +333,11 @@ const CriterionPreviewChart: React.FC<ChartProps> = ({
             tickFormat={yAxisFormatter}
             domain={chartDomain}
           />
-          <Settings baseTheme={chartTheme.baseTheme} locale={i18n.getLocale()} />
+          <Settings
+            baseTheme={chartTheme.baseTheme}
+            theme={{ chartMargins: { top: 40 } }}
+            locale={i18n.getLocale()}
+          />
           <Tooltip {...tooltipProps} />
         </Chart>
       </ChartContainer>


### PR DESCRIPTION
Fixes #175203

### Summary

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/ba83f309-c7c5-4d2d-a8de-832e80bc6eb5)|![image](https://github.com/elastic/kibana/assets/12370520/8c0a5b3a-a420-47fe-be9f-bf184d64809c)|