### PR TITLE
[CI] fix typo in deployment purge criteria

### DIFF
--- a/.buildkite/scripts/steps/cloud/purge_projects.ts
+++ b/.buildkite/scripts/steps/cloud/purge_projects.ts
@@ -88,7 +88,7 @@ async function purgeProjects() {
     } else if (
       !Boolean(
         pullRequest.labels.filter((label: any) =>
-          /^ci:project-deploy-(elasticearch|security|observability)$/.test(label.name)
+          /^ci:project-deploy-(elasticsearch|security|observability)$/.test(label.name)
         ).length
       )
     ) {


### PR DESCRIPTION
## Summary
This was causing `elasticsearch` deployments to vanish before their time is due. 

cc: @pgayvallet 