### PR TITLE
[Dataset quality] - Improve links behavior on flyout

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/degraded_docs_trend/lens_attributes.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/degraded_docs_trend/lens_attributes.ts
@@ -5,21 +5,16 @@
  * 2.0.
  */
 
-import type { DataView } from '@kbn/data-views-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { GenericIndexPatternColumn, TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import { v4 as uuidv4 } from 'uuid';
 
-import { DEFAULT_LOGS_DATA_VIEW } from '../../../../common/constants';
 import {
   flyoutDegradedDocsPercentageText,
   flyoutDegradedDocsTrendText,
 } from '../../../../common/translations';
 
-const defaultDataView = {
-  id: `${DEFAULT_LOGS_DATA_VIEW}-id`,
-  title: DEFAULT_LOGS_DATA_VIEW,
-  timeFieldName: '@timestamp',
-} as DataView;
+const dataViewId = uuidv4();
 
 enum DatasetQualityLensColumn {
   Date = 'date_column',
@@ -34,15 +29,13 @@ const MAX_BREAKDOWN_SERIES = 5;
 
 interface GetLensAttributesParams {
   color: string;
-  dataView: DataView;
-  query: string;
+  dataStream: string;
   breakdownFieldName?: string;
 }
 
 export function getLensAttributes({
   color,
-  dataView = defaultDataView,
-  query = '',
+  dataStream,
   breakdownFieldName,
 }: GetLensAttributesParams) {
   const columnOrder = [
@@ -62,26 +55,16 @@ export function getLensAttributes({
   return {
     visualizationType: 'lnsXY',
     title: flyoutDegradedDocsTrendText,
-    references: [
-      {
-        id: dataView.id!,
-        name: 'indexpattern-datasource-current-indexpattern',
-        type: 'index-pattern',
-      },
-      {
-        id: dataView.id!,
-        name: 'indexpattern-datasource-layer-layer1',
-        type: 'index-pattern',
-      },
-    ],
+    references: [],
     state: {
+      ...getAdHocDataViewState(dataViewId, dataStream),
       datasourceStates: {
         formBased: {
           layers: {
             layer1: {
               columnOrder,
               columns,
-              indexPatternId: dataView.id!,
+              indexPatternId: dataViewId,
             },
           },
         },
@@ -89,7 +72,7 @@ export function getLensAttributes({
       filters: [],
       query: {
         language: 'kuery',
-        query,
+        query: '',
       },
       visualization: {
         axisTitlesVisibilitySettings: {
@@ -143,6 +126,36 @@ export function getLensAttributes({
       },
     },
   } as TypedLensByValueInput['attributes'];
+}
+
+function getAdHocDataViewState(id: string, title: string) {
+  return {
+    internalReferences: [
+      {
+        id,
+        name: 'indexpattern-datasource-current-indexpattern',
+        type: 'index-pattern',
+      },
+      {
+        id,
+        name: 'indexpattern-datasource-layer-layer1',
+        type: 'index-pattern',
+      },
+    ],
+    adHocDataViews: {
+      [id]: {
+        id,
+        title,
+        timeFieldName: '@timestamp',
+        sourceFilters: [],
+        fieldFormats: {},
+        runtimeFieldMap: {},
+        fieldAttrs: {},
+        allowNoIndex: false,
+        name: title,
+      },
+    },
+  };
 }
 
 function getChartColumns(breakdownField?: string): Record<string, GenericIndexPatternColumn> {
@@ -237,7 +250,7 @@ function getChartColumns(breakdownField?: string): Record<string, GenericIndexPa
             params: {
               size: MAX_BREAKDOWN_SERIES,
               orderBy: {
-                type: 'significant',
+                type: 'alphabetical',
                 fallback: true,
               },
               orderDirection: 'desc',
@@ -253,7 +266,7 @@ function getChartColumns(breakdownField?: string): Record<string, GenericIndexPa
   };
 }
 
-export const getFlyoutDegradedDocsTopNText = (count: number, fieldName: string) =>
+const getFlyoutDegradedDocsTopNText = (count: number, fieldName: string) =>
   i18n.translate('xpack.datasetQuality.flyoutDegradedDocsTopNValues', {
     defaultMessage: 'Top {count} values of {fieldName}',
     values: { count, fieldName },

--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/degraded_docs_trend/lens_attributes.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/degraded_docs_trend/lens_attributes.ts
@@ -14,8 +14,6 @@ import {
   flyoutDegradedDocsTrendText,
 } from '../../../../common/translations';
 
-const dataViewId = uuidv4();
-
 enum DatasetQualityLensColumn {
   Date = 'date_column',
   DegradedDocs = 'degraded_docs_column',
@@ -30,14 +28,18 @@ const MAX_BREAKDOWN_SERIES = 5;
 interface GetLensAttributesParams {
   color: string;
   dataStream: string;
+  datasetTitle: string;
   breakdownFieldName?: string;
 }
 
 export function getLensAttributes({
   color,
   dataStream,
+  datasetTitle,
   breakdownFieldName,
 }: GetLensAttributesParams) {
+  const dataViewId = uuidv4();
+
   const columnOrder = [
     DatasetQualityLensColumn.Date,
     DatasetQualityLensColumn.CountIgnored,
@@ -51,13 +53,12 @@ export function getLensAttributes({
   }
 
   const columns = getChartColumns(breakdownFieldName);
-
   return {
     visualizationType: 'lnsXY',
     title: flyoutDegradedDocsTrendText,
     references: [],
     state: {
-      ...getAdHocDataViewState(dataViewId, dataStream),
+      ...getAdHocDataViewState(dataViewId, dataStream, datasetTitle),
       datasourceStates: {
         formBased: {
           layers: {
@@ -128,7 +129,7 @@ export function getLensAttributes({
   } as TypedLensByValueInput['attributes'];
 }
 
-function getAdHocDataViewState(id: string, title: string) {
+function getAdHocDataViewState(id: string, dataStream: string, title: string) {
   return {
     internalReferences: [
       {
@@ -145,7 +146,7 @@ function getAdHocDataViewState(id: string, title: string) {
     adHocDataViews: {
       [id]: {
         id,
-        title,
+        title: dataStream,
         timeFieldName: '@timestamp',
         sourceFilters: [],
         fieldFormats: {},

--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/flyout_summary/flyout_summary_kpis.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/flyout_summary/flyout_summary_kpis.tsx
@@ -36,6 +36,7 @@ export function FlyoutSummaryKpis({
   const logsExplorerLinkProps = useLinkToLogsExplorer({
     dataStreamStat,
     query: { language: 'kuery', query: `${_IGNORED}: *` },
+    timeRangeConfig: timeRange,
   });
 
   const kpis = useMemo(

--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/flyout_summary/get_summary_kpis.test.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/flyout_summary/get_summary_kpis.test.ts
@@ -81,10 +81,7 @@ describe('getSummaryKpis', () => {
       {
         title: flyoutHostsText,
         value: '3',
-        link: {
-          label: flyoutShowAllText,
-          href: hostsRedirectUrl,
-        },
+        link: undefined,
       },
       {
         title: flyoutDegradedDocsText,
@@ -138,10 +135,7 @@ describe('getSummaryKpis', () => {
       {
         title: flyoutHostsText,
         value: '54+',
-        link: {
-          label: flyoutShowAllText,
-          href: hostsRedirectUrl,
-        },
+        link: undefined,
       },
       {
         title: flyoutDegradedDocsText,

--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/flyout_summary/get_summary_kpis.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/flyout/flyout_summary/get_summary_kpis.ts
@@ -109,6 +109,8 @@ function getHostsKpi(
     dateRange: { from: timeRange.from, to: timeRange.to },
     limit: countOfHosts.count,
   });
+
+  // @ts-ignore // TODO: Add link to Infra Hosts page when possible
   const hostsLink = hostsUrl
     ? {
         label: flyoutShowAllText,
@@ -123,7 +125,7 @@ function getHostsKpi(
       countOfHosts.count,
       NUMBER_FORMAT
     ),
-    link: hostsLink,
+    link: undefined,
   };
 }
 

--- a/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_degraded_docs_chart.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_degraded_docs_chart.tsx
@@ -78,13 +78,22 @@ export const useDegradedDocsChart = ({ dataStream }: DegradedDocsChartDeps) => {
   );
 
   useEffect(() => {
+    const dataStreamName = dataStream ?? DEFAULT_LOGS_DATA_VIEW;
+
     const lensAttributes = getLensAttributes({
       color: euiTheme.colors.danger,
-      dataStream: dataStream ?? DEFAULT_LOGS_DATA_VIEW,
+      dataStream: dataStreamName,
+      datasetTitle: dataStreamStat?.title ?? dataStreamName,
       breakdownFieldName: breakdownDataViewField?.name,
     });
     setAttributes(lensAttributes);
-  }, [breakdownDataViewField?.name, euiTheme.colors.danger, setAttributes, dataStream]);
+  }, [
+    breakdownDataViewField?.name,
+    euiTheme.colors.danger,
+    setAttributes,
+    dataStream,
+    dataStreamStat?.title,
+  ]);
 
   const openInLensCallback = useCallback(() => {
     if (attributes) {

--- a/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_degraded_docs_chart.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_degraded_docs_chart.tsx
@@ -62,7 +62,6 @@ export const useDegradedDocsChart = ({ dataStream }: DegradedDocsChartDeps) => {
     () => getDataViewField(dataView, breakdownField),
     [breakdownField, dataView]
   );
-  const filterQuery = `_index: ${dataStream ?? 'match-none'}`;
 
   const handleChartLoading = (isLoading: boolean) => {
     setIsChartLoading(isLoading);
@@ -79,16 +78,13 @@ export const useDegradedDocsChart = ({ dataStream }: DegradedDocsChartDeps) => {
   );
 
   useEffect(() => {
-    if (dataView) {
-      const lensAttributes = getLensAttributes({
-        color: euiTheme.colors.danger,
-        dataView,
-        query: filterQuery,
-        breakdownFieldName: breakdownDataViewField?.name,
-      });
-      setAttributes(lensAttributes);
-    }
-  }, [breakdownDataViewField?.name, dataView, euiTheme.colors.danger, filterQuery, setAttributes]);
+    const lensAttributes = getLensAttributes({
+      color: euiTheme.colors.danger,
+      dataStream: dataStream ?? DEFAULT_LOGS_DATA_VIEW,
+      breakdownFieldName: breakdownDataViewField?.name,
+    });
+    setAttributes(lensAttributes);
+  }, [breakdownDataViewField?.name, euiTheme.colors.danger, setAttributes, dataStream]);
 
   const openInLensCallback = useCallback(() => {
     if (attributes) {

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_flyout.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_flyout.ts
@@ -258,7 +258,8 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       await browser.switchTab(0);
     });
 
-    it('goes to infra hosts for hosts when show all is clicked', async () => {
+    // Blocked by https://github.com/elastic/kibana/issues/181705
+    it.skip('goes to infra hosts for hosts when show all is clicked', async () => {
       const apacheAccessDatasetHumanName = 'Apache access logs';
       await PageObjects.datasetQuality.openDatasetFlyout(apacheAccessDatasetHumanName);
 

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_flyout.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_flyout.ts
@@ -274,7 +274,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await browser.switchTab(0);
     });
 
-    it('goes to infra hosts for hosts when show all is clicked', async () => {
+    // Blocked by https://github.com/elastic/kibana/issues/181705
+    it.skip('goes to infra hosts for hosts when show all is clicked', async () => {
       const apacheAccessDatasetHumanName = 'Apache access logs';
       await PageObjects.datasetQuality.openDatasetFlyout(apacheAccessDatasetHumanName);
 


### PR DESCRIPTION
## Summary

The PR improves/changes the behavior of external links on Dataset Quality flyout:
  1. The "Show all" link to Degraded Docs now considers flyout's time range rather than table's time range.
  2. The "Open in Lens" link will now use an Ad-Hoc Data View representing the current Data Stream rather than an in memory Data View. Thus removing the need to specifying an explicit `_index: ...` based query. Previously a generic Data View (e.g. `logs-*-*`) along with __index_ query was used.
  3. The "Show all" link for Hosts metric has been hidden for now awaiting https://github.com/elastic/kibana/issues/181705.

https://github.com/elastic/kibana/assets/2748376/310c7609-b5c3-49e4-9312-2e9083f9757d


