### PR TITLE
[8.13] [MGMTEX] Fix action data override when adding a second action (#181604)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_form.tsx
@@ -581,7 +581,9 @@ export const ActionForm = ({
             // TODO: fix in https://github.com/elastic/kibana/issues/155993
             // actionTypes with subtypes need to be updated in case they switched to a
             // subtype that is not the default one
-            actions[0].actionTypeId = savedAction.actionTypeId;
+            activeActionItem.indices.forEach((index: number) => {
+              actions[index].actionTypeId = savedAction.actionTypeId;
+            });
             connectors.push(savedAction);
             const indicesToUpdate = activeActionItem.indices || [];
             indicesToUpdate.forEach((index: number) => setActionIdByIndex(savedAction.id, index));

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -360,5 +360,53 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       await discardNewRuleCreation();
     });
+
+    it('should not do a type override when adding a second action', async () => {
+      // create a new rule
+      const ruleName = generateUniqueKey();
+      await rules.common.defineIndexThresholdAlert(ruleName);
+
+      // add server log action
+      await testSubjects.click('.server-log-alerting-ActionTypeSelectOption');
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="Serverlog#xyz"]'
+        )
+      ).to.eql(true);
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="webhook-test"]'
+        )
+      ).to.eql(false);
+
+      // click on add new action
+      await testSubjects.click('addAlertActionButton');
+      await find.existsByCssSelector('[data-test-subj="Serverlog#xyz"]');
+
+      // create webhook connector
+      await testSubjects.click('.webhook-alerting-ActionTypeSelectOption');
+      await testSubjects.click('createActionConnectorButton-1');
+      await testSubjects.setValue('nameInput', 'webhook-test');
+      await testSubjects.setValue('webhookUrlText', 'https://test.test');
+      await testSubjects.setValue('webhookUserInput', 'fakeuser');
+      await testSubjects.setValue('webhookPasswordInput', 'fakepassword');
+      await testSubjects.click('saveActionButtonModal');
+
+      // checking the new one first to avoid flakiness. If the value is checked before the new one is added
+      // it might return a false positive
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="webhook-test"]'
+        )
+      ).to.eql(true);
+      // If it was overridden, the value would change to be empty
+      expect(
+        await find.existsByCssSelector(
+          '[data-test-subj="comboBoxSearchInput"][value="Serverlog#xyz"]'
+        )
+      ).to.eql(true);
+
+      await deleteConnectorByName('webhook-test');
+    });
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[MGMTEX] Fix action data override when adding a second action (#181604)](https://github.com/elastic/kibana/pull/181604)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-25T10:42:28Z","message":"[MGMTEX] Fix action data override when adding a second action (#181604)\n\n## Summary\r\n\r\nWe were overwriting the `actionTypeId` of the first action in the\r\n\"create connector\" callback. The value assigned was the `actionTypeId`\r\nof the newly created action, meaning that we would have converted the\r\nfirst action to be the same as the second one. This fix changes the\r\n`actionTypeId` not for the first option but for all current\r\n`activeActionItem.indices`.\r\n\r\nPreviously, we did add that override to fix a bug related to the slack\r\nconnector https://github.com/elastic/kibana/issues/155722. Its test\r\nshould cover us from breaking it back again. I did test it manually just\r\nin case and it seems to be working still. Feel free to test it too.\r\n\r\nAlso, if you are wondering why `activeActionItems.indices` is an array\r\nof numbers. The user might be using the same connector in more than one\r\naction and then delete the connector. In case this happens, and the user\r\nclicks on \"edit rule\", they will be able to restore both actions by just\r\ncreating the connector once. In order to be able to restore all affected\r\nactions, their index is being stored as a number[]. More info here\r\nhttps://github.com/elastic/kibana/pull/86838\r\n\r\nCloses https://github.com/elastic/kibana/issues/181407\r\n\r\n---------\r\n\r\nCo-authored-by: Antonio <antoniodcoelho@gmail.com>","sha":"60c6cdb9985570a6f58bbf3860539de64ace9aa6","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","Feature:Alerting/RuleActions","v8.13.0","v8.14.0","v8.15.0"],"number":181604,"url":"https://github.com/elastic/kibana/pull/181604","mergeCommit":{"message":"[MGMTEX] Fix action data override when adding a second action (#181604)\n\n## Summary\r\n\r\nWe were overwriting the `actionTypeId` of the first action in the\r\n\"create connector\" callback. The value assigned was the `actionTypeId`\r\nof the newly created action, meaning that we would have converted the\r\nfirst action to be the same as the second one. This fix changes the\r\n`actionTypeId` not for the first option but for all current\r\n`activeActionItem.indices`.\r\n\r\nPreviously, we did add that override to fix a bug related to the slack\r\nconnector https://github.com/elastic/kibana/issues/155722. Its test\r\nshould cover us from breaking it back again. I did test it manually just\r\nin case and it seems to be working still. Feel free to test it too.\r\n\r\nAlso, if you are wondering why `activeActionItems.indices` is an array\r\nof numbers. The user might be using the same connector in more than one\r\naction and then delete the connector. In case this happens, and the user\r\nclicks on \"edit rule\", they will be able to restore both actions by just\r\ncreating the connector once. In order to be able to restore all affected\r\nactions, their index is being stored as a number[]. More info here\r\nhttps://github.com/elastic/kibana/pull/86838\r\n\r\nCloses https://github.com/elastic/kibana/issues/181407\r\n\r\n---------\r\n\r\nCo-authored-by: Antonio <antoniodcoelho@gmail.com>","sha":"60c6cdb9985570a6f58bbf3860539de64ace9aa6"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/181691","number":181691,"state":"MERGED","mergeCommit":{"sha":"36d2b9310c5388c444f90c520b6563360caa5d99","message":"[8.14] [MGMTEX] Fix action data override when adding a second action (#181604) (#181691)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.14`:\n- [[MGMTEX] Fix action data override when adding a second action\n(#181604)](https://github.com/elastic/kibana/pull/181604)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Julian\nGernun\",\"email\":\"17549662+jcger@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2024-04-25T10:42:28Z\",\"message\":\"[MGMTEX]\nFix action data override when adding a second action (#181604)\\n\\n##\nSummary\\r\\n\\r\\nWe were overwriting the `actionTypeId` of the first\naction in the\\r\\n\\\"create connector\\\" callback. The value assigned was\nthe `actionTypeId`\\r\\nof the newly created action, meaning that we would\nhave converted the\\r\\nfirst action to be the same as the second one.\nThis fix changes the\\r\\n`actionTypeId` not for the first option but for\nall current\\r\\n`activeActionItem.indices`.\\r\\n\\r\\nPreviously, we did add\nthat override to fix a bug related to the slack\\r\\nconnector\nhttps://github.com/elastic/kibana/issues/155722. Its test\\r\\nshould\ncover us from breaking it back again. I did test it manually just\\r\\nin\ncase and it seems to be working still. Feel free to test it\ntoo.\\r\\n\\r\\nAlso, if you are wondering why `activeActionItems.indices`\nis an array\\r\\nof numbers. The user might be using the same connector in\nmore than one\\r\\naction and then delete the connector. In case this\nhappens, and the user\\r\\nclicks on \\\"edit rule\\\", they will be able to\nrestore both actions by just\\r\\ncreating the connector once. In order to\nbe able to restore all affected\\r\\nactions, their index is being stored\nas a number[]. More info\nhere\\r\\nhttps://github.com/elastic/kibana/pull/86838\\r\\n\\r\\nCloses\nhttps://github.com/elastic/kibana/issues/181407\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nAntonio\n<antoniodcoelho@gmail.com>\",\"sha\":\"60c6cdb9985570a6f58bbf3860539de64ace9aa6\",\"branchLabelMapping\":{\"^v8.15.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"Team:ResponseOps\",\"Feature:Alerting/RuleActions\",\"v8.13.0\",\"v8.14.0\",\"v8.15.0\"],\"title\":\"[MGMTEX]\nFix action data override when adding a second\naction\",\"number\":181604,\"url\":\"https://github.com/elastic/kibana/pull/181604\",\"mergeCommit\":{\"message\":\"[MGMTEX]\nFix action data override when adding a second action (#181604)\\n\\n##\nSummary\\r\\n\\r\\nWe were overwriting the `actionTypeId` of the first\naction in the\\r\\n\\\"create connector\\\" callback. The value assigned was\nthe `actionTypeId`\\r\\nof the newly created action, meaning that we would\nhave converted the\\r\\nfirst action to be the same as the second one.\nThis fix changes the\\r\\n`actionTypeId` not for the first option but for\nall current\\r\\n`activeActionItem.indices`.\\r\\n\\r\\nPreviously, we did add\nthat override to fix a bug related to the slack\\r\\nconnector\nhttps://github.com/elastic/kibana/issues/155722. Its test\\r\\nshould\ncover us from breaking it back again. I did test it manually just\\r\\nin\ncase and it seems to be working still. Feel free to test it\ntoo.\\r\\n\\r\\nAlso, if you are wondering why `activeActionItems.indices`\nis an array\\r\\nof numbers. The user might be using the same connector in\nmore than one\\r\\naction and then delete the connector. In case this\nhappens, and the user\\r\\nclicks on \\\"edit rule\\\", they will be able to\nrestore both actions by just\\r\\ncreating the connector once. In order to\nbe able to restore all affected\\r\\nactions, their index is being stored\nas a number[]. More info\nhere\\r\\nhttps://github.com/elastic/kibana/pull/86838\\r\\n\\r\\nCloses\nhttps://github.com/elastic/kibana/issues/181407\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nAntonio\n<antoniodcoelho@gmail.com>\",\"sha\":\"60c6cdb9985570a6f58bbf3860539de64ace9aa6\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.13\",\"8.14\"],\"targetPullRequestStates\":[{\"branch\":\"8.13\",\"label\":\"v8.13.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.14\",\"label\":\"v8.14.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.15.0\",\"branchLabelMappingKey\":\"^v8.15.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/181604\",\"number\":181604,\"mergeCommit\":{\"message\":\"[MGMTEX]\nFix action data override when adding a second action (#181604)\\n\\n##\nSummary\\r\\n\\r\\nWe were overwriting the `actionTypeId` of the first\naction in the\\r\\n\\\"create connector\\\" callback. The value assigned was\nthe `actionTypeId`\\r\\nof the newly created action, meaning that we would\nhave converted the\\r\\nfirst action to be the same as the second one.\nThis fix changes the\\r\\n`actionTypeId` not for the first option but for\nall current\\r\\n`activeActionItem.indices`.\\r\\n\\r\\nPreviously, we did add\nthat override to fix a bug related to the slack\\r\\nconnector\nhttps://github.com/elastic/kibana/issues/155722. Its test\\r\\nshould\ncover us from breaking it back again. I did test it manually just\\r\\nin\ncase and it seems to be working still. Feel free to test it\ntoo.\\r\\n\\r\\nAlso, if you are wondering why `activeActionItems.indices`\nis an array\\r\\nof numbers. The user might be using the same connector in\nmore than one\\r\\naction and then delete the connector. In case this\nhappens, and the user\\r\\nclicks on \\\"edit rule\\\", they will be able to\nrestore both actions by just\\r\\ncreating the connector once. In order to\nbe able to restore all affected\\r\\nactions, their index is being stored\nas a number[]. More info\nhere\\r\\nhttps://github.com/elastic/kibana/pull/86838\\r\\n\\r\\nCloses\nhttps://github.com/elastic/kibana/issues/181407\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nAntonio\n<antoniodcoelho@gmail.com>\",\"sha\":\"60c6cdb9985570a6f58bbf3860539de64ace9aa6\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>"}},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181604","number":181604,"mergeCommit":{"message":"[MGMTEX] Fix action data override when adding a second action (#181604)\n\n## Summary\r\n\r\nWe were overwriting the `actionTypeId` of the first action in the\r\n\"create connector\" callback. The value assigned was the `actionTypeId`\r\nof the newly created action, meaning that we would have converted the\r\nfirst action to be the same as the second one. This fix changes the\r\n`actionTypeId` not for the first option but for all current\r\n`activeActionItem.indices`.\r\n\r\nPreviously, we did add that override to fix a bug related to the slack\r\nconnector https://github.com/elastic/kibana/issues/155722. Its test\r\nshould cover us from breaking it back again. I did test it manually just\r\nin case and it seems to be working still. Feel free to test it too.\r\n\r\nAlso, if you are wondering why `activeActionItems.indices` is an array\r\nof numbers. The user might be using the same connector in more than one\r\naction and then delete the connector. In case this happens, and the user\r\nclicks on \"edit rule\", they will be able to restore both actions by just\r\ncreating the connector once. In order to be able to restore all affected\r\nactions, their index is being stored as a number[]. More info here\r\nhttps://github.com/elastic/kibana/pull/86838\r\n\r\nCloses https://github.com/elastic/kibana/issues/181407\r\n\r\n---------\r\n\r\nCo-authored-by: Antonio <antoniodcoelho@gmail.com>","sha":"60c6cdb9985570a6f58bbf3860539de64ace9aa6"}}]}] BACKPORT-->