### PR TITLE
fix(slo): remove assertion on deleted rollup documents

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/observability/slos/delete_slo.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/slos/delete_slo.ts
@@ -136,7 +136,6 @@ export default function ({ getService }: FtrProviderContext) {
           indexName: SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
         });
 
-        const numberOfRollupDocumentsBeforeDeletion = sloRollupData.hits.hits.length;
         expect(sloRollupData.hits.hits.length > 0).to.be(true);
         expect(sloSummaryData.hits.hits.length > 0).to.be(true);
 
@@ -161,19 +160,6 @@ export default function ({ getService }: FtrProviderContext) {
           });
           if (sloSummaryDataAfterDeletion.hits.hits.length > 0) {
             throw new Error('SLO summary data not deleted yet');
-          }
-          return true;
-        });
-
-        await retry.waitForWithTimeout('SLO rollup data is deleted', 60 * 1000, async () => {
-          const sloRollupDataAfterDeletion = await sloApi.getSloData({
-            sloId,
-            indexName: SLO_DESTINATION_INDEX_PATTERN,
-          });
-          if (
-            sloRollupDataAfterDeletion.hits.hits.length >= numberOfRollupDocumentsBeforeDeletion
-          ) {
-            throw new Error('SLO rollup data not deleted yet');
           }
           return true;
         });


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/180982

## Summary

When deleting an SLO, we also start a delete_by_query on the rollup documents. This request is done asynchronously in the background. The serverless integration test asserts on the deletion of the rollup documents but fails some time. 
As the deletion of the rollup document causes no harms if not done, I'm removing this assertion from the test.