### PR TITLE
[Fleet] Scroll to top when changing agent activity date filter

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/flyout_body.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/flyout_body.tsx
@@ -36,6 +36,12 @@ const ButtonsFlexGroup = styled(EuiFlexGroup)`
   padding-left: 24px;
 `;
 
+const ScrollAnchor = styled.div`
+  height: 0;
+  margin: 0;
+  padding: 0;
+`;
+
 export const FlyoutBody: React.FunctionComponent<{
   isFirstLoading: boolean;
   currentActions: ActionStatus[];
@@ -57,6 +63,10 @@ export const FlyoutBody: React.FunctionComponent<{
   onChangeDateFilter,
   agentPolicies,
 }) => {
+  const scrollToTopRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    scrollToTopRef.current?.scrollIntoView();
+  }, [dateFilter]);
   // Loading
   if (isFirstLoading) {
     return (
@@ -79,6 +89,7 @@ export const FlyoutBody: React.FunctionComponent<{
   if (currentActions.length === 0) {
     return (
       <FullHeightFlyoutBody>
+        <ScrollAnchor ref={scrollToTopRef} />
         <EuiFlexGroup
           direction="column"
           justifyContent={'center'}
@@ -135,6 +146,7 @@ export const FlyoutBody: React.FunctionComponent<{
 
   return (
     <FullHeightFlyoutBody>
+      <ScrollAnchor ref={scrollToTopRef} />
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
           <EuiFlexGroup direction="column">

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/flyout_body.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/flyout_body.tsx
@@ -65,7 +65,10 @@ export const FlyoutBody: React.FunctionComponent<{
 }) => {
   const scrollToTopRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
-    scrollToTopRef.current?.scrollIntoView();
+    // Condition needed for jest tests as scrollIntoView is not implemented in jsdom
+    if (scrollToTopRef.current?.scrollIntoView) {
+      scrollToTopRef.current.scrollIntoView();
+    }
   }, [dateFilter]);
   // Loading
   if (isFirstLoading) {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/181137

Scroll to top when changing activity date filter.

## UI Changes

https://github.com/elastic/kibana/assets/1336873/5f1d0da9-0771-44fc-9958-bb8e91cac0fa



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->