### PR TITLE
[Search] Fix mapping tab breaking docLinks and refresh

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -46,7 +46,9 @@ import './index_mappings.scss';
 export const SearchIndexIndexMappings: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
   const { hasDocumentLevelSecurityFeature, isHiddenIndex } = useValues(IndexViewLogic);
-  const { indexMappingComponent: IndexMappingComponent, productFeatures } = useValues(KibanaLogic);
+  const { indexMappingComponent, productFeatures } = useValues(KibanaLogic);
+
+  const IndexMappingComponent = useMemo(() => indexMappingComponent, []);
 
   const [selectedIndexType, setSelectedIndexType] =
     useState<AccessControlSelectorOption['value']>('content-index');
@@ -154,7 +156,12 @@ export const SearchIndexIndexMappings: React.FC = () => {
               </p>
             </EuiText>
             <EuiSpacer size="s" />
-            <EuiLink href={docLinks.connectorsMappings} target="_blank" external>
+            <EuiLink
+              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnHowToCustomizeIndexMappingsAndSettingsLink"
+              href={docLinks.connectorsMappings}
+              target="_blank"
+              external
+            >
               {i18n.translate('xpack.enterpriseSearch.content.searchIndex.mappings.docLink', {
                 defaultMessage: 'Learn how to customize index mappings and settings',
               })}
@@ -187,7 +194,12 @@ export const SearchIndexIndexMappings: React.FC = () => {
               </p>
             </EuiText>
             <EuiSpacer size="s" />
-            <EuiLink href={docLinks.ingestPipelines} target="_blank" external>
+            <EuiLink
+              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
+              href={docLinks.ingestPipelines}
+              target="_blank"
+              external
+            >
               {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.docLink', {
                 defaultMessage: 'Learn more',
               })}

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -141,7 +141,7 @@ export const SelectInferenceId = ({ onChange, 'data-test-subj': dataTestSubj }: 
 
     return subscription.unsubscribe;
   }, [subscribe, onChange]);
-  const selectedOptions = options.filter((option) => option.checked).find((k) => k.label);
+  const selectedOptionLabel = options.find((option) => option.checked)?.label;
   const [isInferencePopoverVisible, setIsInferencePopoverVisible] = useState<boolean>(false);
   const [inferenceEndpointError, setInferenceEndpointError] = useState<string | undefined>(
     undefined
@@ -180,11 +180,13 @@ export const SelectInferenceId = ({ onChange, 'data-test-subj': dataTestSubj }: 
                       setIsInferencePopoverVisible(!isInferencePopoverVisible);
                     }}
                   >
-                    <FormattedMessage
-                      id="xpack.idxMgmt.mappingsEditor.parameters.inferenceId.popover.button"
-                      defaultMessage="{defaultValue}"
-                      values={{ defaultValue: selectedOptions?.label }}
-                    />
+                    {selectedOptionLabel ||
+                      i18n.translate(
+                        'xpack.idxMgmt.mappingsEditor.parameters.inferenceId.popover.defaultLabel',
+                        {
+                          defaultMessage: 'No model selected',
+                        }
+                      )}
                   </EuiButton>
                 </>
               )}

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mapping_with_context.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mapping_with_context.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { documentationService } from '../../../../services';
 import { UIM_APP_NAME } from '../../../../../../common/constants/ui_metric';
 import { httpService } from '../../../../services/http';
 import { notificationService } from '../../../../services/notification';
@@ -28,6 +29,7 @@ export const IndexMappingWithContext: React.FC<IndexMappingWithContextProps> = (
     httpService.setup(core.http);
     notificationService.setup(core.notifications);
   }
+  documentationService.setup(core.docLinks);
 
   const newDependencies: AppDependencies = {
     ...dependencies,

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mappings_embeddable.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mappings_embeddable.tsx
@@ -10,12 +10,6 @@ import { dynamic } from '@kbn/shared-ux-utility';
 import React, { Suspense, ComponentType } from 'react';
 import { IndexMappingWithContextProps } from './index_mapping_with_context_types';
 
-// const IndexMappingWithContext = lazy<ComponentType<IndexMappingWithContextProps>>(async () => {
-//   return {
-//     default: (await import('./index_mapping_with_context')).IndexMappingWithContext,
-//   };
-// });
-
 const IndexMappingWithContext = dynamic<ComponentType<IndexMappingWithContextProps>>(() =>
   import('./index_mapping_with_context').then((mod) => ({ default: mod.IndexMappingWithContext }))
 );


### PR DESCRIPTION
## Summary

This fixes two issues on the mappings tab in Search:
- A frequent refresh caused by input changes unrelated to the mappings component
- Doclinks breaking because they hadn't been initialized yet



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->