### PR TITLE
[8.14] [Console] Allow persistent console to be resizable (#180985)

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
@@ -38,24 +38,9 @@
     animation-duration: $euiAnimSpeedNormal;
     animation-timing-function: $euiAnimSlightResistance;
     animation-fill-mode: forwards;
-  }
-
-  &-isOpen.embeddableConsole--large {
-    animation-name: embeddableConsoleOpenPanelLarge;
-    height: $embeddableConsoleMaxHeight;
-    bottom: map-get($embeddableConsoleHeights, 'l') * -1;
-  }
-
-  &-isOpen.embeddableConsole--medium {
-    animation-name: embeddableConsoleOpenPanelMedium;
-    height: map-get($embeddableConsoleHeights, 'm');
-    bottom: map-get($embeddableConsoleHeights, 'm') * -1;
-  }
-
-  &-isOpen.embeddableConsole--small {
-    animation-name: embeddableConsoleOpenPanelSmall;
-    height: map-get($embeddableConsoleHeights, 's');
-    bottom: map-get($embeddableConsoleHeights, 's') * -1;
+    animation-name: embeddableConsoleOpenPanel;
+    height: var(--embedded-console-height);
+    bottom: var(--embedded-console-bottom);
   }
 }
 
@@ -80,7 +65,6 @@
 
   &--altViewButton-container {
     margin-left: auto;
-    // padding: $euiSizeS;
   }
 }
 
@@ -132,34 +116,13 @@
   }
 }
 
-@keyframes embeddableConsoleOpenPanelLarge {
-  0% {
-    // Accounts for the initial height offset from the top
-    transform: translateY(calc((#{$embeddableConsoleInitialHeight} * 3) * -1));
-  }
-
-  100% {
-    transform: translateY(map-get($embeddableConsoleHeights, 'l') * -1);
-  }
-}
-
-@keyframes embeddableConsoleOpenPanelMedium {
+@keyframes embeddableConsoleOpenPanel {
   0% {
     transform: translateY(-$embeddableConsoleInitialHeight);
   }
 
   100% {
-    transform: translateY(map-get($embeddableConsoleHeights, 'm') * -1);
-  }
-}
-
-@keyframes embeddableConsoleOpenPanelSmall {
-  0% {
-    transform: translateY(-$embeddableConsoleInitialHeight);
-  }
-
-  100% {
-    transform: translateY(map-get($embeddableConsoleHeights, 's') * -1);
+    transform: translateY(var(--embedded-console-bottom));
   }
 }
 

--- a/src/plugins/console/public/application/containers/embeddable/_variables.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_variables.scss
@@ -3,10 +3,3 @@ $embeddableConsoleText: lighten(makeHighContrastColor($euiColorLightestShade, $e
 $embeddableConsoleBorderColor: transparentize($euiColorGhost, .8);
 $embeddableConsoleInitialHeight: $euiSizeXXL;
 $embeddableConsoleMaxHeight: calc(100vh - var(--euiFixedHeadersOffset, 0));
-
-// Pixel heights ensure no blurriness caused by half pixel offsets
-$embeddableConsoleHeights: (
-  s: $euiSize * 30,
-  m: $euiSize * 50,
-  l: 100vh,
-);

--- a/src/plugins/console/public/application/containers/embeddable/console_resize_button.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_resize_button.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useCallback, useEffect, useState, useRef } from 'react';
+import { EuiResizableButton, useEuiTheme, keys, EuiThemeComputed } from '@elastic/eui';
+
+const CONSOLE_MIN_HEIGHT = 200;
+
+const getMouseOrTouchY = (
+  e: TouchEvent | MouseEvent | React.MouseEvent | React.TouchEvent
+): number => {
+  // Some Typescript fooling is needed here
+  const y = (e as TouchEvent).targetTouches
+    ? (e as TouchEvent).targetTouches[0].pageY
+    : (e as MouseEvent).pageY;
+  return y;
+};
+
+export interface EmbeddedConsoleResizeButtonProps {
+  consoleHeight: number;
+  setConsoleHeight: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export function getCurrentConsoleMaxSize(euiTheme: EuiThemeComputed<{}>) {
+  const euiBaseSize = parseInt(euiTheme.size.base, 10);
+  const winHeight = window.innerHeight;
+  const bodyStyle = getComputedStyle(document.body);
+  const headerOffset = parseInt(bodyStyle.getPropertyValue('--euiFixedHeadersOffset') ?? '0px', 10);
+
+  // We leave a buffer of baseSize to allow room for the user to hover on the top border for resizing
+  return Math.max(winHeight - headerOffset - euiBaseSize, CONSOLE_MIN_HEIGHT);
+}
+
+export const EmbeddedConsoleResizeButton = ({
+  consoleHeight,
+  setConsoleHeight,
+}: EmbeddedConsoleResizeButtonProps) => {
+  const { euiTheme } = useEuiTheme();
+  const [maxConsoleHeight, setMaxConsoleHeight] = useState<number>(800);
+  const initialConsoleHeight = useRef(consoleHeight);
+  const initialMouseY = useRef(0);
+
+  useEffect(() => {
+    function handleResize() {
+      const newMaxConsoleHeight = getCurrentConsoleMaxSize(euiTheme);
+      // Calculate and save the console max height. This is the window height minus the header
+      // offset minuse the base size to allow a small buffer for grabbing the resize button.
+      if (maxConsoleHeight !== newMaxConsoleHeight) {
+        setMaxConsoleHeight(newMaxConsoleHeight);
+      }
+      if (consoleHeight > newMaxConsoleHeight && newMaxConsoleHeight > CONSOLE_MIN_HEIGHT) {
+        // When the current console height is greater than the new max height,
+        // we resize the console to the max height. This will ensure there is not weird
+        // behavior with the drag resize.
+        setConsoleHeight(newMaxConsoleHeight);
+      }
+    }
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [maxConsoleHeight, euiTheme, consoleHeight, setConsoleHeight]);
+  const onResizeMouseMove = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      const currentMouseY = getMouseOrTouchY(e);
+      const mouseOffset = (currentMouseY - initialMouseY.current) * -1;
+      const changedConsoleHeight = initialConsoleHeight.current + mouseOffset;
+
+      const newConsoleHeight = Math.min(
+        Math.max(changedConsoleHeight, CONSOLE_MIN_HEIGHT),
+        maxConsoleHeight
+      );
+
+      setConsoleHeight(newConsoleHeight);
+    },
+    [maxConsoleHeight, setConsoleHeight]
+  );
+  const onResizeMouseUp = useCallback(
+    (e: MouseEvent | TouchEvent) => {
+      initialMouseY.current = 0;
+
+      window.removeEventListener('mousemove', onResizeMouseMove);
+      window.removeEventListener('mouseup', onResizeMouseUp);
+      window.removeEventListener('touchmove', onResizeMouseMove);
+      window.removeEventListener('touchend', onResizeMouseUp);
+    },
+    [onResizeMouseMove]
+  );
+  const onResizeMouseDown = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      initialMouseY.current = getMouseOrTouchY(e);
+      initialConsoleHeight.current = consoleHeight;
+
+      // Window event listeners instead of React events are used
+      // in case the user's mouse leaves the component
+      window.addEventListener('mousemove', onResizeMouseMove);
+      window.addEventListener('mouseup', onResizeMouseUp);
+      window.addEventListener('touchmove', onResizeMouseMove);
+      window.addEventListener('touchend', onResizeMouseUp);
+    },
+    [consoleHeight, onResizeMouseUp, onResizeMouseMove]
+  );
+  const onResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const KEYBOARD_OFFSET = 10;
+
+      switch (e.key) {
+        case keys.ARROW_UP:
+          e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
+          setConsoleHeight((height) => Math.min(height + KEYBOARD_OFFSET, maxConsoleHeight));
+          break;
+        case keys.ARROW_DOWN:
+          e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
+          setConsoleHeight((height) => Math.max(height - KEYBOARD_OFFSET, CONSOLE_MIN_HEIGHT));
+      }
+    },
+    [maxConsoleHeight, setConsoleHeight]
+  );
+  const onResizeDoubleClick = useCallback(() => {
+    if (consoleHeight < maxConsoleHeight) {
+      setConsoleHeight(maxConsoleHeight);
+    } else {
+      setConsoleHeight(maxConsoleHeight / 2);
+    }
+  }, [consoleHeight, maxConsoleHeight, setConsoleHeight]);
+
+  return (
+    <EuiResizableButton
+      indicator="border"
+      isHorizontal={false}
+      onMouseDown={onResizeMouseDown}
+      onTouchStart={onResizeMouseDown}
+      onKeyDown={onResizeKeyDown}
+      onDoubleClick={onResizeDoubleClick}
+    />
+  );
+};

--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -29,10 +29,9 @@ import {
   History,
   Settings,
   Storage,
-  createStorage,
   createHistory,
   createSettings,
-  setStorage,
+  getStorage,
 } from '../../../services';
 import { createUsageTracker } from '../../../services/tracker';
 import { MetricsTracker, EmbeddableConsoleDependencies } from '../../../types';
@@ -78,11 +77,7 @@ const loadDependencies = async (
 
   await loadActiveApi(core.http);
   const autocompleteInfo = getAutocompleteInfo();
-  const storage = createStorage({
-    engine: window.localStorage,
-    prefix: 'sense:',
-  });
-  setStorage(storage);
+  const storage = getStorage();
   const history = createHistory({ storage });
   const settings = createSettings({ storage });
   const objectStorageClient = localStorageObjectClient.create(storage);
@@ -107,7 +102,10 @@ const loadDependencies = async (
 };
 
 interface ConsoleWrapperProps
-  extends Omit<EmbeddableConsoleDependencies, 'setDispatch' | 'alternateView'> {
+  extends Omit<
+    EmbeddableConsoleDependencies,
+    'setDispatch' | 'alternateView' | 'setConsoleHeight' | 'getConsoleHeight'
+  > {
   onKeyDown: (this: Window, ev: WindowEventMap['keydown']) => any;
 }
 

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import useObservable from 'react-use/lib/useObservable';
 import {
@@ -14,15 +14,17 @@ import {
   EuiFocusTrap,
   EuiPortal,
   EuiScreenReaderOnly,
+  EuiThemeComputed,
   EuiThemeProvider,
   EuiWindowEvent,
   keys,
+  useEuiTheme,
+  useEuiThemeCSSVariables,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { dynamic } from '@kbn/shared-ux-utility';
 
 import {
-  EmbeddableConsoleProps,
   EmbeddableConsoleDependencies,
   EmbeddableConsoleView,
 } from '../../../types/embeddable_console';
@@ -31,6 +33,7 @@ import * as store from '../../stores/embeddable_console';
 import { setLoadFromParameter, removeLoadFromParameter } from '../../lib/load_from';
 
 import './_index.scss';
+import { EmbeddedConsoleResizeButton, getCurrentConsoleMaxSize } from './console_resize_button';
 
 const KBN_BODY_CONSOLE_CLASS = 'kbnBody--hasEmbeddableConsole';
 
@@ -42,13 +45,38 @@ const ConsoleWrapper = dynamic(async () => ({
   default: (await import('./console_wrapper')).ConsoleWrapper,
 }));
 
+const getInitialConsoleHeight = (
+  getConsoleHeight: EmbeddableConsoleDependencies['getConsoleHeight'],
+  euiTheme: EuiThemeComputed
+) => {
+  const lastHeight = getConsoleHeight();
+  if (lastHeight) {
+    try {
+      const value = parseInt(lastHeight, 10);
+      if (!isNaN(value) && value > 0) {
+        return value;
+      }
+    } catch {
+      // ignore bad local storage value
+    }
+  }
+  return getCurrentConsoleMaxSize(euiTheme);
+};
+
 export const EmbeddableConsole = ({
-  size = 'm',
   core,
   usageCollection,
   setDispatch,
   alternateView,
-}: EmbeddableConsoleProps & EmbeddableConsoleDependencies) => {
+  getConsoleHeight,
+  setConsoleHeight,
+}: EmbeddableConsoleDependencies) => {
+  const { euiTheme } = useEuiTheme();
+  const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
+  const [consoleHeight, setConsoleHeightState] = useState<number>(
+    getInitialConsoleHeight(getConsoleHeight, euiTheme)
+  );
+
   const [consoleState, consoleDispatch] = useReducer(
     store.reducer,
     store.initialValue,
@@ -70,6 +98,13 @@ export const EmbeddableConsole = ({
     document.body.classList.add(KBN_BODY_CONSOLE_CLASS);
     return () => document.body.classList.remove(KBN_BODY_CONSOLE_CLASS);
   }, []);
+  useEffect(() => {
+    setGlobalCSSVariables({
+      '--embedded-console-height': `${consoleHeight}px`,
+      '--embedded-console-bottom': `-${consoleHeight}px`,
+    });
+    setConsoleHeight(consoleHeight.toString());
+  }, [consoleHeight, setGlobalCSSVariables, setConsoleHeight]);
 
   const isOpen = consoleState.view !== EmbeddableConsoleView.Closed;
   const showConsole =
@@ -104,14 +139,10 @@ export const EmbeddableConsole = ({
 
   const classes = classNames('embeddableConsole', {
     'embeddableConsole-isOpen': isOpen,
-    'embeddableConsole--large': size === 'l',
-    'embeddableConsole--medium': size === 'm',
-    'embeddableConsole--small': size === 's',
     'embeddableConsole--classicChrome': chromeStyle === 'classic',
     'embeddableConsole--projectChrome': chromeStyle === 'project',
     'embeddableConsole--unknownChrome': chromeStyle === undefined,
     'embeddableConsole--fixed': true,
-    'embeddableConsole--showOnMobile': false,
   });
 
   return (
@@ -126,27 +157,36 @@ export const EmbeddableConsole = ({
             <h2>{landmarkHeading}</h2>
           </EuiScreenReaderOnly>
           <EuiThemeProvider colorMode={'dark'} wrapperProps={{ cloneElement: true }}>
-            <div className="embeddableConsole__controls">
-              <EuiButtonEmpty
-                color="text"
-                iconType={isOpen ? 'arrowUp' : 'arrowDown'}
-                onClick={toggleConsole}
-                className="embeddableConsole__controls--button"
-                data-test-subj="consoleEmbeddedControlBar"
-                data-telemetry-id="console-embedded-controlbar-button"
-              >
-                {i18n.translate('console.embeddableConsole.title', {
-                  defaultMessage: 'Console',
-                })}
-              </EuiButtonEmpty>
-              {alternateView && (
-                <div className="embeddableConsole__controls--altViewButton-container">
-                  <alternateView.ActivationButton
-                    activeView={showAlternateView}
-                    onClick={clickAlternateViewActivateButton}
-                  />
-                </div>
+            <div>
+              {isOpen && (
+                <EmbeddedConsoleResizeButton
+                  consoleHeight={consoleHeight}
+                  setConsoleHeight={setConsoleHeightState}
+                />
               )}
+
+              <div className="embeddableConsole__controls">
+                <EuiButtonEmpty
+                  color="text"
+                  iconType={isOpen ? 'arrowUp' : 'arrowDown'}
+                  onClick={toggleConsole}
+                  className="embeddableConsole__controls--button"
+                  data-test-subj="consoleEmbeddedControlBar"
+                  data-telemetry-id="console-embedded-controlbar-button"
+                >
+                  {i18n.translate('console.embeddableConsole.title', {
+                    defaultMessage: 'Console',
+                  })}
+                </EuiButtonEmpty>
+                {alternateView && (
+                  <div className="embeddableConsole__controls--altViewButton-container">
+                    <alternateView.ActivationButton
+                      activeView={showAlternateView}
+                      onClick={clickAlternateViewActivateButton}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </EuiThemeProvider>
           {showConsole ? <ConsoleWrapper {...{ core, usageCollection, onKeyDown }} /> : null}

--- a/src/plugins/console/public/application/containers/embeddable/index.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/index.tsx
@@ -8,12 +8,9 @@
 
 import { dynamic } from '@kbn/shared-ux-utility';
 import React from 'react';
-import {
-  EmbeddableConsoleProps,
-  EmbeddableConsoleDependencies,
-} from '../../../types/embeddable_console';
+import { EmbeddableConsoleDependencies } from '../../../types/embeddable_console';
 
-type EmbeddableConsoleInternalProps = EmbeddableConsoleProps & EmbeddableConsoleDependencies;
+type EmbeddableConsoleInternalProps = EmbeddableConsoleDependencies;
 const Console = dynamic(async () => ({
   default: (await import('./embeddable_console')).EmbeddableConsole,
 }));

--- a/src/plugins/console/public/index.ts
+++ b/src/plugins/console/public/index.ts
@@ -17,7 +17,6 @@ export type {
   ConsoleUILocatorParams,
   ConsolePluginSetup,
   ConsolePluginStart,
-  EmbeddableConsoleProps,
   EmbeddedConsoleView,
   EmbeddedConsoleViewButtonProps,
 } from './types';

--- a/src/plugins/console/public/services/embeddable_console.ts
+++ b/src/plugins/console/public/services/embeddable_console.ts
@@ -6,15 +6,27 @@
  * Side Public License, v 1.
  */
 import type { Dispatch } from 'react';
+import { debounce } from 'lodash';
 
 import {
   EmbeddedConsoleAction as EmbeddableConsoleAction,
   EmbeddedConsoleView,
 } from '../types/embeddable_console';
+import { Storage } from '.';
+
+const CONSOLE_HEIGHT_KEY = 'embeddedConsoleHeight';
+const CONSOLE_HEIGHT_LOCAL_STORAGE_DEBOUNCE_WAIT_TIME = 500;
 
 export class EmbeddableConsoleInfo {
   private _dispatch: Dispatch<EmbeddableConsoleAction> | null = null;
   private _alternateView: EmbeddedConsoleView | undefined;
+
+  constructor(private readonly storage: Storage) {
+    this.setConsoleHeight = debounce(
+      this.setConsoleHeight.bind(this),
+      CONSOLE_HEIGHT_LOCAL_STORAGE_DEBOUNCE_WAIT_TIME
+    );
+  }
 
   public get alternateView(): EmbeddedConsoleView | undefined {
     return this._alternateView;
@@ -37,5 +49,13 @@ export class EmbeddableConsoleInfo {
 
   public registerAlternateView(view: EmbeddedConsoleView | null) {
     this._alternateView = view ?? undefined;
+  }
+
+  public getConsoleHeight(): string | undefined {
+    return this.storage.get(CONSOLE_HEIGHT_KEY, undefined);
+  }
+
+  public setConsoleHeight(value: string) {
+    this.storage.set(CONSOLE_HEIGHT_KEY, value);
   }
 }

--- a/src/plugins/console/public/types/embeddable_console.ts
+++ b/src/plugins/console/public/types/embeddable_console.ts
@@ -10,21 +10,13 @@ import type { CoreStart } from '@kbn/core/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { Dispatch } from 'react';
 
-/**
- * EmbeddableConsoleProps are optional props used when rendering the embeddable developer console.
- */
-export interface EmbeddableConsoleProps {
-  /**
-   * The default height of the content area.
-   */
-  size?: 's' | 'm' | 'l';
-}
-
 export interface EmbeddableConsoleDependencies {
   core: CoreStart;
   usageCollection?: UsageCollectionStart;
   setDispatch: (dispatch: Dispatch<EmbeddedConsoleAction> | null) => void;
   alternateView?: EmbeddedConsoleView;
+  getConsoleHeight: () => string | undefined;
+  setConsoleHeight: (value: string) => void;
 }
 
 export type EmbeddedConsoleAction =

--- a/src/plugins/console/public/types/plugin_dependencies.ts
+++ b/src/plugins/console/public/types/plugin_dependencies.ts
@@ -13,7 +13,7 @@ import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collectio
 import { SharePluginSetup, SharePluginStart, LocatorPublic } from '@kbn/share-plugin/public';
 
 import { ConsoleUILocatorParams } from './locator';
-import { EmbeddableConsoleProps, EmbeddedConsoleView } from './embeddable_console';
+import { EmbeddedConsoleView } from './embeddable_console';
 
 export interface AppSetupUIPluginDependencies {
   home?: HomePublicPluginSetup;
@@ -55,7 +55,7 @@ export interface ConsolePluginStart {
   /**
    * EmbeddableConsole is a functional component used to render a portable version of the dev tools console on any page in Kibana
    */
-  EmbeddableConsole?: FC<EmbeddableConsoleProps>;
+  EmbeddableConsole?: FC<{}>;
   /**
    * Register an alternate view for the Embedded Console
    *


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Console] Allow persistent console to be resizable (#180985)](https://github.com/elastic/kibana/pull/180985)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2024-04-24T18:23:10Z","message":"[Console] Allow persistent console to be resizable (#180985)\n\n## Summary\r\n\r\nUpdates the Persistent console to be resizable by the user using an\r\n`EuiResizableButton` at the top of the console flyout.\r\n\r\n- Persistent console now defaults to the maximum size for the window\r\n- Top of console can be dragged to resize\r\n- On resize console size is saved to local storage and used as default\r\n- Double-clicking resize border will maximize console, or set it to 50%\r\nheight if currently at the max height.\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/1972968/46c8da24-56c8-4bda-82f9-f9498ec209a0","sha":"6d06a565b79249f81f868a9d494fea5cf6903989","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.14.0","v8.15.0"],"number":180985,"url":"https://github.com/elastic/kibana/pull/180985","mergeCommit":{"message":"[Console] Allow persistent console to be resizable (#180985)\n\n## Summary\r\n\r\nUpdates the Persistent console to be resizable by the user using an\r\n`EuiResizableButton` at the top of the console flyout.\r\n\r\n- Persistent console now defaults to the maximum size for the window\r\n- Top of console can be dragged to resize\r\n- On resize console size is saved to local storage and used as default\r\n- Double-clicking resize border will maximize console, or set it to 50%\r\nheight if currently at the max height.\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/1972968/46c8da24-56c8-4bda-82f9-f9498ec209a0","sha":"6d06a565b79249f81f868a9d494fea5cf6903989"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/180985","number":180985,"mergeCommit":{"message":"[Console] Allow persistent console to be resizable (#180985)\n\n## Summary\r\n\r\nUpdates the Persistent console to be resizable by the user using an\r\n`EuiResizableButton` at the top of the console flyout.\r\n\r\n- Persistent console now defaults to the maximum size for the window\r\n- Top of console can be dragged to resize\r\n- On resize console size is saved to local storage and used as default\r\n- Double-clicking resize border will maximize console, or set it to 50%\r\nheight if currently at the max height.\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/1972968/46c8da24-56c8-4bda-82f9-f9498ec209a0","sha":"6d06a565b79249f81f868a9d494fea5cf6903989"}}]}] BACKPORT-->