### PR TITLE
[Index Templates][Serverless] Update api integration tests for _source field

### DIFF
--- a/x-pack/test/api_integration/apis/management/index_management/lib/templates.helpers.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/lib/templates.helpers.ts
@@ -14,9 +14,6 @@ const templateMock = {
     number_of_shards: 1,
   },
   mappings: {
-    _source: {
-      enabled: false,
-    },
     properties: {
       host_name: {
         type: 'keyword',
@@ -31,6 +28,22 @@ const templateMock = {
     alias1: {},
   },
 };
+
+const getTemplateMock = (isMappingsSourceFieldEnabled: boolean) => {
+  if (isMappingsSourceFieldEnabled) {
+    return {
+      ...templateMock,
+      mappings: {
+        ...templateMock.mappings,
+        _source: {
+          enabled: false,
+        },
+      },
+    };
+  }
+  return templateMock;
+};
+
 export function templatesHelpers(getService: FtrProviderContext['getService']) {
   const es = getService('es');
 
@@ -39,13 +52,14 @@ export function templatesHelpers(getService: FtrProviderContext['getService']) {
   const getTemplatePayload = (
     name: string,
     indexPatterns: string[] = INDEX_PATTERNS,
-    isLegacy: boolean = false
+    isLegacy: boolean = false,
+    isMappingsSourceFieldEnabled: boolean = true
   ) => {
     const baseTemplate: TemplateDeserialized = {
       name,
       indexPatterns,
       version: 1,
-      template: { ...templateMock },
+      template: { ...getTemplateMock(isMappingsSourceFieldEnabled) },
       _kbnMeta: {
         isLegacy,
         type: 'default',
@@ -63,10 +77,13 @@ export function templatesHelpers(getService: FtrProviderContext['getService']) {
     return baseTemplate;
   };
 
-  const getSerializedTemplate = (indexPatterns: string[] = INDEX_PATTERNS): TemplateSerialized => {
+  const getSerializedTemplate = (
+    indexPatterns: string[] = INDEX_PATTERNS,
+    isMappingsSourceFieldEnabled: boolean = true
+  ): TemplateSerialized => {
     return {
       index_patterns: indexPatterns,
-      template: { ...templateMock },
+      template: { ...getTemplateMock(isMappingsSourceFieldEnabled) },
     };
   };
 

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/index_templates.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/index_templates.ts
@@ -138,13 +138,18 @@ export default function ({ getService }: FtrProviderContext) {
 
     describe('create', () => {
       it('should create an index template', async () => {
-        const payload = getTemplatePayload(`template-${getRandomString()}`, [getRandomString()]);
+        const payload = getTemplatePayload(
+          `template-${getRandomString()}`,
+          [getRandomString()],
+          undefined,
+          false
+        );
         await createTemplate(payload).set('x-elastic-internal-origin', 'xxx').expect(200);
       });
 
       it('should throw a 409 conflict when trying to create 2 templates with the same name', async () => {
         const templateName = `template-${getRandomString()}`;
-        const payload = getTemplatePayload(templateName, [getRandomString()]);
+        const payload = getTemplatePayload(templateName, [getRandomString()], undefined, false);
 
         await createTemplate(payload).set('x-elastic-internal-origin', 'xxx');
 
@@ -154,7 +159,12 @@ export default function ({ getService }: FtrProviderContext) {
       it('should validate the request payload', async () => {
         const templateName = `template-${getRandomString()}`;
         // need to cast as any to avoid errors after deleting index patterns
-        const payload = getTemplatePayload(templateName, [getRandomString()]) as any;
+        const payload = getTemplatePayload(
+          templateName,
+          [getRandomString()],
+          undefined,
+          false
+        ) as any;
 
         delete payload.indexPatterns; // index patterns are required
 
@@ -166,7 +176,12 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('should parse the ES error and return the cause', async () => {
         const templateName = `template-create-parse-es-error`;
-        const payload = getTemplatePayload(templateName, ['create-parse-es-error']);
+        const payload = getTemplatePayload(
+          templateName,
+          ['create-parse-es-error'],
+          undefined,
+          false
+        );
         const runtime = {
           myRuntimeField: {
             type: 'boolean',
@@ -190,7 +205,12 @@ export default function ({ getService }: FtrProviderContext) {
     describe('update', () => {
       it('should update an index template', async () => {
         const templateName = `template-${getRandomString()}`;
-        const indexTemplate = getTemplatePayload(templateName, [getRandomString()]);
+        const indexTemplate = getTemplatePayload(
+          templateName,
+          [getRandomString()],
+          undefined,
+          false
+        );
 
         await createTemplate(indexTemplate).set('x-elastic-internal-origin', 'xxx').expect(200);
 
@@ -217,7 +237,12 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('should parse the ES error and return the cause', async () => {
         const templateName = `template-update-parse-es-error`;
-        const payload = getTemplatePayload(templateName, ['update-parse-es-error']);
+        const payload = getTemplatePayload(
+          templateName,
+          ['update-parse-es-error'],
+          undefined,
+          false
+        );
         const runtime = {
           myRuntimeField: {
             type: 'keyword',
@@ -247,7 +272,7 @@ export default function ({ getService }: FtrProviderContext) {
     describe('delete', () => {
       it('should delete an index template', async () => {
         const templateName = `template-${getRandomString()}`;
-        const payload = getTemplatePayload(templateName, [getRandomString()]);
+        const payload = getTemplatePayload(templateName, [getRandomString()], undefined, false);
 
         const { status: createStatus, body: createBody } = await createTemplate(payload).set(
           'x-elastic-internal-origin',
@@ -283,7 +308,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     describe('simulate', () => {
       it('should simulate an index template', async () => {
-        const payload = getSerializedTemplate([getRandomString()]);
+        const payload = getSerializedTemplate([getRandomString()], false);
 
         const { body } = await simulateTemplate(payload)
           .set('x-elastic-internal-origin', 'xxx')


### PR DESCRIPTION
## Summary

This PR updates the Index templates API integration tests for serverless to not use the `_source` property in the mock template as this property is not supported in serverless.


