### PR TITLE
[maps] add required parameter 'version' to ESQL get columns request

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_utils.ts
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_utils.ts
@@ -8,7 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import { lastValueFrom } from 'rxjs';
 import type { DataView } from '@kbn/data-plugin/common';
-import { getESQLAdHocDataview, getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, getESQLAdHocDataview, getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
 import type { ESQLColumn, ESQLSearchReponse } from '@kbn/es-types';
 import { ES_GEO_FIELD_TYPE } from '../../../../common/constants';
 import { getData, getIndexPatternService } from '../../../kibana_services';
@@ -86,6 +86,7 @@ export function getFieldType(column: ESQLColumn) {
 async function getColumns(esql: string) {
   const params = {
     query: esql + ' | limit 0',
+    version: ESQL_LATEST_VERSION,
   };
 
   try {

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_utils.ts
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_utils.ts
@@ -8,7 +8,11 @@
 import { i18n } from '@kbn/i18n';
 import { lastValueFrom } from 'rxjs';
 import type { DataView } from '@kbn/data-plugin/common';
-import { ESQL_LATEST_VERSION, getESQLAdHocDataview, getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
+import {
+  ESQL_LATEST_VERSION,
+  getESQLAdHocDataview,
+  getIndexPatternFromESQLQuery,
+} from '@kbn/esql-utils';
 import type { ESQLColumn, ESQLSearchReponse } from '@kbn/es-types';
 import { ES_GEO_FIELD_TYPE } from '../../../../common/constants';
 import { getData, getIndexPatternService } from '../../../kibana_services';


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/180248 added `version` ESQL requests. [This PR](https://github.com/elastic/kibana/pull/180248) missed adding version to get columns request, resulting in get column request failing. Resolves issue by populating `version` parameter.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->