### PR TITLE
[Security Solution][Details Flyout] Enable toggle column action in event flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/cell_actions.tsx
@@ -9,7 +9,6 @@ import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { useRightPanelContext } from '../context';
 import { getSourcererScopeId } from '../../../../helpers';
-import { useBasicDataFromDetailsData } from '../../../../timelines/components/side_panel/event_details/helpers';
 import { SecurityCellActionType } from '../../../../actions/constants';
 import {
   CellActionsMode,
@@ -40,12 +39,7 @@ interface CellActionsProps {
  * Security cell action wrapper for document details flyout
  */
 export const CellActions: FC<CellActionsProps> = ({ field, value, isObjectArray, children }) => {
-  const { dataFormattedForFieldBrowser, scopeId, isPreview } = useRightPanelContext();
-  const { isAlert } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
-
-  const triggerId = isAlert
-    ? SecurityCellActionsTrigger.DETAILS_FLYOUT
-    : SecurityCellActionsTrigger.DEFAULT;
+  const { scopeId, isPreview } = useRightPanelContext();
 
   const data = useMemo(() => ({ field, value }), [field, value]);
   const metadata = useMemo(() => ({ scopeId, isObjectArray }), [scopeId, isObjectArray]);
@@ -58,7 +52,7 @@ export const CellActions: FC<CellActionsProps> = ({ field, value, isObjectArray,
     <SecurityCellActions
       data={data}
       mode={CellActionsMode.HOVER_RIGHT}
-      triggerId={triggerId}
+      triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
       visibleCellActions={6}
       sourcererScopeId={getSourcererScopeId(scopeId)}
       metadata={metadata}


### PR DESCRIPTION
## Summary

Address https://github.com/elastic/kibana/issues/181552. Toggle column was previously disabled for non-alerts, enabling in this PR.

![image](https://github.com/elastic/kibana/assets/18648970/7f4dcf8f-8290-4423-8a31-2d4e7e351342)

**How to test**

- Enable feature flag `expandableEventFlyoutEnabled`
- Generate some events and go to Host/User, event table
- Expand on a row with session view
- Hover actions (in table or highlighted fields) should have toggle column action

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->