### PR TITLE
[build/validate-cdn] Add retry

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -108,7 +108,7 @@ echo "--- Validate CDN assets"
     ((i=(i+1)%THREADS)) || wait
     if [[ -f "$CDN_ASSET" ]]; then
       echo -n "Testing $CDN_ASSET..."
-      curl --retry 5 --retry-max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET"
+      curl --retry `0 --retry-max-time 600 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
     fi
   done
 )

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -101,14 +101,11 @@ gcloud auth revoke "$GCS_SA_CDN_EMAIL"
 echo "--- Validate CDN assets"
 (
   shopt -s globstar
-  THREADS=$(grep -c ^processor /proc/cpuinfo)
-  i=0
   cd $CDN_ASSETS_FOLDER
   for CDN_ASSET in **/*; do
-    ((i=(i+1)%THREADS)) || wait
     if [[ -f "$CDN_ASSET" ]]; then
       echo -n "Testing $CDN_ASSET..."
-      curl --retry 10 --retry-max-time 600 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
+      curl --retry 10 --retry-max-time 600  --connect-timeout 120 --max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
     fi
   done
 )

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -105,7 +105,7 @@ echo "--- Validate CDN assets"
   for CDN_ASSET in **/*; do
     if [[ -f "$CDN_ASSET" ]]; then
       echo -n "Testing $CDN_ASSET..."
-      curl --retry 10 --retry-max-time 600  --connect-timeout 120 --max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
+      curl --retry 10 --retry-max-time 600 --connect-timeout 120 --max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
     fi
   done
 )

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -108,7 +108,7 @@ echo "--- Validate CDN assets"
     ((i=(i+1)%THREADS)) || wait
     if [[ -f "$CDN_ASSET" ]]; then
       echo -n "Testing $CDN_ASSET..."
-      curl --retry `0 --retry-max-time 600 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
+      curl --retry 10 --retry-max-time 600 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
     fi
   done
 )

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -108,7 +108,7 @@ echo "--- Validate CDN assets"
     ((i=(i+1)%THREADS)) || wait
     if [[ -f "$CDN_ASSET" ]]; then
       echo -n "Testing $CDN_ASSET..."
-      curl -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET"
+      curl --retry 5 --retry-max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET"
     fi
   done
 )

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -105,7 +105,7 @@ echo "--- Validate CDN assets"
   for CDN_ASSET in **/*; do
     if [[ -f "$CDN_ASSET" ]]; then
       echo -n "Testing $CDN_ASSET..."
-      curl --retry 10 --retry-max-time 600 --connect-timeout 120 --max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET" &
+      curl --retry 10 --retry-max-time 600 --connect-timeout 120 --max-time 120 -I --write-out '%{http_code}\n' --fail --silent --output /dev/null "$GCS_SA_CDN_URL/$CDN_ASSET"
     fi
   done
 )


### PR DESCRIPTION
Addresses timeouts we're seeing.

Example: https://buildkite.com/elastic/kibana-artifacts-container-image/builds/11661#018f16d5-2fe7-465f-bd24-4ec6d8da6cbd