### PR TITLE
[Security Solution][Event flyout] Fix session preview in event details

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.tsx
@@ -29,10 +29,11 @@ const timelineId = 'timeline-1';
  * Checks if the SessionView component is available, if so render it or else render an error message
  */
 export const SessionPreviewContainer: FC = () => {
-  const { dataAsNestedObject, getFieldsData, isPreview } = useRightPanelContext();
+  const { dataAsNestedObject, getFieldsData, isPreview, dataFormattedForFieldBrowser } =
+    useRightPanelContext();
 
   // decide whether to show the session view or not
-  const sessionViewConfig = useSessionPreview({ getFieldsData });
+  const sessionViewConfig = useSessionPreview({ getFieldsData, dataFormattedForFieldBrowser });
   const isEnterprisePlus = useLicense().isEnterprise();
   const isEnabled = sessionViewConfig && isEnterprisePlus;
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.test.tsx
@@ -11,21 +11,77 @@ import type { UseSessionPreviewParams } from './use_session_preview';
 import { useSessionPreview } from './use_session_preview';
 import type { SessionViewConfig } from '@kbn/securitysolution-data-table/common/types';
 import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
+import { mockFieldData, mockGetFieldsData } from '../../shared/mocks/mock_get_fields_data';
 
 describe('useSessionPreview', () => {
   let hookResult: RenderHookResult<UseSessionPreviewParams, SessionViewConfig | null>;
 
-  it(`should return a session view config object`, () => {
-    const getFieldsData: GetFieldsData = (field: string) => field;
+  it(`should return a session view config object if alert ancestor index is available`, () => {
+    const getFieldsData: GetFieldsData = (field: string) => {
+      if (field === 'kibana.alert.ancestors.index') {
+        return field;
+      }
+      return mockFieldData[field];
+    };
+
+    const dataFormattedForFieldBrowser = [
+      ...mockDataFormattedForFieldBrowser,
+      {
+        category: '_id',
+        field: '_id',
+        values: ['id'],
+        originalValue: ['id'],
+        isObjectArray: false,
+      },
+    ];
 
     hookResult = renderHook((props: UseSessionPreviewParams) => useSessionPreview(props), {
-      initialProps: { getFieldsData },
+      initialProps: {
+        getFieldsData,
+        dataFormattedForFieldBrowser,
+      },
     });
 
     expect(hookResult.result.current).toEqual({
       index: 'kibana.alert.ancestors.index',
-      investigatedAlertId: '_id',
-      jumpToCursor: 'kibana.alert.original_time',
+      investigatedAlertId: 'id',
+      jumpToCursor: '2023-01-01T00:00:00.000Z',
+      jumpToEntityId: 'process.entity_id',
+      sessionEntityId: 'process.entry_leader.entity_id',
+      sessionStartTime: 'process.entry_leader.start',
+    });
+  });
+
+  it(`should return a session view config object with document _index if alert ancestor index is not available`, () => {
+    const dataFormattedForFieldBrowser = [
+      ...mockDataFormattedForFieldBrowser,
+      {
+        category: '_id',
+        field: '_id',
+        values: ['id'],
+        originalValue: ['id'],
+        isObjectArray: false,
+      },
+      {
+        category: '_index',
+        field: '_index',
+        values: ['.some-index'],
+        originalValue: ['.some-index'],
+        isObjectArray: false,
+      },
+    ];
+    hookResult = renderHook((props: UseSessionPreviewParams) => useSessionPreview(props), {
+      initialProps: {
+        getFieldsData: mockGetFieldsData,
+        dataFormattedForFieldBrowser,
+      },
+    });
+
+    expect(hookResult.result.current).toEqual({
+      index: '.some-index',
+      investigatedAlertId: 'id',
+      jumpToCursor: '2023-01-01T00:00:00.000Z',
       jumpToEntityId: 'process.entity_id',
       sessionEntityId: 'process.entry_leader.entity_id',
       sessionStartTime: 'process.entry_leader.start',
@@ -36,7 +92,10 @@ describe('useSessionPreview', () => {
     const getFieldsData: GetFieldsData = (field: string) => '';
 
     hookResult = renderHook((props: UseSessionPreviewParams) => useSessionPreview(props), {
-      initialProps: { getFieldsData },
+      initialProps: {
+        getFieldsData,
+        dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+      },
     });
 
     expect(hookResult.result.current).toEqual(null);

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.ts
@@ -5,15 +5,21 @@
  * 2.0.
  */
 
+import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { SessionViewConfig } from '@kbn/securitysolution-data-table/common/types';
 import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
 import { getField } from '../../shared/utils';
+import { useBasicDataFromDetailsData } from '../../../../timelines/components/side_panel/event_details/helpers';
 
 export interface UseSessionPreviewParams {
   /**
    * Retrieves searchHit values for the provided field
    */
   getFieldsData: GetFieldsData;
+  /**
+   * An array of field objects with category and value
+   */
+  dataFormattedForFieldBrowser: TimelineEventsDetailsItem[];
 }
 
 /**
@@ -21,10 +27,12 @@ export interface UseSessionPreviewParams {
  */
 export const useSessionPreview = ({
   getFieldsData,
+  dataFormattedForFieldBrowser,
 }: UseSessionPreviewParams): SessionViewConfig | null => {
-  const _id = getField(getFieldsData('_id'));
-  const index =
-    getField(getFieldsData('kibana.alert.ancestors.index')) || getField(getFieldsData('_index'));
+  const { indexName: _index, alertId: _id } = useBasicDataFromDetailsData(
+    dataFormattedForFieldBrowser
+  );
+  const index = getField(getFieldsData('kibana.alert.ancestors.index')) || _index;
   const entryLeaderEntityId = getField(getFieldsData('process.entry_leader.entity_id'));
   const entryLeaderStart = getField(getFieldsData('process.entry_leader.start'));
   const entityId = getField(getFieldsData('process.entity_id'));

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/mocks/mock_get_fields_data.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/mocks/mock_get_fields_data.ts
@@ -12,8 +12,9 @@ import {
   ALERT_SUPPRESSION_DOCS_COUNT,
 } from '@kbn/rule-data-utils';
 import { EventKind } from '../constants/event_kinds';
+import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
 
-const mockFieldData: Record<string, string[]> = {
+export const mockFieldData: Record<string, string[]> = {
   [ALERT_SEVERITY]: ['low'],
   [ALERT_RISK_SCORE]: ['0'],
   'host.name': ['host1'],
@@ -22,6 +23,10 @@ const mockFieldData: Record<string, string[]> = {
   [ALERT_SUPPRESSION_DOCS_COUNT]: ['1'],
   '@timestamp': ['2023-01-01T00:00:00.000Z'],
   'event.kind': [EventKind.signal],
+  'kibana.alert.original_time': ['2023-01-01T00:00:00.000Z'],
+  'process.entity_id': ['process.entity_id'],
+  'process.entry_leader.entity_id': ['process.entry_leader.entity_id'],
+  'process.entry_leader.start': ['process.entry_leader.start'],
 };
 
 /**
@@ -29,4 +34,5 @@ const mockFieldData: Record<string, string[]> = {
  * @param field
  * @returns string[]
  */
-export const mockGetFieldsData = (field: string): string[] => mockFieldData[field] ?? [];
+export const mockGetFieldsData: GetFieldsData = (field: string): string[] =>
+  mockFieldData[field] ?? [];


### PR DESCRIPTION
## Summary

Address: https://github.com/elastic/kibana/issues/181238

To display session viewer, a valid index is required. `useSessionView` fetches `kibana.alert.ancestors.index` for alerts, and uses `_index` as a fall back. This PR updates how the hook fetches `_id` and `_index`. Previously, they always return null, because they are not included in `getFieldsData` ([code](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts#L93)). 

<img width="192" alt="image" src="https://github.com/elastic/kibana/assets/18648970/0a435d49-e314-4176-986a-66e13e4db4fe">

**How to test**
- Enable feature flag `expandableEventFlyoutEnabled`
- Have enterprise license active
- Generate some events and go to Host/User, event table
- Expand on a row with session view
- Session preview should be present under Overview -> Visulization

<img width="1259" alt="image" src="https://github.com/elastic/kibana/assets/18648970/ca806fc4-9ff0-4265-a6d7-e85b71f85142">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->