### PR TITLE
[Security Solution][Endpoint] Fix index names used to query agents and activity indexes for SentinelOne response actions

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/sentinelone_data_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/sentinelone_data_generator.ts
@@ -9,7 +9,7 @@ import type { DeepPartial } from 'utility-types';
 import { merge } from 'lodash';
 import type { SearchResponse, SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { EndpointActionGenerator } from './endpoint_action_generator';
-import { SENTINEL_ONE_ACTIVITY_INDEX } from '../..';
+import { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from '../..';
 import type {
   LogsEndpointAction,
   SentinelOneActivityEsDoc,
@@ -61,7 +61,7 @@ export class SentinelOneDataGenerator extends EndpointActionGenerator {
   ): SearchHit<SentinelOneActivityEsDoc> {
     const hit = this.toEsSearchHit<SentinelOneActivityEsDoc>(
       this.generateActivityEsDoc(overrides),
-      SENTINEL_ONE_ACTIVITY_INDEX
+      SENTINEL_ONE_ACTIVITY_INDEX_PATTERN
     );
 
     hit.inner_hits = {

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/sentinel_one.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/sentinel_one.ts
@@ -6,9 +6,9 @@
  */
 
 /**
- * Index name where the SentinelOne activity log is written to by the SentinelOne integration
+ * Index pattern where the SentinelOne activity log is written to by the SentinelOne integration
  */
-export const SENTINEL_ONE_ACTIVITY_INDEX = 'logs-sentinel_one.activity-default';
+export const SENTINEL_ONE_ACTIVITY_INDEX_PATTERN = 'logs-sentinel_one.activity-*';
 
 /**
  * The passcode to be used when initiating actions in SentinelOne that require a passcode to be

--- a/x-pack/plugins/security_solution/common/index.ts
+++ b/x-pack/plugins/security_solution/common/index.ts
@@ -22,7 +22,7 @@ export {
 export { ELASTIC_SECURITY_RULE_ID } from './detection_engine/constants';
 export { ENABLED_FIELD } from './detection_engine/rule_management/rule_fields';
 export { allowedExperimentalValues, type ExperimentalFeatures } from './experimental_features';
-export { SENTINEL_ONE_ACTIVITY_INDEX } from './endpoint/service/response_actions/sentinel_one';
+export { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from './endpoint/service/response_actions/sentinel_one';
 
 // Careful of exporting anything from this file as any file(s) you export here will cause your page bundle size to increase.
 // If you're using functions/types/etc... internally it's best to import directly from their paths than expose the functions/types/etc... here.

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../../../../common/endpoint/constants';
 import type { NormalizedExternalConnectorClient } from '../../..';
 import { applyEsClientSearchMock } from '../../../../mocks/utils.mock';
-import { SENTINEL_ONE_ACTIVITY_INDEX } from '../../../../../../common';
+import { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from '../../../../../../common';
 import { SentinelOneDataGenerator } from '../../../../../../common/endpoint/data_generators/sentinelone_data_generator';
 import type {
   EndpointActionResponse,
@@ -407,7 +407,7 @@ describe('SentinelOneActionsClient class', () => {
 
         applyEsClientSearchMock({
           esClientMock: classConstructorOptions.esClient,
-          index: SENTINEL_ONE_ACTIVITY_INDEX,
+          index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
           response: s1ActivitySearchResponse,
         });
       });
@@ -488,7 +488,7 @@ describe('SentinelOneActionsClient class', () => {
               sort: [{ 'sentinel_one.activity.updated_at': 'asc' }],
             },
           },
-          index: SENTINEL_ONE_ACTIVITY_INDEX,
+          index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
           query: {
             bool: {
               minimum_should_match: 1,
@@ -528,7 +528,7 @@ describe('SentinelOneActionsClient class', () => {
               sort: [{ 'sentinel_one.activity.updated_at': 'asc' }],
             },
           },
-          index: SENTINEL_ONE_ACTIVITY_INDEX,
+          index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
           query: {
             bool: {
               minimum_should_match: 1,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
@@ -27,7 +27,7 @@ import type {
   NormalizedExternalConnectorClient,
   NormalizedExternalConnectorClientExecuteOptions,
 } from '../lib/normalized_external_connector_client';
-import { SENTINEL_ONE_ACTIVITY_INDEX } from '../../../../../../common';
+import { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from '../../../../../../common';
 import { catchAndWrapError } from '../../../../utils';
 import type {
   CommonResponseActionMethodOptions,
@@ -601,7 +601,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
       };
 
       const searchRequestOptions: SearchRequest = {
-        index: SENTINEL_ONE_ACTIVITY_INDEX,
+        index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
         query,
         // There may be many documents for each host/agent, so we collapse it and only get back the
         // first one that came in after the isolate request was sent
@@ -621,7 +621,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
       };
 
       this.log.debug(
-        `searching for ${command} responses from [${SENTINEL_ONE_ACTIVITY_INDEX}] index with:\n${stringify(
+        `searching for ${command} responses from [${SENTINEL_ONE_ACTIVITY_INDEX_PATTERN}] index with:\n${stringify(
           searchRequestOptions,
           15
         )}`

--- a/x-pack/plugins/security_solution/server/endpoint/services/agent/clients/sentinel_one/sentinel_one_agent_status_client.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/agent/clients/sentinel_one/sentinel_one_agent_status_client.ts
@@ -13,7 +13,7 @@ import type { ResponseActionAgentType } from '../../../../../../common/endpoint/
 import { AgentStatusClient } from '../lib/base_agent_status_client';
 import { AgentStatusClientError } from '../errors';
 
-const SENTINEL_ONE_AGENT_INDEX = `logs-sentinel_one.agent-default`;
+const SENTINEL_ONE_AGENT_INDEX_PATTERN = `logs-sentinel_one.agent-*`;
 
 enum SENTINEL_ONE_NETWORK_STATUS {
   CONNECTING = 'connecting',
@@ -52,7 +52,7 @@ export class SentinelOneAgentStatusClient extends AgentStatusClient {
       const [searchResponse, allPendingActions] = await Promise.all([
         esClient.search(
           {
-            index: SENTINEL_ONE_AGENT_INDEX,
+            index: SENTINEL_ONE_AGENT_INDEX_PATTERN,
             from: 0,
             size: 10000,
             query,


### PR DESCRIPTION
## Summary

- Changes the names of the Activity and Agents indexes to `*` patterns in order to account for when the SentinelOne integration is configured with a namespace other than `default`






<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->