### PR TITLE
[Discover] Fix view all matches button for timestamps with numeric date formats

### DIFF
--- a/src/plugins/discover/public/application/main/components/no_results/no_results.test.tsx
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results.test.tsx
@@ -35,13 +35,14 @@ jest.spyOn(RxApi, 'lastValueFrom').mockImplementation(async () => ({
   },
 }));
 
+const services = createDiscoverServicesMock();
+
 async function mountAndFindSubjects(
   props: Omit<
     DiscoverNoResultsProps,
     'onDisableFilters' | 'data' | 'isTimeBased' | 'stateContainer'
   >
 ) {
-  const services = createDiscoverServicesMock();
   const isTimeBased = props.dataView.isTimeBased();
 
   let component: ReactWrapper;
@@ -123,6 +124,35 @@ describe('DiscoverNoResults', () => {
           }
         `);
         expect(RxApi.lastValueFrom).toHaveBeenCalledTimes(1);
+      });
+
+      test('passes strict_date_optional_time format to range query', async () => {
+        await mountAndFindSubjects({
+          dataView: stubDataView,
+          query: { language: 'lucene', query: '' },
+          filters: [],
+        });
+        expect(services.data.search.search).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            params: expect.objectContaining({
+              body: expect.objectContaining({
+                aggs: expect.objectContaining({
+                  earliest_timestamp: expect.objectContaining({
+                    min: expect.objectContaining({
+                      format: 'strict_date_optional_time',
+                    }),
+                  }),
+                  latest_timestamp: expect.objectContaining({
+                    max: expect.objectContaining({
+                      format: 'strict_date_optional_time',
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+          expect.any(Object)
+        );
       });
     });
 

--- a/src/plugins/discover/public/application/main/components/no_results/no_results_suggestions/use_fetch_occurances_range.ts
+++ b/src/plugins/discover/public/application/main/components/no_results/no_results_suggestions/use_fetch_occurances_range.ts
@@ -128,11 +128,13 @@ async function fetchDocumentsTimeRange({
               earliest_timestamp: {
                 min: {
                   field: dataView.timeFieldName,
+                  format: 'strict_date_optional_time',
                 },
               },
               latest_timestamp: {
                 max: {
                   field: dataView.timeFieldName,
+                  format: 'strict_date_optional_time',
                 },
               },
             },


### PR DESCRIPTION
This PR fixes an issue where the Discover "View all matches" button doesn't work for timestamps with numeric date formats. There are testing notes in the linked issue.

Fixes #181767.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->