### PR TITLE
Enable advanced setting assertion in the Asset Criticality upsert route

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/upsert.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/routes/upsert.ts
@@ -7,13 +7,18 @@
 import type { Logger } from '@kbn/core/server';
 import { buildSiemResponse } from '@kbn/lists-plugin/server/routes/utils';
 import { transformError } from '@kbn/securitysolution-es-utils';
-import { ASSET_CRITICALITY_URL, APP_ID } from '../../../../../common/constants';
+import {
+  ASSET_CRITICALITY_URL,
+  APP_ID,
+  ENABLE_ASSET_CRITICALITY_SETTING,
+} from '../../../../../common/constants';
 import { checkAndInitAssetCriticalityResources } from '../check_and_init_asset_criticality_resources';
 import { buildRouteValidationWithZod } from '../../../../utils/build_validation/route_validation';
-import { CreateAssetCriticalityRecord } from '../../../../../common/api/entity_analytics/asset_criticality';
+import { CreateAssetCriticalityRecord } from '../../../../../common/api/entity_analytics';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
 import { AssetCriticalityAuditActions } from '../audit';
 import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../../audit';
+import { assertAdvancedSettingsEnabled } from '../../utils/assert_advanced_setting_enabled';
 export const assetCriticalityUpsertRoute = (
   router: EntityAnalyticsRoutesDeps['router'],
   logger: Logger
@@ -38,6 +43,7 @@ export const assetCriticalityUpsertRoute = (
       async (context, request, response) => {
         const siemResponse = buildSiemResponse(response);
         try {
+          await assertAdvancedSettingsEnabled(await context.core, ENABLE_ASSET_CRITICALITY_SETTING);
           await checkAndInitAssetCriticalityResources(context, logger);
 
           const securitySolution = await context.securitySolution;

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality.ts
@@ -13,6 +13,7 @@ import {
   getAssetCriticalityDoc,
   getAssetCriticalityIndex,
   enableAssetCriticalityAdvancedSetting,
+  disableAssetCriticalityAdvancedSetting,
 } from '../../utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
@@ -27,7 +28,7 @@ export default ({ getService }: FtrProviderContext) => {
     beforeEach(async () => {
       await cleanRiskEngine({ kibanaServer, es, log });
       await cleanAssetCriticality({ log, es });
-      enableAssetCriticalityAdvancedSetting(kibanaServer, log);
+      await enableAssetCriticalityAdvancedSetting(kibanaServer, log);
     });
 
     afterEach(async () => {
@@ -36,7 +37,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('initialisation of resources', () => {
-      it('should has index installed on status api call', async () => {
+      it('should have index installed on status api call', async () => {
         let assetCriticalityIndexExist;
 
         try {
@@ -127,6 +128,20 @@ export default ({ getService }: FtrProviderContext) => {
           expectStatusCode: 400,
         });
       });
+
+      it('should return 403 if the advanced setting is disabled', async () => {
+        await disableAssetCriticalityAdvancedSetting(kibanaServer, log);
+
+        const validAssetCriticality = {
+          id_field: 'host.name',
+          id_value: 'host-01',
+          criticality_level: 'high_impact',
+        };
+
+        await assetCriticalityRoutes.upsert(validAssetCriticality, {
+          expectStatusCode: 403,
+        });
+      });
     });
 
     describe('read', () => {
@@ -150,6 +165,14 @@ export default ({ getService }: FtrProviderContext) => {
       it('should return a 400 if id_field is invalid', async () => {
         await assetCriticalityRoutes.get('invalid', 'host-02', {
           expectStatusCode: 400,
+        });
+      });
+
+      it('should return 403 if the advanced setting is disabled', async () => {
+        await disableAssetCriticalityAdvancedSetting(kibanaServer, log);
+
+        await assetCriticalityRoutes.get('host.name', 'doesnt-matter', {
+          expectStatusCode: 403,
         });
       });
     });
@@ -201,6 +224,14 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         expect(doc).to.eql(undefined);
+      });
+
+      it('should return 403 if the advanced setting is disabled', async () => {
+        await disableAssetCriticalityAdvancedSetting(kibanaServer, log);
+
+        await assetCriticalityRoutes.delete('host.name', 'doesnt-matter', {
+          expectStatusCode: 403,
+        });
       });
     });
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality_privileges.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality_privileges.ts
@@ -6,7 +6,10 @@
  */
 import expect from '@kbn/expect';
 import { ROLES as SERVERLESS_USERNAMES } from '@kbn/security-solution-plugin/common/test';
-import { assetCriticalityRouteHelpersFactoryNoAuth } from '../../utils';
+import {
+  assetCriticalityRouteHelpersFactoryNoAuth,
+  enableAssetCriticalityAdvancedSetting,
+} from '../../utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 import { usersAndRolesFactory } from '../../utils/users_and_roles';
 
@@ -64,6 +67,9 @@ const USERNAME_TO_ROLES = {
 };
 
 export default ({ getService }: FtrProviderContext) => {
+  const kibanaServer = getService('kibanaServer');
+  const log = getService('log');
+
   describe('Entity Analytics - Asset Criticality Privileges API', () => {
     describe('@ess Asset Criticality Privileges API', () => {
       const supertestWithoutAuth = getService('supertestWithoutAuth');
@@ -89,6 +95,7 @@ export default ({ getService }: FtrProviderContext) => {
         });
       before(async () => {
         await createPrivilegeTestUsers();
+        await enableAssetCriticalityAdvancedSetting(kibanaServer, log);
       });
 
       describe('Asset Criticality privileges API', () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/utils/asset_criticality.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/utils/asset_criticality.ts
@@ -126,7 +126,11 @@ export const assetCriticalityRouteHelpersFactory = (
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
       .send(body)
       .expect(expectStatusCode),
-  delete: async (idField: string, idValue: string) => {
+  delete: async (
+    idField: string,
+    idValue: string,
+    { expectStatusCode }: { expectStatusCode: number } = { expectStatusCode: 200 }
+  ) => {
     const qs = querystring.stringify({ id_field: idField, id_value: idValue });
     const route = `${routeWithNamespace(ASSET_CRITICALITY_URL, namespace)}?${qs}`;
     return supertest
@@ -134,7 +138,7 @@ export const assetCriticalityRouteHelpersFactory = (
       .set('kbn-xsrf', 'true')
       .set(ELASTIC_HTTP_VERSION_HEADER, '1')
       .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
-      .expect(200);
+      .expect(expectStatusCode);
   },
   get: async (
     idField: string,


### PR DESCRIPTION
## Summary

Asserts that the asset criticality advanced setting is enabled before allowing the asset criticality `upsert` route to be called.

FTR tests were updated and added to flex this scenario.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->