### PR TITLE
[ML] Single metric viewer embeddable: ensures create job rule anomaly click functionality works as expected

### DIFF
--- a/x-pack/plugins/ml/public/application/components/rule_editor/rule_editor_flyout.js
+++ b/x-pack/plugins/ml/public/application/components/rule_editor/rule_editor_flyout.js
@@ -55,7 +55,6 @@ import {
 import { getPartitioningFieldNames } from '../../../../common/util/job_utils';
 import { mlJobService } from '../../services/job_service';
 import { toastNotificationServiceProvider } from '../../services/toast_notification_service';
-import { ml } from '../../services/ml_api_service';
 
 class RuleEditorFlyoutUI extends Component {
   static propTypes = {
@@ -149,7 +148,7 @@ class RuleEditorFlyoutUI extends Component {
 
     if (this.partitioningFieldNames.length > 0 && this.canGetFilters) {
       // Load the current list of filters. These are used for configuring rule scope.
-      ml.filters
+      this.props.kibana.services.mlServices.mlApiServices.filters
         .filters()
         .then((filters) => {
           const filterListIds = filters.map((filter) => filter.filter_id);


### PR DESCRIPTION
## Summary

Fixes #181772 to ensure that job rules can be configured correctly from anomaly markers in the Single Metric Viewer embedded dashboard panel.

Part of #181603.

Uses mlApiServices already passed via kibana services.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->