### PR TITLE
[8.14] [Security Solution] Unskip tests - detection_page_filters.cy.ts (#173163)

### DIFF
--- a/x-pack/plugins/security_solution/common/utils/format_page_filter_search_param.test.ts
+++ b/x-pack/plugins/security_solution/common/utils/format_page_filter_search_param.test.ts
@@ -16,6 +16,7 @@ describe('formatPageFilterSearchParam', () => {
       selectedOptions: ['test_user'],
       existsSelected: true,
       exclude: true,
+      hideActionBar: true,
     };
 
     expect(formatPageFilterSearchParam([filter])).toEqual([filter]);
@@ -33,6 +34,7 @@ describe('formatPageFilterSearchParam', () => {
         fieldName: 'user.name',
         existsSelected: false,
         exclude: false,
+        hideActionBar: false,
       },
     ]);
   });

--- a/x-pack/plugins/security_solution/common/utils/format_page_filter_search_param.ts
+++ b/x-pack/plugins/security_solution/common/utils/format_page_filter_search_param.ts
@@ -9,12 +9,20 @@ import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
 
 export const formatPageFilterSearchParam = (filters: FilterControlConfig[]) => {
   return filters.map(
-    ({ title, fieldName, selectedOptions = [], existsSelected = false, exclude = false }) => ({
+    ({
+      title,
+      fieldName,
+      selectedOptions = [],
+      existsSelected = false,
+      exclude = false,
+      hideActionBar = false,
+    }) => ({
       title: title ?? fieldName,
       selectedOptions,
       fieldName,
       existsSelected,
       exclude,
+      hideActionBar,
     })
   );
 };

--- a/x-pack/plugins/security_solution/public/common/hooks/use_navigate_to_alerts_page_with_filters.test.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_navigate_to_alerts_page_with_filters.test.ts
@@ -31,7 +31,7 @@ describe('useNavigateToAlertsPageWithFilters', () => {
 
     expect(mockNavigateTo).toHaveBeenCalledWith({
       deepLinkId: SecurityPageName.alerts,
-      path: "?pageFilters=!((exclude:!f,existsSelected:!f,fieldName:'test field',selectedOptions:!('test value'),title:'test filter'))",
+      path: "?pageFilters=!((exclude:!f,existsSelected:!f,fieldName:'test field',hideActionBar:!f,selectedOptions:!('test value'),title:'test filter'))",
     });
   });
 
@@ -50,6 +50,7 @@ describe('useNavigateToAlertsPageWithFilters', () => {
         fieldName: 'test field 2',
         exclude: true,
         existsSelected: true,
+        hideActionBar: true,
       },
     ];
 
@@ -61,7 +62,7 @@ describe('useNavigateToAlertsPageWithFilters', () => {
 
     expect(mockNavigateTo).toHaveBeenCalledWith({
       deepLinkId: SecurityPageName.alerts,
-      path: "?pageFilters=!((exclude:!f,existsSelected:!f,fieldName:'test field 1',selectedOptions:!('test value 1'),title:'test filter 1'),(exclude:!t,existsSelected:!t,fieldName:'test field 2',selectedOptions:!('test value 2'),title:'test filter 2'))",
+      path: "?pageFilters=!((exclude:!f,existsSelected:!f,fieldName:'test field 1',hideActionBar:!f,selectedOptions:!('test value 1'),title:'test filter 1'),(exclude:!t,existsSelected:!t,fieldName:'test field 2',hideActionBar:!t,selectedOptions:!('test value 2'),title:'test filter 2'))",
     });
   });
 

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
@@ -54,10 +54,19 @@ describe('AlertDetailsRedirect', () => {
         </TestProviders>
       );
 
+      const expectedSearch = new URLSearchParams({
+        query: "(language:kuery,query:'_id: test-alert-id')",
+        timerange:
+          "(global:(linkTo:!(timeline,socTrends),timerange:(from:'2023-04-20T12:00:00.000Z',kind:absolute,to:'2023-04-20T12:05:00.000Z')),timeline:(linkTo:!(global,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))",
+        pageFilters:
+          '!((exclude:!f,existsSelected:!f,fieldName:kibana.alert.workflow_status,hideActionBar:!f,selectedOptions:!(),title:Status))',
+        flyout: '(panelView:eventDetail,params:(eventId:test-alert-id,indexName:.someTestIndex))',
+      });
+
       expect(historyMock.replace).toHaveBeenCalledWith({
         hash: '',
         pathname: ALERTS_PATH,
-        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272023-04-20T12%3A00%3A00.000Z%27%2Ckind%3Aabsolute%2Cto%3A%272023-04-20T12%3A05%3A00.000Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&flyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.someTestIndex%29%29`,
+        search: `?${expectedSearch.toString()}`,
         state: undefined,
       });
     });
@@ -83,10 +92,19 @@ describe('AlertDetailsRedirect', () => {
         </TestProviders>
       );
 
+      const expectedSearchParam = new URLSearchParams({
+        query: "(language:kuery,query:'_id: test-alert-id')",
+        timerange:
+          "(global:(linkTo:!(timeline,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',kind:absolute,to:'2020-07-08T08:25:18.966Z')),timeline:(linkTo:!(global,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))",
+        pageFilters:
+          '!((exclude:!f,existsSelected:!f,fieldName:kibana.alert.workflow_status,hideActionBar:!f,selectedOptions:!(),title:Status))',
+        flyout: '(panelView:eventDetail,params:(eventId:test-alert-id,indexName:.someTestIndex))',
+      });
+
       expect(historyMock.replace).toHaveBeenCalledWith({
         hash: '',
         pathname: ALERTS_PATH,
-        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2Ckind%3Aabsolute%2Cto%3A%272020-07-08T08%3A25%3A18.966Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&flyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.someTestIndex%29%29`,
+        search: `?${expectedSearchParam.toString()}`,
         state: undefined,
       });
     });
@@ -111,10 +129,20 @@ describe('AlertDetailsRedirect', () => {
         </TestProviders>
       );
 
+      const expectedSearchParam = new URLSearchParams({
+        query: "(language:kuery,query:'_id: test-alert-id')",
+        timerange:
+          "(global:(linkTo:!(timeline,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',kind:absolute,to:'2020-07-08T08:25:18.966Z')),timeline:(linkTo:!(global,socTrends),timerange:(from:'2020-07-07T08:20:18.966Z',fromStr:now/d,kind:relative,to:'2020-07-08T08:20:18.966Z',toStr:now/d)))",
+        pageFilters:
+          '!((exclude:!f,existsSelected:!f,fieldName:kibana.alert.workflow_status,hideActionBar:!f,selectedOptions:!(),title:Status))',
+        flyout:
+          '(panelView:eventDetail,params:(eventId:test-alert-id,indexName:.internal.alerts-security.alerts-default))',
+      });
+
       expect(historyMock.replace).toHaveBeenCalledWith({
         hash: '',
         pathname: ALERTS_PATH,
-        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2Ckind%3Aabsolute%2Cto%3A%272020-07-08T08%3A25%3A18.966Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&flyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.internal.alerts-security.alerts-default%29%29`,
+        search: `?${expectedSearchParam.toString()}`,
         state: undefined,
       });
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/detection_page_filters.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/detection_page_filters.cy.ts
@@ -19,7 +19,6 @@ import {
   OPTION_LIST_VALUES,
   OPTION_SELECTABLE,
   OPTION_SELECTABLE_COUNT,
-  FILTER_GROUP_CONTROL_ACTION_EDIT,
   FILTER_GROUP_EDIT_CONTROL_PANEL_ITEMS,
 } from '../../../screens/common/filter_group';
 import { createRule } from '../../../tasks/api_calls/rules';
@@ -27,25 +26,25 @@ import { login } from '../../../tasks/login';
 import { visitWithTimeRange } from '../../../tasks/navigation';
 import { ALERTS_URL, CASES_URL } from '../../../urls/navigation';
 import {
-  closePageFilterPopover,
   markAcknowledgedFirstAlert,
   openPageFilterPopover,
   resetFilters,
   selectCountTable,
+  selectPageFilterValue,
   togglePageFilterPopover,
   visitAlertsPageWithCustomFilters,
   waitForAlerts,
   waitForPageFilters,
 } from '../../../tasks/alerts';
-import { ALERTS_COUNT, ALERTS_REFRESH_BTN, EMPTY_ALERT_TABLE } from '../../../screens/alerts';
-import { kqlSearch } from '../../../tasks/security_header';
+import { ALERTS_COUNT, EMPTY_ALERT_TABLE } from '../../../screens/alerts';
+import { kqlSearch, refreshPage } from '../../../tasks/security_header';
 import {
   addNewFilterGroupControlValues,
-  cancelFieldEditing,
   deleteFilterGroupControl,
   discardFilterGroupControls,
   editFilterGroupControl,
-  editFilterGroupControls,
+  switchFilterGroupControlsToEditMode,
+  editSingleFilterControl,
   saveFilterGroupControls,
 } from '../../../tasks/common/filter_group';
 import { TOASTER } from '../../../screens/alerts_detection_rules';
@@ -106,36 +105,34 @@ const assertFilterControlsWithFilterObject = (
   });
 };
 
-// FLAKY: https://github.com/elastic/kibana/issues/171890
-describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, () => {
+describe(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: 'custom_rule_filters' }));
+    createRule(getNewRule());
     login();
     visitWithTimeRange(ALERTS_URL);
     waitForAlerts();
   });
 
-  it('Default page filters are populated when nothing is provided in the URL', () => {
+  it('should populate page filters with default values when nothing is provided in the URL', () => {
     assertFilterControlsWithFilterObject();
   });
 
   context('Alert Page Filters Customization ', () => {
-    it('should be able to delete Controls', () => {
-      waitForPageFilters();
-      editFilterGroupControls();
+    it('should be able to customize Controls', () => {
+      const fieldName = 'event.module';
+      const label = 'EventModule';
+      switchFilterGroupControlsToEditMode();
+      cy.log('should be able delete an existing control');
       deleteFilterGroupControl(3);
       cy.get(CONTROL_FRAMES).should((sub) => {
         expect(sub.length).lt(4);
       });
-      discardFilterGroupControls();
-    });
 
-    it('should be able to add new Controls', () => {
-      const fieldName = 'event.module';
-      const label = 'EventModule';
-      editFilterGroupControls();
-      deleteFilterGroupControl(3);
+      // ================================================
+      cy.log('should be able to add a new control');
+      // ================================================
+
       addNewFilterGroupControlValues({
         fieldName,
         label,
@@ -143,12 +140,12 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
       cy.get(CONTROL_FRAME_TITLE).should('contain.text', label);
       discardFilterGroupControls();
       cy.get(CONTROL_FRAME_TITLE).should('not.contain.text', label);
-    });
 
-    it('should be able to edit Controls', () => {
-      const fieldName = 'event.module';
-      const label = 'EventModule';
-      editFilterGroupControls();
+      // ================================================
+      cy.log('should be able to edit an existing control');
+      // ================================================
+
+      switchFilterGroupControlsToEditMode();
       editFilterGroupControl({ idx: 3, fieldName, label });
       cy.get(CONTROL_FRAME_TITLE).should('contain.text', label);
       discardFilterGroupControls();
@@ -157,7 +154,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
 
     it('should not sync to the URL in edit mode but only in view mode', () => {
       cy.url().then((urlString) => {
-        editFilterGroupControls();
+        switchFilterGroupControlsToEditMode();
         deleteFilterGroupControl(3);
         addNewFilterGroupControlValues({ fieldName: 'event.module', label: 'Event Module' });
         cy.url().should('eq', urlString);
@@ -167,7 +164,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     });
   });
 
-  it('Page filters are loaded with custom values provided in the URL', () => {
+  it('should load page filters with custom values provided in the URL', () => {
     const NEW_FILTERS = DEFAULT_DETECTION_PAGE_FILTERS.filter((item) => item.persist).map(
       (filter) => {
         return {
@@ -188,7 +185,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     });
   });
 
-  it('Page filters are loaded with custom filters and values', () => {
+  it('should load page filters with custom filters and values', () => {
     const CUSTOM_URL_FILTER = [
       {
         title: 'Process',
@@ -220,35 +217,47 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('be.visible');
   });
 
-  context('with data modificiation', () => {
-    it(`Alert list is updated when the alerts are updated`, () => {
-      // mark status of one alert to be acknowledged
-      selectCountTable();
-      cy.get(ALERTS_COUNT)
-        .invoke('text')
-        .then((noOfAlerts) => {
-          const originalAlertCount = noOfAlerts.split(' ')[0];
-          markAcknowledgedFirstAlert();
-          waitForAlerts();
-          cy.get(OPTION_LIST_VALUES(0)).click();
-          cy.get(OPTION_SELECTABLE(0, 'acknowledged')).should('be.visible').trigger('click');
-          cy.get(ALERTS_COUNT)
-            .invoke('text')
-            .should((newAlertCount) => {
-              expect(newAlertCount.split(' ')[0]).eq(String(parseInt(originalAlertCount, 10)));
-            });
-        });
-    });
+  context('with data modification', () => {
+    /*
+     *
+     * default scrollBehavior is true, which scrolls the element into view automatically without any scroll Margin
+     * if an element has some hover actions above the element, they get hidden on top of the window.
+     * So, we need to set scrollBehavior to false to avoid scrolling the element into view and we can scroll ourselves
+     * when needed.
+     *
+     * Ref : https://docs.cypress.io/guides/core-concepts/interacting-with-elements#Scrolling
+     */
+    it(
+      `should update alert status list when the alerts are updated`,
+      {
+        scrollBehavior: false,
+      },
+      () => {
+        // mark status of one alert to be acknowledged
+        selectCountTable();
+        cy.get(ALERTS_COUNT)
+          .invoke('text')
+          .then((noOfAlerts) => {
+            const originalAlertCount = noOfAlerts.split(' ')[0];
+            markAcknowledgedFirstAlert();
+            waitForAlerts();
+            selectPageFilterValue(0, 'acknowledged');
+            cy.get(ALERTS_COUNT)
+              .invoke('text')
+              .should((newAlertCount) => {
+                expect(newAlertCount.split(' ')[0]).eq(String(parseInt(originalAlertCount, 10)));
+              });
+          });
+      }
+    );
   });
 
-  it(`URL is updated when filters are updated`, () => {
-    openPageFilterPopover(1);
-    cy.get(OPTION_SELECTABLE(1, 'high')).should('be.visible');
-    cy.get(OPTION_SELECTABLE(1, 'high')).click();
-    closePageFilterPopover(1);
+  it(`should update URL when filters are updated`, () => {
+    selectPageFilterValue(1, 'high');
 
     const NEW_FILTERS = DEFAULT_DETECTION_PAGE_FILTERS.map((filter) => {
       return {
+        hideActionBar: false,
         ...filter,
         selectedOptions: filter.title === 'Severity' ? ['high'] : filter.selectedOptions,
       };
@@ -257,12 +266,10 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     cy.url().should('include', expectedVal);
   });
 
-  it(`Filters are restored from localstorage when user navigates back to the page.`, () => {
-    cy.get(OPTION_LIST_VALUES(1)).click();
-    cy.get(OPTION_SELECTABLE(1, 'high')).should('be.visible');
-    cy.get(OPTION_SELECTABLE(1, 'high')).click({});
+  it(`should restore Filters from localstorage when user navigates back to the page.`, () => {
+    selectPageFilterValue(1, 'high');
 
-    // high should be scuccessfully selected.
+    // high should be successfully selected.
     cy.get(OPTION_LIST_VALUES(1)).contains('high');
     waitForPageFilters();
 
@@ -275,7 +282,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     cy.get(OPTION_LIST_VALUES(1)).contains('high'); // severity should be low as previously selected
   });
 
-  it('Custom filters from URLS are populated & changed banner is displayed', () => {
+  it('should populate Custom filters & display the changed banner', () => {
     visitAlertsPageWithCustomFilters(customFilters);
     waitForPageFilters();
 
@@ -284,7 +291,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('be.visible');
   });
 
-  it('Changed banner should hide on saving changes', () => {
+  it('should hide Changed banner on saving changes', () => {
     visitAlertsPageWithCustomFilters(customFilters);
     waitForPageFilters();
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('be.visible');
@@ -292,7 +299,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('not.exist');
   });
 
-  it('Changed banner should hide on discarding changes', () => {
+  it('should hide Changed banner on discarding changes', () => {
     visitAlertsPageWithCustomFilters(customFilters);
     waitForPageFilters();
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('be.visible');
@@ -300,7 +307,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
     cy.get(FILTER_GROUP_CHANGED_BANNER).should('not.exist');
   });
 
-  it('Changed banner should hide on Reset', () => {
+  it('should hide Changed banner on Reset', () => {
     visitAlertsPageWithCustomFilters(customFilters);
     waitForPageFilters();
     resetFilters();
@@ -310,9 +317,8 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
   context('Impact of inputs', () => {
     it('should recover from invalid kql Query result', () => {
       // do an invalid search
-      //
       kqlSearch('\\');
-      cy.get(ALERTS_REFRESH_BTN).click();
+      refreshPage();
       waitForPageFilters();
       cy.get(TOASTER).should('contain.text', 'KQLSyntaxError');
       togglePageFilterPopover(0);
@@ -323,7 +329,7 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
 
     it('should take kqlQuery into account', () => {
       kqlSearch('kibana.alert.workflow_status: "nothing"');
-      cy.get(ALERTS_REFRESH_BTN).trigger('click');
+      refreshPage();
       waitForPageFilters();
       togglePageFilterPopover(0);
       cy.get(CONTROL_POPOVER(0)).should('contain.text', 'No options found');
@@ -342,31 +348,28 @@ describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, ()
       cy.get(CONTROL_POPOVER(0)).should('contain.text', 'No options found');
       cy.get(EMPTY_ALERT_TABLE).should('be.visible');
     });
-    it('should take timeRange into account', () => {
-      const startDateWithZeroAlerts = 'Jan 1, 2002 @ 00:00:00.000';
-      const endDateWithZeroAlerts = 'Jan 1, 2010 @ 00:00:00.000';
-      setStartDate(startDateWithZeroAlerts);
-      setEndDate(endDateWithZeroAlerts);
 
-      cy.get(ALERTS_REFRESH_BTN).trigger('click');
+    it('should take timeRange into account', () => {
+      const dateRangeWithZeroAlerts = ['Jan 1, 2002 @ 00:00:00.000', 'Jan 1, 2002 @ 00:00:00.000'];
+      setStartDate(dateRangeWithZeroAlerts[0]);
+      setEndDate(dateRangeWithZeroAlerts[1]);
+
+      refreshPage();
       waitForPageFilters();
       togglePageFilterPopover(0);
       cy.get(CONTROL_POPOVER(0)).should('contain.text', 'No options found');
       cy.get(EMPTY_ALERT_TABLE).should('be.visible');
     });
   });
-  it('Number fields are not visible in field edit panel', () => {
+  it('should not show number fields are not visible in field edit panel', () => {
     const idx = 3;
     const { FILTER_FIELD_TYPE, FIELD_TYPES } = FILTER_GROUP_EDIT_CONTROL_PANEL_ITEMS;
-    editFilterGroupControls();
-    cy.get(CONTROL_FRAME_TITLE).eq(idx).realHover();
-    cy.get(FILTER_GROUP_CONTROL_ACTION_EDIT(idx)).click();
+    switchFilterGroupControlsToEditMode();
+    editSingleFilterControl(idx);
     cy.get(FILTER_FIELD_TYPE).click();
     cy.get(FIELD_TYPES.STRING).should('be.visible');
     cy.get(FIELD_TYPES.BOOLEAN).should('be.visible');
     cy.get(FIELD_TYPES.IP).should('be.visible');
     cy.get(FIELD_TYPES.NUMBER).should('not.exist');
-    cancelFieldEditing();
-    discardFilterGroupControls();
   });
 });

--- a/x-pack/test/security_solution_cypress/cypress/screens/alerts.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/alerts.ts
@@ -7,7 +7,6 @@
 
 import { IS_SERVERLESS, CLOUD_SERVERLESS } from '../env_var_names_constants';
 import { getDataTestSubjectSelector } from '../helpers/common';
-import { GLOBAL_FILTERS_CONTAINER } from './date_picker';
 
 export const ADD_EXCEPTION_BTN = '[data-test-subj="add-exception-menu-item"]';
 
@@ -58,8 +57,6 @@ export const TAKE_ACTION_MENU = '[data-test-subj="takeActionPanelMenu"]';
 export const CLOSE_FLYOUT = '[data-test-subj="euiFlyoutCloseButton"]';
 
 export const MARK_ALERT_ACKNOWLEDGED_BTN = '[data-test-subj="acknowledged-alert-status"]';
-
-export const ALERTS_REFRESH_BTN = `${GLOBAL_FILTERS_CONTAINER} [data-test-subj="querySubmitButton"]`;
 
 export const ALERTS_HISTOGRAM_PANEL_LOADER = '[data-test-subj="loadingPanelAlertsHistogram"]';
 

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -65,7 +65,6 @@ import {
 } from '../screens/alerts_details';
 import { FIELD_INPUT } from '../screens/exceptions';
 import {
-  CONTROL_FRAME_TITLE,
   DETECTION_PAGE_FILTERS_LOADING,
   DETECTION_PAGE_FILTER_GROUP_LOADING,
   DETECTION_PAGE_FILTER_GROUP_RESET_BUTTON,
@@ -74,7 +73,6 @@ import {
   OPTION_LIST_VALUES,
   OPTION_LIST_CLEAR_BTN,
   OPTION_SELECTABLE,
-  CONTROL_GROUP,
 } from '../screens/common/filter_group';
 import { LOADING_SPINNER } from '../screens/common/page';
 import { ALERTS_URL } from '../urls/navigation';
@@ -172,7 +170,7 @@ export const setEnrichmentDates = (from?: string, to?: string) => {
 
 export const refreshAlertPageFilter = () => {
   // Currently, system keeps the cache of option List for 1 minute so as to avoid
-  // lot of unncessary traffic. Cypress is too fast and we cannot wait for a minute
+  // lot of unnecessary traffic. Cypress is too fast and we cannot wait for a minute
   // to trigger a reload of Page Filters.
   // It is faster to refresh the page which will reload the Page Filter values
   // cy.reload();
@@ -198,15 +196,8 @@ export const closePageFilterPopover = (filterIndex: number) => {
 };
 
 export const clearAllSelections = (filterIndex: number) => {
-  cy.get(CONTROL_GROUP).scrollIntoView();
-  recurse(
-    () => {
-      cy.get(CONTROL_FRAME_TITLE).eq(filterIndex).realHover();
-      return cy.get(OPTION_LIST_CLEAR_BTN).eq(filterIndex);
-    },
-    ($el) => $el.is(':visible')
-  );
-  cy.get(OPTION_LIST_CLEAR_BTN).eq(filterIndex).should('be.visible').trigger('click');
+  cy.get(OPTION_LIST_VALUES(filterIndex)).realHover();
+  cy.get(OPTION_LIST_CLEAR_BTN).eq(filterIndex).click();
 };
 
 export const selectPageFilterValue = (filterIndex: number, ...values: string[]) => {
@@ -214,7 +205,7 @@ export const selectPageFilterValue = (filterIndex: number, ...values: string[]) 
   clearAllSelections(filterIndex);
   openPageFilterPopover(filterIndex);
   values.forEach((value) => {
-    cy.get(OPTION_SELECTABLE(filterIndex, value)).click({ force: true });
+    cy.get(OPTION_SELECTABLE(filterIndex, value)).click();
   });
   closePageFilterPopover(filterIndex);
   waitForAlerts();

--- a/x-pack/test/security_solution_cypress/cypress/tasks/common/filter_group.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/common/filter_group.ts
@@ -16,7 +16,6 @@ import {
   FILTER_GROUP_SAVE_CHANGES,
   CONTROL_FRAME_TITLE,
   FILTER_GROUP_CONTROL_ACTION_DELETE,
-  FILTER_GROUP_CONTROL_CONFIRM_DIALOG,
   FILTER_GROUP_CONTROL_CONFIRM_BTN,
   DETECTION_PAGE_FILTER_GROUP_WRAPPER,
   DETECTION_PAGE_FILTER_GROUP_LOADING,
@@ -53,9 +52,14 @@ export const resetFilterGroup = () => {
   cy.get(DETECTION_PAGE_FILTER_GROUP_RESET_BUTTON).click();
 };
 
-export const editFilterGroupControls = () => {
+export const switchFilterGroupControlsToEditMode = () => {
   openFilterGroupContextMenu();
   cy.get(FILTER_GROUP_CONTEXT_EDIT_CONTROLS).click();
+};
+
+export const editSingleFilterControl = (idx: number) => {
+  cy.get(CONTROL_FRAME_TITLE).eq(idx).realHover();
+  cy.get(FILTER_GROUP_CONTROL_ACTION_EDIT(idx)).click();
 };
 
 export const cancelFieldEditing = () => {
@@ -106,7 +110,6 @@ export const addNewFilterGroupControlValues = ({
 export const deleteFilterGroupControl = (idx: number) => {
   cy.get(CONTROL_FRAME_TITLE).eq(idx).realHover();
   cy.get(FILTER_GROUP_CONTROL_ACTION_DELETE(idx)).click();
-  cy.get(FILTER_GROUP_CONTROL_CONFIRM_DIALOG).should('be.visible');
   cy.get(FILTER_GROUP_CONTROL_CONFIRM_BTN).click();
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Security Solution] Unskip tests - detection_page_filters.cy.ts (#173163)](https://github.com/elastic/kibana/pull/173163)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2024-04-26T05:09:28Z","message":"[Security Solution] Unskip tests - detection_page_filters.cy.ts (#173163)\n\n## Summary\r\n\r\n### Flaky Tests to be fixed\r\n \r\n  - https://github.com/elastic/kibana/issues/163544\r\n  \r\n  - https://github.com/elastic/kibana/issues/163757\r\n  \r\n  - https://github.com/elastic/kibana/issues/164018\r\n  \r\n  - https://github.com/elastic/kibana/issues/168276\r\n  \r\n  - https://github.com/elastic/kibana/issues/168277\r\n\r\n### Fixes to make the tests more stable\r\n\r\n- Disable `scrollBehaviour` for a [particular\r\ntest](https://github.com/elastic/kibana/pull/173163/files#diff-864d08982a2a67111903c3308f8b7ee797b34ec736f6747fedf46f8c36e08859R230)\r\n- default `scrollBehavior` was true, which scrolls the element into view\r\nautomatically without any scroll Margin if an element has some hover\r\nactions above the element, they get hidden on top of the window. So, we\r\nneed to set scrollBehavior to false to avoid scrolling the element into\r\nview and we can scroll ourselves when needed\r\n- Ref :\r\nhttps://docs.cypress.io/guides/core-concepts/interacting-with-elements#Scrolling\r\n    \r\n- One code change has included a new\r\n[parameter](https://github.com/elastic/kibana/pull/173163/files#diff-864d08982a2a67111903c3308f8b7ee797b34ec736f6747fedf46f8c36e08859R260)\r\nwhich was a cause of failing a couple of tests. (Not flaky but failing)\r\n\r\n \r\n\r\n### Flaky Test Runner Report\r\n\r\n- [50\r\nRuns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5751)\r\n    - Severless -  50/50 Pass\r\n    - ESS -  50/50 Pass\r\n- [100\r\nRuns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5753)\r\n    - Severless -  100/100 Pass\r\n    - ESS -   100/100 Pass\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"b34c8a9ec9b80dc122a45fceae0360351c3fb37c","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:prev-minor","v8.15.0"],"number":173163,"url":"https://github.com/elastic/kibana/pull/173163","mergeCommit":{"message":"[Security Solution] Unskip tests - detection_page_filters.cy.ts (#173163)\n\n## Summary\r\n\r\n### Flaky Tests to be fixed\r\n \r\n  - https://github.com/elastic/kibana/issues/163544\r\n  \r\n  - https://github.com/elastic/kibana/issues/163757\r\n  \r\n  - https://github.com/elastic/kibana/issues/164018\r\n  \r\n  - https://github.com/elastic/kibana/issues/168276\r\n  \r\n  - https://github.com/elastic/kibana/issues/168277\r\n\r\n### Fixes to make the tests more stable\r\n\r\n- Disable `scrollBehaviour` for a [particular\r\ntest](https://github.com/elastic/kibana/pull/173163/files#diff-864d08982a2a67111903c3308f8b7ee797b34ec736f6747fedf46f8c36e08859R230)\r\n- default `scrollBehavior` was true, which scrolls the element into view\r\nautomatically without any scroll Margin if an element has some hover\r\nactions above the element, they get hidden on top of the window. So, we\r\nneed to set scrollBehavior to false to avoid scrolling the element into\r\nview and we can scroll ourselves when needed\r\n- Ref :\r\nhttps://docs.cypress.io/guides/core-concepts/interacting-with-elements#Scrolling\r\n    \r\n- One code change has included a new\r\n[parameter](https://github.com/elastic/kibana/pull/173163/files#diff-864d08982a2a67111903c3308f8b7ee797b34ec736f6747fedf46f8c36e08859R260)\r\nwhich was a cause of failing a couple of tests. (Not flaky but failing)\r\n\r\n \r\n\r\n### Flaky Test Runner Report\r\n\r\n- [50\r\nRuns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5751)\r\n    - Severless -  50/50 Pass\r\n    - ESS -  50/50 Pass\r\n- [100\r\nRuns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5753)\r\n    - Severless -  100/100 Pass\r\n    - ESS -   100/100 Pass\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"b34c8a9ec9b80dc122a45fceae0360351c3fb37c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173163","number":173163,"mergeCommit":{"message":"[Security Solution] Unskip tests - detection_page_filters.cy.ts (#173163)\n\n## Summary\r\n\r\n### Flaky Tests to be fixed\r\n \r\n  - https://github.com/elastic/kibana/issues/163544\r\n  \r\n  - https://github.com/elastic/kibana/issues/163757\r\n  \r\n  - https://github.com/elastic/kibana/issues/164018\r\n  \r\n  - https://github.com/elastic/kibana/issues/168276\r\n  \r\n  - https://github.com/elastic/kibana/issues/168277\r\n\r\n### Fixes to make the tests more stable\r\n\r\n- Disable `scrollBehaviour` for a [particular\r\ntest](https://github.com/elastic/kibana/pull/173163/files#diff-864d08982a2a67111903c3308f8b7ee797b34ec736f6747fedf46f8c36e08859R230)\r\n- default `scrollBehavior` was true, which scrolls the element into view\r\nautomatically without any scroll Margin if an element has some hover\r\nactions above the element, they get hidden on top of the window. So, we\r\nneed to set scrollBehavior to false to avoid scrolling the element into\r\nview and we can scroll ourselves when needed\r\n- Ref :\r\nhttps://docs.cypress.io/guides/core-concepts/interacting-with-elements#Scrolling\r\n    \r\n- One code change has included a new\r\n[parameter](https://github.com/elastic/kibana/pull/173163/files#diff-864d08982a2a67111903c3308f8b7ee797b34ec736f6747fedf46f8c36e08859R260)\r\nwhich was a cause of failing a couple of tests. (Not flaky but failing)\r\n\r\n \r\n\r\n### Flaky Test Runner Report\r\n\r\n- [50\r\nRuns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5751)\r\n    - Severless -  50/50 Pass\r\n    - ESS -  50/50 Pass\r\n- [100\r\nRuns](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5753)\r\n    - Severless -  100/100 Pass\r\n    - ESS -   100/100 Pass\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"b34c8a9ec9b80dc122a45fceae0360351c3fb37c"}}]}] BACKPORT-->