### PR TITLE
[8.14] [Search] Fix mapping tab breaking docLinks and refresh (#181729)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -46,7 +46,9 @@ import './index_mappings.scss';
 export const SearchIndexIndexMappings: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
   const { hasDocumentLevelSecurityFeature, isHiddenIndex } = useValues(IndexViewLogic);
-  const { indexMappingComponent: IndexMappingComponent, productFeatures } = useValues(KibanaLogic);
+  const { indexMappingComponent, productFeatures } = useValues(KibanaLogic);
+
+  const IndexMappingComponent = useMemo(() => indexMappingComponent, []);
 
   const [selectedIndexType, setSelectedIndexType] =
     useState<AccessControlSelectorOption['value']>('content-index');
@@ -154,7 +156,12 @@ export const SearchIndexIndexMappings: React.FC = () => {
               </p>
             </EuiText>
             <EuiSpacer size="s" />
-            <EuiLink href={docLinks.connectorsMappings} target="_blank" external>
+            <EuiLink
+              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnHowToCustomizeIndexMappingsAndSettingsLink"
+              href={docLinks.connectorsMappings}
+              target="_blank"
+              external
+            >
               {i18n.translate('xpack.enterpriseSearch.content.searchIndex.mappings.docLink', {
                 defaultMessage: 'Learn how to customize index mappings and settings',
               })}
@@ -187,7 +194,12 @@ export const SearchIndexIndexMappings: React.FC = () => {
               </p>
             </EuiText>
             <EuiSpacer size="s" />
-            <EuiLink href={docLinks.ingestPipelines} target="_blank" external>
+            <EuiLink
+              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
+              href={docLinks.ingestPipelines}
+              target="_blank"
+              external
+            >
               {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.docLink', {
                 defaultMessage: 'Learn more',
               })}

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mapping_with_context.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mapping_with_context.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { documentationService } from '../../../../services';
 import { UIM_APP_NAME } from '../../../../../../common/constants/ui_metric';
 import { httpService } from '../../../../services/http';
 import { notificationService } from '../../../../services/notification';
@@ -28,6 +29,7 @@ export const IndexMappingWithContext: React.FC<IndexMappingWithContextProps> = (
     httpService.setup(core.http);
     notificationService.setup(core.notifications);
   }
+  documentationService.setup(core.docLinks);
 
   const newDependencies: AppDependencies = {
     ...dependencies,

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mappings_embeddable.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_mappings_embeddable.tsx
@@ -10,12 +10,6 @@ import { dynamic } from '@kbn/shared-ux-utility';
 import React, { Suspense, ComponentType } from 'react';
 import { IndexMappingWithContextProps } from './index_mapping_with_context_types';
 
-// const IndexMappingWithContext = lazy<ComponentType<IndexMappingWithContextProps>>(async () => {
-//   return {
-//     default: (await import('./index_mapping_with_context')).IndexMappingWithContext,
-//   };
-// });
-
 const IndexMappingWithContext = dynamic<ComponentType<IndexMappingWithContextProps>>(() =>
   import('./index_mapping_with_context').then((mod) => ({ default: mod.IndexMappingWithContext }))
 );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Search] Fix mapping tab breaking docLinks and refresh (#181729)](https://github.com/elastic/kibana/pull/181729)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-25T17:44:49Z","message":"[Search] Fix mapping tab breaking docLinks and refresh (#181729)\n\n## Summary\r\n\r\nThis fixes two issues on the mappings tab in Search:\r\n- A frequent refresh caused by input changes unrelated to the mappings\r\ncomponent\r\n- Doclinks breaking because they hadn't been initialized yet","sha":"35974ca8166ebc702308f04b9333c47b9ff04cfe","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.14.0","v8.15.0"],"number":181729,"url":"https://github.com/elastic/kibana/pull/181729","mergeCommit":{"message":"[Search] Fix mapping tab breaking docLinks and refresh (#181729)\n\n## Summary\r\n\r\nThis fixes two issues on the mappings tab in Search:\r\n- A frequent refresh caused by input changes unrelated to the mappings\r\ncomponent\r\n- Doclinks breaking because they hadn't been initialized yet","sha":"35974ca8166ebc702308f04b9333c47b9ff04cfe"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181729","number":181729,"mergeCommit":{"message":"[Search] Fix mapping tab breaking docLinks and refresh (#181729)\n\n## Summary\r\n\r\nThis fixes two issues on the mappings tab in Search:\r\n- A frequent refresh caused by input changes unrelated to the mappings\r\ncomponent\r\n- Doclinks breaking because they hadn't been initialized yet","sha":"35974ca8166ebc702308f04b9333c47b9ff04cfe"}}]}] BACKPORT-->