### PR TITLE
[Search] Change empty check condition for sync rules

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -39,6 +39,7 @@ import { LicensingLogic } from '../../../shared/licensing';
 import { EuiButtonTo, EuiLinkTo } from '../../../shared/react_router_helpers';
 import { GenerateConnectorApiKeyApiLogic } from '../../api/connector/generate_connector_api_key_api_logic';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
+import { isAdvancedSyncRuleSnippetEmpty } from '../../utils/sync_rules_helpers';
 import { SyncsContextMenu } from '../search_index/components/header_actions/syncs_context_menu';
 import { ApiKeyConfig } from '../search_index/connector/api_key_configuration';
 
@@ -64,6 +65,7 @@ export const ConnectorConfiguration: React.FC = () => {
   const { hasPlatinumLicense } = useValues(LicensingLogic);
   const { errorConnectingMessage, http } = useValues(HttpLogic);
   const { advancedSnippet } = useValues(ConnectorFilteringLogic);
+  const isAdvancedSnippetEmpty = isAdvancedSyncRuleSnippetEmpty(advancedSnippet);
 
   const { connectorTypes } = useValues(KibanaLogic);
   const BETA_CONNECTORS = useMemo(
@@ -264,36 +266,38 @@ export const ConnectorConfiguration: React.FC = () => {
                             />
                           )}
                           <EuiSpacer size="s" />
-                          {connector.status && hasAdvancedFilteringFeature && !!advancedSnippet && (
-                            <EuiCallOut
-                              title={i18n.translate(
-                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout',
-                                { defaultMessage: 'Configuration warning' }
-                              )}
-                              iconType="iInCircle"
-                              color="warning"
-                            >
-                              <FormattedMessage
-                                id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout.description"
-                                defaultMessage="{advancedSyncRulesDocs} can override some configuration fields."
-                                values={{
-                                  advancedSyncRulesDocs: (
-                                    <EuiLink
-                                      data-test-subj="entSearchContent-connector-configuration-advancedSyncRulesDocsLink"
-                                      data-telemetry-id="entSearchContent-connector-configuration-advancedSyncRulesDocsLink"
-                                      href={docLinks.syncRules}
-                                      target="_blank"
-                                    >
-                                      {i18n.translate(
-                                        'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedSyncRulesDocs',
-                                        { defaultMessage: 'Advanced Sync Rules' }
-                                      )}
-                                    </EuiLink>
-                                  ),
-                                }}
-                              />
-                            </EuiCallOut>
-                          )}
+                          {connector.status &&
+                            hasAdvancedFilteringFeature &&
+                            !isAdvancedSnippetEmpty && (
+                              <EuiCallOut
+                                title={i18n.translate(
+                                  'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout',
+                                  { defaultMessage: 'Configuration warning' }
+                                )}
+                                iconType="iInCircle"
+                                color="warning"
+                              >
+                                <FormattedMessage
+                                  id="xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedRulesCallout.description"
+                                  defaultMessage="{advancedSyncRulesDocs} can override some configuration fields."
+                                  values={{
+                                    advancedSyncRulesDocs: (
+                                      <EuiLink
+                                        data-test-subj="entSearchContent-connector-configuration-advancedSyncRulesDocsLink"
+                                        data-telemetry-id="entSearchContent-connector-configuration-advancedSyncRulesDocsLink"
+                                        href={docLinks.syncRules}
+                                        target="_blank"
+                                      >
+                                        {i18n.translate(
+                                          'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedSyncRulesDocs',
+                                          { defaultMessage: 'Advanced Sync Rules' }
+                                        )}
+                                      </EuiLink>
+                                    ),
+                                  }}
+                                />
+                              </EuiCallOut>
+                            )}
                         </ConnectorConfigurationComponent>
                       ),
                       status:

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -27,6 +27,7 @@ import { HttpLogic } from '../../../../../shared/http';
 import { LicensingLogic } from '../../../../../shared/licensing';
 
 import { ConnectorConfigurationApiLogic } from '../../../../api/connector/update_connector_configuration_api_logic';
+import { isAdvancedSyncRuleSnippetEmpty } from '../../../../utils/sync_rules_helpers';
 import { ConnectorViewLogic } from '../../../connector_detail/connector_view_logic';
 import { ConnectorFilteringLogic } from '../sync_rules/connector_filtering_logic';
 
@@ -45,6 +46,8 @@ export const NativeConnectorConfigurationConfig: React.FC<
   const { hasAdvancedFilteringFeature } = useValues(ConnectorViewLogic);
   const { advancedSnippet } = useValues(ConnectorFilteringLogic);
   const { http } = useValues(HttpLogic);
+  const isAdvancedSnippetEmpty = isAdvancedSyncRuleSnippetEmpty(advancedSnippet);
+
   return (
     <ConnectorConfigurationComponent
       connector={connector}
@@ -71,7 +74,12 @@ export const NativeConnectorConfigurationConfig: React.FC<
       <EuiSpacer />
       <EuiFlexGroup direction="row">
         <EuiFlexItem grow={false}>
-          <EuiLink href={docLinks.elasticsearchSecureCluster} target="_blank">
+          <EuiLink
+            data-test-subj="entSearchContent-connector-nativeConnector-learnMoreAboutSecurityLink"
+            data-telemetry-id="entSearchContent-connector-nativeConnector-learnMoreAboutSecurityLink"
+            href={docLinks.elasticsearchSecureCluster}
+            target="_blank"
+          >
             {i18n.translate(
               'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.config.securityDocumentationLinkLabel',
               {
@@ -82,7 +90,12 @@ export const NativeConnectorConfigurationConfig: React.FC<
         </EuiFlexItem>
         {nativeConnector.externalAuthDocsUrl && (
           <EuiFlexItem grow={false}>
-            <EuiLink href={nativeConnector.externalAuthDocsUrl} target="_blank">
+            <EuiLink
+              data-test-subj="entSearchContent-connector-nativeConnector-configNameAuthenticationLink"
+              data-telemetry-id="entSearchContent-connector-nativeConnector-configNameAuthenticationLink"
+              href={nativeConnector.externalAuthDocsUrl}
+              target="_blank"
+            >
               {i18n.translate(
                 'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.config.sourceSecurityDocumentationLinkLabel',
                 {
@@ -114,7 +127,7 @@ export const NativeConnectorConfigurationConfig: React.FC<
         </>
       )}
 
-      {connector.status && hasAdvancedFilteringFeature && !!advancedSnippet && (
+      {connector.status && hasAdvancedFilteringFeature && !isAdvancedSnippetEmpty && (
         <>
           <EuiSpacer size="l" />
           <EuiCallOut
@@ -130,7 +143,12 @@ export const NativeConnectorConfigurationConfig: React.FC<
               defaultMessage="{advancedSyncRulesDocs} can override some configuration fields."
               values={{
                 advancedSyncRulesDocs: (
-                  <EuiLink href={docLinks.syncRules} target="_blank">
+                  <EuiLink
+                    data-test-subj="entSearchContent-connector-nativeConnector-advancedSyncRulesDocsLink"
+                    data-telemetry-id="entSearchContent-connector-nativeConnector-advancedSyncRulesDocsLink"
+                    href={docLinks.syncRules}
+                    target="_blank"
+                  >
                     {i18n.translate(
                       'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.advancedSyncRulesDocs',
                       { defaultMessage: 'Advanced Sync Rules' }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/advanced_sync_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/advanced_sync_rules.tsx
@@ -15,6 +15,8 @@ import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { isAdvancedSyncRuleSnippetEmpty } from '../../../../utils/sync_rules_helpers';
+
 import { ConnectorFilteringLogic } from './connector_filtering_logic';
 
 export const AdvancedSyncRules: React.FC = () => {
@@ -24,6 +26,9 @@ export const AdvancedSyncRules: React.FC = () => {
     advancedSnippet,
   } = useValues(ConnectorFilteringLogic);
   const { setLocalAdvancedSnippet } = useActions(ConnectorFilteringLogic);
+  const isAdvancedSnippetEmpty = isAdvancedSyncRuleSnippetEmpty(advancedSnippet);
+  const isLocalSnippetEmpty = isAdvancedSyncRuleSnippetEmpty(localAdvancedSnippet);
+
   return (
     <>
       <EuiFormRow
@@ -63,7 +68,7 @@ export const AdvancedSyncRules: React.FC = () => {
         />
       </EuiFormRow>
 
-      {(!!advancedSnippet || !!localAdvancedSnippet) && (
+      {(!isAdvancedSnippetEmpty || !isLocalSnippetEmpty) && (
         <EuiCallOut
           title={i18n.translate(
             'xpack.enterpriseSearch.content.index.connector.syncRules.advancedTabCallout.title',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
@@ -26,6 +26,7 @@ import { i18n } from '@kbn/i18n';
 
 import { docLinks } from '../../../../../shared/doc_links';
 
+import { isAdvancedSyncRuleSnippetEmpty } from '../../../../utils/sync_rules_helpers';
 import { ConnectorViewLogic } from '../../../connector_detail/connector_view_logic';
 import { FilteringRulesTable } from '../../../shared/filtering_rules_table/filtering_rules_table';
 
@@ -40,6 +41,8 @@ export const ConnectorSyncRules: React.FC = () => {
     useActions(ConnectorFilteringLogic);
   const { advancedSnippet, draftErrors, draftState, filteringRules, hasDraft, isEditing } =
     useValues(ConnectorFilteringLogic);
+
+  const isAdvancedSnippetEmpty = isAdvancedSyncRuleSnippetEmpty(advancedSnippet);
 
   return (
     <>
@@ -92,7 +95,13 @@ export const ConnectorSyncRules: React.FC = () => {
                   })}
                 </p>
                 <p>
-                  <EuiLink href={docLinks.syncRules} external target="_blank">
+                  <EuiLink
+                    data-test-subj="entSearchContent-connector-syncRules-learnMoreLink"
+                    data-telemetry-id="entSearchContent-connector-syncRules-learnMoreLink"
+                    href={docLinks.syncRules}
+                    external
+                    target="_blank"
+                  >
                     {i18n.translate(
                       'xpack.enterpriseSearch.index.connector.syncRules.syncRulesLabel',
                       {
@@ -105,6 +114,7 @@ export const ConnectorSyncRules: React.FC = () => {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton
+                data-test-subj="enterpriseSearchConnectorSyncRulesButton"
                 data-telemetry-id="entSearchContent-connector-syncRules-editRules-editDraftRules"
                 color="primary"
                 onClick={() => setIsEditing(!isEditing)}
@@ -159,7 +169,7 @@ export const ConnectorSyncRules: React.FC = () => {
             </EuiPanel>
           </EuiFlexItem>
         )}
-        {hasAdvancedFilteringFeature && !!advancedSnippet && (
+        {hasAdvancedFilteringFeature && !isAdvancedSnippetEmpty && (
           <EuiFlexItem>
             <EuiPanel color="plain" hasShadow={false} hasBorder>
               <EuiFlexGroup direction="column">
@@ -186,7 +196,13 @@ export const ConnectorSyncRules: React.FC = () => {
                       )}
                     </p>
                     <p>
-                      <EuiLink external href={docLinks.syncRulesAdvanced} target="_blank">
+                      <EuiLink
+                        data-test-subj="entSearchContent-connector-syncRules-learnMoreLink"
+                        data-telemetry-id="entSearchContent-connector-syncRules-learnMoreLink"
+                        external
+                        href={docLinks.syncRulesAdvanced}
+                        target="_blank"
+                      >
                         {i18n.translate(
                           'xpack.enterpriseSearch.content.index.connector.syncRules.advancedFiltersLinkTitle',
                           {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/sync_rules_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/sync_rules_helpers.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const isAdvancedSyncRuleSnippetEmpty = (snippet: string | undefined | null) => {
+  if (!snippet) {
+    return true;
+  }
+  const trimmedSnippet = snippet.trim();
+
+  // quick hatch
+  if (trimmedSnippet === '{}' || trimmedSnippet === '[]') {
+    return true;
+  }
+
+  try {
+    const parsedJson = JSON.parse(trimmedSnippet);
+    if (Array.isArray(parsedJson)) {
+      return parsedJson.length === 0;
+    } else if (typeof parsedJson === 'object') {
+      return Object.keys(parsedJson).length === 0;
+    }
+  } catch (error) {
+    // we have somewhat invalid JSON in the advanced snippet,
+    // it is not empty and cause problems somewhere else
+    // we should handle it here so our pages doesn't crash
+    return false;
+  }
+  return false;
+};


### PR DESCRIPTION
<img width="616" alt="Screenshot 2024-04-26 at 12 02 42" src="https://github.com/elastic/kibana/assets/1410658/032676e7-4829-4b07-8fd5-ed16c7d46b43">
<img width="376" alt="Screenshot 2024-04-26 at 12 02 50" src="https://github.com/elastic/kibana/assets/1410658/a64e739f-b9c7-4d37-bc66-d653204dce8f">
<img width="364" alt="Screenshot 2024-04-26 at 12 04 32" src="https://github.com/elastic/kibana/assets/1410658/3f9311a6-0caa-42a0-a932-f0728fdf05f0">
<img width="273" alt="Screenshot 2024-04-26 at 12 04 39" src="https://github.com/elastic/kibana/assets/1410658/e704ba0d-b298-4e53-91be-9bd9eafa6855">


Moved empty check for advanced rules snippet to a function and updated it to cover empty array and object cases.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->