### PR TITLE
[Cloud Security] Remove aws-ebs from cloud security billing

### DIFF
--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.test.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.test.ts
@@ -203,7 +203,6 @@ describe('getSearchQueryByCloudSecuritySolution', () => {
           {
             terms: {
               'resource.sub_type': [
-                'aws-ebs',
                 'aws-ec2',
                 'aws-s3',
                 'aws-rds',

--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/constants.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/constants.ts
@@ -49,7 +49,7 @@ export const BILLABLE_ASSETS_CONFIG = {
   [CSPM]: {
     filter_attribute: 'resource.sub_type',
     values: [
-      'aws-ebs',
+      // 'aws-ebs', we can't include EBS volumes until https://github.com/elastic/security-team/issues/9283 is resolved
       'aws-ec2',
       'aws-s3',
       'aws-rds',


### PR DESCRIPTION
## Summary

Due to the bug related to `aws-ebs` subtime we need to remove it from billable assets until https://github.com/elastic/security-team/issues/9283 is fixed and we don't find a way to report on the number of EBS volumes the user have

part of:
- https://github.com/elastic/security-team/issues/9189
