### PR TITLE
[Fleet] UI allow to edit agent policy with agent policy ALL permission

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
@@ -68,7 +68,7 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
     const {
       agents: { enabled: isFleetEnabled },
     } = useConfig();
-    const hasFleetAllPrivileges = useAuthz().fleet.all;
+    const hasAllAgentPoliciesPrivileges = useAuthz().fleet.allAgentPolicies;
     const refreshAgentPolicy = useAgentPolicyRefresh();
     const [agentPolicy, setAgentPolicy] = useState<AgentPolicy>({
       ...originalAgentPolicy,
@@ -228,7 +228,7 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
                         onClick={onSubmit}
                         isLoading={isLoading}
                         isDisabled={
-                          !hasFleetAllPrivileges ||
+                          !hasAllAgentPoliciesPrivileges ||
                           isLoading ||
                           Object.keys(validation).length > 0 ||
                           hasAdvancedSettingsErrors


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/180559

Fix editing the agent policy from the UI, we were not checking the correct permission, that PR fix that

## Test

I did not added any automated test.


### Manual test

Create a role and user with agent policy ALL and no other roles, and check you can update  agent policy settings.

<img width="993" alt="Screenshot 2024-04-26 at 8 50 07 AM" src="https://github.com/elastic/kibana/assets/1336873/4c19e4b3-a0fa-4b46-9c6e-21923bfe1014">



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->