### PR TITLE
[8.14] [Security Solution][Endpoint] Fix index names used to query agents and activity indexes for SentinelOne response actions (#181765)

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/sentinelone_data_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/sentinelone_data_generator.ts
@@ -9,7 +9,7 @@ import type { DeepPartial } from 'utility-types';
 import { merge } from 'lodash';
 import type { SearchResponse, SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { EndpointActionGenerator } from './endpoint_action_generator';
-import { SENTINEL_ONE_ACTIVITY_INDEX } from '../..';
+import { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from '../..';
 import type {
   LogsEndpointAction,
   SentinelOneActivityEsDoc,
@@ -61,7 +61,7 @@ export class SentinelOneDataGenerator extends EndpointActionGenerator {
   ): SearchHit<SentinelOneActivityEsDoc> {
     const hit = this.toEsSearchHit<SentinelOneActivityEsDoc>(
       this.generateActivityEsDoc(overrides),
-      SENTINEL_ONE_ACTIVITY_INDEX
+      SENTINEL_ONE_ACTIVITY_INDEX_PATTERN
     );
 
     hit.inner_hits = {

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/sentinel_one.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/sentinel_one.ts
@@ -6,6 +6,6 @@
  */
 
 /**
- * Index name where the SentinelOne activity log is written to by the SentinelOne integration
+ * Index pattern where the SentinelOne activity log is written to by the SentinelOne integration
  */
-export const SENTINEL_ONE_ACTIVITY_INDEX = 'logs-sentinel_one.activity-default';
+export const SENTINEL_ONE_ACTIVITY_INDEX_PATTERN = 'logs-sentinel_one.activity-*';

--- a/x-pack/plugins/security_solution/common/index.ts
+++ b/x-pack/plugins/security_solution/common/index.ts
@@ -22,7 +22,7 @@ export {
 export { ELASTIC_SECURITY_RULE_ID } from './detection_engine/constants';
 export { ENABLED_FIELD } from './detection_engine/rule_management/rule_fields';
 export { allowedExperimentalValues, type ExperimentalFeatures } from './experimental_features';
-export { SENTINEL_ONE_ACTIVITY_INDEX } from './endpoint/service/response_actions/sentinel_one';
+export { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from './endpoint/service/response_actions/sentinel_one';
 
 // Careful of exporting anything from this file as any file(s) you export here will cause your page bundle size to increase.
 // If you're using functions/types/etc... internally it's best to import directly from their paths than expose the functions/types/etc... here.

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../../../../common/endpoint/constants';
 import type { NormalizedExternalConnectorClient } from '../../..';
 import { applyEsClientSearchMock } from '../../../../mocks/utils.mock';
-import { SENTINEL_ONE_ACTIVITY_INDEX } from '../../../../../../common';
+import { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from '../../../../../../common';
 import { SentinelOneDataGenerator } from '../../../../../../common/endpoint/data_generators/sentinelone_data_generator';
 import type {
   EndpointActionResponse,
@@ -412,7 +412,7 @@ describe('SentinelOneActionsClient class', () => {
 
         applyEsClientSearchMock({
           esClientMock: classConstructorOptions.esClient,
-          index: SENTINEL_ONE_ACTIVITY_INDEX,
+          index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
           response: s1ActivitySearchResponse,
         });
       });
@@ -493,7 +493,7 @@ describe('SentinelOneActionsClient class', () => {
               sort: [{ 'sentinel_one.activity.updated_at': 'asc' }],
             },
           },
-          index: SENTINEL_ONE_ACTIVITY_INDEX,
+          index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
           query: {
             bool: {
               minimum_should_match: 1,
@@ -533,7 +533,7 @@ describe('SentinelOneActionsClient class', () => {
               sort: [{ 'sentinel_one.activity.updated_at': 'asc' }],
             },
           },
-          index: SENTINEL_ONE_ACTIVITY_INDEX,
+          index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
           query: {
             bool: {
               minimum_should_match: 1,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/sentinelone/sentinel_one_actions_client.ts
@@ -24,7 +24,7 @@ import type {
   NormalizedExternalConnectorClientExecuteOptions,
   NormalizedExternalConnectorClient,
 } from '../lib/normalized_external_connector_client';
-import { SENTINEL_ONE_ACTIVITY_INDEX } from '../../../../../../common';
+import { SENTINEL_ONE_ACTIVITY_INDEX_PATTERN } from '../../../../../../common';
 import { catchAndWrapError } from '../../../../utils';
 import type {
   CommonResponseActionMethodOptions,
@@ -473,7 +473,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
       };
 
       const searchRequestOptions: SearchRequest = {
-        index: SENTINEL_ONE_ACTIVITY_INDEX,
+        index: SENTINEL_ONE_ACTIVITY_INDEX_PATTERN,
         query,
         // There may be many documents for each host/agent, so we collapse it and only get back the
         // first one that came in after the isolate request was sent
@@ -493,7 +493,7 @@ export class SentinelOneActionsClient extends ResponseActionsClientImpl {
       };
 
       this.log.debug(
-        `searching for ${command} responses from [${SENTINEL_ONE_ACTIVITY_INDEX}] index with:\n${stringify(
+        `searching for ${command} responses from [${SENTINEL_ONE_ACTIVITY_INDEX_PATTERN}] index with:\n${stringify(
           searchRequestOptions,
           15
         )}`


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Security Solution][Endpoint] Fix index names used to query agents and activity indexes for SentinelOne response actions (#181765)](https://github.com/elastic/kibana/pull/181765)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-26T12:30:02Z","message":"[Security Solution][Endpoint] Fix index names used to query agents and activity indexes for SentinelOne response actions (#181765)\n\n## Summary\r\n\r\n- Changes the names of the Activity and Agents indexes to `*` patterns\r\nin order to account for when the SentinelOne integration is configured\r\nwith a namespace other than `default`","sha":"22faf26bb2326beeb3bdbdbbc67f730781aeedc8","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","Team:Defend Workflows","v8.14.0","v8.15.0"],"number":181765,"url":"https://github.com/elastic/kibana/pull/181765","mergeCommit":{"message":"[Security Solution][Endpoint] Fix index names used to query agents and activity indexes for SentinelOne response actions (#181765)\n\n## Summary\r\n\r\n- Changes the names of the Activity and Agents indexes to `*` patterns\r\nin order to account for when the SentinelOne integration is configured\r\nwith a namespace other than `default`","sha":"22faf26bb2326beeb3bdbdbbc67f730781aeedc8"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181765","number":181765,"mergeCommit":{"message":"[Security Solution][Endpoint] Fix index names used to query agents and activity indexes for SentinelOne response actions (#181765)\n\n## Summary\r\n\r\n- Changes the names of the Activity and Agents indexes to `*` patterns\r\nin order to account for when the SentinelOne integration is configured\r\nwith a namespace other than `default`","sha":"22faf26bb2326beeb3bdbdbbc67f730781aeedc8"}}]}] BACKPORT-->