### PR TITLE
[Search] Fix broken connector doc links

### DIFF
--- a/x-pack/plugins/search_connectors/common/constants.ts
+++ b/x-pack/plugins/search_connectors/common/constants.ts
@@ -8,6 +8,8 @@
 import { ConnectorClientSideDefinition } from './types';
 import { docLinks } from './doc_links';
 
+// needs to be a function because, docLinks are only populated with actual
+// documentation links in browser after SearchConnectorsPlugin starts
 export const getConnectorsDict = (): Record<string, ConnectorClientSideDefinition> => ({
   azure_blob_storage: {
     docsUrl: docLinks.connectorsAzureBlobStorage,

--- a/x-pack/plugins/search_connectors/common/constants.ts
+++ b/x-pack/plugins/search_connectors/common/constants.ts
@@ -8,7 +8,7 @@
 import { ConnectorClientSideDefinition } from './types';
 import { docLinks } from './doc_links';
 
-export const CONNECTORS_DICT: Record<string, ConnectorClientSideDefinition> = {
+export const getConnectorsDict = (): Record<string, ConnectorClientSideDefinition> => ({
   azure_blob_storage: {
     docsUrl: docLinks.connectorsAzureBlobStorage,
     externalAuthDocsUrl: 'https://learn.microsoft.com/azure/storage/common/authorize-data-access',
@@ -177,4 +177,4 @@ export const CONNECTORS_DICT: Record<string, ConnectorClientSideDefinition> = {
     externalDocsUrl: '',
     platinumOnly: true,
   },
-};
+});

--- a/x-pack/plugins/search_connectors/common/lib/connector_types.ts
+++ b/x-pack/plugins/search_connectors/common/lib/connector_types.ts
@@ -7,7 +7,8 @@
 
 import { IStaticAssets } from '@kbn/core-http-browser';
 import { ConnectorServerSideDefinition, CONNECTOR_DEFINITIONS } from '../connectors';
-import { CONNECTORS_DICT } from '../constants';
+import { getConnectorsDict } from '../constants';
+
 import { ConnectorDefinition } from '../types';
 
 // used on server and in browser before plugin start when we don't have docLinks yet
@@ -22,6 +23,8 @@ export function getConnectorTypes(staticAssets: IStaticAssets): ConnectorServerS
 
 // used in browser after pluginStart, when docLinks has been populated
 export function getConnectorFullTypes(staticAssets: IStaticAssets): ConnectorDefinition[] {
+  const CONNECTORS_DICT = getConnectorsDict();
+
   const CONNECTORS = CONNECTOR_DEFINITIONS.map((connector) => ({
     ...connector,
     ...(connector.serviceType && CONNECTORS_DICT[connector.serviceType]


### PR DESCRIPTION
## Summary

Make getConnectorDict a function to reflect docLinks being populated on the client side

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->