### PR TITLE
[Fleet] UI Fix readonly output replace secret button

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
@@ -42,6 +42,24 @@ describe('SecretFormRow', () => {
     expect(queryByText(initialValue)).not.toBeInTheDocument();
   });
 
+  it('should not enable the replace button if the row is disabled', () => {
+    const { getByText } = render(
+      <SecretFormRow
+        title={title}
+        initialValue={initialValue}
+        clear={clear}
+        useSecretsStorage={useSecretsStorage}
+        onToggleSecretStorage={onToggleSecretStorage}
+        cancelEdit={cancelEdit}
+        disabled={true}
+      >
+        <input id="myinput" type="text" value={initialValue} />
+      </SecretFormRow>
+    );
+
+    expect(getByText('Replace Test Secret')).toBeDisabled();
+  });
+
   it('should call the cancelEdit function when the cancel button is clicked', () => {
     const { getByText } = render(
       <SecretFormRow

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.test.tsx
@@ -57,7 +57,7 @@ describe('SecretFormRow', () => {
       </SecretFormRow>
     );
 
-    expect(getByText('Replace Test Secret')).toBeDisabled();
+    expect(getByText('Replace Test Secret').closest('button')).toBeDisabled();
   });
 
   it('should call the cancelEdit function when the cancel button is clicked', () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_secret_form_row.tsx
@@ -35,6 +35,7 @@ export const SecretFormRow: React.FC<{
   initialValue?: any;
   cancelEdit?: () => void;
   label?: JSX.Element;
+  disabled?: boolean;
 }> = ({
   fullWidth,
   error,
@@ -48,6 +49,7 @@ export const SecretFormRow: React.FC<{
   useSecretsStorage,
   isConvertedToSecret = false,
   label,
+  disabled,
 }) => {
   const hasInitialValue = !!initialValue;
   const [editMode, setEditMode] = useState(isConvertedToSecret || !initialValue);
@@ -64,6 +66,7 @@ export const SecretFormRow: React.FC<{
       </EuiText>
       <EuiSpacer size="s" />
       <EuiButtonEmpty
+        disabled={disabled}
         onClick={() => setEditMode(true)}
         color="primary"
         iconType="refresh"

--- a/x-pack/plugins/fleet/public/hooks/use_input.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_input.ts
@@ -128,6 +128,7 @@ export function useSecretInput(
       error: errors,
       isInvalid,
       initialValue,
+      disabled,
       clear: () => {
         setValue('');
       },


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/181121

That PR disable the `Replace password/certificates` for Output secrets if a user only have read access to settings

## UI Changes

Before
<img width="400" alt="Screenshot 2024-04-26 at 9 54 44 AM" src="https://github.com/elastic/kibana/assets/1336873/e4647787-07a8-4def-9df3-94f1d0a6e4dd">
After
<img width="300" alt="Screenshot 2024-04-26 at 9 55 53 AM" src="https://github.com/elastic/kibana/assets/1336873/aa7001a0-fb4e-453d-84a7-a6bf9edd687e">


## Tests

I updated unit test to add a scenario for disabled secrets

You can manually test this, by creating an output with secrets and check the replace is disabled when viewing the output with a  user with only`Fleet:Settings:Read` privileges


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->