### PR TITLE
[Security Solution] - use old flyout for user and host details when open within timeline (to avoid cell action bug)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
@@ -286,7 +286,8 @@ describe('HostName', () => {
     });
   });
 
-  test('should open expandable flyout in timeline', async () => {
+  // TODO re-enable this when the cell actions bug in timeline is fixed (see https://github.com/elastic/kibana/issues/181863)
+  test.skip('should open expandable flyout in timeline', async () => {
     (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation((feature: string) => {
       if (feature === 'newHostDetailsFlyout') return true;
       if (feature === 'expandableTimelineFlyoutEnabled') return true;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.tsx
@@ -50,9 +50,9 @@ const HostNameComponent: React.FC<Props> = ({
   value,
 }) => {
   const isNewHostDetailsFlyoutEnabled = useIsExperimentalFeatureEnabled('newHostDetailsFlyout');
-  const expandableTimelineFlyoutEnabled = useIsExperimentalFeatureEnabled(
-    'expandableTimelineFlyoutEnabled'
-  );
+  // const expandableTimelineFlyoutEnabled = useIsExperimentalFeatureEnabled(
+  //   'expandableTimelineFlyoutEnabled'
+  // );
   const { openRightPanel } = useExpandableFlyoutApi();
 
   const dispatch = useDispatch();
@@ -105,9 +105,12 @@ const HostNameComponent: React.FC<Props> = ({
       };
 
       if (
-        (isTimelineScope(timelineID) &&
-          isNewHostDetailsFlyoutEnabled &&
-          expandableTimelineFlyoutEnabled) ||
+        // TODO re-enable this when the cell actions bug in timeline is fixed (see https://github.com/elastic/kibana/issues/181863)
+        // (isTimelineScope(timelineID) &&
+        //   isNewHostDetailsFlyoutEnabled &&
+        //   expandableTimelineFlyoutEnabled) ||
+        // isNewHostDetailsFlyoutEnabled
+        !isTimelineScope(timelineID) &&
         isNewHostDetailsFlyoutEnabled
       ) {
         openNewFlyout();
@@ -119,7 +122,7 @@ const HostNameComponent: React.FC<Props> = ({
       contextId,
       dispatch,
       eventContext,
-      expandableTimelineFlyoutEnabled,
+      // expandableTimelineFlyoutEnabled,
       hostName,
       isDraggable,
       isInTimelineContext,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.test.tsx
@@ -260,7 +260,8 @@ describe('UserName', () => {
     });
   });
 
-  test('should open expandable flyout in timeline', async () => {
+  // TODO re-enable this when the cell actions bug in timeline is fixed (see https://github.com/elastic/kibana/issues/181863)
+  test.skip('should open expandable flyout in timeline', async () => {
     (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation((feature: string) => {
       if (feature === 'newUserDetailsFlyout') return true;
       if (feature === 'expandableTimelineFlyoutEnabled') return true;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.tsx
@@ -52,9 +52,9 @@ const UserNameComponent: React.FC<Props> = ({
   const dispatch = useDispatch();
   const eventContext = useContext(StatefulEventContext);
   const isNewUserDetailsFlyoutEnable = useIsExperimentalFeatureEnabled('newUserDetailsFlyout');
-  const expandableTimelineFlyoutEnabled = useIsExperimentalFeatureEnabled(
-    'expandableTimelineFlyoutEnabled'
-  );
+  // const expandableTimelineFlyoutEnabled = useIsExperimentalFeatureEnabled(
+  //   'expandableTimelineFlyoutEnabled'
+  // );
   const userName = `${value}`;
   const isInTimelineContext = userName && eventContext?.timelineID;
   const { openRightPanel } = useExpandableFlyoutApi();
@@ -104,9 +104,12 @@ const UserNameComponent: React.FC<Props> = ({
       };
 
       if (
-        (isTimelineScope(timelineID) &&
-          isNewUserDetailsFlyoutEnable &&
-          expandableTimelineFlyoutEnabled) ||
+        // TODO re-enable this when the cell actions bug in timeline is fixed (see https://github.com/elastic/kibana/issues/181863)
+        // (isTimelineScope(timelineID) &&
+        //   isNewUserDetailsFlyoutEnable &&
+        //   expandableTimelineFlyoutEnabled) ||
+        // isNewUserDetailsFlyoutEnable
+        !isTimelineScope(timelineID) &&
         isNewUserDetailsFlyoutEnable
       ) {
         openNewFlyout();
@@ -118,7 +121,7 @@ const UserNameComponent: React.FC<Props> = ({
       contextId,
       dispatch,
       eventContext,
-      expandableTimelineFlyoutEnabled,
+      // expandableTimelineFlyoutEnabled,
       isDraggable,
       isInTimelineContext,
       isNewUserDetailsFlyoutEnable,


### PR DESCRIPTION
### Notes

**The intend is to merge this PR if we cannot fix the issue during the BC period.**

## Summary

A bug was introduced when we merged [the PR](https://github.com/elastic/kibana/pull/177087) that enabled the expandable flyout for alerts, hosts and users within timeline. The bug was raised [here](https://github.com/elastic/kibana/pull/177087#pullrequestreview-1897976158) and here's [the ticket](https://github.com/elastic/kibana/issues/181863) for it.

At the time we decided to merge the code anyway as the bug was hidden behind a feature flag that was turned off by default. We'd like to turn on the feature flag, but the fix seems to be a big complex and involved.

This PR makes very small changes to revert the use of the expandable flyout for hosts and users within timeline, until we can fix the actual issue.

https://github.com/elastic/kibana/assets/17276605/98324a68-87a5-4639-a32a-a6e3d304908e