### PR TITLE
[8.14] [Bug][Investigations] - Fix eql tab scrolling (#181763)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -162,7 +162,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   );
 
   return (
-    <> 
+    <>
       <InPortal node={eqlEventsCountPortalNode}>
         {totalCount >= 0 ? <EventsCountBadge>{totalCount}</EventsCountBadge> : null}
       </InPortal>
@@ -214,52 +214,52 @@ export const EqlTabContentComponent: React.FC<Props> = ({
           <TabHeaderContainer data-test-subj="timelineHeader">
             <EqlQueryBarTimeline timelineId={timelineId} />
           </TabHeaderContainer>
-            <EventDetailsWidthProvider>
-              <StyledEuiFlyoutBody
-                data-test-subj={`${TimelineTabs.eql}-tab-flyout-body`}
-                className="timeline-flyout-body"
-              >
-                <StatefulBody
-                  activePage={pageInfo.activePage}
-                  browserFields={browserFields}
-                  data={isBlankTimeline ? EMPTY_EVENTS : events}
-                  id={timelineId}
-                  refetch={refetch}
-                  renderCellValue={renderCellValue}
-                  rowRenderers={rowRenderers}
-                  sort={NO_SORTING}
-                  tabType={TimelineTabs.eql}
-                  totalPages={calculateTotalPages({
-                    itemsCount: totalCount,
-                    itemsPerPage,
-                  })}
-                  leadingControlColumns={leadingControlColumns}
-                  trailingControlColumns={trailingControlColumns}
-                />
-              </StyledEuiFlyoutBody>
+          <EventDetailsWidthProvider>
+            <StyledEuiFlyoutBody
+              data-test-subj={`${TimelineTabs.eql}-tab-flyout-body`}
+              className="timeline-flyout-body"
+            >
+              <StatefulBody
+                activePage={pageInfo.activePage}
+                browserFields={browserFields}
+                data={isBlankTimeline ? EMPTY_EVENTS : events}
+                id={timelineId}
+                refetch={refetch}
+                renderCellValue={renderCellValue}
+                rowRenderers={rowRenderers}
+                sort={NO_SORTING}
+                tabType={TimelineTabs.eql}
+                totalPages={calculateTotalPages({
+                  itemsCount: totalCount,
+                  itemsPerPage,
+                })}
+                leadingControlColumns={leadingControlColumns}
+                trailingControlColumns={trailingControlColumns}
+              />
+            </StyledEuiFlyoutBody>
 
-              <StyledEuiFlyoutFooter
-                data-test-subj={`${TimelineTabs.eql}-tab-flyout-footer`}
-                className="timeline-flyout-footer"
-              >
-                {!isBlankTimeline && (
-                  <Footer
-                    activePage={pageInfo?.activePage ?? 0}
-                    data-test-subj="timeline-footer"
-                    updatedAt={refreshedAt}
-                    height={footerHeight}
-                    id={timelineId}
-                    isLive={isLive}
-                    isLoading={isQueryLoading || loadingSourcerer}
-                    itemsCount={isBlankTimeline ? 0 : events.length}
-                    itemsPerPage={itemsPerPage}
-                    itemsPerPageOptions={itemsPerPageOptions}
-                    onChangePage={loadPage}
-                    totalCount={isBlankTimeline ? 0 : totalCount}
-                  />
-                )}
-              </StyledEuiFlyoutFooter>
-            </EventDetailsWidthProvider>
+            <StyledEuiFlyoutFooter
+              data-test-subj={`${TimelineTabs.eql}-tab-flyout-footer`}
+              className="timeline-flyout-footer"
+            >
+              {!isBlankTimeline && (
+                <Footer
+                  activePage={pageInfo?.activePage ?? 0}
+                  data-test-subj="timeline-footer"
+                  updatedAt={refreshedAt}
+                  height={footerHeight}
+                  id={timelineId}
+                  isLive={isLive}
+                  isLoading={isQueryLoading || loadingSourcerer}
+                  itemsCount={isBlankTimeline ? 0 : events.length}
+                  itemsPerPage={itemsPerPage}
+                  itemsPerPageOptions={itemsPerPageOptions}
+                  onChangePage={loadPage}
+                  totalCount={isBlankTimeline ? 0 : totalCount}
+                />
+              )}
+            </StyledEuiFlyoutFooter>
+          </EventDetailsWidthProvider>
         </ScrollableFlexItem>
         {showExpandedDetails && (
           <>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -162,7 +162,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   );
 
   return (
-    <>
+    <> 
       <InPortal node={eqlEventsCountPortalNode}>
         {totalCount >= 0 ? <EventsCountBadge>{totalCount}</EventsCountBadge> : null}
       </InPortal>
@@ -175,97 +175,91 @@ export const EqlTabContentComponent: React.FC<Props> = ({
       />
       <FullWidthFlexGroup>
         <ScrollableFlexItem grow={2}>
-          <EuiFlexGroup gutterSize="s" direction="column">
-            <EuiFlexItem grow={false}>
-              <StyledEuiFlyoutHeader
-                data-test-subj={`${activeTab}-tab-flyout-header`}
-                hasBorder={false}
+          <EuiFlexItem grow={false}>
+            <StyledEuiFlyoutHeader
+              data-test-subj={`${activeTab}-tab-flyout-header`}
+              hasBorder={false}
+            >
+              <EuiFlexGroup
+                className="euiScrollBar"
+                alignItems="flexStart"
+                gutterSize="s"
+                data-test-subj="timeline-date-picker-container"
+                responsive={false}
               >
-                <TabHeaderContainer data-test-subj="timelineHeader">
-                  <EuiFlexGroup
-                    className="euiScrollBar"
-                    alignItems="flexStart"
-                    gutterSize="s"
-                    data-test-subj="timeline-date-picker-container"
-                    responsive={false}
-                  >
-                    {timelineFullScreen && setTimelineFullScreen != null && (
-                      <ExitFullScreen
-                        fullScreen={timelineFullScreen}
-                        setFullScreen={setTimelineFullScreen}
-                      />
-                    )}
-                    <EuiFlexItem grow={false}>
-                      {activeTab === TimelineTabs.eql && (
-                        <Sourcerer scope={SourcererScopeName.timeline} />
-                      )}
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <SuperDatePicker
-                        width="auto"
-                        id={InputsModelId.timeline}
-                        timelineId={timelineId}
-                      />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <TimelineDatePickerLock />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </TabHeaderContainer>
-              </StyledEuiFlyoutHeader>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EqlQueryBarTimeline timelineId={timelineId} />
-            </EuiFlexItem>
-            <EuiFlexItem grow={true}>
-              <EventDetailsWidthProvider>
-                <StyledEuiFlyoutBody
-                  data-test-subj={`${TimelineTabs.eql}-tab-flyout-body`}
-                  className="timeline-flyout-body"
-                >
-                  <StatefulBody
-                    activePage={pageInfo.activePage}
-                    browserFields={browserFields}
-                    data={isBlankTimeline ? EMPTY_EVENTS : events}
-                    id={timelineId}
-                    refetch={refetch}
-                    renderCellValue={renderCellValue}
-                    rowRenderers={rowRenderers}
-                    sort={NO_SORTING}
-                    tabType={TimelineTabs.eql}
-                    totalPages={calculateTotalPages({
-                      itemsCount: totalCount,
-                      itemsPerPage,
-                    })}
-                    leadingControlColumns={leadingControlColumns}
-                    trailingControlColumns={trailingControlColumns}
+                {timelineFullScreen && setTimelineFullScreen != null && (
+                  <ExitFullScreen
+                    fullScreen={timelineFullScreen}
+                    setFullScreen={setTimelineFullScreen}
                   />
-                </StyledEuiFlyoutBody>
-
-                <StyledEuiFlyoutFooter
-                  data-test-subj={`${TimelineTabs.eql}-tab-flyout-footer`}
-                  className="timeline-flyout-footer"
-                >
-                  {!isBlankTimeline && (
-                    <Footer
-                      activePage={pageInfo?.activePage ?? 0}
-                      data-test-subj="timeline-footer"
-                      updatedAt={refreshedAt}
-                      height={footerHeight}
-                      id={timelineId}
-                      isLive={isLive}
-                      isLoading={isQueryLoading || loadingSourcerer}
-                      itemsCount={isBlankTimeline ? 0 : events.length}
-                      itemsPerPage={itemsPerPage}
-                      itemsPerPageOptions={itemsPerPageOptions}
-                      onChangePage={loadPage}
-                      totalCount={isBlankTimeline ? 0 : totalCount}
-                    />
+                )}
+                <EuiFlexItem grow={false}>
+                  {activeTab === TimelineTabs.eql && (
+                    <Sourcerer scope={SourcererScopeName.timeline} />
                   )}
-                </StyledEuiFlyoutFooter>
-              </EventDetailsWidthProvider>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <SuperDatePicker
+                    width="auto"
+                    id={InputsModelId.timeline}
+                    timelineId={timelineId}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <TimelineDatePickerLock />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </StyledEuiFlyoutHeader>
+          </EuiFlexItem>
+          <TabHeaderContainer data-test-subj="timelineHeader">
+            <EqlQueryBarTimeline timelineId={timelineId} />
+          </TabHeaderContainer>
+            <EventDetailsWidthProvider>
+              <StyledEuiFlyoutBody
+                data-test-subj={`${TimelineTabs.eql}-tab-flyout-body`}
+                className="timeline-flyout-body"
+              >
+                <StatefulBody
+                  activePage={pageInfo.activePage}
+                  browserFields={browserFields}
+                  data={isBlankTimeline ? EMPTY_EVENTS : events}
+                  id={timelineId}
+                  refetch={refetch}
+                  renderCellValue={renderCellValue}
+                  rowRenderers={rowRenderers}
+                  sort={NO_SORTING}
+                  tabType={TimelineTabs.eql}
+                  totalPages={calculateTotalPages({
+                    itemsCount: totalCount,
+                    itemsPerPage,
+                  })}
+                  leadingControlColumns={leadingControlColumns}
+                  trailingControlColumns={trailingControlColumns}
+                />
+              </StyledEuiFlyoutBody>
+
+              <StyledEuiFlyoutFooter
+                data-test-subj={`${TimelineTabs.eql}-tab-flyout-footer`}
+                className="timeline-flyout-footer"
+              >
+                {!isBlankTimeline && (
+                  <Footer
+                    activePage={pageInfo?.activePage ?? 0}
+                    data-test-subj="timeline-footer"
+                    updatedAt={refreshedAt}
+                    height={footerHeight}
+                    id={timelineId}
+                    isLive={isLive}
+                    isLoading={isQueryLoading || loadingSourcerer}
+                    itemsCount={isBlankTimeline ? 0 : events.length}
+                    itemsPerPage={itemsPerPage}
+                    itemsPerPageOptions={itemsPerPageOptions}
+                    onChangePage={loadPage}
+                    totalCount={isBlankTimeline ? 0 : totalCount}
+                  />
+                )}
+              </StyledEuiFlyoutFooter>
+            </EventDetailsWidthProvider>
         </ScrollableFlexItem>
         {showExpandedDetails && (
           <>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/layout.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/layout.tsx
@@ -16,6 +16,7 @@ import {
 import styled from 'styled-components';
 
 export const TabHeaderContainer = styled.div`
+  margin-top: ${(props) => props.theme.eui.euiSizeS};
   width: 100%;
 `;
 
@@ -26,6 +27,7 @@ export const StyledEuiFlyoutHeader = styled(EuiFlyoutHeader)`
   box-shadow: none;
   display: flex;
   flex-direction: column;
+  padding: 0;
 
   &.euiFlyoutHeader {
     ${({ theme }) => `padding: ${theme.eui.euiSizeS} 0 0 0;`}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Bug][Investigations] - Fix eql tab scrolling (#181763)](https://github.com/elastic/kibana/pull/181763)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Michael Olorunnisola","email":"michael.olorunnisola@elastic.co"},"sourceCommit":{"committedDate":"2024-04-26T14:55:43Z","message":"[Bug][Investigations] - Fix eql tab scrolling (#181763)\n\n## Summary\r\n\r\nThis issue only affects 8.14.\r\n\r\nSome wrappers were added unnecessarily to the correlations tab in\r\nTimeline preventing users from scrolling in this PR:\r\nhttps://github.com/elastic/kibana/pull/179832\r\n\r\nThis PR fixes it by placing the structure more in line with how it was\r\nprior here:\r\nhttps://github.com/elastic/kibana/pull/179832/files#diff-a11ba69be2253bc1c3183eb6589e3f30b9ec6e77353364208e906526712562fe\r\n\r\nThe fix:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17211684/fc288ab8-3cbf-4f4d-8303-4fb5e970dfcd","sha":"11eb39b4b6aa9eada1b7c3e63dc1490762d9d8ea","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Threat Hunting:Investigations","v8.14.0","v8.15.0"],"number":181763,"url":"https://github.com/elastic/kibana/pull/181763","mergeCommit":{"message":"[Bug][Investigations] - Fix eql tab scrolling (#181763)\n\n## Summary\r\n\r\nThis issue only affects 8.14.\r\n\r\nSome wrappers were added unnecessarily to the correlations tab in\r\nTimeline preventing users from scrolling in this PR:\r\nhttps://github.com/elastic/kibana/pull/179832\r\n\r\nThis PR fixes it by placing the structure more in line with how it was\r\nprior here:\r\nhttps://github.com/elastic/kibana/pull/179832/files#diff-a11ba69be2253bc1c3183eb6589e3f30b9ec6e77353364208e906526712562fe\r\n\r\nThe fix:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17211684/fc288ab8-3cbf-4f4d-8303-4fb5e970dfcd","sha":"11eb39b4b6aa9eada1b7c3e63dc1490762d9d8ea"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181763","number":181763,"mergeCommit":{"message":"[Bug][Investigations] - Fix eql tab scrolling (#181763)\n\n## Summary\r\n\r\nThis issue only affects 8.14.\r\n\r\nSome wrappers were added unnecessarily to the correlations tab in\r\nTimeline preventing users from scrolling in this PR:\r\nhttps://github.com/elastic/kibana/pull/179832\r\n\r\nThis PR fixes it by placing the structure more in line with how it was\r\nprior here:\r\nhttps://github.com/elastic/kibana/pull/179832/files#diff-a11ba69be2253bc1c3183eb6589e3f30b9ec6e77353364208e906526712562fe\r\n\r\nThe fix:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17211684/fc288ab8-3cbf-4f4d-8303-4fb5e970dfcd","sha":"11eb39b4b6aa9eada1b7c3e63dc1490762d9d8ea"}}]}] BACKPORT-->