### PR TITLE
[Observability Onboarding] Move data-test-subj for first question

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -158,10 +158,12 @@ export const OnboardingFlowForm: FunctionComponent = () => {
       <EuiSpacer size="m" />
       <EuiFlexGroup css={{ ...customMargin, maxWidth: '560px' }} gutterSize="l" direction="column">
         {options.map((option) => (
-          <EuiFlexItem key={option.id}>
+          <EuiFlexItem
+            key={option.id}
+            data-test-subj={`observabilityOnboardingUseCaseCard-${option.id}`}
+          >
             <EuiCheckableCard
               id={`${radioGroupId}_${option.id}`}
-              data-test-subj={`observabilityOnboardingUseCaseCard-${option.id}`}
               name={radioGroupId}
               label={
                 <>


### PR DESCRIPTION
The data-test-subj of the first question was only set on the radio button which means it's not recorded when the text is clicked.

This moves it up to the wrapping element so it's always captured correctly.