### PR TITLE
[Cloud Security] add azure-storage-account for csp billing

### DIFF
--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.test.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.test.ts
@@ -216,7 +216,6 @@ describe('getSearchQueryByCloudSecuritySolution', () => {
                 'azure-storage-account',
                 'azure-vm',
                 'gcp-bigquery-dataset',
-                'gcp-bigquery-table',
                 'gcp-compute-disk',
                 'gcp-compute-instance',
                 'gcp-sqladmin-instance',

--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.test.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/cloud_security_metering_task.test.ts
@@ -213,6 +213,7 @@ describe('getSearchQueryByCloudSecuritySolution', () => {
                 'azure-mysql-server-db',
                 'azure-postgresql-server-db',
                 'azure-sql-server',
+                'azure-storage-account',
                 'azure-vm',
                 'gcp-bigquery-dataset',
                 'gcp-bigquery-table',

--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/constants.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/constants.ts
@@ -60,6 +60,7 @@ export const BILLABLE_ASSETS_CONFIG = {
       'azure-mysql-server-db',
       'azure-postgresql-server-db',
       'azure-sql-server',
+      'azure-storage-account',
       'azure-vm',
       'gcp-bigquery-dataset',
       'gcp-bigquery-table',

--- a/x-pack/plugins/security_solution_serverless/server/cloud_security/constants.ts
+++ b/x-pack/plugins/security_solution_serverless/server/cloud_security/constants.ts
@@ -63,7 +63,6 @@ export const BILLABLE_ASSETS_CONFIG = {
       'azure-storage-account',
       'azure-vm',
       'gcp-bigquery-dataset',
-      'gcp-bigquery-table',
       'gcp-compute-disk',
       'gcp-compute-instance',
       'gcp-sqladmin-instance',


### PR DESCRIPTION
## Summary

Initially `azure-storage-account` wasn't included in the billing due to unclear relationship with the actual number of Azure blob storage assets. But as we don't have a better way to count storage assets in Azure we should include it.

Also removing `gcp-bigquery-table` from assets as per discussion with @smriti0321 

Part of:
- https://github.com/elastic/security-team/issues/9146