### PR TITLE
[Profiling] Differential views based on same data show different values

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/e2e/cypress/e2e/profiling_views/differential_functions.cy.ts
+++ b/x-pack/plugins/observability_solution/profiling/e2e/cypress/e2e/profiling_views/differential_functions.cy.ts
@@ -31,9 +31,9 @@ describe('Differential Functions page', () => {
       cy.wait('@getTopNFunctions');
       [
         { id: 'overallPerformance', value: '0%' },
-        { id: 'annualizedCo2', value: '79.81 lbs / 36.2 kg' },
-        { id: 'annualizedCost', value: '$341.05' },
-        { id: 'totalNumberOfSamples', value: '17,186' },
+        { id: 'annualizedCo2', value: '74.49 lbs / 33.79 kg' },
+        { id: 'annualizedCost', value: '$318.32' },
+        { id: 'totalNumberOfSamples', value: '513' },
       ].forEach((item) => {
         cy.get(`[data-test-subj="${item.id}_value"]`).contains(item.value);
         cy.get(`[data-test-subj="${item.id}_comparison_value"]`).should('not.exist');
@@ -50,9 +50,9 @@ describe('Differential Functions page', () => {
       cy.wait('@getTopNFunctions');
       [
         { id: 'overallPerformance', value: '0%' },
-        { id: 'annualizedCo2', value: '0 lbs / 0 kg', comparisonValue: '79.81 lbs / 36.2 kg' },
-        { id: 'annualizedCost', value: '$0', comparisonValue: '$341.05' },
-        { id: 'totalNumberOfSamples', value: '0', comparisonValue: '515,580' },
+        { id: 'annualizedCo2', value: '0 lbs / 0 kg', comparisonValue: '74.49 lbs / 33.79 kg' },
+        { id: 'annualizedCost', value: '$0', comparisonValue: '$318.32' },
+        { id: 'totalNumberOfSamples', value: '0', comparisonValue: '15,390' },
       ].forEach((item) => {
         cy.get(`[data-test-subj="${item.id}_value"]`).contains(item.value);
         if (item.comparisonValue) {
@@ -73,23 +73,23 @@ describe('Differential Functions page', () => {
       cy.wait('@getTopNFunctions');
       cy.wait('@getTopNFunctions');
       [
-        { id: 'overallPerformance', value: '78.01%', icon: 'sortUp_success' },
+        { id: 'overallPerformance', value: '65.89%', icon: 'sortUp_success' },
         {
           id: 'annualizedCo2',
-          value: '9.81 lbs / 36.2 kg',
-          comparisonValue: '28.23 lbs / 12.81 kg (64.62%)',
+          value: '74.49 lbs / 33.79 kg',
+          comparisonValue: '25.41 lbs / 11.53 kg (65.89%)',
           icon: 'comparison_sortUp_success',
         },
         {
           id: 'annualizedCost',
-          value: '$341.05',
-          comparisonValue: '$120.65 (64.62%)',
+          value: '$318.32',
+          comparisonValue: '$108.59 (65.89%)',
           icon: 'comparison_sortUp_success',
         },
         {
           id: 'totalNumberOfSamples',
-          value: '17,186',
-          comparisonValue: '3,780 (78.01%)',
+          value: '513',
+          comparisonValue: '175 (65.89%)',
           icon: 'comparison_sortUp_success',
         },
       ].forEach((item) => {
@@ -113,23 +113,23 @@ describe('Differential Functions page', () => {
       cy.wait('@getTopNFunctions');
       cy.wait('@getTopNFunctions');
       [
-        { id: 'overallPerformance', value: '354.66%', icon: 'sortDown_danger' },
+        { id: 'overallPerformance', value: '193.14%', icon: 'sortDown_danger' },
         {
           id: 'annualizedCo2',
-          value: '28.23 lbs / 12.81 kg',
-          comparisonValue: '79.81 lbs / 36.2 kg (182.67%)',
+          value: '25.41 lbs / 11.53 kg',
+          comparisonValue: '74.49 lbs / 33.79 kg (193.14%)',
           icon: 'comparison_sortDown_danger',
         },
         {
           id: 'annualizedCost',
-          value: '$120.65',
-          comparisonValue: '$341.05 (182.67%)',
+          value: '$108.59',
+          comparisonValue: '$318.32 (193.14%)',
           icon: 'comparison_sortDown_danger',
         },
         {
           id: 'totalNumberOfSamples',
-          value: '3,780',
-          comparisonValue: '17,186 (354.66%)',
+          value: '175',
+          comparisonValue: '513 (193.14%)',
           icon: 'comparison_sortDown_danger',
         },
       ].forEach((item) => {

--- a/x-pack/plugins/observability_solution/profiling/e2e/cypress/e2e/profiling_views/functions.cy.ts
+++ b/x-pack/plugins/observability_solution/profiling/e2e/cypress/e2e/profiling_views/functions.cy.ts
@@ -38,8 +38,8 @@ describe('Functions page', () => {
     cy.get(firstRowSelector).eq(2).contains('vmlinux');
     cy.get(firstRowSelector).eq(3).contains('0.16%');
     cy.get(firstRowSelector).eq(4).contains('0.16%');
-    cy.get(firstRowSelector).eq(5).contains('4.41 lbs / 2 kg');
-    cy.get(firstRowSelector).eq(6).contains('$18.61');
+    cy.get(firstRowSelector).eq(5).contains('3.97 lbs / 1.8 kg');
+    cy.get(firstRowSelector).eq(6).contains('$17.37');
     cy.get(firstRowSelector).eq(7).contains('28');
   });
 
@@ -66,16 +66,16 @@ describe('Functions page', () => {
       { parentKey: 'impactEstimates', key: 'annualizedSelfCoreSeconds', value: '17.03 days' },
       { parentKey: 'impactEstimates', key: 'co2Emission', value: '~0.00 lbs / ~0.00 kg' },
       { parentKey: 'impactEstimates', key: 'selfCo2Emission', value: '~0.00 lbs / ~0.00 kg' },
-      { parentKey: 'impactEstimates', key: 'annualizedCo2Emission', value: '4.41 lbs / 2 kg' },
+      { parentKey: 'impactEstimates', key: 'annualizedCo2Emission', value: '3.97 lbs / 1.8 kg' },
       {
         parentKey: 'impactEstimates',
         key: 'annualizedSelfCo2Emission',
-        value: '4.41 lbs / 2 kg',
+        value: '3.97 lbs / 1.8 kg',
       },
       { parentKey: 'impactEstimates', key: 'dollarCost', value: '$~0.00' },
       { parentKey: 'impactEstimates', key: 'selfDollarCost', value: '$~0.00' },
-      { parentKey: 'impactEstimates', key: 'annualizedDollarCost', value: '$18.61' },
-      { parentKey: 'impactEstimates', key: 'annualizedSelfDollarCost', value: '$18.61' },
+      { parentKey: 'impactEstimates', key: 'annualizedDollarCost', value: '$17.37' },
+      { parentKey: 'impactEstimates', key: 'annualizedSelfDollarCost', value: '$17.37' },
     ].forEach(({ parentKey, key, value }) => {
       cy.get(`[data-test-subj="${parentKey}_${key}"]`).contains(value);
     });
@@ -134,7 +134,7 @@ describe('Functions page', () => {
         columnIndex: 5,
         highRank: 693,
         lowRank: 44,
-        highValue: '48.28 lbs / 21.9 kg',
+        highValue: '44.97 lbs / 20.4 kg',
         lowValue: '0 lbs / 0 kg',
       },
       {
@@ -142,8 +142,8 @@ describe('Functions page', () => {
         columnIndex: 6,
         highRank: 693,
         lowRank: 44,
-        highValue: '$206.09',
-        lowValue: '$0.66',
+        highValue: '$192.36',
+        lowValue: '$0.62',
       },
     ].forEach(({ columnKey, columnIndex, highRank, highValue, lowRank, lowValue }) => {
       cy.get(`[data-test-subj="dataGridHeaderCell-${columnKey}"]`).click();
@@ -189,7 +189,7 @@ describe('Functions page', () => {
       const firstRowSelector = '[data-grid-row-index="0"] [data-test-subj="dataGridRowCell"]';
       cy.get(firstRowSelector).eq(1).contains('1');
       cy.get(firstRowSelector).eq(2).contains('vmlinux');
-      cy.get(firstRowSelector).eq(5).contains('4.41 lbs / 2 kg');
+      cy.get(firstRowSelector).eq(5).contains('3.97 lbs / 1.8 kg');
       cy.contains('Settings').click();
       cy.contains('Advanced Settings');
       cy.get(`[data-test-subj="management-settings-editField-${profilingCo2PerKWH}"]`)
@@ -208,7 +208,7 @@ describe('Functions page', () => {
       });
       cy.go('back');
       cy.wait('@getTopNFunctions');
-      cy.get(firstRowSelector).eq(5).contains('2k lbs / 908.4 kg');
+      cy.get(firstRowSelector).eq(5).contains('1.87k lbs / 847.8 kg');
       const firstRowSelectorActionButton =
         '[data-grid-row-index="0"] [data-test-subj="dataGridRowCell"] .euiButtonIcon';
       cy.get(firstRowSelectorActionButton).click();
@@ -218,12 +218,12 @@ describe('Functions page', () => {
         {
           parentKey: 'impactEstimates',
           key: 'annualizedCo2Emission',
-          value: '2k lbs / 908.4 kg',
+          value: '1.87k lbs / 847.8 kg',
         },
         {
           parentKey: 'impactEstimates',
           key: 'annualizedSelfCo2Emission',
-          value: '2k lbs / 908.4 kg',
+          value: '1.87k lbs / 847.8 kg',
         },
       ].forEach(({ parentKey, key, value }) => {
         cy.get(`[data-test-subj="${parentKey}_${key}"]`).contains(value);

--- a/x-pack/plugins/observability_solution/profiling/public/views/functions/differential_topn/index.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/views/functions/differential_topn/index.tsx
@@ -173,7 +173,7 @@ export function DifferentialTopNFunctionsView() {
               baseValue={
                 state.data
                   ? {
-                      totalCount: state.data.TotalCount,
+                      totalCount: state.data.selfCPU,
                       scaleFactor: isNormalizedByTime ? baselineTime : baseline,
                       totalAnnualCO2Kgs: state.data.totalAnnualCO2Kgs,
                       totalAnnualCostUSD: state.data.totalAnnualCostUSD,
@@ -183,7 +183,7 @@ export function DifferentialTopNFunctionsView() {
               comparisonValue={
                 comparisonState.data
                   ? {
-                      totalCount: comparisonState.data.TotalCount,
+                      totalCount: comparisonState.data.selfCPU,
                       scaleFactor: isNormalizedByTime ? comparisonTime : comparison,
                       totalAnnualCO2Kgs: comparisonState.data.totalAnnualCO2Kgs,
                       totalAnnualCostUSD: comparisonState.data.totalAnnualCostUSD,

--- a/x-pack/plugins/observability_solution/profiling/server/routes/functions.ts
+++ b/x-pack/plugins/observability_solution/profiling/server/routes/functions.ts
@@ -67,6 +67,7 @@ export function registerTopNFunctionsSearchRoute({
         const useStacktracesAPI = await core.uiSettings.client.get<boolean>(
           profilingFetchTopNFunctionsFromStacktraces
         );
+        const totalSeconds = endSecs - startSecs;
 
         const topNFunctions = useStacktracesAPI
           ? await profilingDataAccess.services.fetchFunctions({
@@ -74,7 +75,7 @@ export function registerTopNFunctionsSearchRoute({
               esClient,
               startIndex,
               endIndex,
-              totalSeconds: endSecs - startSecs,
+              totalSeconds,
               query,
             })
           : await profilingDataAccess.services.fetchESFunctions({
@@ -82,6 +83,7 @@ export function registerTopNFunctionsSearchRoute({
               esClient,
               query,
               aggregationField: 'service.name',
+              totalSeconds,
             });
 
         return response.ok({

--- a/x-pack/plugins/observability_solution/profiling_data_access/common/profiling_es_client.ts
+++ b/x-pack/plugins/observability_solution/profiling_data_access/common/profiling_es_client.ts
@@ -65,5 +65,6 @@ export interface ProfilingESClient {
     awsCostDiscountRate?: number;
     azureCostDiscountRate?: number;
     costPervCPUPerHour?: number;
+    durationSeconds: number;
   }): Promise<ESTopNFunctions>;
 }

--- a/x-pack/plugins/observability_solution/profiling_data_access/server/services/functions/es_functions.ts
+++ b/x-pack/plugins/observability_solution/profiling_data_access/server/services/functions/es_functions.ts
@@ -33,6 +33,7 @@ export interface FetchFunctionsParams {
   query: QueryDslQueryContainer;
   aggregationField?: AggregationField;
   limit?: number;
+  totalSeconds: number;
 }
 
 const targetSampleSize = 20000; // minimum number of samples to get statistically sound results
@@ -46,6 +47,7 @@ export function createFetchESFunctions({ createProfilingEsClient }: RegisterServ
     query,
     aggregationField,
     limit,
+    totalSeconds,
   }: FetchFunctionsParams) => {
     const [
       co2PerKWH,
@@ -82,6 +84,7 @@ export function createFetchESFunctions({ createProfilingEsClient }: RegisterServ
       awsCostDiscountRate: percentToFactor(awsCostDiscountRate),
       costPervCPUPerHour,
       azureCostDiscountRate: percentToFactor(azureCostDiscountRate),
+      durationSeconds: totalSeconds,
     });
 
     return transformToKibanaTopNFunction(esTopNFunctions);

--- a/x-pack/plugins/observability_solution/profiling_data_access/server/utils/create_profiling_es_client.ts
+++ b/x-pack/plugins/observability_solution/profiling_data_access/server/utils/create_profiling_es_client.ts
@@ -165,6 +165,7 @@ export function createProfilingEsClient({
       azureCostDiscountRate,
       sampleSize,
       limit,
+      durationSeconds,
     }) {
       const controller = new AbortController();
 
@@ -187,6 +188,7 @@ export function createProfilingEsClient({
               aws_cost_factor: awsCostDiscountRate,
               cost_per_core_hour: costPervCPUPerHour,
               azure_cost_factor: azureCostDiscountRate,
+              requested_duration: durationSeconds,
             },
           },
           {


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/180677
closes https://github.com/elastic/kibana/issues/181886

There's still a small difference on the CO2 values, but that's due to different formats returned by ES apis:
```
TopN Functions
"self_annual_co2_tons": 0.0068555964801996295

Flamegraph
"AnnualCO2TonsInclusive": [
    0.0069,
```

After:
<img width="1765" alt="Screenshot 2024-04-29 at 16 34 57" src="https://github.com/elastic/kibana/assets/55978943/092a704f-69fe-4dd0-99d5-9ac9bce77188">
<img width="1788" alt="Screenshot 2024-04-29 at 16 35 03" src="https://github.com/elastic/kibana/assets/55978943/da4a1406-fad7-48de-81ac-e8aae64cba67">


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->