### PR TITLE
[Fix] fix type issues from unparameterized PropsWithChildren type usages

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -70,6 +70,16 @@ steps:
         - exit_status: '-1'
           limit: 3
 
+  - command: .buildkite/scripts/steps/check_types.sh
+    label: 'Check Types'
+    agents:
+      queue: n2-4-spot
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'
     agents:

--- a/packages/core/i18n/core-i18n-browser-mocks/src/i18n_context_mock.tsx
+++ b/packages/core/i18n/core-i18n-browser-mocks/src/i18n_context_mock.tsx
@@ -14,7 +14,7 @@ import { i18n } from '@kbn/i18n';
 
 const emptyMessages = {};
 
-export const I18nProviderMock: FC<PropsWithChildren> = ({ children }) => {
+export const I18nProviderMock: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <IntlProvider
       locale={i18n.getLocale()}

--- a/packages/kbn-alerts-ui-shared/src/maintenance_window_callout/index.test.tsx
+++ b/packages/kbn-alerts-ui-shared/src/maintenance_window_callout/index.test.tsx
@@ -24,7 +24,7 @@ jest.mock('./api', () => ({
   fetchActiveMaintenanceWindows: jest.fn(() => Promise.resolve([])),
 }));
 
-const TestProviders: FC<PropsWithChildren> = ({ children }) => {
+const TestProviders: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const queryClient = new QueryClient();
   return (
     <I18nProvider>
@@ -231,7 +231,7 @@ describe('MaintenanceWindowCallout', () => {
           warn: console.warn,
         },
       });
-      const wrapper: FC<PropsWithChildren> = ({ children }) => (
+      const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
         <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
       );
       return wrapper;

--- a/packages/kbn-cell-actions/src/context/cell_actions_context.test.tsx
+++ b/packages/kbn-cell-actions/src/context/cell_actions_context.test.tsx
@@ -13,7 +13,7 @@ import { CellActionsProvider, useCellActionsContext } from './cell_actions_conte
 
 const action = makeAction('action-1', 'icon', 1);
 const mockGetTriggerCompatibleActions = jest.fn(async () => [action]);
-const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <CellActionsProvider getTriggerCompatibleActions={mockGetTriggerCompatibleActions}>
     {children}
   </CellActionsProvider>

--- a/packages/kbn-i18n-react/src/provider.tsx
+++ b/packages/kbn-i18n-react/src/provider.tsx
@@ -20,7 +20,7 @@ import { PseudoLocaleWrapper } from './pseudo_locale_wrapper';
  * IntlProvider should wrap react app's root component (inside each react render method).
  */
 
-export const I18nProvider: FC<PropsWithChildren<void>> = ({ children }) => (
+export const I18nProvider: FC<PropsWithChildren<any>> = ({ children }) => (
   <IntlProvider
     locale={i18n.getLocale()}
     messages={i18n.getTranslation().messages}

--- a/packages/kbn-i18n-react/src/provider.tsx
+++ b/packages/kbn-i18n-react/src/provider.tsx
@@ -20,7 +20,7 @@ import { PseudoLocaleWrapper } from './pseudo_locale_wrapper';
  * IntlProvider should wrap react app's root component (inside each react render method).
  */
 
-export const I18nProvider: FC<PropsWithChildren<any>> = ({ children }) => (
+export const I18nProvider: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <IntlProvider
     locale={i18n.getLocale()}
     messages={i18n.getTranslation().messages}

--- a/packages/kbn-i18n-react/src/provider.tsx
+++ b/packages/kbn-i18n-react/src/provider.tsx
@@ -20,7 +20,7 @@ import { PseudoLocaleWrapper } from './pseudo_locale_wrapper';
  * IntlProvider should wrap react app's root component (inside each react render method).
  */
 
-export const I18nProvider: FC<PropsWithChildren> = ({ children }) => (
+export const I18nProvider: FC<PropsWithChildren<void>> = ({ children }) => (
   <IntlProvider
     locale={i18n.getLocale()}
     messages={i18n.getTranslation().messages}

--- a/packages/shared-ux/error_boundary/mocks/src/storybook_template.tsx
+++ b/packages/shared-ux/error_boundary/mocks/src/storybook_template.tsx
@@ -16,7 +16,7 @@ import {
   EuiPageTemplate,
 } from '@elastic/eui';
 
-export const Template: FC<PropsWithChildren<void>> = ({ children }) => {
+export const Template: FC<PropsWithChildren<any>> = ({ children }) => {
   return (
     <>
       <EuiHeader position="fixed">

--- a/packages/shared-ux/error_boundary/mocks/src/storybook_template.tsx
+++ b/packages/shared-ux/error_boundary/mocks/src/storybook_template.tsx
@@ -16,7 +16,7 @@ import {
   EuiPageTemplate,
 } from '@elastic/eui';
 
-export const Template: FC<PropsWithChildren<any>> = ({ children }) => {
+export const Template: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <>
       <EuiHeader position="fixed">

--- a/packages/shared-ux/error_boundary/mocks/src/storybook_template.tsx
+++ b/packages/shared-ux/error_boundary/mocks/src/storybook_template.tsx
@@ -16,7 +16,7 @@ import {
   EuiPageTemplate,
 } from '@elastic/eui';
 
-export const Template: FC<PropsWithChildren> = ({ children }) => {
+export const Template: FC<PropsWithChildren<void>> = ({ children }) => {
   return (
     <>
       <EuiHeader position="fixed">

--- a/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
+++ b/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
@@ -22,7 +22,7 @@ describe('<KibanaErrorBoundary>', () => {
     services = getServicesMock();
   });
 
-  const Template: FC<PropsWithChildren> = ({ children }) => {
+  const Template: FC<PropsWithChildren<void>> = ({ children }) => {
     return (
       <KibanaErrorBoundaryDepsProvider {...services}>
         <KibanaErrorBoundary>{children}</KibanaErrorBoundary>

--- a/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
+++ b/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
@@ -22,7 +22,7 @@ describe('<KibanaErrorBoundary>', () => {
     services = getServicesMock();
   });
 
-  const Template: FC<PropsWithChildren<void>> = ({ children }) => {
+  const Template: FC<PropsWithChildren<any>> = ({ children }) => {
     return (
       <KibanaErrorBoundaryDepsProvider {...services}>
         <KibanaErrorBoundary>{children}</KibanaErrorBoundary>

--- a/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
+++ b/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
@@ -22,7 +22,7 @@ describe('<KibanaErrorBoundary>', () => {
     services = getServicesMock();
   });
 
-  const Template: FC<PropsWithChildren<any>> = ({ children }) => {
+  const Template: FC<PropsWithChildren<unknown>> = ({ children }) => {
     return (
       <KibanaErrorBoundaryDepsProvider {...services}>
         <KibanaErrorBoundary>{children}</KibanaErrorBoundary>

--- a/src/plugins/content_management/public/content_client/content_client_mutation_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_mutation_hooks.test.tsx
@@ -28,7 +28,7 @@ const setup = () => {
   });
   const contentClient = new ContentClient(() => crudClient, contentTypeRegistry);
 
-  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+  const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
     <ContentClientProvider contentClient={contentClient}>{children}</ContentClientProvider>
   );
 

--- a/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
@@ -24,7 +24,7 @@ const setup = () => {
   });
   const contentClient = new ContentClient(() => crudClient, contentTypeRegistry);
 
-  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+  const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
     <ContentClientProvider contentClient={contentClient}>{children}</ContentClientProvider>
   );
 

--- a/src/plugins/custom_integrations/public/mocks.tsx
+++ b/src/plugins/custom_integrations/public/mocks.tsx
@@ -25,7 +25,7 @@ function createCustomIntegrationsStart(): jest.Mocked<CustomIntegrationsStart> {
 
   return {
     languageClientsUiComponents: {},
-    ContextProvider: jest.fn(({ children }: PropsWithChildren) => (
+    ContextProvider: jest.fn(({ children }: PropsWithChildren<unknown>) => (
       <CustomIntegrationsServicesProvider {...services}>
         {children}
       </CustomIntegrationsServicesProvider>

--- a/src/plugins/custom_integrations/public/plugin.tsx
+++ b/src/plugins/custom_integrations/public/plugin.tsx
@@ -71,7 +71,7 @@ export class CustomIntegrationsPlugin
       })),
     };
 
-    const ContextProvider: FC<PropsWithChildren> = ({ children }) => (
+    const ContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <CustomIntegrationsServicesProvider {...services}>
         {children}
       </CustomIntegrationsServicesProvider>

--- a/src/plugins/custom_integrations/public/types.ts
+++ b/src/plugins/custom_integrations/public/types.ts
@@ -15,7 +15,7 @@ export interface CustomIntegrationsSetup {
 }
 
 export interface CustomIntegrationsStart {
-  ContextProvider: FC<PropsWithChildren>;
+  ContextProvider: FC<PropsWithChildren<unknown>>;
   languageClientsUiComponents: Record<string, FC>;
 }
 

--- a/src/plugins/dashboard/public/dashboard_listing/dashboard_listing.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_listing/dashboard_listing.test.tsx
@@ -27,9 +27,11 @@ jest.mock('@kbn/content-management-table-list-view-table', () => {
   return {
     __esModule: true,
     ...originalModule,
-    TableListViewKibanaProvider: jest.fn().mockImplementation(({ children }: PropsWithChildren) => {
-      return <>{children}</>;
-    }),
+    TableListViewKibanaProvider: jest
+      .fn()
+      .mockImplementation(({ children }: PropsWithChildren<unknown>) => {
+        return <>{children}</>;
+      }),
   };
 });
 jest.mock('@kbn/content-management-table-list-view', () => {

--- a/src/plugins/data_view_editor/public/components/flyout_panels/flyout_panels_content.tsx
+++ b/src/plugins/data_view_editor/public/components/flyout_panels/flyout_panels_content.tsx
@@ -9,7 +9,7 @@ import React, { useEffect, FC, PropsWithChildren } from 'react';
 
 import { useFlyoutPanelContext } from './flyout_panel';
 
-export const PanelContent: FC<PropsWithChildren> = (props) => {
+export const PanelContent: FC<PropsWithChildren<unknown>> = (props) => {
   const { registerContent } = useFlyoutPanelContext();
 
   useEffect(() => {

--- a/src/plugins/discover/public/application/context/context_app_content.tsx
+++ b/src/plugins/discover/public/application/context/context_app_content.tsx
@@ -242,7 +242,7 @@ export function ContextAppContent({
   );
 }
 
-const WrapperWithPadding: FC<PropsWithChildren> = ({ children }) => {
+const WrapperWithPadding: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const padding = useEuiPaddingSize('s');
 
   return (

--- a/src/plugins/es_ui_shared/__packages_do_not_import__/global_flyout/global_flyout.tsx
+++ b/src/plugins/es_ui_shared/__packages_do_not_import__/global_flyout/global_flyout.tsx
@@ -41,7 +41,7 @@ const DEFAULT_FLYOUT_PROPS = {
   maxWidth: 500,
 };
 
-export const GlobalFlyoutProvider: FC<PropsWithChildren> = ({ children }) => {
+export const GlobalFlyoutProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const [activeContent, setActiveContent] = useState<Content<any> | undefined>(undefined);
 

--- a/src/plugins/es_ui_shared/public/components/page_loading/page_loading.tsx
+++ b/src/plugins/es_ui_shared/public/components/page_loading/page_loading.tsx
@@ -9,7 +9,7 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { EuiLoadingSpinner, EuiText, EuiPageTemplate } from '@elastic/eui';
 
-export const PageLoading: FC<PropsWithChildren> = ({ children }) => {
+export const PageLoading: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <EuiPageTemplate.EmptyPrompt
       title={<EuiLoadingSpinner size="xl" />}

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/__stories__/form_global_fields.tsx
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/__stories__/form_global_fields.tsx
@@ -48,7 +48,7 @@ const useGlobalFields = () => {
   return ctx;
 };
 
-const FormGlobalFields: FC<PropsWithChildren> = ({ children }) => {
+const FormGlobalFields: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <UseMultiFields fields={globalFields}>
       {(fields) => {
@@ -170,7 +170,7 @@ const useGlobalFields = () => {
   return ctx;
 };
 
-const FormGlobalFields: FC<PropsWithChildren> = ({ children }) => {
+const FormGlobalFields: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <UseMultiFields fields={globalFields}>
       {(fields) => {

--- a/src/plugins/interactive_setup/public/text_truncate.tsx
+++ b/src/plugins/interactive_setup/public/text_truncate.tsx
@@ -10,7 +10,7 @@ import { EuiToolTip } from '@elastic/eui';
 import type { FC, PropsWithChildren } from 'react';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 
-export const TextTruncate: FC<PropsWithChildren> = ({ children }) => {
+export const TextTruncate: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const textRef = useRef<HTMLSpanElement>(null);
   const [showTooltip, setShowTooltip] = useState(false);
 

--- a/src/plugins/interactive_setup/public/use_verification.tsx
+++ b/src/plugins/interactive_setup/public/use_verification.tsx
@@ -38,7 +38,7 @@ const [OuterVerificationProvider, useVerification] = constate(
   }
 );
 
-const InnerVerificationProvider: FC<PropsWithChildren> = ({ children }) => {
+const InnerVerificationProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { http } = useKibana();
   const { status, setStatus, setCode } = useVerification();
 

--- a/src/plugins/presentation_util/public/services/create/provider.tsx
+++ b/src/plugins/presentation_util/public/services/create/provider.tsx
@@ -62,7 +62,7 @@ export class PluginServiceProvider<
   private _requiredServices?: RequiredServices;
   private context = createContext<Service | null>(null);
   private pluginService: Service | null = null;
-  public readonly Provider: FC<PropsWithChildren> = ({ children }) => {
+  public readonly Provider: FC<PropsWithChildren<unknown>> = ({ children }) => {
     return <this.context.Provider value={this.getService()}>{children}</this.context.Provider>;
   };
 

--- a/src/plugins/presentation_util/public/services/create/registry.tsx
+++ b/src/plugins/presentation_util/public/services/create/registry.tsx
@@ -58,7 +58,7 @@ export class PluginServiceRegistry<
 
     // Collect and combine Context.Provider elements from each Service Provider into a single
     // Functional Component.
-    const provider: FC<PropsWithChildren> = ({ children }) => (
+    const provider: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <>
         {values.reduceRight((acc, serviceProvider) => {
           return <serviceProvider.Provider>{acc}</serviceProvider.Provider>;

--- a/src/plugins/presentation_util/public/types.ts
+++ b/src/plugins/presentation_util/public/types.ts
@@ -17,7 +17,7 @@ import { PresentationLabsService } from './services/labs/types';
 export interface PresentationUtilPluginSetup {}
 
 export interface PresentationUtilPluginStart {
-  ContextProvider: FC<PropsWithChildren>;
+  ContextProvider: FC<PropsWithChildren<unknown>>;
   labsService: PresentationLabsService;
   registerExpressionsLanguage: typeof registerExpressionsLanguage;
 }

--- a/src/plugins/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
+++ b/src/plugins/saved_objects/public/save_modal/show_saved_object_save_modal.tsx
@@ -32,7 +32,7 @@ interface MinimalSaveModalProps {
 
 export function showSaveModal(
   saveModal: React.ReactElement<MinimalSaveModalProps>,
-  Wrapper?: FC<PropsWithChildren>
+  Wrapper?: FC<PropsWithChildren<unknown>>
 ) {
   const container = document.createElement('div');
   const closeModal = () => {

--- a/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/mount_section.tsx
@@ -43,7 +43,7 @@ export const mountManagementSection = async ({ core, mountParams }: MountParams)
 
   coreStart.chrome.docTitle.change(title);
 
-  const RedirectToHomeIfUnauthorized: FC<PropsWithChildren> = ({ children }) => {
+  const RedirectToHomeIfUnauthorized: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const allowed = capabilities?.management?.kibana?.objects ?? false;
 
     if (!allowed) {

--- a/src/plugins/ui_actions_enhanced/public/drilldowns/drilldown_manager/containers/drilldown_manager_footer/drilldown_manager_footer.tsx
+++ b/src/plugins/ui_actions_enhanced/public/drilldowns/drilldown_manager/containers/drilldown_manager_footer/drilldown_manager_footer.tsx
@@ -9,7 +9,7 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { useDrilldownManager } from '../context';
 
-export const DrilldownManagerFooter: FC<PropsWithChildren> = ({ children }) => {
+export const DrilldownManagerFooter: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const drilldowns = useDrilldownManager();
   React.useEffect(() => {
     drilldowns.setFooter(children);

--- a/src/plugins/usage_collection/public/plugin.tsx
+++ b/src/plugins/usage_collection/public/plugin.tsx
@@ -74,7 +74,7 @@ export interface UsageCollectionSetup {
      * }
      * ```
      */
-    ApplicationUsageTrackingProvider: FC<PropsWithChildren>;
+    ApplicationUsageTrackingProvider: FC<PropsWithChildren<unknown>>;
   };
 
   /** Report whenever a UI event occurs for UI counters to report it **/

--- a/x-pack/packages/ml/date_picker/src/components/date_picker_wrapper.test.tsx
+++ b/x-pack/packages/ml/date_picker/src/components/date_picker_wrapper.test.tsx
@@ -27,10 +27,10 @@ jest.mock('@elastic/eui', () => {
   const EuiSuperDatePickerMock = jest.fn(() => {
     return null;
   });
-  const EuiFlexGroupMock = jest.fn(({ children }: PropsWithChildren) => {
+  const EuiFlexGroupMock = jest.fn(({ children }: PropsWithChildren<unknown>) => {
     return <>{children}</>;
   });
-  const EuiFlexItemMock = jest.fn(({ children }: PropsWithChildren) => {
+  const EuiFlexItemMock = jest.fn(({ children }: PropsWithChildren<unknown>) => {
     return <>{children}</>;
   });
   return {

--- a/x-pack/packages/ml/url_state/src/url_state.tsx
+++ b/x-pack/packages/ml/url_state/src/url_state.tsx
@@ -92,7 +92,7 @@ export const urlStateStore = createContext<UrlState>({
 
 export const { Provider } = urlStateStore;
 
-export const UrlStateProvider: FC<PropsWithChildren<void>> = ({ children }) => {
+export const UrlStateProvider: FC<PropsWithChildren<any>> = ({ children }) => {
   const history = useHistory();
   const { search: searchString } = useLocation();
 

--- a/x-pack/packages/ml/url_state/src/url_state.tsx
+++ b/x-pack/packages/ml/url_state/src/url_state.tsx
@@ -92,7 +92,7 @@ export const urlStateStore = createContext<UrlState>({
 
 export const { Provider } = urlStateStore;
 
-export const UrlStateProvider: FC<PropsWithChildren> = ({ children }) => {
+export const UrlStateProvider: FC<PropsWithChildren<void>> = ({ children }) => {
   const history = useHistory();
   const { search: searchString } = useLocation();
 

--- a/x-pack/packages/ml/url_state/src/url_state.tsx
+++ b/x-pack/packages/ml/url_state/src/url_state.tsx
@@ -92,7 +92,7 @@ export const urlStateStore = createContext<UrlState>({
 
 export const { Provider } = urlStateStore;
 
-export const UrlStateProvider: FC<PropsWithChildren<any>> = ({ children }) => {
+export const UrlStateProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const history = useHistory();
   const { search: searchString } = useLocation();
 

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/data_quality_context/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/data_quality_context/index.test.tsx
@@ -19,7 +19,7 @@ const mockTelemetryEvents = {
   reportDataQualityIndexChecked: mockReportDataQualityIndexChecked,
   reportDataQualityCheckAllCompleted: mockReportDataQualityCheckAllClicked,
 };
-const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <DataQualityProvider
     httpFetch={mockHttpFetch}
     telemetryEvents={mockTelemetryEvents}

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/use_mappings/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/use_mappings/index.test.tsx
@@ -23,7 +23,7 @@ const mockTelemetryEvents = {
 };
 const { toasts } = notificationServiceMock.createSetupContract();
 
-const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <DataQualityProvider
     httpFetch={mockHttpFetch}
     telemetryEvents={mockTelemetryEvents}

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/use_stats/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/use_stats/index.test.tsx
@@ -23,7 +23,7 @@ const mockTelemetryEvents = {
 };
 const { toasts } = notificationServiceMock.createSetupContract();
 
-const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <DataQualityProvider
     httpFetch={mockHttpFetch}
     telemetryEvents={mockTelemetryEvents}
@@ -34,7 +34,7 @@ const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
   </DataQualityProvider>
 );
 
-const ContextWrapperILMNotAvailable: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapperILMNotAvailable: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <DataQualityProvider
     httpFetch={mockHttpFetch}
     telemetryEvents={mockTelemetryEvents}

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/use_unallowed_values/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/use_unallowed_values/index.test.tsx
@@ -26,7 +26,7 @@ const mockTelemetryEvents = {
 };
 const { toasts } = notificationServiceMock.createSetupContract();
 
-const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <DataQualityProvider
     httpFetch={mockHttpFetch}
     telemetryEvents={mockTelemetryEvents}

--- a/x-pack/packages/security-solution/navigation/src/__mocks__/context.tsx
+++ b/x-pack/packages/security-solution/navigation/src/__mocks__/context.tsx
@@ -11,7 +11,7 @@ import { mockCoreStart } from '../../mocks/context';
 
 const navigationContext = createContext<CoreStart | null>(mockCoreStart);
 
-export const NavigationProvider: FC<PropsWithChildren> = ({ children }) => (
+export const NavigationProvider: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <navigationContext.Provider value={mockCoreStart}>{children}</navigationContext.Provider>
 );
 

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_context.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_context.tsx
@@ -99,7 +99,7 @@ export const useChangePointDetectionControlsContext = () => {
   return useContext(ChangePointDetectionControlsContext);
 };
 
-export const ChangePointDetectionControlsContextProvider: FC<PropsWithChildren> = ({
+export const ChangePointDetectionControlsContextProvider: FC<PropsWithChildren<unknown>> = ({
   children,
 }) => {
   const { dataView } = useDataSource();
@@ -129,7 +129,9 @@ export const ChangePointDetectionControlsContextProvider: FC<PropsWithChildren> 
   );
 };
 
-export const ChangePointDetectionContextProvider: FC<PropsWithChildren> = ({ children }) => {
+export const ChangePointDetectionContextProvider: FC<PropsWithChildren<unknown>> = ({
+  children,
+}) => {
   const { dataView, savedSearch } = useDataSource();
   const {
     uiSettings,

--- a/x-pack/plugins/aiops/public/components/log_categorization/format_category.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/format_category.tsx
@@ -175,7 +175,7 @@ export const FormattedTokens: FC<Props> = ({ category }) => {
   );
 };
 
-const WrapInText: FC<PropsWithChildren> = ({ children }) => (
+const WrapInText: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiText css={{ fontWeight: 'bold' }} size="s">
     {children}
   </EuiText>

--- a/x-pack/plugins/aiops/public/shared_lazy_components.tsx
+++ b/x-pack/plugins/aiops/public/shared_lazy_components.tsx
@@ -20,7 +20,7 @@ const LogRateAnalysisContentWrapperLazy = React.lazy(
   () => import('./components/log_rate_analysis/log_rate_analysis_content')
 );
 
-const LazyWrapper: FC<PropsWithChildren> = ({ children }) => (
+const LazyWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiErrorBoundary>
     <Suspense fallback={<EuiSkeletonText lines={3} />}>{children}</Suspense>
   </EuiErrorBoundary>

--- a/x-pack/plugins/alerting/public/lib/test_utils.tsx
+++ b/x-pack/plugins/alerting/public/lib/test_utils.tsx
@@ -29,7 +29,7 @@ export interface AppMockRenderer {
   render: UiRender;
   coreStart: CoreStart;
   queryClient: QueryClient;
-  AppWrapper: FC<PropsWithChildren>;
+  AppWrapper: FC<PropsWithChildren<unknown>>;
   mocked: {
     setBadge: jest.Mock;
   };
@@ -78,7 +78,7 @@ export const createAppMockRenderer = ({
       setBadge: mockedSetBadge,
     },
   };
-  const AppWrapper = React.memo<PropsWithChildren>(({ children }) => (
+  const AppWrapper = React.memo<PropsWithChildren<unknown>>(({ children }) => (
     <KibanaRenderContextProvider {...core}>
       <KibanaContextProvider services={services}>
         <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/x-pack/plugins/alerting/public/pages/maintenance_windows/components/submit_button.test.tsx
+++ b/x-pack/plugins/alerting/public/pages/maintenance_windows/components/submit_button.test.tsx
@@ -17,7 +17,7 @@ import { AppMockRenderer, createAppMockRenderer } from '../../../lib/test_utils'
 describe('SubmitButton', () => {
   const onSubmit = jest.fn();
 
-  const MockHookWrapperComponent: FC<PropsWithChildren> = ({ children }) => {
+  const MockHookWrapperComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>({
       defaultValue: { title: 'title' },
       schema: {

--- a/x-pack/plugins/canvas/public/components/home/my_workpads/upload_dropzone.tsx
+++ b/x-pack/plugins/canvas/public/components/home/my_workpads/upload_dropzone.tsx
@@ -15,7 +15,7 @@ import { UploadDropzone as Component } from './upload_dropzone.component';
 
 const { WorkpadDropzone: errors } = ErrorStrings;
 
-export const UploadDropzone: FC<PropsWithChildren> = ({ children }) => {
+export const UploadDropzone: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const notify = useNotifyService();
   const uploadWorkpad = useImportWorkpad();
   const [isDisabled, setIsDisabled] = useState(false);

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_autoplay_helper.test.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_autoplay_helper.test.tsx
@@ -19,7 +19,7 @@ const getMockedContext = (context: any) =>
     ...context,
   } as WorkpadRoutingContextType);
 
-const getContextWrapper: (context: WorkpadRoutingContextType) => FC<PropsWithChildren> =
+const getContextWrapper: (context: WorkpadRoutingContextType) => FC<PropsWithChildren<unknown>> =
   (context) =>
   ({ children }) =>
     <WorkpadRoutingContext.Provider value={context}>{children}</WorkpadRoutingContext.Provider>;

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_refresh_helper.test.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_refresh_helper.test.tsx
@@ -31,7 +31,7 @@ const getMockedContext = (context: any) =>
 
 const getContextWrapper =
   (context: WorkpadRoutingContextType) =>
-  ({ children }: PropsWithChildren) =>
+  ({ children }: PropsWithChildren<unknown>) =>
     <WorkpadRoutingContext.Provider value={context}>{children}</WorkpadRoutingContext.Provider>;
 
 describe('useRefreshHelper', () => {

--- a/x-pack/plugins/canvas/public/routes/workpad/workpad_presentation_helper.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/workpad_presentation_helper.tsx
@@ -21,7 +21,7 @@ const getWorkpadLabel = () =>
     defaultMessage: 'Workpad',
   });
 
-export const WorkpadPresentationHelper: FC<PropsWithChildren> = ({ children }) => {
+export const WorkpadPresentationHelper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const platformService = usePlatformService();
   const workpad = useSelector(getWorkpad);
   useFullscreenPresentationHelper();

--- a/x-pack/plugins/canvas/public/routes/workpad/workpad_route.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/workpad_route.tsx
@@ -110,7 +110,7 @@ const ExportWorkpadRouteComponent: FC<{ route: WorkpadRouteProps }> = ({ route: 
   );
 };
 
-export const ExportRouteManager: FC<PropsWithChildren> = ({ children }) => {
+export const ExportRouteManager: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const params = useParams<WorkpadPageRouteParams>();
   usePageSync();
 
@@ -123,7 +123,7 @@ export const ExportRouteManager: FC<PropsWithChildren> = ({ children }) => {
   return <>{children}</>;
 };
 
-export const WorkpadHistoryManager: FC<PropsWithChildren> = ({ children }) => {
+export const WorkpadHistoryManager: FC<PropsWithChildren<unknown>> = ({ children }) => {
   useRestoreHistory();
   useWorkpadHistory();
   usePageSync();

--- a/x-pack/plugins/canvas/public/routes/workpad/workpad_routing_context.tsx
+++ b/x-pack/plugins/canvas/public/routes/workpad/workpad_routing_context.tsx
@@ -46,7 +46,7 @@ export const WorkpadRoutingContext = createContext<WorkpadRoutingContextType>(
   basicWorkpadRoutingContext
 );
 
-export const WorkpadRoutingContextComponent: FC<PropsWithChildren> = ({ children }) => {
+export const WorkpadRoutingContextComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const routingContext = useRoutingContext();
 
   return (

--- a/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/selector_modal/use_cases_add_to_existing_case_modal.test.tsx
@@ -65,7 +65,7 @@ describe('use cases add to existing case modal hook', () => {
 
   const dispatch = jest.fn();
   let appMockRender: AppMockRenderer;
-  const wrapper: FC<PropsWithChildren> = ({ children }) => {
+  const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
     return (
       <CasesContext.Provider
         value={{

--- a/x-pack/plugins/cases/public/components/create/assignees.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/assignees.test.tsx
@@ -28,7 +28,7 @@ describe('Assignees', () => {
   let globalForm: FormHook;
   let appMockRender: AppMockRenderer;
 
-  const MockHookWrapperComponent: FC<PropsWithChildren> = ({ children }) => {
+  const MockHookWrapperComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>();
     globalForm = form;
 

--- a/x-pack/plugins/cases/public/components/create/category.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/category.test.tsx
@@ -27,7 +27,7 @@ describe('Category', () => {
   let appMockRender: AppMockRenderer;
   const onSubmit = jest.fn();
 
-  const FormComponent: FC<PropsWithChildren> = ({ children }) => {
+  const FormComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>({ onSubmit });
 
     return (

--- a/x-pack/plugins/cases/public/components/create/connector.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/connector.test.tsx
@@ -66,7 +66,7 @@ describe('Connector', () => {
   let appMockRender: AppMockRenderer;
   let globalForm: FormHook;
 
-  const MockHookWrapperComponent: FC<PropsWithChildren> = ({ children }) => {
+  const MockHookWrapperComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>({
       defaultValue: { connectorId: connectorsMock[0].id, fields: null },
       schema: {

--- a/x-pack/plugins/cases/public/components/create/flyout/use_cases_add_to_new_case_flyout.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/flyout/use_cases_add_to_new_case_flyout.test.tsx
@@ -23,7 +23,7 @@ const persistableStateAttachmentTypeRegistry = new PersistableStateAttachmentTyp
 
 describe('use cases add to new case flyout hook', () => {
   const dispatch = jest.fn();
-  let wrapper: FC<PropsWithChildren>;
+  let wrapper: FC<PropsWithChildren<unknown>>;
   beforeEach(() => {
     dispatch.mockReset();
     wrapper = ({ children }) => {

--- a/x-pack/plugins/cases/public/components/create/sync_alerts_toggle.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/sync_alerts_toggle.test.tsx
@@ -19,7 +19,7 @@ import { schema } from './schema';
 describe('SyncAlertsToggle', () => {
   let globalForm: FormHook;
 
-  const MockHookWrapperComponent: FC<PropsWithChildren> = ({ children }) => {
+  const MockHookWrapperComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>({
       defaultValue: { syncAlerts: true },
       schema: {

--- a/x-pack/plugins/cases/public/components/create/tags.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/tags.test.tsx
@@ -29,7 +29,7 @@ describe('Tags', () => {
   let globalForm: FormHook;
   let appMockRender: AppMockRenderer;
 
-  const MockHookWrapperComponent: FC<PropsWithChildren> = ({ children }) => {
+  const MockHookWrapperComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>({
       defaultValue: { tags: [] },
       schema: {

--- a/x-pack/plugins/cases/public/components/create/title.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/title.test.tsx
@@ -19,7 +19,7 @@ import { schema } from './schema';
 describe('Title', () => {
   let globalForm: FormHook;
 
-  const MockHookWrapperComponent: FC<PropsWithChildren> = ({ children }) => {
+  const MockHookWrapperComponent: FC<PropsWithChildren<unknown>> = ({ children }) => {
     const { form } = useForm<FormProps>({
       defaultValue: { title: 'My title' },
       schema: {

--- a/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/use_user_actions_handler.test.tsx
@@ -29,7 +29,9 @@ const patchComment = jest.fn();
 const clearDraftComment = jest.fn();
 const openLensModal = jest.fn();
 
-const wrapper: FC<PropsWithChildren> = ({ children }) => <TestProviders>{children}</TestProviders>;
+const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
+  <TestProviders>{children}</TestProviders>
+);
 
 describe('useUserActionsHandler', () => {
   beforeAll(() => {

--- a/x-pack/plugins/cases/public/components/visualizations/actions/__mocks__/action_wrapper.tsx
+++ b/x-pack/plugins/cases/public/components/visualizations/actions/__mocks__/action_wrapper.tsx
@@ -10,6 +10,6 @@ import React from 'react';
 
 export const ActionWrapper = jest
   .fn()
-  .mockImplementation(({ children }: PropsWithChildren) => (
+  .mockImplementation(({ children }: PropsWithChildren<unknown>) => (
     <div data-test-subj="action-wrapper">{children}</div>
   ));

--- a/x-pack/plugins/cases/public/components/visualizations/actions/add_to_existing_case.test.tsx
+++ b/x-pack/plugins/cases/public/components/visualizations/actions/add_to_existing_case.test.tsx
@@ -47,7 +47,7 @@ jest.mock('../../../client/helpers/can_use_cases', () => {
 jest.mock('@kbn/kibana-react-plugin/public', () => ({
   KibanaThemeProvider: jest
     .fn()
-    .mockImplementation(({ children }: PropsWithChildren) => <>{children}</>),
+    .mockImplementation(({ children }: PropsWithChildren<unknown>) => <>{children}</>),
 }));
 
 jest.mock('@kbn/react-kibana-mount', () => ({

--- a/x-pack/plugins/cases/public/containers/use_get_case.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case.test.tsx
@@ -17,7 +17,7 @@ import { useToasts } from '../common/lib/kibana';
 jest.mock('./api');
 jest.mock('../common/lib/kibana');
 
-const wrapper: FC<PropsWithChildren> = ({ children }) => {
+const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {

--- a/x-pack/plugins/cases/public/containers/use_get_case_metrics.test.tsx
+++ b/x-pack/plugins/cases/public/containers/use_get_case_metrics.test.tsx
@@ -19,7 +19,9 @@ import { CaseMetricsFeature } from '../../common/types/api';
 jest.mock('./api');
 jest.mock('../common/lib/kibana');
 
-const wrapper: FC<PropsWithChildren> = ({ children }) => <TestProviders>{children}</TestProviders>;
+const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
+  <TestProviders>{children}</TestProviders>
+);
 
 describe('useGetCaseMetrics', () => {
   const abortCtrl = new AbortController();

--- a/x-pack/plugins/cases/public/mocks/mock_cases_context.tsx
+++ b/x-pack/plugins/cases/public/mocks/mock_cases_context.tsx
@@ -8,7 +8,7 @@
 import type { FC, PropsWithChildren } from 'react';
 import React from 'react';
 
-export const mockCasesContext: FC<PropsWithChildren> = (props) => {
+export const mockCasesContext: FC<PropsWithChildren<unknown>> = (props) => {
   return <>{props?.children ?? null}</>;
 };
 mockCasesContext.displayName = 'CasesContextMock';

--- a/x-pack/plugins/cloud/public/mocks.tsx
+++ b/x-pack/plugins/cloud/public/mocks.tsx
@@ -35,7 +35,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
   };
 }
 
-const getContextProvider: () => FC<PropsWithChildren> =
+const getContextProvider: () => FC<PropsWithChildren<unknown>> =
   () =>
   ({ children }) =>
     <>{children}</>;

--- a/x-pack/plugins/cloud/public/plugin.tsx
+++ b/x-pack/plugins/cloud/public/plugin.tsx
@@ -56,7 +56,7 @@ export class CloudPlugin implements Plugin<CloudSetup> {
   private readonly config: CloudConfigType;
   private readonly isCloudEnabled: boolean;
   private readonly isServerlessEnabled: boolean;
-  private readonly contextProviders: Array<FC<PropsWithChildren>> = [];
+  private readonly contextProviders: Array<FC<PropsWithChildren<unknown>>> = [];
   private readonly logger: Logger;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
@@ -112,7 +112,7 @@ export class CloudPlugin implements Plugin<CloudSetup> {
 
     // Nest all the registered context providers under the Cloud Services Provider.
     // This way, plugins only need to require Cloud's context provider to have all the enriched Cloud services.
-    const CloudContextProvider: FC<PropsWithChildren> = ({ children }) => {
+    const CloudContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
       return (
         <>
           {this.contextProviders.reduce(

--- a/x-pack/plugins/cloud/public/types.ts
+++ b/x-pack/plugins/cloud/public/types.ts
@@ -11,7 +11,7 @@ export interface CloudStart {
   /**
    * A React component that provides a pre-wired `React.Context` which connects components to Cloud services.
    */
-  CloudContextProvider: FC<PropsWithChildren>;
+  CloudContextProvider: FC<PropsWithChildren<unknown>>;
   /**
    * `true` when Kibana is running on Elastic Cloud.
    */

--- a/x-pack/plugins/cloud_integrations/cloud_chat/.storybook/decorator.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_chat/.storybook/decorator.tsx
@@ -27,7 +27,7 @@ const services: CloudChatServices = {
   },
 };
 
-export const getCloudContextProvider: () => FC<PropsWithChildren> =
+export const getCloudContextProvider: () => FC<PropsWithChildren<unknown>> =
   () =>
   ({ children }) =>
     <ServicesProvider {...services}>{children}</ServicesProvider>;

--- a/x-pack/plugins/cloud_integrations/cloud_chat/public/components/chat/when_idle.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_chat/public/components/chat/when_idle.tsx
@@ -21,7 +21,7 @@ export function whenIdle(doWork: () => void) {
 /**
  * Postpone rendering of children until the page is loaded and browser is idle.
  */
-export const WhenIdle: FC<PropsWithChildren> = ({ children }) => {
+export const WhenIdle: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [idleFired, setIdleFired] = React.useState(false);
 
   React.useEffect(() => {

--- a/x-pack/plugins/cloud_integrations/cloud_chat/public/plugin.tsx
+++ b/x-pack/plugins/cloud_integrations/cloud_chat/public/plugin.tsx
@@ -58,7 +58,7 @@ export class CloudChatPlugin implements Plugin<void, void, CloudChatSetupDeps, C
   }
 
   public start(core: CoreStart) {
-    const CloudChatContextProvider: FC<PropsWithChildren> = ({ children }) => {
+    const CloudChatContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
       // There's a risk that the request for chat config will take too much time to complete, and the provider
       // will maintain a stale value.  To avoid this, we'll use an Observable.
       const chatConfig = useObservable(this.chatConfig$, undefined);

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/additional_controls.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/additional_controls.tsx
@@ -13,7 +13,7 @@ import { useStyles } from './use_styles';
 import { getAbbreviatedNumber } from '../../common/utils/get_abbreviated_number';
 import { CSP_FIELDS_SELECTOR_OPEN_BUTTON } from '../test_subjects';
 
-const GroupSelectorWrapper: FC<PropsWithChildren> = ({ children }) => {
+const GroupSelectorWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const styles = useStyles();
 
   return (

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.test.tsx
@@ -36,7 +36,9 @@ const queryClient = new QueryClient({
 });
 
 const getWrapper =
-  ({ canUpdate = true }: { canUpdate: boolean } = { canUpdate: true }): FC<PropsWithChildren> =>
+  (
+    { canUpdate = true }: { canUpdate: boolean } = { canUpdate: true }
+  ): FC<PropsWithChildren<unknown>> =>
   ({ children }) => {
     const coreStart = coreMock.createStart();
     const core = {

--- a/x-pack/plugins/cross_cluster_replication/public/app/components/auto_follow_pattern_delete_provider.d.ts
+++ b/x-pack/plugins/cross_cluster_replication/public/app/components/auto_follow_pattern_delete_provider.d.ts
@@ -7,4 +7,4 @@
 
 import { FC, PropsWithChildren } from 'react';
 
-declare const AutoFollowPatternDeleteProvider: FC<PropsWithChildren>;
+declare const AutoFollowPatternDeleteProvider: FC<PropsWithChildren<unknown>>;

--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/file_data_visualizer.tsx
@@ -39,7 +39,7 @@ export const FileDataVisualizer: FC<Props> = ({ getAdditionalLinks, resultLinks 
     fieldFormats,
   };
 
-  const EmptyContext: FC<PropsWithChildren> = ({ children }) => <>{children}</>;
+  const EmptyContext: FC<PropsWithChildren<unknown>> = ({ children }) => <>{children}</>;
   const CloudContext = cloud?.CloudContextProvider || EmptyContext;
 
   return (

--- a/x-pack/plugins/data_visualizer/public/lazy_load_bundle/component_wrapper.tsx
+++ b/x-pack/plugins/data_visualizer/public/lazy_load_bundle/component_wrapper.tsx
@@ -11,7 +11,7 @@ import { EuiErrorBoundary, EuiSkeletonText } from '@elastic/eui';
 import type { ResultLinks } from '../../common/app';
 import type { DataDriftDetectionAppStateProps } from '../application/data_drift/data_drift_app_state';
 
-const LazyWrapper: FC<PropsWithChildren> = ({ children }) => (
+const LazyWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiErrorBoundary>
     <Suspense fallback={<EuiSkeletonText lines={3} />}>{children}</Suspense>
   </EuiErrorBoundary>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_log/api_log_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/api_logs/api_log/api_log_flyout.tsx
@@ -124,7 +124,7 @@ export const ApiLogFlyout: React.FC = () => {
   );
 };
 
-export const ApiLogHeading: FC<PropsWithChildren> = ({ children }) => (
+export const ApiLogHeading: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiTitle size="xs">
     <h3>{children}</h3>
   </EuiTitle>

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/search_applications/components/empty_search_applications_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/search_applications/components/empty_search_applications_prompt.tsx
@@ -10,7 +10,7 @@ import React, { FC, PropsWithChildren } from 'react';
 import { EuiEmptyPrompt } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-export const EmptySearchApplicationsPrompt: FC<PropsWithChildren> = ({ children }) => {
+export const EmptySearchApplicationsPrompt: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <EuiEmptyPrompt
       iconType="aggregate"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_sync_form.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_sync_form.tsx
@@ -17,7 +17,7 @@ import { UnsavedChangesPrompt } from '../../../../../shared/unsaved_changes_prom
 
 import { ConnectorFilteringLogic } from './connector_filtering_logic';
 
-export const ConnectorSyncRulesForm: FC<PropsWithChildren> = ({ children }) => {
+export const ConnectorSyncRulesForm: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { saveDraftFilteringRules, setIsEditing } = useActions(ConnectorFilteringLogic);
   const { hasJsonValidationError, isEditing, isLoading } = useValues(ConnectorFilteringLogic);
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/inference_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/inference_config.tsx
@@ -38,7 +38,7 @@ export const InferenceConfiguration: React.FC = () => {
   }
 };
 
-const InferenceConfigurationWrapper: FC<PropsWithChildren> = ({ children }) => {
+const InferenceConfigurationWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <>
       <EuiSpacer />

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -92,7 +92,7 @@ export const renderApp = (
   const productAccess = access || noProductAccess;
   const productFeatures = features ?? { ...DEFAULT_PRODUCT_FEATURES };
 
-  const EmptyContext: FC<PropsWithChildren> = ({ children }) => <>{children}</>;
+  const EmptyContext: FC<PropsWithChildren<unknown>> = ({ children }) => <>{children}</>;
   const CloudContext = cloud?.CloudContextProvider || EmptyContext;
 
   resetContext({ createStore: true });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/flash_messages/flash_messages.tsx
@@ -14,7 +14,7 @@ import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { FLASH_MESSAGE_TYPES } from './constants';
 import { FlashMessagesLogic } from './flash_messages_logic';
 
-export const FlashMessages: FC<PropsWithChildren> = ({ children }) => {
+export const FlashMessages: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { messages } = useValues(FlashMessagesLogic);
 
   return (

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/endpoints_header_action.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/endpoints_header_action.tsx
@@ -39,7 +39,7 @@ import { KibanaLogic } from '../kibana';
 
 import { EndpointIcon } from './endpoint_icon';
 
-export const EndpointsHeaderAction: FC<PropsWithChildren> = ({ children }) => {
+export const EndpointsHeaderAction: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [isPopoverOpen, setPopoverOpen] = useState(false);
   const { cloud, esConfig, navigateToUrl } = useValues(KibanaLogic);
   const { makeRequest } = useActions(FetchApiKeysAPILogic);

--- a/x-pack/plugins/ml/public/application/components/field_stats_flyout/field_stats_flyout_provider.tsx
+++ b/x-pack/plugins/ml/public/application/components/field_stats_flyout/field_stats_flyout_provider.tsx
@@ -22,7 +22,7 @@ import { MLFieldStatsFlyoutContext } from './use_field_stats_flytout_context';
 import { PopulatedFieldsCacheManager } from './populated_fields/populated_fields_cache_manager';
 
 export const FieldStatsFlyoutProvider: FC<{
-  children: React.ReactNode;
+  children?: React.ReactNode;
   dataView: DataView;
   fieldStatsServices: FieldStatsServices;
   timeRangeMs?: TimeRangeMs;

--- a/x-pack/plugins/ml/public/application/components/page_header/page_header.tsx
+++ b/x-pack/plugins/ml/public/application/components/page_header/page_header.tsx
@@ -14,7 +14,7 @@ import { MlPageControlsContext } from '../ml_page/ml_page';
 /**
  * Component for setting the page header content.
  */
-export const MlPageHeader: FC<PropsWithChildren> = ({ children }) => {
+export const MlPageHeader: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { headerPortal, setIsHeaderMounted } = useContext(MlPageControlsContext);
 
   useEffect(() => {

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/advanced_detector_modal/descriptions.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/advanced_detector_modal/descriptions.tsx
@@ -13,7 +13,7 @@ import { EuiDescribedFormGroup, EuiFormRow, EuiFlexGroup, EuiFlexItem } from '@e
 
 import { FunctionHelpPopover } from './function_help';
 
-export const AggDescription = memo<PropsWithChildren>(({ children }) => {
+export const AggDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.aggSelect.title',
     {
@@ -46,7 +46,7 @@ export const AggDescription = memo<PropsWithChildren>(({ children }) => {
   );
 });
 
-export const FieldDescription = memo<PropsWithChildren>(({ children }) => {
+export const FieldDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.fieldSelect.title',
     {
@@ -70,7 +70,7 @@ export const FieldDescription = memo<PropsWithChildren>(({ children }) => {
   );
 });
 
-export const ByFieldDescription = memo<PropsWithChildren>(({ children }) => {
+export const ByFieldDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.byFieldSelect.title',
     {
@@ -94,7 +94,7 @@ export const ByFieldDescription = memo<PropsWithChildren>(({ children }) => {
   );
 });
 
-export const OverFieldDescription = memo<PropsWithChildren>(({ children }) => {
+export const OverFieldDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.overFieldSelect.title',
     {
@@ -118,7 +118,7 @@ export const OverFieldDescription = memo<PropsWithChildren>(({ children }) => {
   );
 });
 
-export const PartitionFieldDescription = memo<PropsWithChildren>(({ children }) => {
+export const PartitionFieldDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.partitionFieldSelect.title',
     {
@@ -142,7 +142,7 @@ export const PartitionFieldDescription = memo<PropsWithChildren>(({ children }) 
   );
 });
 
-export const ExcludeFrequentDescription = memo<PropsWithChildren>(({ children }) => {
+export const ExcludeFrequentDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.excludeFrequent.title',
     {
@@ -166,7 +166,7 @@ export const ExcludeFrequentDescription = memo<PropsWithChildren>(({ children })
   );
 });
 
-export const DescriptionDescription = memo<PropsWithChildren>(({ children }) => {
+export const DescriptionDescription = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate(
     'xpack.ml.newJob.wizard.pickFieldsStep.advancedDetectorModal.description.title',
     {

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_partition_field/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_partition_field/description.tsx
@@ -10,11 +10,7 @@ import React, { memo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
-
-interface Props {
-  children: React.ReactNode;
-}
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.perPartitionCategorization.enable.title', {
     defaultMessage: 'Per-partition categorization',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/field_examples.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/categorization_view/field_examples.tsx
@@ -73,6 +73,6 @@ export const FieldExamples: FC<Props> = ({ fieldExamples }) => {
   );
 };
 
-const Token: FC<PropsWithChildren> = ({ children }) => (
+const Token: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <span style={{ backgroundColor: TOKEN_HIGHLIGHT_COLOR }}>{children}</span>
 );

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/geo_field/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/geo_field/description.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.geoField.title', {
     defaultMessage: 'Geo field',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/influencers/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/influencers/description.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.influencers.title', {
     defaultMessage: 'Influencers',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/population_field/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/population_field/description.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.populationField.title', {
     defaultMessage: 'Population field',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/rare_field/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/rare_field/description.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.splitRareField.title', {
     defaultMessage: 'Rare field',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/sparse_data/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/sparse_data/description.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.sparseData.title', {
     defaultMessage: 'Sparse data',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/split_field/description.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/pick_fields_step/components/split_field/description.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiDescribedFormGroup, EuiFormRow } from '@elastic/eui';
 
-export const Description = memo<PropsWithChildren>(({ children }) => {
+export const Description = memo<PropsWithChildren<unknown>>(({ children }) => {
   const title = i18n.translate('xpack.ml.newJob.wizard.pickFieldsStep.splitField.title', {
     defaultMessage: 'Split field',
   });

--- a/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/summary_step/components/common.tsx
+++ b/x-pack/plugins/ml/public/application/jobs/new_job/pages/components/summary_step/components/common.tsx
@@ -50,6 +50,6 @@ export const DatafeedSectionTitle: FC = () => (
   </EuiTitle>
 );
 
-export const Italic: FC<PropsWithChildren> = ({ children }) => (
+export const Italic: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <span style={{ fontStyle: 'italic' }}>{children}</span>
 );

--- a/x-pack/plugins/ml/public/application/notifications/components/notifications_list.test.tsx
+++ b/x-pack/plugins/ml/public/application/notifications/components/notifications_list.test.tsx
@@ -57,7 +57,7 @@ const getMockedDatePickeDependencies = () => {
   } as unknown as DatePickerDependencies;
 };
 
-const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <I18nProvider>
     <DatePickerContextProvider {...getMockedDatePickeDependencies()}>
       {children}

--- a/x-pack/plugins/ml/public/application/routing/routes/timeseriesexplorer/timeseriesexplorer.test.tsx
+++ b/x-pack/plugins/ml/public/application/routing/routes/timeseriesexplorer/timeseriesexplorer.test.tsx
@@ -25,7 +25,7 @@ jest.mock('../../../timeseriesexplorer', () => ({
 }));
 
 jest.mock('../../../timeseriesexplorer/timeseriesexplorer_page', () => ({
-  TimeSeriesExplorerPage: jest.fn(({ children }: PropsWithChildren) => {
+  TimeSeriesExplorerPage: jest.fn(({ children }: PropsWithChildren<unknown>) => {
     return <>{children}</>;
   }),
 }));

--- a/x-pack/plugins/observability_solution/apm/public/components/alerting/ui_components/chart_preview/chart_preview_helper.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/alerting/ui_components/chart_preview/chart_preview_helper.tsx
@@ -38,7 +38,7 @@ export const getDomain = (series: Array<{ name?: string; data: Coordinate[] }>) 
   };
 };
 
-const EmptyContainer: FC<PropsWithChildren> = ({ children }) => (
+const EmptyContainer: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <div
     style={{
       width: '100%',

--- a/x-pack/plugins/observability_solution/apm/public/hooks/use_breakpoints.test.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/hooks/use_breakpoints.test.tsx
@@ -10,7 +10,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { EuiProvider } from '@elastic/eui';
 import { useBreakpoints } from './use_breakpoints';
 
-const wrapper: FC<PropsWithChildren> = ({ children }) => (
+const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiProvider
     modify={{
       // set in apm/public/application/index.tsx

--- a/x-pack/plugins/observability_solution/infra/public/alerting/common/criterion_preview_chart/criterion_preview_chart.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/common/criterion_preview_chart/criterion_preview_chart.tsx
@@ -70,7 +70,7 @@ export const getDomain = (series: Series, stacked: boolean = false) => {
   return { yMin: min || 0, yMax: max || 0, xMin: minTimestamp, xMax: maxTimestamp };
 };
 
-export const EmptyContainer: FC<PropsWithChildren> = ({ children }) => (
+export const EmptyContainer: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <div
     style={{
       width: '100%',
@@ -84,7 +84,7 @@ export const EmptyContainer: FC<PropsWithChildren> = ({ children }) => (
   </div>
 );
 
-export const ChartContainer: FC<PropsWithChildren> = ({ children }) => (
+export const ChartContainer: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <div
     style={{
       width: '100%',

--- a/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
@@ -115,7 +115,7 @@ export const ExpressionEditor: React.FC<
   );
 };
 
-export const SourceStatusWrapper: FC<PropsWithChildren> = ({ children }) => {
+export const SourceStatusWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { load, isLoading, hasFailedLoading, isUninitialized } = useLogViewContext();
 
   return (

--- a/x-pack/plugins/observability_solution/infra/public/components/loading_overlay_wrapper.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/loading_overlay_wrapper.tsx
@@ -24,7 +24,7 @@ export const LoadingOverlayWrapper: React.FC<
   );
 };
 
-const Overlay: FC<PropsWithChildren> = ({ children }) => (
+const Overlay: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <OverlayDiv>{children ? children : <EuiLoadingSpinner size="xl" />}</OverlayDiv>
 );
 

--- a/x-pack/plugins/observability_solution/infra/public/pages/logs/log_entry_categories/page_providers.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/logs/log_entry_categories/page_providers.tsx
@@ -16,7 +16,7 @@ import { useActiveKibanaSpace } from '../../../hooks/use_kibana_space';
 import { ConnectedLogViewErrorPage } from '../shared/page_log_view_error';
 import { useLogMlJobIdFormatsShimContext } from '../shared/use_log_ml_job_id_formats_shim';
 
-export const LogEntryCategoriesPageProviders: FC<PropsWithChildren> = ({ children }) => {
+export const LogEntryCategoriesPageProviders: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const {
     hasFailedLoading,
     isLoading,

--- a/x-pack/plugins/observability_solution/infra/public/pages/logs/log_entry_rate/page_providers.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/logs/log_entry_rate/page_providers.tsx
@@ -18,7 +18,7 @@ import { useActiveKibanaSpace } from '../../../hooks/use_kibana_space';
 import { ConnectedLogViewErrorPage } from '../shared/page_log_view_error';
 import { useLogMlJobIdFormatsShimContext } from '../shared/use_log_ml_job_id_formats_shim';
 
-export const LogEntryRatePageProviders: FC<PropsWithChildren> = ({ children }) => {
+export const LogEntryRatePageProviders: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const {
     hasFailedLoading,
     isLoading,

--- a/x-pack/plugins/observability_solution/infra/public/pages/logs/page_providers.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/logs/page_providers.tsx
@@ -16,7 +16,7 @@ import { LogAnalysisCapabilitiesProvider } from '../../containers/logs/log_analy
 import { useKibanaContextForPlugin } from '../../hooks/use_kibana';
 import { useKbnUrlStateStorageFromRouterContext } from '../../utils/kbn_url_state_context';
 
-export const LogsPageProviders: FC<PropsWithChildren> = ({ children }) => {
+export const LogsPageProviders: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const {
     services: {
       notifications: { toasts: toastsService },

--- a/x-pack/plugins/observability_solution/infra/public/pages/logs/stream/page_providers.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/logs/stream/page_providers.tsx
@@ -24,7 +24,7 @@ import { LogViewConfigurationProvider } from '../../../containers/logs/log_view_
 import { ViewLogInContextProvider } from '../../../containers/logs/view_log_in_context';
 import { MatchedStateFromActor } from '../../../observability_logs/xstate_helpers';
 
-const ViewLogInContext: FC<PropsWithChildren> = ({ children }) => {
+const ViewLogInContext: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { startTimestamp, endTimestamp } = useLogPositionStateContext();
   const { logViewReference } = useLogViewContext();
 

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/metric_detail/hooks/metrics_time.test.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/metric_detail/hooks/metrics_time.test.tsx
@@ -70,7 +70,7 @@ const createProviderWrapper = () => {
   history.push(INITIAL_URL);
   const scopedHistory = new CoreScopedHistory(history, INITIAL_URL);
 
-  const ProviderWrapper: FC<PropsWithChildren> = ({ children }) => {
+  const ProviderWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
     return <Router history={scopedHistory}>{children}</Router>;
   };
 

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.test.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/metrics_explorer/hooks/use_metrics_explorer_data.test.tsx
@@ -36,7 +36,7 @@ const queryClient = new QueryClient({
 });
 
 const renderUseMetricsExplorerDataHook = () => {
-  const wrapper: FC<PropsWithChildren> = ({ children }) => {
+  const wrapper: FC<PropsWithChildren<any>> = ({ children }) => {
     const services = {
       http: {
         post: mockedFetch,

--- a/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_entry_flyout/log_entry_actions_menu.test.tsx
+++ b/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_entry_flyout/log_entry_actions_menu.test.tsx
@@ -19,7 +19,7 @@ coreStartMock.application.getUrlForApp.mockImplementation((app, options) => {
   return `/test-basepath/s/test-space/app/${app}${options?.path}`;
 });
 
-const ProviderWrapper: FC<PropsWithChildren> = ({ children }) => {
+const ProviderWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return <KibanaContextProvider services={{ ...coreStartMock }}>{children}</KibanaContextProvider>;
 };
 

--- a/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_text_stream/log_text_separator.tsx
+++ b/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_text_stream/log_text_separator.tsx
@@ -11,7 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule } from '@elastic/eui';
 /**
  * Create a separator with a text on the right side
  */
-export const LogTextSeparator: FC<PropsWithChildren> = ({ children }) => {
+export const LogTextSeparator: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s">
       <EuiFlexItem grow={false}>{children}</EuiFlexItem>

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/hooks/use_conversation.test.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/hooks/use_conversation.test.tsx
@@ -85,7 +85,7 @@ describe('useConversation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    wrapper = ({ children }: PropsWithChildren) => (
+    wrapper = ({ children }: PropsWithChildren<unknown>) => (
       <KibanaContextProvider services={useKibanaMockServices}>
         <ObservabilityAIAssistantAppServiceProvider value={mockService}>
           {children}

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/wrappers/service_allowed_wrapper.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/wrappers/service_allowed_wrapper.tsx
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 import { EuiButton, EuiEmptyPrompt, EuiLoadingLogo } from '@elastic/eui';
 import { useSyntheticsServiceAllowed } from '../../../hooks/use_service_allowed';
 
-export const ServiceAllowedWrapper: FC<PropsWithChildren> = ({ children }) => {
+export const ServiceAllowedWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { isAllowed, signupUrl, loading } = useSyntheticsServiceAllowed();
 
   if (loading) {

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitor_details/monitor_pending_wrapper.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitor_details/monitor_pending_wrapper.tsx
@@ -15,7 +15,7 @@ import { resetMonitorLastRunAction } from '../../state';
 import { useMonitorLatestPing } from './hooks/use_monitor_latest_ping';
 import { useSyntheticsRefreshContext } from '../../contexts';
 
-export const MonitorPendingWrapper: FC<PropsWithChildren> = ({ children }) => {
+export const MonitorPendingWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const dispatch = useDispatch();
   const history = useHistory();
   const currentLocation = useLocation();

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/contexts/synthetics_refresh_context.tsx
@@ -34,7 +34,7 @@ const defaultContext: SyntheticsRefreshContext = {
 
 export const SyntheticsRefreshContext = createContext(defaultContext);
 
-export const SyntheticsRefreshContextProvider: FC<PropsWithChildren> = ({ children }) => {
+export const SyntheticsRefreshContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [lastRefresh, setLastRefresh] = useState<number>(Date.now());
 
   const refreshPaused = useSelector(selectRefreshPaused);

--- a/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/monitor_tags.test.tsx
+++ b/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/monitor_tags.test.tsx
@@ -165,7 +165,7 @@ describe('MonitorTags component', () => {
 
   it('expand tag show tags on click', () => {
     summaryPing.state.summaryPings[0].tags = ['red', 'green', 'blue', 'black', 'purple', 'yellow'];
-    const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <MemoryRouter>{children}</MemoryRouter>
     );
     render(<MonitorTags ping={summaryPing.state.summaryPings[0]} />, { wrapper: Wrapper });

--- a/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/contexts/uptime_refresh_context.tsx
+++ b/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/contexts/uptime_refresh_context.tsx
@@ -21,7 +21,7 @@ const defaultContext: UptimeRefreshContext = {
 
 export const UptimeRefreshContext = createContext(defaultContext);
 
-export const UptimeRefreshContextProvider: FC<PropsWithChildren> = ({ children }) => {
+export const UptimeRefreshContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [lastRefresh, setLastRefresh] = useState<number>(Date.now());
 
   const refreshApp = () => {

--- a/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/hooks/use_overview_filter_check.test.tsx
+++ b/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/hooks/use_overview_filter_check.test.tsx
@@ -12,7 +12,7 @@ import * as reactRedux from 'react-redux';
 import { useOverviewFilterCheck } from './use_overview_filter_check';
 import { MockRouter } from '../lib/helper/rtl_helpers';
 
-function getWrapper(customSearch?: string): FC<PropsWithChildren> {
+function getWrapper(customSearch?: string): FC<PropsWithChildren<unknown>> {
   return ({ children }) => {
     const { location, ...rest } = createMemoryHistory();
     return (

--- a/x-pack/plugins/osquery/public/shared_components/osquery_results/test_utils.tsx
+++ b/x-pack/plugins/osquery/public/shared_components/osquery_results/test_utils.tsx
@@ -78,4 +78,6 @@ export const getMockedKibanaConfig = (permissionType: unknown) =>
     },
   } as unknown as ReturnType<typeof useKibana>);
 
-export const mockCasesContext: FC<PropsWithChildren> = (props) => <>{props?.children ?? null}</>;
+export const mockCasesContext: FC<PropsWithChildren<unknown>> = (props) => (
+  <>{props?.children ?? null}</>
+);

--- a/x-pack/plugins/reporting/public/lib/ilm_policy_status_context.tsx
+++ b/x-pack/plugins/reporting/public/lib/ilm_policy_status_context.tsx
@@ -20,7 +20,7 @@ interface ContextValue {
 
 const IlmPolicyStatusContext = createContext<undefined | ContextValue>(undefined);
 
-export const IlmPolicyStatusContextProvider: FC<PropsWithChildren> = ({ children }) => {
+export const IlmPolicyStatusContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { isLoading, data, resendRequest: recheckStatus } = useCheckIlmPolicyStatus();
 
   return (

--- a/x-pack/plugins/search_notebooks/public/components/title_panel.tsx
+++ b/x-pack/plugins/search_notebooks/public/components/title_panel.tsx
@@ -7,7 +7,7 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { EuiHorizontalRule, EuiPanel, EuiText } from '@elastic/eui';
 
-export const TitlePanel: FC<PropsWithChildren> = ({ children }) => (
+export const TitlePanel: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <>
     <EuiPanel hasShadow={false} paddingSize="s">
       <EuiText size="s" color="subdued">

--- a/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_sidebar.test.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_sidebar.test.tsx
@@ -19,7 +19,7 @@ jest.mock('../../hooks/use_query_indices', () => ({
   useQueryIndices: jest.fn(),
 }));
 
-const Wrapper: FC<PropsWithChildren> = ({ children }) => {
+const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <>
       <IntlProvider locale="en">{children}</IntlProvider>

--- a/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.test.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.test.tsx
@@ -28,7 +28,7 @@ jest.mock('../../hooks/use_kibana', () => ({
   })),
 }));
 
-const Wrapper: FC<PropsWithChildren> = ({ children }) => {
+const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <>
       <IntlProvider locale="en">{children}</IntlProvider>

--- a/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
+++ b/x-pack/plugins/security/public/account_management/user_profile/user_profile.test.tsx
@@ -7,7 +7,8 @@
 
 import { act, renderHook } from '@testing-library/react-hooks';
 import { mount } from 'enzyme';
-import React, { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import React from 'react';
 
 import { coreMock, scopedHistoryMock } from '@kbn/core/public/mocks';
 
@@ -24,7 +25,7 @@ const coreStart = coreMock.createStart();
 let history = scopedHistoryMock.create();
 const authc = securityMock.createSetup().authc;
 
-const wrapper: FC<PropsWithChildren> = ({ children }) => (
+const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <Providers
     services={coreStart}
     history={history}

--- a/x-pack/plugins/security/public/components/breadcrumb.tsx
+++ b/x-pack/plugins/security/public/components/breadcrumb.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { EuiBreadcrumb } from '@elastic/eui';
-import type { FunctionComponent } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import React, { createContext, useContext, useEffect, useRef } from 'react';
 
 import type { ChromeStart } from '@kbn/core/public';
@@ -42,7 +42,7 @@ export interface BreadcrumbProps extends EuiBreadcrumb {
  * </Breadcrumb>
  * ```
  */
-export const Breadcrumb: FunctionComponent<BreadcrumbProps> = ({ children, ...breadcrumb }) => {
+export const Breadcrumb: FC<PropsWithChildren<BreadcrumbProps>> = ({ children, ...breadcrumb }) => {
   const context = useContext(BreadcrumbsContext);
   const component = <InnerBreadcrumb breadcrumb={breadcrumb}>{children}</InnerBreadcrumb>;
 

--- a/x-pack/plugins/security_solution/public/assistant/provider.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/provider.tsx
@@ -115,7 +115,7 @@ export const createConversations = async (
 /**
  * This component configures the Elastic AI Assistant context provider for the Security Solution app.
  */
-export const AssistantProvider: FC<PropsWithChildren> = ({ children }) => {
+export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const {
     http,
     notifications,

--- a/x-pack/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/send_to_timeline/index.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { FC, PropsWithChildren } from 'react';
 import React, { useCallback } from 'react';
 import { EuiButton, EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';

--- a/x-pack/plugins/security_solution/public/common/__mocks__/query_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/common/__mocks__/query_wrapper.tsx
@@ -11,7 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 export const createQueryWrapperMock = (): {
   queryClient: QueryClient;
-  wrapper: FC<PropsWithChildren>;
+  wrapper: FC<PropsWithChildren<unknown>>;
 } => {
   const queryClient = new QueryClient({
     defaultOptions: {

--- a/x-pack/plugins/security_solution/public/common/components/current_license/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/current_license/index.tsx
@@ -13,7 +13,7 @@ import type { ILicense } from '@kbn/licensing-plugin/common/types';
 import { licenseService } from '../../hooks/use_license';
 import type { AppAction } from '../../store/actions';
 
-export const CurrentLicense = memo<PropsWithChildren>(({ children }) => {
+export const CurrentLicense = memo<PropsWithChildren<unknown>>(({ children }) => {
   const dispatch = useDispatch<Dispatch<AppAction>>();
   useEffect(() => {
     const subscription = licenseService

--- a/x-pack/plugins/security_solution/public/common/components/endpoint/route_capture.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/endpoint/route_capture.tsx
@@ -17,7 +17,7 @@ import { timelineActions } from '../../../timelines/store';
  * This component should be used above all routes, but below the Provider.
  * It dispatches actions when the URL is changed.
  */
-export const RouteCapture = memo<PropsWithChildren>(({ children }) => {
+export const RouteCapture = memo<PropsWithChildren<unknown>>(({ children }) => {
   const location: AppLocation = useLocation();
   const dispatch = useDispatch();
 

--- a/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/cti_details/threat_summary_view.tsx
@@ -28,7 +28,7 @@ const UppercaseEuiTitle = styled(EuiTitle)`
   text-transform: uppercase;
 `;
 
-const ThreatSummaryPanelTitle: FC<PropsWithChildren> = ({ children }) => (
+const ThreatSummaryPanelTitle: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <UppercaseEuiTitle size="xxxs">
     <h5>{children}</h5>
   </UppercaseEuiTitle>

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/event_details_width_context.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/event_details_width_context.tsx
@@ -15,7 +15,7 @@ const EventDetailsWidthContext = createContext(DEFAULT_WIDTH);
 
 export const useEventDetailsWidthContext = () => useContext(EventDetailsWidthContext);
 
-export const EventDetailsWidthProvider = React.memo<PropsWithChildren>(({ children }) => {
+export const EventDetailsWidthProvider = React.memo<PropsWithChildren<unknown>>(({ children }) => {
   const { ref, width } = useThrottledResizeObserver();
 
   return (

--- a/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/__mocks__/product_switch.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/__mocks__/product_switch.tsx
@@ -10,6 +10,6 @@ import React from 'react';
 
 export const ProductSwitch = jest
   .fn()
-  .mockImplementation(({ children }: PropsWithChildren) => (
+  .mockImplementation(({ children }: PropsWithChildren<unknown>) => (
     <div data-test-subj="product-switch">{children}</div>
   ));

--- a/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/__mocks__/toggle_panel.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/landing_page/onboarding/__mocks__/toggle_panel.tsx
@@ -10,6 +10,6 @@ import React from 'react';
 
 export const TogglePanel = jest
   .fn()
-  .mockImplementation(({ children }: PropsWithChildren) => (
+  .mockImplementation(({ children }: PropsWithChildren<unknown>) => (
     <div data-test-subj="toggle-panel">{children}</div>
   ));

--- a/x-pack/plugins/security_solution/public/common/components/ml/permissions/ml_capabilities_provider.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/ml/permissions/ml_capabilities_provider.tsx
@@ -30,7 +30,7 @@ export const MlCapabilitiesContext = React.createContext<MlCapabilitiesProvider>
 
 MlCapabilitiesContext.displayName = 'MlCapabilitiesContext';
 
-export const MlCapabilitiesProvider = React.memo<PropsWithChildren>(({ children }) => {
+export const MlCapabilitiesProvider = React.memo<PropsWithChildren<unknown>>(({ children }) => {
   const [capabilities, setCapabilities] = useState<MlCapabilitiesProvider>(
     emptyMlCapabilitiesProvider
   );

--- a/x-pack/plugins/security_solution/public/common/components/security_route_page_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/security_route_page_wrapper/index.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { FC, PropsWithChildren } from 'react';
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';

--- a/x-pack/plugins/security_solution/public/common/hooks/use_upselling.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_upselling.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../lib/kibana', () => {
 });
 
 const TestComponent = () => <div>{'TEST 1 2 3'}</div>;
-const RenderWrapper: FC<PropsWithChildren> = ({ children }) => {
+const RenderWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return <UpsellingProvider upsellingService={mockUpselling}>{children}</UpsellingProvider>;
 };
 

--- a/x-pack/plugins/security_solution/public/common/mock/storybook_providers.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/storybook_providers.tsx
@@ -94,7 +94,7 @@ const KibanaReactContext = createKibanaReactContext(coreMock);
  * It is a simplified version of TestProvidersComponent.
  * To reuse TestProvidersComponent here, we need to remove all references to jest from mocks.
  */
-export const StorybookProviders: FC<PropsWithChildren> = ({ children }) => {
+export const StorybookProviders: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const store = createMockStore();
 
   return (

--- a/x-pack/plugins/security_solution/public/dashboards/context/dashboard_context.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/context/dashboard_context.tsx
@@ -19,7 +19,7 @@ export interface DashboardContextType {
 
 const DashboardContext = React.createContext<DashboardContextType | null>({ securityTags: null });
 
-export const DashboardContextProvider: FC<PropsWithChildren> = ({ children }) => {
+export const DashboardContextProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { tags, isLoading } = useFetchSecurityTags();
   const securityTags = isLoading || !tags ? null : tags;
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
@@ -146,7 +146,7 @@ const convertToDiffFile = (oldSource: string, newSource: string) => {
   return diffFile;
 };
 
-const CustomStyles: FC<PropsWithChildren> = ({ children }) => {
+const CustomStyles: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { euiTheme } = useEuiTheme();
 
   const customCss = css`

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/json_diff.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/json_diff.test.tsx
@@ -64,7 +64,7 @@ describe('Rule upgrade workflow: viewing rule changes in JSON diff view', () => 
       delete oldRule.license;
       newRule.license = 'GPLv3';
 
-      const ThemeWrapper: FC<PropsWithChildren> = ({ children }) => (
+      const ThemeWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
         <EuiThemeProvider colorMode={colorMode}>{children}</EuiThemeProvider>
       );
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_details_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_details_flyout.tsx
@@ -101,7 +101,7 @@ const tabPaddingClassName = css`
   padding: 0 ${euiThemeVars.euiSizeM} ${euiThemeVars.euiSizeXL} ${euiThemeVars.euiSizeM};
 `;
 
-export const TabContentPadding: FC<PropsWithChildren> = ({ children }) => (
+export const TabContentPadding: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <div className={tabPaddingClassName}>{children}</div>
 );
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_errors_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/bulk_action_rule_errors_list.test.tsx
@@ -15,7 +15,7 @@ import { BulkActionsDryRunErrCode } from '../../../../../../common/constants';
 import type { DryRunResult } from './types';
 import { BulkActionTypeEnum } from '../../../../../../common/api/detection_engine/rule_management';
 
-const Wrapper: FC<PropsWithChildren> = ({ children }) => {
+const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <IntlProvider locale="en">
       <>{children}</>

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/components/execution_events_table/use_execution_events.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/components/execution_events_table/use_execution_events.test.tsx
@@ -42,7 +42,7 @@ describe('useExecutionEvents', () => {
         },
       },
     });
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
     return wrapper;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/components/execution_results_table/use_execution_results.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/components/execution_results_table/use_execution_results.test.tsx
@@ -37,7 +37,7 @@ describe('useExecutionResults', () => {
         },
       },
     });
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
     return wrapper;

--- a/x-pack/plugins/security_solution/public/detections/components/host_isolation/use_host_isolation_action.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/host_isolation/use_host_isolation_action.test.tsx
@@ -34,7 +34,7 @@ describe('useHostIsolationAction', () => {
   ])('works with %s hook', (name, hook) => {
     const createReactQueryWrapper = () => {
       const queryClient = new QueryClient();
-      const wrapper: FC<PropsWithChildren> = ({ children }) => (
+      const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
         <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
       );
       return wrapper;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/related_integrations/use_installed_integrations.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/related_integrations/use_installed_integrations.test.tsx
@@ -36,7 +36,7 @@ describe('useInstalledIntegrations', () => {
         },
       },
     });
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
     return wrapper;

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
@@ -48,7 +48,7 @@ const queryClient = new QueryClient({
   },
 });
 
-const ContextWrapper: FC<PropsWithChildren> = ({ children }) => (
+const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <QueryClientProvider client={queryClient}>
     <AssistantProvider
       actionTypeRegistry={actionTypeRegistry}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_process_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_process_data.test.tsx
@@ -61,7 +61,7 @@ const panelContextValue = {
   getFieldsData: jest.fn().mockReturnValue('test'),
 } as unknown as RightPanelContext;
 
-const ProviderComponent: FC<PropsWithChildren> = ({ children }) => (
+const ProviderComponent: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <RightPanelContext.Provider value={panelContextValue}>{children}</RightPanelContext.Provider>
 );
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/components/exception_items_summary.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/components/exception_items_summary.test.tsx
@@ -28,7 +28,7 @@ describe('Fleet event filters card', () => {
   const renderComponent: (
     stats: GetExceptionSummaryResponse
   ) => reactTestingLibrary.RenderResult = (stats) => {
-    const Wrapper: React.FC<PropsWithChildren> = ({ children }) => (
+    const Wrapper: React.FC<PropsWithChildren<unknown>> = ({ children }) => (
       <I18nProvider>
         <ThemeProvider theme={mockTheme}>{children}</ThemeProvider>
       </I18nProvider>

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_agent_tamper_protection_extension.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/endpoint_agent_tamper_protection_extension.tsx
@@ -9,12 +9,14 @@ import type { PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 import { useUpsellingComponent } from '../../../../../common/hooks/use_upselling';
 
-export const EndpointAgentTamperProtectionExtension = memo<PropsWithChildren>(({ children }) => {
-  const Component = useUpsellingComponent('endpoint_agent_tamper_protection');
-  if (!Component) {
-    return <>{children}</>;
+export const EndpointAgentTamperProtectionExtension = memo<PropsWithChildren<unknown>>(
+  ({ children }) => {
+    const Component = useUpsellingComponent('endpoint_agent_tamper_protection');
+    if (!Component) {
+      return <>{children}</>;
+    }
+    return <Component />;
   }
-  return <Component />;
-});
+);
 
 EndpointAgentTamperProtectionExtension.displayName = 'EndpointAgentTamperProtectionExtension';

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/mocks.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/ingest_manager_integration/mocks.tsx
@@ -83,7 +83,7 @@ export const createFleetContextRendererMock = (): AppContextTestRender => {
     additionalMiddleware: [mockedContext.middlewareSpy.actionSpyMiddleware],
   });
 
-  const Wrapper: RenderOptions['wrapper'] = ({ children }: PropsWithChildren) => {
+  const Wrapper: RenderOptions['wrapper'] = ({ children }: PropsWithChildren<unknown>) => {
     useEffect(() => {
       return () => {
         // When the component un-mounts, reset the Experimental features since

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/policy_settings_form.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/policy_settings_form.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 import { EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -110,7 +111,7 @@ export const PolicySettingsForm = memo<PolicySettingsFormProps>((props) => {
 });
 PolicySettingsForm.displayName = 'PolicySettingsForm';
 
-const FormSectionTitle = memo<PropsWithChildren>(({ children }) => {
+const FormSectionTitle = memo<PropsWithChildren<unknown>>(({ children }) => {
   return (
     <EuiText size="xs" color="subdued">
       <h4>{children}</h4>

--- a/x-pack/plugins/security_solution/public/overview/pages/landing.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/pages/landing.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../common/components/landing_page');
 jest.mock('../../common/components/page_wrapper', () => ({
   SecuritySolutionPageWrapper: jest
     .fn()
-    .mockImplementation(({ children }: PropsWithChildren) => <div>{children}</div>),
+    .mockImplementation(({ children }: PropsWithChildren<unknown>) => <div>{children}</div>),
 }));
 const history = createBrowserHistory();
 describe('LandingPage', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/stateful_event.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/events/stateful_event.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import type { PropsWithChildren } from 'react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { isEventBuildingBlockType } from '@kbn/securitysolution-data-table';
@@ -75,10 +76,12 @@ interface Props {
 
 const emptyNotes: string[] = [];
 
-const EventsTrSupplementContainerWrapper = React.memo<PropsWithChildren>(({ children }) => {
-  const width = useEventDetailsWidthContext();
-  return <EventsTrSupplementContainer width={width}>{children}</EventsTrSupplementContainer>;
-});
+const EventsTrSupplementContainerWrapper = React.memo<PropsWithChildren<unknown>>(
+  ({ children }) => {
+    const width = useEventDetailsWidthContext();
+    return <EventsTrSupplementContainer width={width}>{children}</EventsTrSupplementContainer>;
+  }
+);
 
 EventsTrSupplementContainerWrapper.displayName = 'EventsTrSupplementContainerWrapper';
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/session/use_session_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/session/use_session_view.test.tsx
@@ -85,7 +85,7 @@ describe('useSessionView with active timeline and a session id and graph event i
   let setTimelineFullScreen: jest.Mock;
   let setGlobalFullScreen: jest.Mock;
   let kibana: ReturnType<typeof useKibana>;
-  const Wrapper = memo<PropsWithChildren>(({ children }) => {
+  const Wrapper = memo<PropsWithChildren<unknown>>(({ children }) => {
     kibana = useKibana();
     return <TestProviders>{children}</TestProviders>;
   });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
@@ -136,7 +136,7 @@ const TestComponent = (props: Partial<ComponentProps<typeof UnifiedTimeline>>) =
 
 const customStore = createMockStore();
 
-const TestProviderWrapperWithCustomStore: FC<PropsWithChildren> = ({ children }) => {
+const TestProviderWrapperWithCustomStore: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return <TestProviders store={customStore}>{children}</TestProviders>;
 };
 

--- a/x-pack/plugins/security_solution_serverless/public/common/services/__mocks__/index.tsx
+++ b/x-pack/plugins/security_solution_serverless/public/common/services/__mocks__/index.tsx
@@ -12,7 +12,7 @@ import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { mockServices } from './services.mock';
 import { NavigationProvider } from '@kbn/security-solution-navigation';
 
-export const ServicesProvider: FC<PropsWithChildren> = ({ children }) => (
+export const ServicesProvider: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <I18nProvider>
     <KibanaContextProvider services={mockServices}>
       <NavigationProvider core={mockServices}>{children}</NavigationProvider>

--- a/x-pack/plugins/serverless_search/public/application/components/index_management/overview_panel.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/index_management/overview_panel.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import { EuiSpacer, EuiSplitPanel, EuiTitle } from '@elastic/eui';
 
 export interface IndexOverviewPanelProps {
@@ -34,7 +34,7 @@ export const IndexOverviewPanel: FC<PropsWithChildren<IndexOverviewPanelProps>> 
   </EuiSplitPanel.Outer>
 );
 
-export const IndexOverviewPanelStat: FC<PropsWithChildren> = ({ children }) => (
+export const IndexOverviewPanelStat: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiTitle size="l">
     <p>{children}</p>
   </EuiTitle>

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -484,7 +484,7 @@ const OverviewFooter = () => {
   );
 };
 
-const FooterButtonContainer: FC<PropsWithChildren> = ({ children }) => (
+const FooterButtonContainer: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiFlexItem>
     <EuiPanel hasShadow={false} paddingSize="none">
       <EuiFlexGroup>

--- a/x-pack/plugins/serverless_search/public/test/test_utils.tsx
+++ b/x-pack/plugins/serverless_search/public/test/test_utils.tsx
@@ -32,7 +32,7 @@ const queryClient = new QueryClient({
   },
 });
 
-const AllTheProviders: FC<PropsWithChildren> = ({ children }) => {
+const AllTheProviders: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <KibanaThemeProvider theme={core.theme}>
       <KibanaContextProvider services={{ ...core, ...services }}>

--- a/x-pack/plugins/spaces/public/spaces_context/context.tsx
+++ b/x-pack/plugins/spaces/public/spaces_context/context.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React, { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
+import React from 'react';
 
 import type { CoreStart } from '@kbn/core/public';
 
@@ -32,7 +33,7 @@ export const createSpacesReactContext = <Services extends Partial<CoreStart>>(
     spacesDataPromise,
     services,
   };
-  const Provider: FC<PropsWithChildren> = ({ children }) =>
+  const Provider: FC<PropsWithChildren<unknown>> = ({ children }) =>
     createElement(context.Provider as React.ComponentType<any>, { value, children });
 
   return {

--- a/x-pack/plugins/spaces/public/spaces_context/types.ts
+++ b/x-pack/plugins/spaces/public/spaces_context/types.ts
@@ -21,7 +21,7 @@ export interface SpacesReactContextValue<Services extends Partial<CoreStart>> {
 
 export interface SpacesReactContext<Services extends Partial<CoreStart>> {
   value: SpacesReactContextValue<Services>;
-  Provider: React.FC<React.PropsWithChildren>;
+  Provider: React.FC<React.PropsWithChildren<unknown>>;
   Consumer: React.Consumer<SpacesReactContextValue<Services>>;
 }
 

--- a/x-pack/plugins/stack_alerts/public/rule_types/components/source_fields_select.test.tsx
+++ b/x-pack/plugins/stack_alerts/public/rule_types/components/source_fields_select.test.tsx
@@ -11,7 +11,7 @@ import { I18nProvider } from '@kbn/i18n-react';
 import { SourceFields } from './source_fields_select';
 import { SourceField } from '../es_query/types';
 
-const AppWrapper = React.memo<PropsWithChildren>(({ children }) => (
+const AppWrapper = React.memo<PropsWithChildren<unknown>>(({ children }) => (
   <I18nProvider>{children}</I18nProvider>
 ));
 

--- a/x-pack/plugins/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.test.tsx
+++ b/x-pack/plugins/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.test.tsx
@@ -27,7 +27,7 @@ jest.mock('@kbn/text-based-editor', () => ({
 const { fetchFieldsFromESQL } = jest.requireMock('@kbn/text-based-editor');
 const { getFields } = jest.requireMock('@kbn/triggers-actions-ui-plugin/public');
 
-const AppWrapper = React.memo<PropsWithChildren>(({ children }) => (
+const AppWrapper = React.memo<PropsWithChildren<unknown>>(({ children }) => (
   <I18nProvider>{children}</I18nProvider>
 ));
 

--- a/x-pack/plugins/stack_alerts/public/rule_types/es_query/test_query_row/test_query_row_table.test.tsx
+++ b/x-pack/plugins/stack_alerts/public/rule_types/es_query/test_query_row/test_query_row_table.test.tsx
@@ -10,7 +10,7 @@ import { render } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import { TestQueryRowTable } from './test_query_row_table';
 
-const AppWrapper = React.memo<PropsWithChildren>(({ children }) => (
+const AppWrapper = React.memo<PropsWithChildren<unknown>>(({ children }) => (
   <I18nProvider>{children}</I18nProvider>
 ));
 

--- a/x-pack/plugins/threat_intelligence/public/containers/enterprise_guard.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/enterprise_guard.tsx
@@ -11,7 +11,7 @@ import { Paywall } from '../components/paywall';
 import { useSecurityContext } from '../hooks/use_security_context';
 import { SecuritySolutionPluginTemplateWrapper } from './security_solution_plugin_template_wrapper';
 
-export const EnterpriseGuard = memo<PropsWithChildren>(({ children }) => {
+export const EnterpriseGuard = memo<PropsWithChildren<unknown>>(({ children }) => {
   const { licenseService } = useSecurityContext();
 
   if (licenseService.isEnterprise()) {

--- a/x-pack/plugins/threat_intelligence/public/containers/field_types_provider.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/field_types_provider.tsx
@@ -15,7 +15,7 @@ export const FieldTypesContext = createContext<FieldTypesContextValue | undefine
 /**
  * Exposes mapped field types for threat intel shared use
  */
-export const FieldTypesProvider: FC<PropsWithChildren> = ({ children }) => {
+export const FieldTypesProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const { indexPattern } = useSourcererDataView();
 
   // field name to field type map to allow the cell_renderer to format dates

--- a/x-pack/plugins/threat_intelligence/public/containers/filters_global.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/filters_global.tsx
@@ -8,7 +8,7 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { useSecurityContext } from '../hooks/use_security_context';
 
-export const FiltersGlobal: FC<PropsWithChildren> = ({ children }) => {
+export const FiltersGlobal: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const contextValue = useSecurityContext();
 
   const Component = contextValue.getFiltersGlobalComponent();

--- a/x-pack/plugins/threat_intelligence/public/containers/inspector.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/inspector.tsx
@@ -14,7 +14,7 @@ export interface InspectorContextValue {
 
 export const InspectorContext = createContext<InspectorContextValue | undefined>(undefined);
 
-export const InspectorProvider: FC<PropsWithChildren> = ({ children }) => {
+export const InspectorProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const inspectorAdapters = useMemo(() => ({ requests: new RequestAdapter() }), []);
 
   return (

--- a/x-pack/plugins/threat_intelligence/public/containers/integrations_guard.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/integrations_guard.tsx
@@ -19,7 +19,7 @@ import { SecuritySolutionPluginTemplateWrapper } from './security_solution_plugi
  * If none are received, show the EmptyPage with a link to go install integrations.
  * While the indicators call and the integrations call are loading, display a loading screen.
  */
-export const IntegrationsGuard = memo<PropsWithChildren>(({ children }) => {
+export const IntegrationsGuard = memo<PropsWithChildren<unknown>>(({ children }) => {
   const { isLoading: indicatorsTotalCountLoading, count: indicatorsTotalCount } =
     useIndicatorsTotalCount();
 

--- a/x-pack/plugins/threat_intelligence/public/containers/security_solution_page_wrapper.tsx
+++ b/x-pack/plugins/threat_intelligence/public/containers/security_solution_page_wrapper.tsx
@@ -11,7 +11,7 @@ import { useSecurityContext } from '../hooks/use_security_context';
 /**
  * Security solution page wrapper, with some extra styling etc.
  */
-export const SecuritySolutionPageWrapper: FC<PropsWithChildren> = ({ children }) => {
+export const SecuritySolutionPageWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const contextValue = useSecurityContext();
 
   const Component = contextValue.getPageWrapper();

--- a/x-pack/plugins/threat_intelligence/public/mocks/test_providers.tsx
+++ b/x-pack/plugins/threat_intelligence/public/mocks/test_providers.tsx
@@ -138,7 +138,7 @@ export const mockedServices = {
   },
 };
 
-export const TestProvidersComponent: FC<PropsWithChildren> = ({ children }) => (
+export const TestProvidersComponent: FC<PropsWithChildren<any>> = ({ children }) => (
   <MemoryRouter>
     <InspectorContext.Provider value={{ requests: new RequestAdapter() }}>
       <QueryClientProvider client={new QueryClient()}>

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/block_list_provider.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/block_list_provider.tsx
@@ -21,7 +21,7 @@ export interface BlockListContextValue {
 
 export const BlockListContext = createContext<BlockListContextValue | undefined>(undefined);
 
-export const BlockListProvider: FC<PropsWithChildren> = ({ children }) => {
+export const BlockListProvider: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [blockListIndicatorValue, setBlockListIndicatorValue] = useState('');
 
   const context: BlockListContextValue = {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/filters.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/containers/filters.tsx
@@ -16,7 +16,7 @@ import {
 /**
  * Container used to wrap components and share the {@link FilterManager} through React context.
  */
-export const IndicatorsFilters: FC<PropsWithChildren> = ({ children }) => {
+export const IndicatorsFilters: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const securityContext = useSecurityContext();
 
   const {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/pages/indicators.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/pages/indicators.tsx
@@ -24,7 +24,7 @@ import { IndicatorsFilters } from '../containers/filters';
 import { UpdateStatus } from '../../../components/update_status';
 import { QueryBar } from '../../query_bar/components/query_bar';
 
-const IndicatorsPageProviders: FC<PropsWithChildren> = ({ children }) => (
+const IndicatorsPageProviders: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <IndicatorsFilters>
     <FieldTypesProvider>
       <InspectorProvider>

--- a/x-pack/plugins/transform/public/app/hooks/use_index_data.test.tsx
+++ b/x-pack/plugins/transform/public/app/hooks/use_index_data.test.tsx
@@ -48,7 +48,7 @@ const queryClient = new QueryClient();
 describe('Transform: useIndexData()', () => {
   test('dataView set triggers loading', async () => {
     const mlShared = await getMlSharedImports();
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <QueryClientProvider client={queryClient}>
         <IntlProvider locale="en">
           <MlSharedContext.Provider value={mlShared}>{children}</MlSharedContext.Provider>

--- a/x-pack/plugins/transform/public/app/sections/edit_transform/state_management/edit_transform_flyout_state.test.tsx
+++ b/x-pack/plugins/transform/public/app/sections/edit_transform/state_management/edit_transform_flyout_state.test.tsx
@@ -21,7 +21,7 @@ import { useIsFormValid } from './selectors/is_form_valid';
 describe('Transform: useEditTransformFlyoutActions/Selector()', () => {
   it('field updates should trigger form validation', () => {
     const transformConfigMock = getTransformConfigMock();
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <EditTransformFlyoutProvider config={transformConfigMock} dataViewId={'the-data-view-id'}>
         {children}
       </EditTransformFlyoutProvider>

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_actions.test.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_actions.test.tsx
@@ -17,7 +17,7 @@ import { useActions } from './use_actions';
 describe('Transform: Transform List Actions', () => {
   test('useActions()', async () => {
     const queryClient = new QueryClient();
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
     const { result, waitForNextUpdate } = renderHook(

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.test.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/transform_list/use_columns.test.tsx
@@ -17,7 +17,7 @@ jest.mock('../../../../app_dependencies');
 describe('Transform: Job List Columns', () => {
   test('useColumns()', async () => {
     const queryClient = new QueryClient();
-    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+    const wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
     const { result, waitForNextUpdate } = renderHook(() => useColumns([], () => {}, 1, [], false), {

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/toast_with_circuit_breaker_content.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/toast_with_circuit_breaker_content.tsx
@@ -23,7 +23,7 @@ const hideFullErrorMessage = i18n.translate(
   }
 );
 
-export const ToastWithCircuitBreakerContent: FC<PropsWithChildren> = ({ children }) => {
+export const ToastWithCircuitBreakerContent: FC<PropsWithChildren<unknown>> = ({ children }) => {
   const [showDetails, setShowDetails] = useState(false);
 
   const onToggleShowDetails = useCallback(() => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/test_utils.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/test_utils.tsx
@@ -25,7 +25,7 @@ export interface AppMockRenderer {
   render: UiRender;
   coreStart: TriggersAndActionsUiServices;
   queryClient: QueryClient;
-  AppWrapper: FC<PropsWithChildren>;
+  AppWrapper: FC<PropsWithChildren<unknown>>;
 }
 
 export const createAppMockRenderer = (
@@ -51,7 +51,7 @@ export const createAppMockRenderer = (
     },
   });
 
-  const AppWrapper = React.memo<PropsWithChildren>(({ children }) => (
+  const AppWrapper = React.memo<PropsWithChildren<unknown>>(({ children }) => (
     <I18nProvider>
       <KibanaRenderContextProvider {...core}>
         <KibanaContextProvider services={services}>

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/components/loading_issues_error.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/fix_issues_step/components/loading_issues_error.tsx
@@ -8,7 +8,7 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiIcon } from '@elastic/eui';
 
-export const LoadingIssuesError: FC<PropsWithChildren> = ({ children }) => (
+export const LoadingIssuesError: FC<PropsWithChildren<unknown>> = ({ children }) => (
   <EuiText color="subdued" data-test-subj="loadingIssuesError">
     <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary
Original problem: `PropsWithChildren` require a generic type parameter (there's no default). This was not made visible in the merged PR, because we had type-checking on the PRs temporarily (accidentally) removed.

Thsi PR fixes the fallout from https://github.com/elastic/kibana/pull/181257  => Errors: https://buildkite.com/elastic/kibana-on-merge/builds/44454

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->