### PR TITLE
[CI] Re-add type-check

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -70,6 +70,16 @@ steps:
         - exit_status: '-1'
           limit: 3
 
+  - command: .buildkite/scripts/steps/check_types.sh
+    label: 'Check Types'
+    agents:
+      queue: n2-4-spot
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
   - command: .buildkite/scripts/steps/lint_with_types.sh
     label: 'Linting (with types)'
     agents:


### PR DESCRIPTION
## Summary
In #180784 I removed the type-check step from the Build API Docs step, because I thought it was covered by other steps in the pipeline, and it was just an unnecessary duplication there.

This PR re-adds it because there was no exhaustive type-check run on PRs.
