### PR TITLE
[Playground] Adding TECH PREVIEW badge for Playground

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -46,4 +46,4 @@ xpack.ml.compatibleModuleType: 'search'
 data_visualizer.resultLinks.fileBeat.enabled: false
 
 # Search Playground
-xpack.searchPlayground.ui.enabled: false
+xpack.searchPlayground.ui.enabled: true

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
@@ -11,7 +11,10 @@ import { useSearchParams } from 'react-router-dom-v5-compat';
 
 import { useValues } from 'kea';
 
+import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { KibanaLogic } from '../../../shared/kibana';
 import { EnterpriseSearchApplicationsPageTemplate } from '../layout/page_template';
@@ -39,9 +42,29 @@ export const Playground: React.FC = () => {
           }),
         ]}
         pageHeader={{
-          pageTitle: i18n.translate('xpack.enterpriseSearch.content.playground.headerTitle', {
-            defaultMessage: 'Playground',
-          }),
+          pageTitle: (
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <span data-test-subj="chat-playground-home-page-title">
+                  <FormattedMessage
+                    id="xpack.enterpriseSearch.content.playground.headerTitle"
+                    defaultMessage="Playground"
+                  />
+                </span>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBetaBadge
+                  label={i18n.translate(
+                    'xpack.enterpriseSearch.content.playground.headerTitle.techPreview',
+                    {
+                      defaultMessage: 'TECH PREVIEW',
+                    }
+                  )}
+                  color="hollow"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ),
           rightSideItems: [<searchPlayground.PlaygroundToolbar />],
         }}
         pageViewTelemetry="Playground"

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
@@ -45,12 +45,10 @@ export const Playground: React.FC = () => {
           pageTitle: (
             <EuiFlexGroup>
               <EuiFlexItem grow={false}>
-                <span data-test-subj="chat-playground-home-page-title">
-                  <FormattedMessage
-                    id="xpack.enterpriseSearch.content.playground.headerTitle"
-                    defaultMessage="Playground"
-                  />
-                </span>
+                <FormattedMessage
+                  id="xpack.enterpriseSearch.content.playground.headerTitle"
+                  defaultMessage="Playground"
+                />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiBetaBadge

--- a/x-pack/plugins/search_playground/public/chat_playground_overview.tsx
+++ b/x-pack/plugins/search_playground/public/chat_playground_overview.tsx
@@ -7,7 +7,8 @@
 
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { EuiPageTemplate } from '@elastic/eui';
+import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiPageTemplate } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { PlaygroundProvider } from './providers/playground_provider';
 
 import { App } from './components/app';
@@ -23,11 +24,27 @@ export const ChatPlaygroundOverview: React.FC = () => {
     >
       <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlPlaygroundPage">
         <EuiPageTemplate.Header
-          pageTitle={i18n.translate('xpack.searchPlayground.pageTitle', {
-            defaultMessage: 'Playground',
-          })}
-          data-test-subj="svlPlaygroundPageTitle"
-          restrictWidth
+          pageTitle={
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <span data-test-subj="chat-playground-home-page-title">
+                  <FormattedMessage
+                    id="xpack.searchPlayground.pageTitle"
+                    defaultMessage="Playground"
+                  />
+                </span>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBetaBadge
+                  label={i18n.translate('xpack.searchPlayground.pageTitle.techPreview', {
+                    defaultMessage: 'TECH PREVIEW',
+                  })}
+                  color="hollow"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+          data-test-subj="chat-playground-home-page"
           rightSideItems={[<PlaygroundHeaderDocs />, <PlaygroundToolbar />]}
         />
         <App />


### PR DESCRIPTION
## Summary

- Adding badge in Playground
- Enabling for Serverless

### Serverless
![serverless](https://github.com/elastic/kibana/assets/150824886/6dde57b1-dd2b-4c55-ac6f-37e55cc4a61e)

### Stack
![stack](https://github.com/elastic/kibana/assets/150824886/3fd7f81f-c324-499a-bdd5-1f0bb1eae3e1)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->