### PR TITLE
[Canvas] Update limits and change some imports

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -143,7 +143,7 @@ pageLoadAssetSize:
   snapshotRestore: 79032
   spaces: 57868
   stackAlerts: 58316
-  stackConnectors: 67227
+  stackConnectors: 52131
   synthetics: 40958
   telemetry: 51957
   telemetryManagementSection: 38586

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -8,7 +8,7 @@ pageLoadAssetSize:
   assetManager: 25000
   banners: 17946
   bfetch: 22837
-  canvas: 1066647
+  canvas: 20000
   cases: 180037
   charts: 55000
   cloud: 21076
@@ -25,7 +25,7 @@ pageLoadAssetSize:
   core: 435325
   crossClusterReplication: 65408
   customIntegrations: 22034
-  dashboard: 82025
+  dashboard: 52967
   dashboardEnhanced: 65646
   data: 454087
   datasetQuality: 50624
@@ -143,7 +143,7 @@ pageLoadAssetSize:
   snapshotRestore: 79032
   spaces: 57868
   stackAlerts: 58316
-  stackConnectors: 52131
+  stackConnectors: 67227
   synthetics: 40958
   telemetry: 51957
   telemetryManagementSection: 38586

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -8,7 +8,7 @@ pageLoadAssetSize:
   assetManager: 25000
   banners: 17946
   bfetch: 22837
-  canvas: 20000
+  canvas: 29355
   cases: 180037
   charts: 55000
   cloud: 21076

--- a/x-pack/plugins/canvas/common/lib/constants.ts
+++ b/x-pack/plugins/canvas/common/lib/constants.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-// eslint-disable-next-line @kbn/imports/no_boundary_crossing
-import { SHAREABLE_RUNTIME_NAME } from '../../shareable_runtime/constants_static';
 import { FilterField } from '../../types';
+
+// avoid import from shareable_runtime
+const SHAREABLE_RUNTIME_NAME = 'kbn_canvas';
 
 export const CANVAS_TYPE = 'canvas-workpad';
 export const CUSTOM_ELEMENT_TYPE = 'canvas-element';

--- a/x-pack/plugins/canvas/public/index.ts
+++ b/x-pack/plugins/canvas/public/index.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { PluginInitializerContext } from '@kbn/core/public';
-import { CoreStart } from '@kbn/core/public';
-import { CanvasServices } from './services';
-import { CanvasSetup, CanvasStart, CanvasStartDeps, CanvasPlugin } from './plugin';
+import type { PluginInitializerContext } from '@kbn/core/public';
+import type { CoreStart } from '@kbn/core/public';
+import type { CanvasServices } from './services';
+import { type CanvasSetup, type CanvasStart, type CanvasStartDeps, CanvasPlugin } from './plugin';
 
 export type { CanvasSetup, CanvasStart };
 

--- a/x-pack/plugins/canvas/public/lib/loading_indicator.ts
+++ b/x-pack/plugins/canvas/public/lib/loading_indicator.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import * as Rx from 'rxjs';
 import { CoreStart } from '@kbn/core/public';
+import { BehaviorSubject } from 'rxjs';
 
 let isActive = false;
 
@@ -15,7 +15,7 @@ export interface LoadingIndicatorInterface {
   hide: () => void;
 }
 
-const loadingCount$ = new Rx.BehaviorSubject(0);
+const loadingCount$ = new BehaviorSubject(0);
 
 export const initLoadingIndicator = (addLoadingCount: CoreStart['http']['addLoadingCountSource']) =>
   addLoadingCount(loadingCount$);


### PR DESCRIPTION
## Summary
This PR updates the `limits.yml` to reflect that Canvas is actually _much_ smaller than it appears. Also did some small changes to the imports which looks like it shaves off `.1kb` from the page load. This PR also lowers the dashboard plugin's limit to be more inline with the actual size of the Dashboard plugin.