### PR TITLE
[Semantic Text UI] Handle the case when the model is not yet downloaded

### DIFF
--- a/x-pack/plugins/ml/public/index.ts
+++ b/x-pack/plugins/ml/public/index.ts
@@ -26,6 +26,7 @@ export const plugin: PluginInitializer<
 > = (initializerContext: PluginInitializerContext) => new MlPlugin(initializerContext);
 
 export type { MlPluginSetup, MlPluginStart };
+export type { TrainedModelConfigResponse } from '../common/types/trained_models';
 
 export type { MlCapabilitiesResponse } from '../common/types/capabilities';
 export type { MlSummaryJob } from '../common/types/anomaly_detection_jobs';


### PR DESCRIPTION
When the trained model is not yet downloaded, it can't be deployed. This PR has covered the following:
- Download the model if it does not exist
- Tests to support this change

### How to test the changes locally
-  Download the elasticsearch changes from GitHub [branch](https://github.com/elastic/elasticsearch/tree/feature/semantic-text) 
- Run the elasticsearch: `./gradlew :run -Drun.license_type=trial`
- Download the changes of this PR in local kibana and do the following steps
    +  Set   isSemanticTextEnabled = true in this [location](https://github.com/elastic/kibana/pull/180246/files#diff-92f4739f8a4a6917951a1b6e1af21a96d54313eaa2b5ce4c0e0553dd2ee11fcaL80)
    +  Run `yarn start`