### PR TITLE
[ES|QL] Move setting from Discover to the General section

### DIFF
--- a/src/plugins/discover/server/ui_settings.ts
+++ b/src/plugins/discover/server/ui_settings.ts
@@ -328,7 +328,6 @@ export const getUiSettings: (
       },
     }),
     requiresPageReload: true,
-    category: ['discover'],
     schema: schema.boolean(),
   },
 });


### PR DESCRIPTION
## Summary

Move the setting from Discover to the General section. The setting is being used by many consumers outside Discover so having this setting to this section causes confusion.