### PR TITLE
Add missing type defaults to RouteDependencies

### DIFF
--- a/x-pack/plugins/index_management/server/routes/api/component_templates/register_privileges_route.test.ts
+++ b/x-pack/plugins/index_management/server/routes/api/component_templates/register_privileges_route.test.ts
@@ -49,7 +49,7 @@ describe('GET privileges', () => {
         isLegacyTemplatesEnabled: true,
         isIndexStatsEnabled: true,
         isDataStreamsStorageColumnEnabled: true,
-        enableTogglingDataRetention: false,
+        enableTogglingDataRetention: true,
       },
       indexDataEnricher: mockedIndexDataEnricher,
       lib: {
@@ -119,7 +119,7 @@ describe('GET privileges', () => {
           isLegacyTemplatesEnabled: true,
           isIndexStatsEnabled: true,
           isDataStreamsStorageColumnEnabled: true,
-          enableTogglingDataRetention: false,
+          enableTogglingDataRetention: true,
         },
         indexDataEnricher: mockedIndexDataEnricher,
         lib: {

--- a/x-pack/plugins/index_management/server/routes/api/component_templates/register_privileges_route.test.ts
+++ b/x-pack/plugins/index_management/server/routes/api/component_templates/register_privileges_route.test.ts
@@ -49,6 +49,7 @@ describe('GET privileges', () => {
         isLegacyTemplatesEnabled: true,
         isIndexStatsEnabled: true,
         isDataStreamsStorageColumnEnabled: true,
+        enableTogglingDataRetention: false,
       },
       indexDataEnricher: mockedIndexDataEnricher,
       lib: {
@@ -118,6 +119,7 @@ describe('GET privileges', () => {
           isLegacyTemplatesEnabled: true,
           isIndexStatsEnabled: true,
           isDataStreamsStorageColumnEnabled: true,
+          enableTogglingDataRetention: false,
         },
         indexDataEnricher: mockedIndexDataEnricher,
         lib: {

--- a/x-pack/plugins/index_management/server/routes/api/enrich_policies/register_privileges_route.test.ts
+++ b/x-pack/plugins/index_management/server/routes/api/enrich_policies/register_privileges_route.test.ts
@@ -49,7 +49,7 @@ describe('GET privileges', () => {
         isLegacyTemplatesEnabled: true,
         isIndexStatsEnabled: true,
         isDataStreamsStorageColumnEnabled: true,
-        enableTogglingDataRetention: false,
+        enableTogglingDataRetention: true,
       },
       indexDataEnricher: mockedIndexDataEnricher,
       lib: {
@@ -119,7 +119,7 @@ describe('GET privileges', () => {
           isLegacyTemplatesEnabled: true,
           isIndexStatsEnabled: true,
           isDataStreamsStorageColumnEnabled: true,
-          enableTogglingDataRetention: false,
+          enableTogglingDataRetention: true,
         },
         indexDataEnricher: mockedIndexDataEnricher,
         lib: {

--- a/x-pack/plugins/index_management/server/routes/api/enrich_policies/register_privileges_route.test.ts
+++ b/x-pack/plugins/index_management/server/routes/api/enrich_policies/register_privileges_route.test.ts
@@ -49,6 +49,7 @@ describe('GET privileges', () => {
         isLegacyTemplatesEnabled: true,
         isIndexStatsEnabled: true,
         isDataStreamsStorageColumnEnabled: true,
+        enableTogglingDataRetention: false,
       },
       indexDataEnricher: mockedIndexDataEnricher,
       lib: {
@@ -118,6 +119,7 @@ describe('GET privileges', () => {
           isLegacyTemplatesEnabled: true,
           isIndexStatsEnabled: true,
           isDataStreamsStorageColumnEnabled: true,
+          enableTogglingDataRetention: false,
         },
         indexDataEnricher: mockedIndexDataEnricher,
         lib: {

--- a/x-pack/plugins/index_management/server/test/helpers/route_dependencies.ts
+++ b/x-pack/plugins/index_management/server/test/helpers/route_dependencies.ts
@@ -15,7 +15,7 @@ export const routeDependencies: Omit<RouteDependencies, 'router'> = {
     isLegacyTemplatesEnabled: true,
     isIndexStatsEnabled: true,
     isDataStreamsStorageColumnEnabled: true,
-    enableTogglingDataRetention: false,
+    enableTogglingDataRetention: true,
   },
   indexDataEnricher: new IndexDataEnricher(),
   lib: {

--- a/x-pack/plugins/index_management/server/test/helpers/route_dependencies.ts
+++ b/x-pack/plugins/index_management/server/test/helpers/route_dependencies.ts
@@ -15,6 +15,7 @@ export const routeDependencies: Omit<RouteDependencies, 'router'> = {
     isLegacyTemplatesEnabled: true,
     isIndexStatsEnabled: true,
     isDataStreamsStorageColumnEnabled: true,
+    enableTogglingDataRetention: false,
   },
   indexDataEnricher: new IndexDataEnricher(),
   lib: {


### PR DESCRIPTION
## Summary
Typescript was temporarily out, so some type issues snuck in.
This PR attempts to fix it, by adding missed field `enableTogglingDataRetention` on type `RouteDependencies`

