### PR TITLE
[Fix] Add missing totalSeconds field

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/server/routes/apm.ts
+++ b/x-pack/plugins/observability_solution/profiling/server/routes/apm.ts
@@ -83,6 +83,7 @@ export function registerTopNFunctionsAPMTransactionsRoute({
               indices: transactionIndices.split(','),
               stacktraceIdsField: 'transaction.profiler_stack_trace_ids',
               limit: 1000,
+              totalSeconds: endSecs - startSecs,
             });
             const apmFunction = apmFunctions.TopN.find(
               (topNFunction) => topNFunction.Frame.FunctionName === functionName


### PR DESCRIPTION
## Summary
The PR https://github.com/elastic/kibana/pull/182001 was verified at a point where typechecking was missing for a bit, this allowed a missing field to slip in. This PR tries to fix it.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->