### PR TITLE
Config: add support for `${VAR:default}` syntax

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -14,8 +14,11 @@ KBN_PATH_CONF=/home/kibana/config ./bin/kibana
 --
 
 The default host and port settings configure {kib} to run on `localhost:5601`. To change this behavior and allow remote users to connect, you'll need to update your `kibana.yml` file. You can also enable SSL and set a
-variety of other options. Finally, environment variables can be injected into
-configuration using `${MY_ENV_VAR}` syntax.
+variety of other options. 
+
+Environment variables can be injected into configuration using `${MY_ENV_VAR}` syntax. By default, configuration validation
+will fail if an environment variable used in the config file is not present when Kibana starts. This behavior can be changed by using a default value
+for the environment variable, using the `${MY_ENV_VAR:defaultValue}` syntax.
 
 `console.ui.enabled`::
 Toggling this causes the server to regenerate assets on the next startup,

--- a/packages/kbn-config/src/__fixtures__/en_var_with_defaults.yml
+++ b/packages/kbn-config/src/__fixtures__/en_var_with_defaults.yml
@@ -1,0 +1,4 @@
+foo: 'pre-${KBN_ENV_VAR1}-mid-${KBN_ENV_VAR2:default2}-post'
+nested_list:
+  - id: 'a'
+    values: ['${KBN_ENV_VAR1:default1}', '${KBN_ENV_VAR2:default2}']

--- a/packages/kbn-config/src/raw/read_config.test.ts
+++ b/packages/kbn-config/src/raw/read_config.test.ts
@@ -130,3 +130,26 @@ test('supports unsplittable key syntax on nested list', () => {
     }
   `);
 });
+
+test('supports var:default syntax', () => {
+  process.env.KBN_ENV_VAR1 = 'val1';
+
+  const config = getConfigFromFiles([fixtureFile('/en_var_with_defaults.yml')]);
+
+  delete process.env.KBN_ENV_VAR1;
+
+  expect(config).toMatchInlineSnapshot(`
+    Object {
+      "foo": "pre-val1-mid-default2-post",
+      "nested_list": Array [
+        Object {
+          "id": "a",
+          "values": Array [
+            "val1",
+            "default2",
+          ],
+        },
+      ],
+    }
+  `);
+});

--- a/packages/kbn-config/src/raw/read_config.ts
+++ b/packages/kbn-config/src/raw/read_config.ts
@@ -11,20 +11,9 @@ import { safeLoad } from 'js-yaml';
 import { set } from '@kbn/safer-lodash-set';
 import { isPlainObject } from 'lodash';
 import { ensureValidObjectPath } from '@kbn/std';
-import { splitKey, getUnsplittableKey } from './utils';
+import { splitKey, getUnsplittableKey, replaceEnvVarRefs } from './utils';
 
 const readYaml = (path: string) => safeLoad(readFileSync(path, 'utf8'));
-
-function replaceEnvVarRefs(val: string) {
-  return val.replace(/\$\{(\w+)\}/g, (match, envVarName) => {
-    const envVarValue = process.env[envVarName];
-    if (envVarValue !== undefined) {
-      return envVarValue;
-    }
-
-    throw new Error(`Unknown environment variable referenced in config : ${envVarName}`);
-  });
-}
 
 interface YamlEntry {
   path: string[];

--- a/packages/kbn-config/src/raw/utils.test.ts
+++ b/packages/kbn-config/src/raw/utils.test.ts
@@ -34,7 +34,7 @@ describe('getUnsplittableKey', () => {
   });
 });
 
-describe.only('replaceEnvVarRefs', () => {
+describe('replaceEnvVarRefs', () => {
   it('throws an error if the variable is not defined', () => {
     expect(() => replaceEnvVarRefs('${VAR_1}', {})).toThrowErrorMatchingInlineSnapshot(
       `"Unknown environment variable referenced in config : VAR_1"`

--- a/packages/kbn-config/src/raw/utils.test.ts
+++ b/packages/kbn-config/src/raw/utils.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { splitKey, getUnsplittableKey } from './utils';
+import { splitKey, getUnsplittableKey, replaceEnvVarRefs } from './utils';
 
 describe('splitKey', () => {
   it('correctly splits on the dot delimiter', () => {
@@ -31,5 +31,41 @@ describe('getUnsplittableKey', () => {
     expect(getUnsplittableKey('[foo.bar')).toEqual(undefined);
     expect(getUnsplittableKey('foo.bar]')).toEqual(undefined);
     expect(getUnsplittableKey('foo.bar')).toEqual(undefined);
+  });
+});
+
+describe.only('replaceEnvVarRefs', () => {
+  it('throws an error if the variable is not defined', () => {
+    expect(() => replaceEnvVarRefs('${VAR_1}', {})).toThrowErrorMatchingInlineSnapshot(
+      `"Unknown environment variable referenced in config : VAR_1"`
+    );
+  });
+  it('replaces the environment variable with its value', () => {
+    expect(replaceEnvVarRefs('${VAR_1}', { VAR_1: 'foo' })).toEqual('foo');
+  });
+  it('replaces the environment variable within a longer string', () => {
+    expect(replaceEnvVarRefs('hello ${VAR_1} bar', { VAR_1: 'foo' })).toEqual('hello foo bar');
+  });
+  it('replaces multiple occurrences of the same variable', () => {
+    expect(replaceEnvVarRefs('${VAR_1}-${VAR_1}', { VAR_1: 'foo' })).toEqual('foo-foo');
+  });
+  it('replaces multiple occurrences of different variables', () => {
+    expect(replaceEnvVarRefs('${VAR_1}-${VAR_2}', { VAR_1: 'foo', VAR_2: 'bar' })).toEqual(
+      'foo-bar'
+    );
+  });
+  it('uses the default value if specified and the var is not defined', () => {
+    expect(replaceEnvVarRefs('${VAR:default}', {})).toEqual('default');
+  });
+  it('uses the value from the var if specified even with a default value', () => {
+    expect(replaceEnvVarRefs('${VAR:default}', { VAR: 'value' })).toEqual('value');
+  });
+  it('supports defining a default value for multiple variables', () => {
+    expect(replaceEnvVarRefs('${VAR1:var}:${VAR2:var2}', {})).toEqual('var:var2');
+  });
+  it('only use default value for variables that are not set', () => {
+    expect(replaceEnvVarRefs('${VAR1:default1}:${VAR2:default2}', { VAR2: 'var2' })).toEqual(
+      'default1:var2'
+    );
   });
 });

--- a/packages/kbn-config/src/raw/utils.ts
+++ b/packages/kbn-config/src/raw/utils.ts
@@ -19,3 +19,25 @@ export const getUnsplittableKey = (rawKey: string): string | undefined => {
   }
   return undefined;
 };
+
+export function replaceEnvVarRefs(
+  val: string,
+  env: {
+    [key: string]: string | undefined;
+  } = process.env
+) {
+  return val.replace(/\$\{(\w+)(:(\w+))?\}/g, (match, ...groups) => {
+    const envVarName = groups[0];
+    const defaultValue = groups[2];
+
+    const envVarValue = env[envVarName];
+    if (envVarValue !== undefined) {
+      return envVarValue;
+    }
+    if (defaultValue !== undefined) {
+      return defaultValue;
+    }
+
+    throw new Error(`Unknown environment variable referenced in config : ${envVarName}`);
+  });
+}


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/100854

### Release note

The Kibana configuration file now supports assigning default value for environment variables, using the `${VAR_ENV:defaultValue}` syntax.