### PR TITLE
[Security Solution][Alert details] - fix filter in and out not working on user and host expandable flyout opened from timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/entity_details/shared/components/entity_table/columns.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/shared/components/entity_table/columns.tsx
@@ -59,6 +59,7 @@ export const getEntityTableColumns = <T extends BasicEntityData>(
             idPrefix={contextID ? `entityTable-${contextID}` : 'entityTable'}
             isDraggable={isDraggable}
             sourcererScopeId={getSourcererScopeId(scopeId)}
+            scopeId={scopeId}
             render={renderField}
             data-test-subj="entity-table-value"
           />

--- a/x-pack/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/field_renderers/field_renderers.tsx
@@ -201,6 +201,7 @@ interface DefaultFieldRendererProps {
   render?: (item: string) => React.ReactNode;
   rowItems: string[] | null | undefined;
   sourcererScopeId?: SourcererScopeName;
+  scopeId?: string;
 }
 
 export const DefaultFieldRendererComponent: React.FC<DefaultFieldRendererProps> = ({
@@ -212,6 +213,7 @@ export const DefaultFieldRendererComponent: React.FC<DefaultFieldRendererProps> 
   render,
   rowItems,
   sourcererScopeId,
+  scopeId,
 }) => {
   if (rowItems != null && rowItems.length > 0) {
     const draggables = rowItems.slice(0, displayCount).map((rowItem, index) => {
@@ -234,6 +236,7 @@ export const DefaultFieldRendererComponent: React.FC<DefaultFieldRendererProps> 
               value={rowItem}
               isAggregatable={true}
               fieldType={'keyword'}
+              scopeId={scopeId}
             >
               {render ? render(rowItem) : rowItem}
             </DefaultDraggable>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
@@ -312,7 +312,7 @@ describe('HostName', () => {
         params: {
           hostName: props.value,
           contextID: props.contextId,
-          scopeId: TableId.alertsOnAlertsPage,
+          scopeId: 'timeline-1',
           isDraggable: false,
         },
       });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.tsx
@@ -9,7 +9,6 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import type { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 import { isString } from 'lodash/fp';
-import { TableId } from '@kbn/securitysolution-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { HostPanelKey } from '../../../../../flyout/entity_details/host_right';
@@ -81,7 +80,7 @@ const HostNameComponent: React.FC<Props> = ({
           params: {
             hostName,
             contextID: contextId,
-            scopeId: TableId.alertsOnAlertsPage,
+            scopeId: timelineID,
             isDraggable,
           },
         });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.test.tsx
@@ -286,7 +286,7 @@ describe('UserName', () => {
         params: {
           userName: props.value,
           contextID: props.contextId,
-          scopeId: TableId.alertsOnAlertsPage,
+          scopeId: 'timeline-1',
           isDraggable: false,
         },
       });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_name.tsx
@@ -9,7 +9,6 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import type { EuiButtonEmpty, EuiButtonIcon } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 import { isString } from 'lodash/fp';
-import { TableId } from '@kbn/securitysolution-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { UserPanelKey } from '../../../../../flyout/entity_details/user_right';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
@@ -79,7 +78,7 @@ const UserNameComponent: React.FC<Props> = ({
           params: {
             userName,
             contextID: contextId,
-            scopeId: TableId.alertsOnAlertsPage,
+            scopeId: timelineID,
             isDraggable,
           },
         });


### PR DESCRIPTION
## Summary

This PR fixes a small bug happening on the host and user details flyouts (using the expandable flyout) when opened within timeline. When trying to filter in/out values from the table, the filters was applied to the alerts page instead of to timeline.
Passing the `scopeId` to the `DefaultDraggable` component fixed the issue.

This code will hopefully be removed soon when we migrate everything to SecurityCellActions (see [this ticket](https://github.com/elastic/kibana/issues/181849))

Before fix

https://github.com/elastic/kibana/assets/17276605/fb688689-b71c-44ec-90e1-7adb2be4976c

After fix

https://github.com/elastic/kibana/assets/17276605/af40bd4f-a0c5-4d53-b888-115d38cbff70

https://github.com/elastic/security-team/issues/9212
https://github.com/elastic/kibana/issues/181863

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->