### PR TITLE
[Security Solution][Alert details] - turn on expandable flyout in timeline feature flag by default

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -125,7 +125,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables expandable flyout in timeline
    */
-  expandableTimelineFlyoutEnabled: false,
+  expandableTimelineFlyoutEnabled: true,
   /*
 
   /**


### PR DESCRIPTION
DO NOT MERGE YET

## Summary

This PR turns the `expandableTimelineFlyoutEnabled` feature flag on by default. This renders the expandable flyout in timline instead of the side panel.

With FF turned off

![Screenshot 2024-04-30 at 12 09 11 PM](https://github.com/elastic/kibana/assets/17276605/5205a042-4424-407b-a0b4-a9393131462c)

With FF turned on

![Screenshot 2024-04-30 at 12 07 27 PM](https://github.com/elastic/kibana/assets/17276605/7f51ebda-f623-4fde-8673-bb515720b02e)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### TODO

- [ ] fix unit tests
- [ ] fix e2e tests

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->