### PR TITLE
Adding alerts to the data telemetry

### DIFF
--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/constants.ts
@@ -63,6 +63,7 @@ export const DATA_DATASETS_INDEX_PATTERNS = [
   { pattern: 'winlogbeat-*', patternName: 'winlogbeat', shipper: 'winlogbeat' },
   { pattern: 'packetbeat-*', patternName: 'packetbeat', shipper: 'packetbeat' },
   { pattern: 'filebeat-*', patternName: 'filebeat', shipper: 'filebeat' },
+  { pattern: '.internal.alerts-*', patternName: 'alerts' },
   // Security - 3rd party
   { pattern: '*apache*', patternName: 'apache' }, // Already in Observability (keeping it in here for documentation)
   { pattern: '*tomcat*', patternName: 'tomcat' },

--- a/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
+++ b/src/plugins/telemetry/server/telemetry_collection/get_data_telemetry/get_data_telemetry.test.ts
@@ -71,6 +71,7 @@ describe('get_data_telemetry', () => {
           { name: 'filebeat-12314', docCount: 100, sizeInBytes: 10 },
           { name: 'metricbeat-1234', docCount: 100, sizeInBytes: 10, isECS: false },
           { name: '.app-search-1234', docCount: 0 },
+          { name: '.internal.alerts-stack.alerts-default-0000001', sizeInBytes: 999 },
           { name: 'logs-endpoint.1234', docCount: 0 }, // Matching pattern with a dot in the name
           { name: 'ml_host_risk_score_latest_default', docCount: 0 },
           { name: 'ml_host_risk_score_latest', docCount: 0 }, // This should not match,
@@ -164,6 +165,11 @@ describe('get_data_telemetry', () => {
           pattern_name: 'app-search',
           index_count: 1,
           doc_count: 0,
+        },
+        {
+          pattern_name: 'alerts',
+          index_count: 1,
+          size_in_bytes: 999,
         },
         {
           pattern_name: 'logs-endpoint',


### PR DESCRIPTION
## Summary

Previously, alerts were not included in the data telemetry. This caused complications when trying to assess the storage required for alerts. This PR adds alerts to the standard data telemetry.


### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

N/A

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
