### PR TITLE
rename SerializedMapState to ParsedMapStateJSON and SerializedUiState to ParsedUiStateJSON

### DIFF
--- a/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
+++ b/x-pack/plugins/maps/public/routes/map_page/map_app/map_app.tsx
@@ -62,7 +62,7 @@ import {
   unsavedChangesWarning,
 } from '../saved_map';
 import { waitUntilTimeLayersLoad$ } from './wait_until_time_layers_load';
-import { RefreshConfig as MapRefreshConfig, SerializedMapState } from '../saved_map';
+import { RefreshConfig as MapRefreshConfig, ParsedMapStateJSON } from '../saved_map';
 
 export interface Props {
   savedMap: SavedMap;
@@ -310,24 +310,24 @@ export class MapApp extends React.Component<Props, State> {
     this._updateGlobalState(updatedGlobalState);
   };
 
-  _getInitialTime(serializedMapState?: SerializedMapState) {
+  _getInitialTime(mapState?: ParsedMapStateJSON) {
     if (this._initialTimeFromUrl) {
       return this._initialTimeFromUrl;
     }
 
-    return !this.props.savedMap.hasSaveAndReturnConfig() && serializedMapState?.timeFilters
-      ? serializedMapState.timeFilters
+    return !this.props.savedMap.hasSaveAndReturnConfig() && mapState?.timeFilters
+      ? mapState.timeFilters
       : getTimeFilter().getTime();
   }
 
-  _initMapAndLayerSettings(serializedMapState?: SerializedMapState) {
+  _initMapAndLayerSettings(mapState?: ParsedMapStateJSON) {
     const globalState = this._getGlobalState();
 
-    const savedObjectFilters = serializedMapState?.filters ? serializedMapState.filters : [];
+    const savedObjectFilters = mapState?.filters ? mapState.filters : [];
     const appFilters = this._appStateManager.getFilters() || [];
 
     const query = getInitialQuery({
-      serializedMapState,
+      mapState,
       appState: this._appStateManager.getAppState(),
     });
     if (query) {
@@ -337,12 +337,12 @@ export class MapApp extends React.Component<Props, State> {
     this._onQueryChange({
       filters: [..._.get(globalState, 'filters', []), ...appFilters, ...savedObjectFilters],
       query,
-      time: this._getInitialTime(serializedMapState),
+      time: this._getInitialTime(mapState),
     });
 
     this._onRefreshConfigChange(
       getInitialRefreshConfig({
-        serializedMapState,
+        mapState,
         globalState,
       })
     );
@@ -453,16 +453,16 @@ export class MapApp extends React.Component<Props, State> {
       );
     }
 
-    let serializedMapState: SerializedMapState | undefined;
+    let mapState: ParsedMapStateJSON | undefined;
     try {
       const attributes = this.props.savedMap.getAttributes();
       if (attributes.mapStateJSON) {
-        serializedMapState = JSON.parse(attributes.mapStateJSON);
+        mapState = JSON.parse(attributes.mapStateJSON);
       }
     } catch (e) {
       // ignore malformed mapStateJSON, not a critical error for viewing map - map will just use defaults
     }
-    this._initMapAndLayerSettings(serializedMapState);
+    this._initMapAndLayerSettings(mapState);
 
     this.setState({ initialized: true });
   }

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_query.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_query.ts
@@ -7,21 +7,21 @@
 
 import { getData } from '../../../kibana_services';
 import { MapsAppState } from '../url_state';
-import { SerializedMapState } from './types';
+import { ParsedMapStateJSON } from './types';
 
 export function getInitialQuery({
-  serializedMapState,
+  mapState,
   appState = {},
 }: {
-  serializedMapState?: SerializedMapState;
+  mapState?: ParsedMapStateJSON;
   appState: MapsAppState;
 }) {
   if (appState.query) {
     return appState.query;
   }
 
-  if (serializedMapState?.query) {
-    return serializedMapState.query;
+  if (mapState?.query) {
+    return mapState.query;
   }
 
   return getData().query.queryString.getDefaultQuery();

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_refresh_config.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/get_initial_refresh_config.ts
@@ -8,19 +8,19 @@
 import { GlobalQueryStateFromUrl } from '@kbn/data-plugin/public';
 import { UI_SETTINGS } from '@kbn/data-plugin/public';
 import { getUiSettings } from '../../../kibana_services';
-import { SerializedMapState } from './types';
+import { ParsedMapStateJSON } from './types';
 
 export function getInitialRefreshConfig({
-  serializedMapState,
+  mapState,
   globalState = {},
 }: {
-  serializedMapState?: SerializedMapState;
+  mapState?: ParsedMapStateJSON;
   globalState: GlobalQueryStateFromUrl;
 }) {
   const uiSettings = getUiSettings();
 
-  if (serializedMapState?.refreshConfig) {
-    return serializedMapState.refreshConfig;
+  if (mapState?.refreshConfig) {
+    return mapState.refreshConfig;
   }
 
   const defaultRefreshConfig = uiSettings.get(UI_SETTINGS.TIMEPICKER_REFRESH_INTERVAL_DEFAULTS);

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/index.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export type { RefreshConfig, ParsedMapStateJSON, ParsedUiState } from './types';
+export type { RefreshConfig, ParsedMapStateJSON, ParsedUiStateJSON } from './types';
 export { SavedMap } from './saved_map';
 export { getInitialLayersFromUrlParam } from './get_initial_layers_from_url_param';
 export { getInitialQuery } from './get_initial_query';

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/index.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export type { RefreshConfig, SerializedMapState, SerializedUiState } from './types';
+export type { RefreshConfig, ParsedMapStateJSON, ParsedUiState } from './types';
 export { SavedMap } from './saved_map';
 export { getInitialLayersFromUrlParam } from './get_initial_layers_from_url_param';
 export { getInitialQuery } from './get_initial_query';

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -53,7 +53,7 @@ import { getBreadcrumbs } from './get_breadcrumbs';
 import { DEFAULT_IS_LAYER_TOC_OPEN } from '../../../reducers/ui';
 import { createBasemapLayerDescriptor } from '../../../classes/layers/create_basemap_layer_descriptor';
 import { whenLicenseInitialized } from '../../../licensed_features';
-import { ParsedMapStateJSON, ParsedUiState } from './types';
+import { ParsedMapStateJSON, ParsedUiStateJSON } from './types';
 import { setAutoOpenLayerWizardId } from '../../../actions/ui_actions';
 import { LayerStatsCollector, MapSettingsCollector } from '../../../../common/telemetry';
 import { getIndexPatternsFromIds } from '../../../index_pattern_util';
@@ -181,7 +181,7 @@ export class SavedMap {
       isLayerTOCOpen = this._mapEmbeddableInput.isLayerTOCOpen;
     } else if (this._attributes?.uiStateJSON) {
       try {
-        const uiState = JSON.parse(this._attributes.uiStateJSON) as ParsedUiState;
+        const uiState = JSON.parse(this._attributes.uiStateJSON) as ParsedUiStateJSON;
         if ('isLayerTOCOpen' in uiState) {
           isLayerTOCOpen = uiState.isLayerTOCOpen;
         }
@@ -196,7 +196,7 @@ export class SavedMap {
       openTOCDetails = this._mapEmbeddableInput.openTOCDetails;
     } else if (this._attributes?.uiStateJSON) {
       try {
-        const uiState = JSON.parse(this._attributes.uiStateJSON) as ParsedUiState;
+        const uiState = JSON.parse(this._attributes.uiStateJSON) as ParsedUiStateJSON;
         if ('openTOCDetails' in uiState) {
           openTOCDetails = uiState.openTOCDetails;
         }
@@ -585,7 +585,7 @@ export class SavedMap {
     this._attributes!.uiStateJSON = JSON.stringify({
       isLayerTOCOpen: getIsLayerTOCOpen(state),
       openTOCDetails: getOpenTOCDetails(state),
-    } as ParsedUiState);
+    } as ParsedUiStateJSON);
   }
 
   private async _getAdHocDataViews() {

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -53,7 +53,7 @@ import { getBreadcrumbs } from './get_breadcrumbs';
 import { DEFAULT_IS_LAYER_TOC_OPEN } from '../../../reducers/ui';
 import { createBasemapLayerDescriptor } from '../../../classes/layers/create_basemap_layer_descriptor';
 import { whenLicenseInitialized } from '../../../licensed_features';
-import { SerializedMapState, SerializedUiState } from './types';
+import { ParsedMapStateJSON, ParsedUiState } from './types';
 import { setAutoOpenLayerWizardId } from '../../../actions/ui_actions';
 import { LayerStatsCollector, MapSettingsCollector } from '../../../../common/telemetry';
 import { getIndexPatternsFromIds } from '../../../index_pattern_util';
@@ -150,7 +150,7 @@ export class SavedMap {
 
     if (this._attributes?.mapStateJSON) {
       try {
-        const mapState = JSON.parse(this._attributes.mapStateJSON) as SerializedMapState;
+        const mapState = JSON.parse(this._attributes.mapStateJSON) as ParsedMapStateJSON;
         if (mapState.adHocDataViews && mapState.adHocDataViews.length > 0) {
           const dataViewService = getIndexPatternService();
           const promises = mapState.adHocDataViews.map((spec) => {
@@ -167,7 +167,7 @@ export class SavedMap {
       this._store.dispatch(setMapSettingsFromEncodedState(this._mapEmbeddableInput.mapSettings));
     } else if (this._attributes?.mapStateJSON) {
       try {
-        const mapState = JSON.parse(this._attributes.mapStateJSON) as SerializedMapState;
+        const mapState = JSON.parse(this._attributes.mapStateJSON) as ParsedMapStateJSON;
         if (mapState.settings) {
           this._store.dispatch(setMapSettingsFromEncodedState(mapState.settings));
         }
@@ -181,7 +181,7 @@ export class SavedMap {
       isLayerTOCOpen = this._mapEmbeddableInput.isLayerTOCOpen;
     } else if (this._attributes?.uiStateJSON) {
       try {
-        const uiState = JSON.parse(this._attributes.uiStateJSON) as SerializedUiState;
+        const uiState = JSON.parse(this._attributes.uiStateJSON) as ParsedUiState;
         if ('isLayerTOCOpen' in uiState) {
           isLayerTOCOpen = uiState.isLayerTOCOpen;
         }
@@ -196,7 +196,7 @@ export class SavedMap {
       openTOCDetails = this._mapEmbeddableInput.openTOCDetails;
     } else if (this._attributes?.uiStateJSON) {
       try {
-        const uiState = JSON.parse(this._attributes.uiStateJSON) as SerializedUiState;
+        const uiState = JSON.parse(this._attributes.uiStateJSON) as ParsedUiState;
         if ('openTOCDetails' in uiState) {
           openTOCDetails = uiState.openTOCDetails;
         }
@@ -216,7 +216,7 @@ export class SavedMap {
       );
     } else if (this._attributes?.mapStateJSON) {
       try {
-        const mapState = JSON.parse(this._attributes.mapStateJSON) as SerializedMapState;
+        const mapState = JSON.parse(this._attributes.mapStateJSON) as ParsedMapStateJSON;
         this._store.dispatch(
           setGotoWithCenter({
             lat: mapState.center.lat,
@@ -418,7 +418,7 @@ export class SavedMap {
     }
 
     try {
-      const mapState = JSON.parse(this._attributes.mapStateJSON) as SerializedMapState;
+      const mapState = JSON.parse(this._attributes.mapStateJSON) as ParsedMapStateJSON;
       if (mapState?.settings.autoFitToDataBounds !== undefined) {
         return mapState.settings.autoFitToDataBounds;
       }
@@ -580,12 +580,12 @@ export class SavedMap {
           return { ...icon, svg: Buffer.from(icon.svg).toString('base64') };
         }),
       },
-    } as SerializedMapState);
+    } as ParsedMapStateJSON);
 
     this._attributes!.uiStateJSON = JSON.stringify({
       isLayerTOCOpen: getIsLayerTOCOpen(state),
       openTOCDetails: getOpenTOCDetails(state),
-    } as SerializedUiState);
+    } as ParsedUiState);
   }
 
   private async _getAdHocDataViews() {

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/types.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/types.ts
@@ -16,7 +16,7 @@ export interface RefreshConfig {
 }
 
 // parsed contents of mapStateJSON
-export interface SerializedMapState {
+export interface ParsedMapStateJSON {
   adHocDataViews?: DataViewSpec[];
   zoom: number;
   center: MapCenter;
@@ -28,7 +28,7 @@ export interface SerializedMapState {
 }
 
 // parsed contents of uiStateJSON
-export interface SerializedUiState {
+export interface ParsedUiState {
   isLayerTOCOpen: boolean;
   openTOCDetails: string[];
 }

--- a/x-pack/plugins/maps/public/routes/map_page/saved_map/types.ts
+++ b/x-pack/plugins/maps/public/routes/map_page/saved_map/types.ts
@@ -28,7 +28,7 @@ export interface ParsedMapStateJSON {
 }
 
 // parsed contents of uiStateJSON
-export interface ParsedUiState {
+export interface ParsedUiStateJSON {
   isLayerTOCOpen: boolean;
   openTOCDetails: string[];
 }


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/174960

https://github.com/elastic/kibana/pull/178158 creates a new type `MapSerializeState`. This new type name is very confusing with existing `SerializedMapState` type name. This PR renames `SerializedMapState` to `ParsedMapStateJSON` to avoid this confusion. Breaking this change out of https://github.com/elastic/kibana/issues/174960 to make things clearer and avoid confusion during reviewing https://github.com/elastic/kibana/issues/174960