### PR TITLE
[Security solution] Add additional properties to attack discovery telemetry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1348,8 +1348,9 @@ x-pack/plugins/cloud_integrations/cloud_full_story/server/config.ts @elastic/kib
 /x-pack/plugins/security_solution_ess/ @elastic/security-solution
 /x-pack/plugins/security_solution_serverless/ @elastic/security-solution
 
-# AI Assistant in Security Solution
+# GenAI in Security Solution
 /x-pack/plugins/security_solution/public/assistant @elastic/security-generative-ai
+/x-pack/plugins/security_solution/public/attack_discovery @elastic/security-generative-ai
 /x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant @elastic/security-generative-ai
 
 # Security Solution cross teams ownership

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/helpers.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/helpers.tsx
@@ -30,16 +30,19 @@ interface GenAiConfig {
 export const getGenAiConfig = (connector: ActionConnector | undefined): GenAiConfig | undefined => {
   if (!connector?.isPreconfigured) {
     const config = (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
-    if (config?.apiProvider === OpenAiProviderType.AzureAi) {
-      return {
-        ...config,
-        defaultModel: getAzureApiVersionParameter(config.apiUrl ?? ''),
-      };
-    }
+    const { apiProvider, apiUrl, defaultModel } = config ?? {};
 
-    return (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
+    return {
+      apiProvider,
+      apiUrl,
+      defaultModel:
+        apiProvider === OpenAiProviderType.AzureAi
+          ? getAzureApiVersionParameter(apiUrl ?? '')
+          : defaultModel,
+    };
   }
-  return undefined;
+
+  return undefined; // the connector is neither available nor editable
 };
 
 export const getActionTypeTitle = (actionType: ActionTypeModel): string => {

--- a/x-pack/plugins/security_solution/public/attack_discovery/hooks/use_attack_discovery_telemetry/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/hooks/use_attack_discovery_telemetry/index.test.tsx
@@ -42,10 +42,14 @@ describe('useAttackDiscoveryTelemetry', () => {
     await result.current.reportAttackDiscoveriesGenerated({
       actionTypeId: '.gen-ai',
       model: 'gpt-4',
+      durationMs: 8000,
+      alertCount: 20,
     });
     expect(reportAttackDiscoveriesGenerated).toHaveBeenCalledWith({
       actionTypeId: '.gen-ai',
       model: 'gpt-4',
+      durationMs: 8000,
+      alertCount: 20,
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/attack_discovery/hooks/use_attack_discovery_telemetry/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/hooks/use_attack_discovery_telemetry/index.test.tsx
@@ -43,13 +43,15 @@ describe('useAttackDiscoveryTelemetry', () => {
       actionTypeId: '.gen-ai',
       model: 'gpt-4',
       durationMs: 8000,
-      alertCount: 20,
+      alertsCount: 20,
+      configuredAlertsCount: 30,
     });
     expect(reportAttackDiscoveriesGenerated).toHaveBeenCalledWith({
       actionTypeId: '.gen-ai',
       model: 'gpt-4',
       durationMs: 8000,
-      alertCount: 20,
+      alertsCount: 20,
+      configuredAlertsCount: 30,
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/helpers.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/helpers.ts
@@ -29,16 +29,19 @@ interface GenAiConfig {
 export const getGenAiConfig = (connector: ActionConnector | undefined): GenAiConfig | undefined => {
   if (!connector?.isPreconfigured) {
     const config = (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
-    if (config?.apiProvider === OpenAiProviderType.AzureAi) {
-      return {
-        ...config,
-        defaultModel: getAzureApiVersionParameter(config.apiUrl ?? ''),
-      };
-    }
+    const { apiProvider, apiUrl, defaultModel } = config ?? {};
 
-    return (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
+    return {
+      apiProvider,
+      apiUrl,
+      defaultModel:
+        apiProvider === OpenAiProviderType.AzureAi
+          ? getAzureApiVersionParameter(apiUrl ?? '')
+          : defaultModel,
+    };
   }
-  return undefined;
+
+  return undefined; // the connector is neither available nor editable
 };
 
 const getAzureApiVersionParameter = (url: string): string | undefined => {

--- a/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/helpers.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/helpers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ActionConnector } from '@kbn/triggers-actions-ui-plugin/public';
+import type { ActionConnectorProps } from '@kbn/triggers-actions-ui-plugin/public/types';
+
+// aligns with OpenAiProviderType from '@kbn/stack-connectors-plugin/common/openai/types'
+enum OpenAiProviderType {
+  OpenAi = 'OpenAI',
+  AzureAi = 'Azure OpenAI',
+}
+
+interface GenAiConfig {
+  apiProvider?: OpenAiProviderType;
+  apiUrl?: string;
+  defaultModel?: string;
+}
+
+/**
+ * Returns the GenAiConfig for a given ActionConnector. Note that if the connector is preconfigured,
+ * the config will be undefined as the connector is neither available nor editable.
+ *
+ * @param connector
+ */
+export const getGenAiConfig = (connector: ActionConnector | undefined): GenAiConfig | undefined => {
+  if (!connector?.isPreconfigured) {
+    const config = (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
+    if (config?.apiProvider === OpenAiProviderType.AzureAi) {
+      return {
+        ...config,
+        defaultModel: getAzureApiVersionParameter(config.apiUrl ?? ''),
+      };
+    }
+
+    return (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
+  }
+  return undefined;
+};
+
+const getAzureApiVersionParameter = (url: string): string | undefined => {
+  const urlSearchParams = new URLSearchParams(new URL(url).search);
+  return urlSearchParams.get('api-version') ?? undefined;
+};

--- a/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
@@ -11,6 +11,7 @@ import {
   useAssistantContext,
   useLoadConnectors,
 } from '@kbn/elastic-assistant';
+import { uniq } from 'lodash';
 import type { AttackDiscoveryPostRequestBody, Replacements } from '@kbn/elastic-assistant-common';
 import {
   AttackDiscoveryPostResponse,
@@ -235,7 +236,10 @@ export const useAttackDiscovery = ({
       reportAttackDiscoveriesGenerated({
         actionTypeId,
         durationMs,
-        alertCount: knowledgeBase.latestAlerts,
+        alertsCount: uniq(
+          newAttackDiscoveries.flatMap((attackDiscovery) => attackDiscovery.alertIds)
+        ).length,
+        configuredAlertsCount: knowledgeBase.latestAlerts,
         provider: connectorConfig?.apiProvider,
         model: connectorConfig?.defaultModel,
       });

--- a/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
@@ -41,6 +41,7 @@ import {
 } from '../pages/session_storage';
 import { ERROR_GENERATING_ATTACK_DISCOVERIES } from '../pages/translations';
 import type { AttackDiscovery, GenerationInterval } from '../types';
+import { getGenAiConfig } from './helpers';
 
 const MAX_GENERATION_INTERVALS = 5;
 
@@ -230,7 +231,14 @@ export const useAttackDiscovery = ({
       setAttackDiscoveries(newAttackDiscoveries);
       setLastUpdated(newLastUpdated);
       setConnectorId?.(connectorId);
-      reportAttackDiscoveriesGenerated({ actionTypeId });
+      const connectorConfig = getGenAiConfig(selectedConnector);
+      reportAttackDiscoveriesGenerated({
+        actionTypeId,
+        durationMs,
+        alertCount: knowledgeBase.latestAlerts,
+        provider: connectorConfig?.apiProvider,
+        model: connectorConfig?.defaultModel,
+      });
     } catch (error) {
       toasts?.addDanger(error, {
         title: ERROR_GENERATING_ATTACK_DISCOVERIES,

--- a/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
@@ -11,13 +11,12 @@ import {
   useAssistantContext,
   useLoadConnectors,
 } from '@kbn/elastic-assistant';
-import { uniq } from 'lodash/fp';
 import type { AttackDiscoveryPostRequestBody, Replacements } from '@kbn/elastic-assistant-common';
 import {
   AttackDiscoveryPostResponse,
   ELASTIC_AI_ASSISTANT_INTERNAL_API_VERSION,
 } from '@kbn/elastic-assistant-common';
-import { isEmpty } from 'lodash/fp';
+import { isEmpty, uniq } from 'lodash/fp';
 import moment from 'moment';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useLocalStorage, useSessionStorage } from 'react-use';

--- a/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/use_attack_discovery/index.tsx
@@ -11,7 +11,7 @@ import {
   useAssistantContext,
   useLoadConnectors,
 } from '@kbn/elastic-assistant';
-import { uniq } from 'lodash';
+import { uniq } from 'lodash/fp';
 import type { AttackDiscoveryPostRequestBody, Replacements } from '@kbn/elastic-assistant-common';
 import {
   AttackDiscoveryPostResponse,

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/index.ts
@@ -18,6 +18,20 @@ export const insightsGeneratedEvent: TelemetryEvent = {
         optional: false,
       },
     },
+    durationMs: {
+      type: 'integer',
+      _meta: {
+        description: 'Duration of request in ms',
+        optional: false,
+      },
+    },
+    alertCount: {
+      type: 'integer',
+      _meta: {
+        description: 'Number of alerts evaluated',
+        optional: false,
+      },
+    },
     model: {
       type: 'keyword',
       _meta: {

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/index.ts
@@ -25,10 +25,17 @@ export const insightsGeneratedEvent: TelemetryEvent = {
         optional: false,
       },
     },
-    alertCount: {
+    alertsCount: {
       type: 'integer',
       _meta: {
         description: 'Number of alerts evaluated',
+        optional: false,
+      },
+    },
+    configuredAlertsCount: {
+      type: 'integer',
+      _meta: {
+        description: 'Number of alerts configured by the user',
         optional: false,
       },
     },

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/index.ts
@@ -28,7 +28,7 @@ export const insightsGeneratedEvent: TelemetryEvent = {
     alertsCount: {
       type: 'integer',
       _meta: {
-        description: 'Number of alerts evaluated',
+        description: 'Number of unique alerts referenced in the attack discoveries',
         optional: false,
       },
     },

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/types.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/types.ts
@@ -12,6 +12,8 @@ export interface ReportAttackDiscoveriesGeneratedParams {
   actionTypeId: string;
   provider?: string;
   model?: string;
+  durationMs: number;
+  alertCount: number;
 }
 
 export type ReportAttackDiscoveryTelemetryEventParams = ReportAttackDiscoveriesGeneratedParams;

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/types.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/attack_discovery/types.ts
@@ -13,7 +13,8 @@ export interface ReportAttackDiscoveriesGeneratedParams {
   provider?: string;
   model?: string;
   durationMs: number;
-  alertCount: number;
+  alertsCount: number;
+  configuredAlertsCount: number;
 }
 
 export type ReportAttackDiscoveryTelemetryEventParams = ReportAttackDiscoveriesGeneratedParams;


### PR DESCRIPTION
## Summary

Adds 3 new properties to the `reportAttackDiscoveriesGenerated` telemetry event: `durationMs`, `alertsCount`, and  `configuredAlertsCount`. These fields represent how long the request took, how many alerts were used for the generation, and how many alerts were configured by the user for the generation. 

I also added the `provider` and `model` arguments which were already defined, but not passed. Here is an example of what this looks like for Bedrock and Azure:

<img width="1204" alt="Screenshot 2024-05-01 at 12 56 07 PM" src="https://github.com/elastic/kibana/assets/6935300/12e45ae6-e154-4c99-84c8-6c6d95daeabb">
<img width="1210" alt="Screenshot 2024-05-01 at 12 57 06 PM" src="https://github.com/elastic/kibana/assets/6935300/65b7b3a2-7e58-4aaf-ac85-c5b6eaa87b7b">

## CODEOWNERS change

Added the `attack_discovery` dir to be under @elastic/security-generative-ai ownership 👍 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->