### PR TITLE
Fix storybook config

### DIFF
--- a/packages/kbn-storybook/src/webpack.config.ts
+++ b/packages/kbn-storybook/src/webpack.config.ts
@@ -139,6 +139,9 @@ export default ({ config: storybookConfig }: { config: Configuration }) => {
     stats,
   };
 
+  // Override storybookConfig mainFields instead of merging with config
+  delete storybookConfig.resolve?.mainFields;
+
   const updatedModuleRules = [];
   // clone and modify the module.rules config provided by storybook so that the default babel plugins run after the typescript preset
   for (const originalRule of storybookConfig.module?.rules ?? []) {


### PR DESCRIPTION
Storybook is attempting to load an esm after the merge of #182244.  This updates the webpack configuration to only load files from the browser and main properties.

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->