### PR TITLE
[ML] Single Metric Viewer: fixes hover functionality in the anomalies table

### DIFF
--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/components/timeseries_chart/timeseries_chart.js
@@ -254,7 +254,7 @@ class TimeseriesChartIntl extends Component {
     }
 
     this.rowMouseenterSubscriber = mlTableService.rowMouseenter$.subscribe(
-      tableRecordMousenterListener
+      tableRecordMousenterListener.bind(this)
     );
     this.rowMouseleaveSubscriber = mlTableService.rowMouseleave$.subscribe(
       tableRecordMouseleaveListener


### PR DESCRIPTION
## Summary

Fixes hover functionality for the anomalies table in the Single Metric Viewer to highlight the corresponding marker in the chart. 

Issue mentioned in https://github.com/elastic/kibana/issues/181910#issuecomment-2082456621



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->