### PR TITLE
add some basic CSS for table rendering

### DIFF
--- a/x-pack/plugins/stack_connectors/server/connector_types/email/send_email.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/email/send_email.ts
@@ -72,11 +72,17 @@ export async function sendEmail(
   const { message, messageHTML } = content;
 
   const renderedMessage = messageHTML ?? htmlFromMarkdown(logger, message);
+  const enhancedRenderedMessage = `${getHtmlPrefix()}\n${renderedMessage}`;
 
   if (transport.service === AdditionalEmailServices.EXCHANGE) {
-    return await sendEmailWithExchange(logger, options, renderedMessage, connectorTokenClient);
+    return await sendEmailWithExchange(
+      logger,
+      options,
+      enhancedRenderedMessage,
+      connectorTokenClient
+    );
   } else {
-    return await sendEmailWithNodemailer(logger, options, renderedMessage);
+    return await sendEmailWithNodemailer(logger, options, enhancedRenderedMessage);
   }
 }
 
@@ -305,4 +311,26 @@ function getUseProxy(host?: string, proxySettings?: ProxySettings) {
     }
   }
   return !!proxySettings;
+}
+
+function getHtmlPrefix() {
+  return `
+  <style>
+  table {
+    border-collapse: collapse;
+    border:          thin solid;
+  }
+  tbody tr:nth-child(odd) {
+  /*  background-color: #e495e4; */
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: #e0e0e0;
+  }
+  tbody td, thead th {
+    border: thin solid;
+    padding: 0.5em;
+  }
+  </style>
+`;
 }


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/182303

## Summary

Add some basic CSS for table formatting in the email connector; currently that's the only connector which uses markdown that supports a "native" table syntax.

### Before / After

<img width="1471" height="412" alt="image" src="https://github.com/user-attachments/assets/7842e83b-cd64-465a-965b-6961673c2ee2" />

## To verify

TBD

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
