### PR TITLE
[build] Fix canvas shareable runtime

### DIFF
--- a/x-pack/plugins/canvas/shareable_runtime/webpack.config.js
+++ b/x-pack/plugins/canvas/shareable_runtime/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = {
       core_app_image_assets: path.resolve(KIBANA_ROOT, 'src/core/public/styles/core_app/images'),
     },
     extensions: ['.js', '.json', '.ts', '.tsx', '.scss'],
+    mainFields: ['browser', 'main'],
   },
   module: {
     rules: [


### PR DESCRIPTION
A recent dependency update is attempting to load an es module.  This updates the canvas webpack configuration to skip modules when checking the main field.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->