### PR TITLE
[data views] demo data view caching

### DIFF
--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_capabilities.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_capabilities.ts
@@ -56,6 +56,7 @@ export async function getFieldCapabilities(params: FieldCapabilitiesParams) {
   } = params;
 
   const excludedTiers = await uiSettingsClient?.get<string>(DATA_VIEWS_FIELDS_EXCLUDED_TIERS);
+  console.log('calling field caps');
   const esFieldCaps = await callFieldCapsApi({
     callCluster,
     indices,

--- a/src/plugins/data_views/server/rest_api_routes/public/get_data_view.ts
+++ b/src/plugins/data_views/server/rest_api_routes/public/get_data_view.ts
@@ -39,7 +39,14 @@ export const getDataView = async ({
   id,
 }: GetDataViewArgs) => {
   usageCollection?.incrementCounter({ counterName });
-  return dataViewsService.getDataViewLazy(id);
+  console.log('get data view');
+  const dataView = await dataViewsService.get(id);
+  console.log('get data view lazy');
+  const dataViewLazy = await dataViewsService.toDataViewLazy(dataView);
+  // this shouldn't trigger a field caps call
+  console.log('get data view again');
+  await dataViewsService.toDataView(dataViewLazy);
+  return dataViewLazy;
 };
 
 const getDataViewRouteFactory =
@@ -97,6 +104,7 @@ const getDataViewRouteFactory =
             id,
           });
 
+          console.log('data view lazy will get fields here');
           const responseBody: Record<string, DataViewSpecRestResponse> = {
             [serviceKey]: {
               ...(await dataView.toSpec({ fieldParams: { fieldName: ['*'] } })),


### PR DESCRIPTION
## Summary

Note: this PR is for demo purposes and is not intended to be merged to main.

Getting a data view via the public api will get the data view twice BUT field_caps is only called once. Its call additionally from dataViewLazy but this can be ignored for the purposes of this test

Add some data and create a data view. Sample data is fine. Then go to the dev console and GET a data view - 

```
GET kbn:api/data_views/default

GET kbn:api/data_views/data_view/{id}
```

in the kibana server logs you'll see - 

```
get data view
calling field caps
get data view lazy
get data view again
data view lazy will get fields here
calling field caps
```

We see that get data view is called, field caps is called, we get the lazy version of the data view and the regular version of the data view - without another field caps call! Finally, there's a field caps call thats expected and can be ignored.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
