### PR TITLE
[8.14] [SLOs]  Disable federated view settings in serverless (#181880)

### DIFF
--- a/x-pack/packages/kbn-slo-schema/src/rest_specs/routes/put_settings.ts
+++ b/x-pack/packages/kbn-slo-schema/src/rest_specs/routes/put_settings.ts
@@ -5,10 +5,14 @@
  * 2.0.
  */
 import * as t from 'io-ts';
-import { sloSettingsSchema } from '../../schema/settings';
+import { sloServerlessSettingsSchema, sloSettingsSchema } from '../../schema/settings';
 
 const putSLOSettingsParamsSchema = t.type({
   body: sloSettingsSchema,
+});
+
+const putSLOServerlessSettingsParamsSchema = t.type({
+  body: sloServerlessSettingsSchema,
 });
 
 const putSLOSettingsResponseSchema = sloSettingsSchema;
@@ -17,5 +21,9 @@ type PutSLOSettingsParams = t.TypeOf<typeof putSLOSettingsParamsSchema.props.bod
 type PutSLOSettingsResponse = t.OutputOf<typeof putSLOSettingsResponseSchema>;
 type GetSLOSettingsResponse = t.OutputOf<typeof sloSettingsSchema>;
 
-export { putSLOSettingsParamsSchema, putSLOSettingsResponseSchema };
+export {
+  putSLOSettingsParamsSchema,
+  putSLOSettingsResponseSchema,
+  putSLOServerlessSettingsParamsSchema,
+};
 export type { PutSLOSettingsParams, PutSLOSettingsResponse, GetSLOSettingsResponse };

--- a/x-pack/packages/kbn-slo-schema/src/schema/settings.ts
+++ b/x-pack/packages/kbn-slo-schema/src/schema/settings.ts
@@ -11,3 +11,5 @@ export const sloSettingsSchema = t.type({
   useAllRemoteClusters: t.boolean,
   selectedRemoteClusters: t.array(t.string),
 });
+
+export const sloServerlessSettingsSchema = t.type({});

--- a/x-pack/plugins/observability_solution/slo/public/application.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/application.tsx
@@ -21,18 +21,22 @@ import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { ObservabilityRuleTypeRegistry } from '@kbn/observability-plugin/public';
 
 import { i18n } from '@kbn/i18n';
+import { usePluginContext } from './hooks/use_plugin_context';
 import { PluginContext } from './context/plugin_context';
 
 import { SloPublicPluginsStart } from './types';
-import { routes } from './routes/routes';
+import { getRoutes } from './routes/routes';
 import { ExperimentalFeatures } from '../common/config';
 
 function App() {
+  const { isServerless } = usePluginContext();
+
+  const routes = getRoutes(isServerless);
+
   return (
     <>
       <Routes>
-        {Object.keys(routes).map((key) => {
-          const path = key as keyof typeof routes;
+        {Object.keys(routes).map((path) => {
           const { handler, exact } = routes[path];
           const Wrapper = () => {
             return handler();
@@ -124,6 +128,7 @@ export const renderApp = ({
                 <PluginContext.Provider
                   value={{
                     isDev,
+                    isServerless,
                     appMountParameters,
                     ObservabilityPageTemplate,
                     observabilityRuleTypeRegistry,

--- a/x-pack/plugins/observability_solution/slo/public/components/header_menu/header_menu.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/components/header_menu/header_menu.tsx
@@ -16,7 +16,7 @@ import { SLOS_BASE_PATH, SLO_SETTINGS_PATH } from '../../../common/locators/path
 export function HeaderMenu(): React.ReactElement | null {
   const { http, theme } = useKibana().services;
 
-  const { appMountParameters } = usePluginContext();
+  const { appMountParameters, isServerless } = usePluginContext();
   return (
     <HeaderMenuPortal
       setHeaderActionMenu={appMountParameters?.setHeaderActionMenu!}
@@ -34,15 +34,17 @@ export function HeaderMenu(): React.ReactElement | null {
                 defaultMessage: 'Add integrations',
               })}
             </EuiHeaderLink>
-            <EuiHeaderLink
-              color="primary"
-              href={http.basePath.prepend(`${SLOS_BASE_PATH}${SLO_SETTINGS_PATH}`)}
-              iconType="gear"
-            >
-              {i18n.translate('xpack.slo.headerMenu.settings', {
-                defaultMessage: 'Settings',
-              })}
-            </EuiHeaderLink>
+            {!isServerless && (
+              <EuiHeaderLink
+                color="primary"
+                href={http.basePath.prepend(`${SLOS_BASE_PATH}${SLO_SETTINGS_PATH}`)}
+                iconType="gear"
+              >
+                {i18n.translate('xpack.slo.headerMenu.settings', {
+                  defaultMessage: 'Settings',
+                })}
+              </EuiHeaderLink>
+            )}
           </EuiHeaderLinks>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -13,6 +13,7 @@ import { ExperimentalFeatures } from '../../common/config';
 
 export interface PluginContextValue {
   isDev?: boolean;
+  isServerless?: boolean;
   appMountParameters?: AppMountParameters;
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
   ObservabilityPageTemplate: React.ComponentType<LazyObservabilityPageTemplateProps>;

--- a/x-pack/plugins/observability_solution/slo/public/routes/routes.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/routes/routes.tsx
@@ -22,54 +22,68 @@ import {
 import { SlosOutdatedDefinitions } from '../pages/slo_outdated_definitions';
 import { SloSettingsPage } from '../pages/slo_settings/slo_settings';
 
-export const routes = {
-  [SLOS_PATH]: {
-    handler: () => {
-      return <SlosPage />;
+export const getRoutes = (
+  isServerless?: boolean
+): {
+  [key: string]: {
+    handler: () => React.ReactElement;
+    params: Record<string, string>;
+    exact: boolean;
+  };
+} => {
+  return {
+    [SLOS_PATH]: {
+      handler: () => {
+        return <SlosPage />;
+      },
+      params: {},
+      exact: true,
     },
-    params: {},
-    exact: true,
-  },
-  [SLO_CREATE_PATH]: {
-    handler: () => {
-      return <SloEditPage />;
+    [SLO_CREATE_PATH]: {
+      handler: () => {
+        return <SloEditPage />;
+      },
+      params: {},
+      exact: true,
     },
-    params: {},
-    exact: true,
-  },
-  [SLOS_WELCOME_PATH]: {
-    handler: () => {
-      return <SlosWelcomePage />;
+    [SLOS_WELCOME_PATH]: {
+      handler: () => {
+        return <SlosWelcomePage />;
+      },
+      params: {},
+      exact: true,
     },
-    params: {},
-    exact: true,
-  },
-  [SLOS_OUTDATED_DEFINITIONS_PATH]: {
-    handler: () => {
-      return <SlosOutdatedDefinitions />;
+    [SLOS_OUTDATED_DEFINITIONS_PATH]: {
+      handler: () => {
+        return <SlosOutdatedDefinitions />;
+      },
+      params: {},
+      exact: true,
     },
-    params: {},
-    exact: true,
-  },
-  [SLO_EDIT_PATH]: {
-    handler: () => {
-      return <SloEditPage />;
+    [SLO_EDIT_PATH]: {
+      handler: () => {
+        return <SloEditPage />;
+      },
+      params: {},
+      exact: true,
     },
-    params: {},
-    exact: true,
-  },
-  [SLO_SETTINGS_PATH]: {
-    handler: () => {
-      return <SloSettingsPage />;
+    ...(!isServerless
+      ? {
+          [SLO_SETTINGS_PATH]: {
+            handler: () => {
+              return <SloSettingsPage />;
+            },
+            params: {},
+            exact: true,
+          },
+        }
+      : {}),
+    [SLO_DETAIL_PATH]: {
+      handler: () => {
+        return <SloDetailsPage />;
+      },
+      params: {},
+      exact: true,
     },
-    params: {},
-    exact: true,
-  },
-  [SLO_DETAIL_PATH]: {
-    handler: () => {
-      return <SloDetailsPage />;
-    },
-    params: {},
-    exact: true,
-  },
+  };
 };

--- a/x-pack/plugins/observability_solution/slo/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/slo/server/plugin.ts
@@ -29,6 +29,7 @@ import { SpacesPluginSetup, SpacesPluginStart } from '@kbn/spaces-plugin/server'
 import { AlertsLocatorDefinition } from '@kbn/observability-plugin/common';
 import { SLO_BURN_RATE_RULE_TYPE_ID } from '@kbn/rule-data-utils';
 import { sloFeatureId } from '@kbn/observability-plugin/common';
+import { ServerlessPluginStart } from '@kbn/serverless/server';
 import { registerSloUsageCollector } from './lib/collectors/register';
 import { SloOrphanSummaryCleanupTask } from './services/tasks/orphan_summary_cleanup_task';
 import { slo, SO_SLO_TYPE } from './saved_objects';
@@ -56,6 +57,7 @@ export interface PluginStart {
   alerting: PluginStartContract;
   taskManager: TaskManagerStartContract;
   spaces?: SpacesPluginStart;
+  serverless: ServerlessPluginStart;
 }
 
 const sloRuleTypes = [SLO_BURN_RATE_RULE_TYPE_ID];
@@ -150,7 +152,9 @@ export class SloPlugin implements Plugin<SloPluginSetup> {
           getRulesClientWithRequest: pluginStart.alerting.getRulesClientWithRequest,
         },
         logger: this.logger,
-        repository: getSloServerRouteRepository(config),
+        repository: getSloServerRouteRepository({
+          isServerless: !!pluginStart.serverless,
+        }),
       });
 
       const esInternalClient = coreStart.elasticsearch.client.asInternalUser;

--- a/x-pack/plugins/observability_solution/slo/server/routes/get_slo_server_route_repository.ts
+++ b/x-pack/plugins/observability_solution/slo/server/routes/get_slo_server_route_repository.ts
@@ -5,14 +5,12 @@
  * 2.0.
  */
 
-import { SloConfig } from '..';
-import { sloRouteRepository } from './slo/route';
+import { getSloRouteRepository } from './slo/route';
 
-export function getSloServerRouteRepository(config: SloConfig) {
-  const repository = {
-    ...sloRouteRepository,
+export function getSloServerRouteRepository({ isServerless }: { isServerless?: boolean } = {}) {
+  return {
+    ...getSloRouteRepository(isServerless),
   };
-  return repository;
 }
 
 export type SloServerRouteRepository = ReturnType<typeof getSloServerRouteRepository>;

--- a/x-pack/plugins/observability_solution/slo/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability_solution/slo/server/routes/slo/route.ts
@@ -20,6 +20,8 @@ import {
   getSLOInstancesParamsSchema,
   getSLOParamsSchema,
   manageSLOParamsSchema,
+  putSLOServerlessSettingsParamsSchema,
+  PutSLOSettingsParams,
   putSLOSettingsParamsSchema,
   resetSLOParamsSchema,
   updateSLOParamsSchema,
@@ -607,39 +609,42 @@ const getSloSettingsRoute = createSloServerRoute({
   },
 });
 
-const putSloSettings = createSloServerRoute({
-  endpoint: 'PUT /internal/slo/settings',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'internal',
-  },
-  params: putSLOSettingsParamsSchema,
-  handler: async ({ context, params }) => {
-    await assertPlatinumLicense(context);
+const putSloSettings = (isServerless?: boolean) =>
+  createSloServerRoute({
+    endpoint: 'PUT /internal/slo/settings',
+    options: {
+      tags: ['access:slo_write'],
+      access: 'internal',
+    },
+    params: isServerless ? putSLOServerlessSettingsParamsSchema : putSLOSettingsParamsSchema,
+    handler: async ({ context, params }) => {
+      await assertPlatinumLicense(context);
 
-    const soClient = (await context.core).savedObjects.client;
-    return await storeSloSettings(soClient, params.body);
-  },
-});
+      const soClient = (await context.core).savedObjects.client;
+      return await storeSloSettings(soClient, params.body as PutSLOSettingsParams);
+    },
+  });
 
-export const sloRouteRepository = {
-  ...getSloSettingsRoute,
-  ...putSloSettings,
-  ...createSLORoute,
-  ...inspectSLORoute,
-  ...deleteSLORoute,
-  ...deleteSloInstancesRoute,
-  ...disableSLORoute,
-  ...enableSLORoute,
-  ...fetchHistoricalSummary,
-  ...findSloDefinitionsRoute,
-  ...findSLORoute,
-  ...getSLORoute,
-  ...updateSLORoute,
-  ...getDiagnosisRoute,
-  ...getSloBurnRates,
-  ...getPreviewData,
-  ...getSLOInstancesRoute,
-  ...resetSLORoute,
-  ...findSLOGroupsRoute,
+export const getSloRouteRepository = (isServerless?: boolean) => {
+  return {
+    ...getSloSettingsRoute,
+    ...putSloSettings(isServerless),
+    ...createSLORoute,
+    ...inspectSLORoute,
+    ...deleteSLORoute,
+    ...deleteSloInstancesRoute,
+    ...disableSLORoute,
+    ...enableSLORoute,
+    ...fetchHistoricalSummary,
+    ...findSloDefinitionsRoute,
+    ...findSLORoute,
+    ...getSLORoute,
+    ...updateSLORoute,
+    ...getDiagnosisRoute,
+    ...getSloBurnRates,
+    ...getPreviewData,
+    ...getSLOInstancesRoute,
+    ...resetSLORoute,
+    ...findSLOGroupsRoute,
+  };
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[SLOs]  Disable federated view settings in serverless (#181880)](https://github.com/elastic/kibana/pull/181880)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2024-04-30T20:04:10Z","message":"[SLOs]  Disable federated view settings in serverless (#181880)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/181739\r\n\r\nDisable federated view settings in serverless !!\r\n\r\n- [ ] Disabled route and settings page in public\r\n- [ ] Uses different put request schema on serverless which doesn't\r\ncontains remote cluster settings","sha":"390628d665bda92a4450c586511bf170af3fab7f","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v8.14.0","v8.15.0"],"number":181880,"url":"https://github.com/elastic/kibana/pull/181880","mergeCommit":{"message":"[SLOs]  Disable federated view settings in serverless (#181880)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/181739\r\n\r\nDisable federated view settings in serverless !!\r\n\r\n- [ ] Disabled route and settings page in public\r\n- [ ] Uses different put request schema on serverless which doesn't\r\ncontains remote cluster settings","sha":"390628d665bda92a4450c586511bf170af3fab7f"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181880","number":181880,"mergeCommit":{"message":"[SLOs]  Disable federated view settings in serverless (#181880)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/181739\r\n\r\nDisable federated view settings in serverless !!\r\n\r\n- [ ] Disabled route and settings page in public\r\n- [ ] Uses different put request schema on serverless which doesn't\r\ncontains remote cluster settings","sha":"390628d665bda92a4450c586511bf170af3fab7f"}}]}] BACKPORT-->