### PR TITLE
chore: bump `ejs` from `3.1.8` to `3.1.10`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1581,7 +1581,7 @@
     "date-fns": "^2.29.3",
     "debug": "^2.6.9",
     "dependency-check": "^4.1.0",
-    "ejs": "^3.1.8",
+    "ejs": "^3.1.10",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
     "eslint": "^8.46.0",

--- a/renovate.json
+++ b/renovate.json
@@ -685,6 +685,24 @@
         "backport:prev-minor"
       ],
       "enabled": true
+    },
+    {
+      "groupName": "machine learning modules",
+      "matchPackageNames": [
+        "apidoc-markdown"
+      ],
+      "reviewers": [
+        "team:ml-ui"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "Team:ML",
+        "release_note:skip",
+        "backport:all-open"
+      ],
+      "enabled": true
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15856,10 +15856,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ejs@^3.1.8, ejs@^3.1.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
-  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
+ejs@^3.1.10, ejs@^3.1.9:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
   dependencies:
     jake "^10.8.5"
 


### PR DESCRIPTION
## Summary

Bump `ejs` from `3.1.8` to `3.1.10`. While looking at other packages that depend on `ejs` noticed `apidoc-markdown` that is only used by ML team, so assigned ownership in Rennovate as well (cc @elastic/ml-ui).

```shell
npm ls ejs
kibana@8.15.0 /kibana
├─┬ apidoc-markdown@7.3.2
│ └── ejs@3.1.10 deduped
└── ejs@3.1.10
```


<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->