### PR TITLE
[EDR Workflows] Fix `on_write_scan` migration script

### DIFF
--- a/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v8_14_0.test.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v8_14_0.test.ts
@@ -85,8 +85,12 @@ describe('8.14.0 Endpoint Package Policy migration', () => {
   });
 
   describe('backfilling `on_write_scan`', () => {
-    it('should backfill `on_write_scan` field to malware protections on Kibana update', () => {
+    it('should backfill `on_write_scan` field as `true` for `malware prevent` on Kibana update', () => {
       const originalPolicyConfigSO = cloneDeep(policyDoc);
+      const originalPolicyConfig = originalPolicyConfigSO.attributes.inputs[0].config?.policy.value;
+      originalPolicyConfig.windows.malware.mode = 'prevent';
+      originalPolicyConfig.mac.malware.mode = 'prevent';
+      originalPolicyConfig.linux.malware.mode = 'prevent';
 
       const migratedPolicyConfigSO = migrator.migrate<PackagePolicy, PackagePolicy>({
         document: originalPolicyConfigSO,
@@ -98,6 +102,44 @@ describe('8.14.0 Endpoint Package Policy migration', () => {
       expect(migratedPolicyConfig.windows.malware.on_write_scan).toBe(true);
       expect(migratedPolicyConfig.mac.malware.on_write_scan).toBe(true);
       expect(migratedPolicyConfig.linux.malware.on_write_scan).toBe(true);
+    });
+
+    it('should backfill `on_write_scan` field as `true` for `malware detect` on Kibana update', () => {
+      const originalPolicyConfigSO = cloneDeep(policyDoc);
+      const originalPolicyConfig = originalPolicyConfigSO.attributes.inputs[0].config?.policy.value;
+      originalPolicyConfig.windows.malware.mode = 'detect';
+      originalPolicyConfig.mac.malware.mode = 'detect';
+      originalPolicyConfig.linux.malware.mode = 'detect';
+
+      const migratedPolicyConfigSO = migrator.migrate<PackagePolicy, PackagePolicy>({
+        document: originalPolicyConfigSO,
+        fromVersion: 5,
+        toVersion: 6,
+      });
+
+      const migratedPolicyConfig = migratedPolicyConfigSO.attributes.inputs[0].config?.policy.value;
+      expect(migratedPolicyConfig.windows.malware.on_write_scan).toBe(true);
+      expect(migratedPolicyConfig.mac.malware.on_write_scan).toBe(true);
+      expect(migratedPolicyConfig.linux.malware.on_write_scan).toBe(true);
+    });
+
+    it('should backfill `on_write_scan` field as `false` for `malware off` on Kibana update', () => {
+      const originalPolicyConfigSO = cloneDeep(policyDoc);
+      const originalPolicyConfig = originalPolicyConfigSO.attributes.inputs[0].config?.policy.value;
+      originalPolicyConfig.windows.malware.mode = 'off';
+      originalPolicyConfig.mac.malware.mode = 'off';
+      originalPolicyConfig.linux.malware.mode = 'off';
+
+      const migratedPolicyConfigSO = migrator.migrate<PackagePolicy, PackagePolicy>({
+        document: originalPolicyConfigSO,
+        fromVersion: 5,
+        toVersion: 6,
+      });
+
+      const migratedPolicyConfig = migratedPolicyConfigSO.attributes.inputs[0].config?.policy.value;
+      expect(migratedPolicyConfig.windows.malware.on_write_scan).toBe(false);
+      expect(migratedPolicyConfig.mac.malware.on_write_scan).toBe(false);
+      expect(migratedPolicyConfig.linux.malware.on_write_scan).toBe(false);
     });
 
     it('should not backfill `on_write_scan` field if already present due to user edit before migration is performed on serverless', () => {

--- a/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v8_14_0.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/migrations/security_solution/to_v8_14_0.ts
@@ -28,9 +28,12 @@ export const migratePackagePolicyToV8140: SavedObjectModelDataBackfillFn<
   if (input && input.config) {
     const policy = input.config.policy.value;
 
-    policy.windows.malware.on_write_scan ??= ON_WRITE_SCAN_DEFAULT_VALUE;
-    policy.mac.malware.on_write_scan ??= ON_WRITE_SCAN_DEFAULT_VALUE;
-    policy.linux.malware.on_write_scan ??= ON_WRITE_SCAN_DEFAULT_VALUE;
+    policy.windows.malware.on_write_scan ??=
+      policy.windows.malware.mode === 'off' ? false : ON_WRITE_SCAN_DEFAULT_VALUE;
+    policy.mac.malware.on_write_scan ??=
+      policy.mac.malware.mode === 'off' ? false : ON_WRITE_SCAN_DEFAULT_VALUE;
+    policy.linux.malware.on_write_scan ??=
+      policy.linux.malware.mode === 'off' ? false : ON_WRITE_SCAN_DEFAULT_VALUE;
   }
 
   return { attributes: updatedPackagePolicyDoc.attributes };


### PR DESCRIPTION
## Summary

Fixes migration script for `on_write_scan`. Currently it backfills it `true` always, which is a bit weird if Malware protection is turned off.
<img width="789" alt="image" src="https://github.com/elastic/kibana/assets/39014407/48b73633-3eb5-4603-b595-3f1ccba23177">

It does not cause any issue on Endpoint.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->