### PR TITLE
Add treeshake to some core, ml and shared-ux modules

### DIFF
--- a/packages/core/notifications/core-notifications-browser-internal/package.json
+++ b/packages/core/notifications/core-notifications-browser-internal/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "author": "Kibana Core",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/core/notifications/core-notifications-browser/package.json
+++ b/packages/core/notifications/core-notifications-browser/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "author": "Kibana Core",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/avatar/solution/package.json
+++ b/packages/shared-ux/avatar/solution/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-avatar-solution",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/button/exit_full_screen/package.json
+++ b/packages/shared-ux/button/exit_full_screen/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-button-exit-full-screen",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/button_toolbar/package.json
+++ b/packages/shared-ux/button_toolbar/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-button-toolbar",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/card/no_data/impl/package.json
+++ b/packages/shared-ux/card/no_data/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-card-no-data",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/chrome/navigation/package.json
+++ b/packages/shared-ux/chrome/navigation/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-chrome-navigation",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/code_editor/impl/package.json
+++ b/packages/shared-ux/code_editor/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/code-editor",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/error_boundary/package.json
+++ b/packages/shared-ux/error_boundary/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-error-boundary",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/file/context/package.json
+++ b/packages/shared-ux/file/context/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-file-context",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/file/file_picker/impl/package.json
+++ b/packages/shared-ux/file/file_picker/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-file-picker",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/file/file_upload/impl/package.json
+++ b/packages/shared-ux/file/file_upload/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-file-upload",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/file/image/impl/package.json
+++ b/packages/shared-ux/file/image/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-file-image",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/file/util/package.json
+++ b/packages/shared-ux/file/util/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-file-util",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/link/redirect_app/impl/package.json
+++ b/packages/shared-ux/link/redirect_app/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-link-redirect-app",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/markdown/impl/package.json
+++ b/packages/shared-ux/markdown/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-markdown",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/modal/tabbed/package.json
+++ b/packages/shared-ux/modal/tabbed/package.json
@@ -2,5 +2,6 @@
     "name": "@kbn/shared-ux-tabbed-modal",
     "private": true,
     "version": "1.0.0",
-    "license": "SSPL-1.0 OR Elastic License 2.0"
+    "license": "SSPL-1.0 OR Elastic License 2.0",
+    "sideEffects": false
   }

--- a/packages/shared-ux/page/analytics_no_data/impl/package.json
+++ b/packages/shared-ux/page/analytics_no_data/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-page-analytics-no-data",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/page/kibana_no_data/impl/package.json
+++ b/packages/shared-ux/page/kibana_no_data/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-page-kibana-no-data",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/page/kibana_template/impl/package.json
+++ b/packages/shared-ux/page/kibana_template/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-page-kibana-template",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/page/no_data/impl/package.json
+++ b/packages/shared-ux/page/no_data/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-page-no-data",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/page/no_data_config/impl/package.json
+++ b/packages/shared-ux/page/no_data_config/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-page-no-data-config",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/page/solution_nav/package.json
+++ b/packages/shared-ux/page/solution_nav/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-page-solution-nav",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/prompt/no_data_views/impl/package.json
+++ b/packages/shared-ux/prompt/no_data_views/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-prompt-no-data-views",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/prompt/not_found/package.json
+++ b/packages/shared-ux/prompt/not_found/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-prompt-not-found",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/packages/shared-ux/router/impl/package.json
+++ b/packages/shared-ux/router/impl/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/shared-ux-router",
   "private": true,
   "version": "1.0.0",
-  "license": "SSPL-1.0 OR Elastic License 2.0"
+  "license": "SSPL-1.0 OR Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/agg_utils/package.json
+++ b/x-pack/packages/ml/agg_utils/package.json
@@ -5,5 +5,6 @@
   "homepage": "https://docs.elastic.dev/kibana-dev-docs/api/kbn-ml-agg-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/aiops_change_point_detection/package.json
+++ b/x-pack/packages/ml/aiops_change_point_detection/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/aiops-change-point-detection",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/aiops_common/package.json
+++ b/x-pack/packages/ml/aiops_common/package.json
@@ -5,5 +5,6 @@
   "homepage": "https://docs.elastic.dev/kibana-dev-docs/api/kbn-aiops-common",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/aiops_log_pattern_analysis/package.json
+++ b/x-pack/packages/ml/aiops_log_pattern_analysis/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/aiops-log-pattern-analysis",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/aiops_log_rate_analysis/package.json
+++ b/x-pack/packages/ml/aiops_log_rate_analysis/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/aiops-log-rate-analysis",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/cancellable_search/package.json
+++ b/x-pack/packages/ml/cancellable_search/package.json
@@ -4,5 +4,6 @@
   "author": "Machine Learning UI",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/category_validator/package.json
+++ b/x-pack/packages/ml/category_validator/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-category-validator",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/data_view_utils/package.json
+++ b/x-pack/packages/ml/data_view_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-data-view-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/error_utils/package.json
+++ b/x-pack/packages/ml/error_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-error-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/inference_integration_flyout/package.json
+++ b/x-pack/packages/ml/inference_integration_flyout/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/inference_integration_flyout",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/is_defined/package.json
+++ b/x-pack/packages/ml/is_defined/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-is-defined",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/is_populated_object/package.json
+++ b/x-pack/packages/ml/is_populated_object/package.json
@@ -5,5 +5,6 @@
   "homepage": "https://docs.elastic.dev/kibana-dev-docs/api/kbn-ml-is-populated-object",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/nested_property/package.json
+++ b/x-pack/packages/ml/nested_property/package.json
@@ -5,5 +5,6 @@
   "homepage": "https://docs.elastic.dev/kibana-dev-docs/api/kbn-ml-nested-property",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/number_utils/package.json
+++ b/x-pack/packages/ml/number_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-number-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/query_utils/package.json
+++ b/x-pack/packages/ml/query_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-query-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/random_sampler_utils/package.json
+++ b/x-pack/packages/ml/random_sampler_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-random-sampler-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/response_stream/package.json
+++ b/x-pack/packages/ml/response_stream/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-response-stream",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/route_utils/package.json
+++ b/x-pack/packages/ml/route_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-route-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/runtime_field_utils/package.json
+++ b/x-pack/packages/ml/runtime_field_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-runtime-field-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/string_hash/package.json
+++ b/x-pack/packages/ml/string_hash/package.json
@@ -5,5 +5,6 @@
   "homepage": "https://docs.elastic.dev/kibana-dev-docs/api/kbn-ml-string-hash",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/time_buckets/package.json
+++ b/x-pack/packages/ml/time_buckets/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-time-buckets",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/trained_models_utils/package.json
+++ b/x-pack/packages/ml/trained_models_utils/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-trained-models-utils",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/ui_actions/package.json
+++ b/x-pack/packages/ml/ui_actions/package.json
@@ -2,5 +2,6 @@
   "name": "@kbn/ml-ui-actions",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }

--- a/x-pack/packages/ml/url_state/package.json
+++ b/x-pack/packages/ml/url_state/package.json
@@ -5,5 +5,6 @@
   "homepage": "https://docs.elastic.dev/kibana-dev-docs/api/kbn-ml-url-state",
   "private": true,
   "version": "1.0.0",
-  "license": "Elastic License 2.0"
+  "license": "Elastic License 2.0",
+  "sideEffects": false
 }


### PR DESCRIPTION
## Summary

While debugging another issue I've noticed there were few packages without treeshake enabled who could be optimized for bundle size, so I've enabled it for a few of them.
This PR focuses only on `shared-ux`, `core` and `ml` packages for now.

it relies on the tests to check if the treeshake broke anything deep.