### PR TITLE
[Lens] [Inline editing] fix clip path cutting mobile view

### DIFF
--- a/x-pack/plugins/lens/public/_mixins.scss
+++ b/x-pack/plugins/lens/public/_mixins.scss
@@ -54,7 +54,6 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  clip-path: polygon(-50% 0, 100% 0, 100% 100%, -50% 100%);
 }
 
 @keyframes euiFlyoutAnimation {

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -413,10 +413,14 @@ export function LensEditConfigurationFlyout({
               flex-direction: column;
             }
             .euiAccordion__childWrapper {
-              overflow-y: auto !important;
               ${euiScrollBarStyles(euiTheme)}
+              overflow-y: auto !important;
+              pointer-events: none;
               padding-left: ${euiThemeVars.euiFormMaxWidth};
               margin-left: -${euiThemeVars.euiFormMaxWidth};
+              > * {
+                pointer-events: auto;
+              }
 
               .euiAccordion-isOpen & {
                 block-size: auto !important;

--- a/x-pack/plugins/lens/public/shared_components/flyout_container.scss
+++ b/x-pack/plugins/lens/public/shared_components/flyout_container.scss
@@ -6,9 +6,10 @@
   // But with custom positioning to keep it within the sidebar contents
   animation: euiFlyoutAnimation $euiAnimSpeedNormal $euiAnimSlightResistance;
   max-width: none !important;
+  left: 0;
   z-index: $euiZContentMenu;
 
-  @include euiBreakpoint('l', 'xl') {
+  @include euiBreakpoint('m', 'l', 'xl') {
     height: 100% !important;
     position: absolute;
     top: 0 !important;

--- a/x-pack/plugins/lens/public/shared_components/flyout_container.scss
+++ b/x-pack/plugins/lens/public/shared_components/flyout_container.scss
@@ -5,7 +5,6 @@
   @include euiFlyout;
   // But with custom positioning to keep it within the sidebar contents
   animation: euiFlyoutAnimation $euiAnimSpeedNormal $euiAnimSlightResistance;
-  left: 0;
   max-width: none !important;
   z-index: $euiZContentMenu;
 

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/helpers.scss
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/helpers.scss
@@ -1,6 +1,9 @@
 // styles needed to display extra drop targets that are outside of the config panel main area while also allowing to scroll vertically
 .lnsConfigPanel__overlay {
   clip-path: polygon(-100% 0, 100% 0, 100% 100%, -100% 100%);
+  @include euiBreakpoint('xs', 's', 'm') {
+    clip-path: none;
+  }
   background: $euiColorLightestShade;
   .kbnOverlayMountWrapper {
     padding-left: $euiFormMaxWidth;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/182332

Fixes two problems:
1. clip-path used in eui flyout has to be overriden for mobile, otherwise the content gets clipped and doesn't display properly.
2. pointer-events had to be set to none for the overlay and then set to auto for the children to fix the second porblem.

Unfortunately I am not able to get rid of the layer Marco points out as a problem because it's needed to display extra drop targets while also allowing to scroll vertically:
<img width="1296" alt="Screenshot 2024-05-02 at 16 44 38" src="https://github.com/elastic/kibana/assets/4283304/42bcbd98-d4c8-40ba-b0f5-7570f56264b1">



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->