### PR TITLE
[CI] Fix axios requests to allow retry

### DIFF
--- a/.buildkite/scripts/steps/artifacts/validate_cdn_assets.ts
+++ b/.buildkite/scripts/steps/artifacts/validate_cdn_assets.ts
@@ -46,14 +46,22 @@ async function main() {
 
 async function headAssetUrl(assetPath: string) {
   const testUrl = `${CDN_URL_PREFIX}/${assetPath}`;
-  const response = await axios.head(testUrl, {
-    timeout: 1000,
-  });
-  return {
-    status: response.status,
-    testUrl,
-    assetPath,
-  };
+  try {
+    const response = await axios.head(testUrl, {
+      timeout: 1000,
+    });
+    return {
+      status: response.status,
+      testUrl,
+      assetPath,
+    };
+  } catch (error) {
+    return {
+      status: error.response?.status || 0,
+      testUrl,
+      assetPath,
+    };
+  }
 }
 
 async function headAssetUrlWithRetry(


### PR DESCRIPTION
## Summary
Related to #181733 - I didn't check, and axios rejects requests' promises that don't result in `2xx`.

This PR wraps the attempt in a try-catch to be able to retry.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->