### PR TITLE
[Security Solution] - Rename esql setting

### DIFF
--- a/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
@@ -9,9 +9,14 @@ import { useMemo } from 'react';
 import { useKibana } from '../../lib/kibana';
 import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
 
+/**
+ * This hook combines the checks for esql availability within the security solution
+ * If the advanced setting is disabled, ESQL will not be accessible in the UI for any new timeline or new rule creation workflows
+ * The feature flags are still available to provide users an escape hatch in case of any esql related performance issues
+ */
 export const useEsqlAvailability = () => {
   const { uiSettings } = useKibana().services;
-  const isEsqlAdvancedSettingEnabled = uiSettings?.get('discover:enableESQL');
+  const isEsqlAdvancedSettingEnabled = uiSettings?.get('enableESQL');
   const isEsqlRuleTypeEnabled =
     !useIsExperimentalFeatureEnabled('esqlRulesDisabled') && isEsqlAdvancedSettingEnabled;
   const isESQLTabInTimelineEnabled =

--- a/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
@@ -7,6 +7,7 @@
 
 import { useMemo } from 'react';
 import { useKibana } from '../../lib/kibana';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
 
 /**
@@ -16,7 +17,7 @@ import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
  */
 export const useEsqlAvailability = () => {
   const { uiSettings } = useKibana().services;
-  const isEsqlAdvancedSettingEnabled = uiSettings?.get('enableESQL');
+  const isEsqlAdvancedSettingEnabled = uiSettings?.get(ENABLE_ESQL);
   const isEsqlRuleTypeEnabled =
     !useIsExperimentalFeatureEnabled('esqlRulesDisabled') && isEsqlAdvancedSettingEnabled;
   const isESQLTabInTimelineEnabled =

--- a/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
@@ -6,8 +6,8 @@
  */
 
 import { useMemo } from 'react';
-import { useKibana } from '../../lib/kibana';
 import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { useKibana } from '../../lib/kibana';
 import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
 
 /**


### PR DESCRIPTION
## Summary

Follow up to this PR: https://github.com/elastic/kibana/pull/181616
Renaming `discover:enableEsql` to `enableESQL` according to this change: https://github.com/elastic/kibana/pull/182074

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->