### PR TITLE
[Fleet] Add not upgradable warning message for multiple agents

### DIFF
--- a/x-pack/plugins/fleet/common/services/is_agent_upgradeable.test.ts
+++ b/x-pack/plugins/fleet/common/services/is_agent_upgradeable.test.ts
@@ -11,7 +11,7 @@ import {
   getRecentUpgradeInfoForAgent,
   isAgentUpgradeable,
   isAgentUpgrading,
-  getNotUpgradeableMessage,
+  getAgentNotUpgradeableMessage,
   isAgentUpgradeAvailable,
   isAgentUpgradeableToVersion,
 } from './is_agent_upgradeable';
@@ -249,38 +249,38 @@ describe('Fleet - isAgentUpgradeableToVersion', () => {
 
 describe('Fleet - getNotUpgradeableMessage', () => {
   it('if agent reports not upgradeable with agent version < latest agent version', () => {
-    expect(getNotUpgradeableMessage(getAgent({ version: '7.9.0' }), '8.0.0')).toBe(
+    expect(getAgentNotUpgradeableMessage(getAgent({ version: '7.9.0' }), '8.0.0')).toBe(
       'agent cannot be upgraded through Fleet. It may be running in a container or it is not installed as a service.'
     );
   });
 
   it('if agent reports not upgradeable with agent version > latest agent version', () => {
-    expect(getNotUpgradeableMessage(getAgent({ version: '8.0.0' }), '7.9.0')).toBe(
+    expect(getAgentNotUpgradeableMessage(getAgent({ version: '8.0.0' }), '7.9.0')).toBe(
       'agent cannot be upgraded through Fleet. It may be running in a container or it is not installed as a service.'
     );
   });
 
   it('returns false if agent reports not upgradeable with agent version === latest agent version', () => {
-    expect(getNotUpgradeableMessage(getAgent({ version: '8.0.0' }), '8.0.0')).toBe(
+    expect(getAgentNotUpgradeableMessage(getAgent({ version: '8.0.0' }), '8.0.0')).toBe(
       'agent cannot be upgraded through Fleet. It may be running in a container or it is not installed as a service.'
     );
   });
 
   it('if agent reports upgradeable, with agent version === latest agent version', () => {
     expect(
-      getNotUpgradeableMessage(getAgent({ version: '8.0.0', upgradeable: true }), '8.0.0')
+      getAgentNotUpgradeableMessage(getAgent({ version: '8.0.0', upgradeable: true }), '8.0.0')
     ).toBe(undefined);
   });
 
   it('if agent reports upgradeable, with agent version > latest agent version', () => {
     expect(
-      getNotUpgradeableMessage(getAgent({ version: '8.0.0', upgradeable: true }), '7.9.0')
+      getAgentNotUpgradeableMessage(getAgent({ version: '8.0.0', upgradeable: true }), '7.9.0')
     ).toBe('agent is running on a version greater than the latest available version.');
   });
 
   it('if agent reports upgradeable, but agent is unenrolling', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({ version: '7.9.0', upgradeable: true, unenrolling: true }),
         '8.0.0'
       )
@@ -289,7 +289,7 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('if agent reports upgradeable, but agent is unenrolled', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({ version: '7.9.0', upgradeable: true, unenrolled: true }),
         '8.0.0'
       )
@@ -298,19 +298,22 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('Returns no error message if agent reports upgradeable, with agent version < latest agent version', () => {
     expect(
-      getNotUpgradeableMessage(getAgent({ version: '7.9.0', upgradeable: true }), '8.0.0')
+      getAgentNotUpgradeableMessage(getAgent({ version: '7.9.0', upgradeable: true }), '8.0.0')
     ).toBeUndefined();
   });
 
   it('if agent reports upgradeable, with agent snapshot version === latest agent version', () => {
     expect(
-      getNotUpgradeableMessage(getAgent({ version: '7.9.0-SNAPSHOT', upgradeable: true }), '7.9.0')
+      getAgentNotUpgradeableMessage(
+        getAgent({ version: '7.9.0-SNAPSHOT', upgradeable: true }),
+        '7.9.0'
+      )
     ).toBe(undefined);
   });
 
   it('it does not return message if agent reports upgradeable, with upgrade to agent snapshot version newer than latest agent version', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({ version: '8.10.2', upgradeable: true }),
         '8.10.2',
         '8.11.0-SNAPSHOT'
@@ -320,19 +323,27 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('if agent reports upgradeable, with target version < current agent version ', () => {
     expect(
-      getNotUpgradeableMessage(getAgent({ version: '7.9.0', upgradeable: true }), '8.0.0', '7.8.0')
+      getAgentNotUpgradeableMessage(
+        getAgent({ version: '7.9.0', upgradeable: true }),
+        '8.0.0',
+        '7.8.0'
+      )
     ).toBe('agent does not support downgrades.');
   });
 
   it('if agent reports upgradeable, with target version == current agent version ', () => {
     expect(
-      getNotUpgradeableMessage(getAgent({ version: '7.9.0', upgradeable: true }), '8.0.0', '7.9.0')
+      getAgentNotUpgradeableMessage(
+        getAgent({ version: '7.9.0', upgradeable: true }),
+        '8.0.0',
+        '7.9.0'
+      )
     ).toBe('agent is already running on the selected version.');
   });
 
   it('if agent with no upgrade details reports upgradeable, but is already upgrading', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({ version: '7.9.0', upgradeable: true, upgrading: true }),
         '8.0.0'
       )
@@ -341,7 +352,7 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('if agent reports upgradeable, but has an upgrade status other than failed', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({
           version: '7.9.0',
           upgradeable: true,
@@ -358,7 +369,7 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('it does not return a message if agent reports upgradeable and has a failed upgrade status', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({
           version: '7.9.0',
           upgradeable: true,
@@ -378,7 +389,7 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('if the agent reports upgradeable but was upgraded less than 10 minutes ago', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({ version: '7.9.0', upgradeable: true, minutesSinceUpgrade: 9 }),
         '8.0.0'
       )
@@ -387,7 +398,7 @@ describe('Fleet - getNotUpgradeableMessage', () => {
 
   it('if agent reports upgradeable and was upgraded more than 10 minutes ago', () => {
     expect(
-      getNotUpgradeableMessage(
+      getAgentNotUpgradeableMessage(
         getAgent({ version: '7.9.0', upgradeable: true, minutesSinceUpgrade: 11 }),
         '8.0.0'
       )

--- a/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
+++ b/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
@@ -18,6 +18,7 @@ export const AGENT_UPGRADE_COOLDOWN_IN_MIN = 10;
 export const AGENT_UPGARDE_DETAILS_SUPPORTED_VERSION = '8.12.0';
 
 // Error messages for agent not upgradeable
+// TODO: localize
 export const VERSION_MISSING_ERROR = `agent version is missing.`;
 export const UNENROLLED_ERROR = `agent has been unenrolled.`;
 export const ONGOING_UNEROLLMENT_ERROR = `agent is being unenrolled.`;
@@ -59,6 +60,10 @@ export function isAgentUpgradeable(agent: Agent): boolean {
   return true;
 }
 
+export function areAgentsUpgradeableToVersion(agents: Agent[], versionToUpgrade?: string): boolean {
+  return agents.every((agent) => isAgentUpgradeableToVersion(agent, versionToUpgrade));
+}
+
 export function isAgentUpgradeableToVersion(agent: Agent, versionToUpgrade?: string): boolean {
   const isAgentUpgradeableCheck = isAgentUpgradeable(agent);
   if (!isAgentUpgradeableCheck) return false;
@@ -88,7 +93,7 @@ export const isAgentVersionLessThanLatest = (
 };
 
 // Based on the previous, returns a detailed message explaining why the agent is not upgradeable
-export const getNotUpgradeableMessage = (
+export const getAgentNotUpgradeableMessage = (
   agent: Agent,
   latestAgentVersion?: string,
   versionToUpgrade?: string
@@ -138,6 +143,20 @@ export const getNotUpgradeableMessage = (
 
   // in all the other cases, the agent is upgradeable; don't return any message.
   return undefined;
+};
+
+// Returns the first not upgradable message found
+export const getAgentsNotUpgradeableMessage = (
+  agents: Agent[],
+  latestAgentVersion?: string,
+  versionToUpgrade?: string
+): string | undefined => {
+  for (const agent of agents) {
+    const message = getAgentNotUpgradeableMessage(agent, latestAgentVersion, versionToUpgrade);
+    if (message) {
+      return message;
+    }
+  }
 };
 
 const isNotDowngrade = (agentVersion: string, versionToUpgrade: string): boolean => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.tsx
@@ -13,7 +13,7 @@ import moment from 'moment';
 import type { Agent } from '../../../../types';
 import type { AgentUpgradeDetails } from '../../../../../../../common/types';
 import {
-  getNotUpgradeableMessage,
+  getAgentNotUpgradeableMessage,
   isAgentUpgradeAvailable,
 } from '../../../../../../../common/services';
 
@@ -281,7 +281,7 @@ export const AgentUpgradeStatus: React.FC<{
   );
   const status = useMemo(() => getStatusComponents(agent.upgrade_details), [agent.upgrade_details]);
   const minVersion = '8.12';
-  const notUpgradeableMessage = getNotUpgradeableMessage(agent, latestAgentVersion);
+  const notUpgradeableMessage = getAgentNotUpgradeableMessage(agent, latestAgentVersion);
 
   if (isAgentUpgradable && isAgentUpgradeAvailable(agent, latestAgentVersion)) {
     return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -255,7 +255,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       !isAgentUpgradeableToVersion(agents[0], selectedVersion[0].value)
     ) {
       return i18n.translate('xpack.fleet.upgradeAgents.notUpgradable.singleAgentMessage', {
-        defaultMessage: 'The selected agent is not upgradeable: ${reason}',
+        defaultMessage: 'The selected agent is not upgradeable: {reason}',
         values: {
           reason: getAgentNotUpgradeableMessage(
             agents[0],
@@ -267,7 +267,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
     }
     if (isListOfAgents && !areAgentsUpgradeableToVersion(agents, selectedVersion[0].value)) {
       return i18n.translate('xpack.fleet.upgradeAgents.notUpgradable.multipleAgentsMessage', {
-        defaultMessage: 'The selected agents are not upgradeable: ${reason}',
+        defaultMessage: 'The selected agents are not upgradeable: {reason}',
         values: {
           reason: getAgentsNotUpgradeableMessage(
             agents,
@@ -282,7 +282,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       !isAgentVersionLessThanFleetServer(selectedVersion[0].value, fleetServerAgents)
     ) {
       return i18n.translate('xpack.fleet.upgradeAgents.notUpgradable.fleetServerVersionMessage', {
-        defaultMessage: 'Please choose another version. ${reason}',
+        defaultMessage: 'Please choose another version. {reason}',
         values: {
           reason: getFleetServerVersionMessage(selectedVersion[0].value, fleetServerAgents),
         },

--- a/x-pack/plugins/fleet/public/services/index.ts
+++ b/x-pack/plugins/fleet/public/services/index.ts
@@ -34,7 +34,7 @@ export {
   isValidNamespace,
   LicenseService,
   isAgentUpgradeable,
-  getNotUpgradeableMessage,
+  getAgentNotUpgradeableMessage,
   doesPackageHaveIntegrations,
   validatePackagePolicy,
   validatePackagePolicyConfig,

--- a/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.ts
@@ -24,7 +24,7 @@ import {
   getRecentUpgradeInfoForAgent,
   AGENT_UPGRADE_COOLDOWN_IN_MIN,
   isAgentUpgrading,
-  getNotUpgradeableMessage,
+  getAgentNotUpgradeableMessage,
   isAgentUpgradeableToVersion,
   differsOnlyInPatch,
 } from '../../../common/services';
@@ -115,7 +115,9 @@ export const postAgentUpgradeHandler: RequestHandler<
       return response.customError({
         statusCode: 400,
         body: {
-          message: `Agent ${request.params.agentId} is not upgradeable: ${getNotUpgradeableMessage(
+          message: `Agent ${
+            request.params.agentId
+          } is not upgradeable: ${getAgentNotUpgradeableMessage(
             agent,
             latestAgentVersion,
             version

--- a/x-pack/plugins/fleet/server/services/agents/upgrade_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade_action_runner.ts
@@ -12,7 +12,7 @@ import moment from 'moment';
 
 import {
   getRecentUpgradeInfoForAgent,
-  getNotUpgradeableMessage,
+  getAgentNotUpgradeableMessage,
   isAgentUpgradeableToVersion,
 } from '../../../common/services';
 
@@ -95,7 +95,7 @@ export async function upgradeBatch(
           !isAgentUpgradeableToVersion(agent, options.version));
       if (isNotAllowed) {
         throw new FleetError(
-          `Agent ${agent.id} is not upgradeable: ${getNotUpgradeableMessage(
+          `Agent ${agent.id} is not upgradeable: ${getAgentNotUpgradeableMessage(
             agent,
             latestAgentVersion,
             options.version


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
