### PR TITLE
[SLO] POC Platform agnostic tests

### DIFF
--- a/.buildkite/ftr_configs.yml
+++ b/.buildkite/ftr_configs.yml
@@ -476,6 +476,7 @@ enabled:
   - x-pack/performance/journeys_e2e/infra_hosts_view.ts
   - x-pack/test/custom_branding/config.ts
   - x-pack/test/profiling_api_integration/cloud/config.ts
+  - x-pack/test/api_integration/apis/all_deployments/config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/ess.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/ess.config.ts

--- a/x-pack/test/api_integration/apis/all_deployments/config.ts
+++ b/x-pack/test/api_integration/apis/all_deployments/config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseIntegrationTestsConfig = await readConfigFile(require.resolve('../../config.ts'));
+
+  return {
+    ...baseIntegrationTestsConfig.getAll(),
+    testFiles: [
+      require.resolve('../../../../test_all_deployments/api_integration/test_suites/observability'),
+    ],
+  };
+}

--- a/x-pack/test/api_integration/services/alerting_api.ts
+++ b/x-pack/test/api_integration/services/alerting_api.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AggregationsAggregate,
+  SearchResponse,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import { MetricThresholdParams } from '@kbn/infra-plugin/common/alerting/metrics';
+import { ThresholdParams } from '@kbn/observability-plugin/common/custom_threshold_rule/types';
+import { SloBurnRateRuleParams } from './slo';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function AlertingApiProvider({ getService }: FtrProviderContext) {
+  const retry = getService('retry');
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const requestTimeout = 30 * 1000;
+  const retryTimeout = 120 * 1000;
+  const logger = getService('log');
+
+  return {
+    async waitForRuleStatus({
+      ruleId,
+      expectedStatus,
+    }: {
+      ruleId: string;
+      expectedStatus: string;
+    }) {
+      if (!ruleId) {
+        throw new Error(`'ruleId' is undefined`);
+      }
+      return await retry.tryForTime(retryTimeout, async () => {
+        const response = await supertest
+          .get(`/api/alerting/rule/${ruleId}`)
+          .set('kbn-xsrf', 'foo')
+          .set('x-elastic-internal-origin', 'foo')
+          .timeout(requestTimeout);
+        const { execution_status: executionStatus } = response.body || {};
+        const { status } = executionStatus || {};
+        if (status !== expectedStatus) {
+          throw new Error(`waitForStatus(${expectedStatus}): got ${status}`);
+        }
+        return executionStatus?.status;
+      });
+    },
+
+    async waitForDocumentInIndex<T>({
+      indexName,
+      docCountTarget = 1,
+    }: {
+      indexName: string;
+      docCountTarget?: number;
+    }): Promise<SearchResponse<T, Record<string, AggregationsAggregate>>> {
+      return await retry.tryForTime(retryTimeout, async () => {
+        const response = await es.search<T>({
+          index: indexName,
+          rest_total_hits_as_int: true,
+        });
+        logger.debug(`Found ${response.hits.total} docs, looking for atleast ${docCountTarget}.`);
+        if (!response.hits.total || response.hits.total < docCountTarget) {
+          throw new Error('No hits found');
+        }
+        return response;
+      });
+    },
+
+    async waitForAlertInIndex<T>({
+      indexName,
+      ruleId,
+    }: {
+      indexName: string;
+      ruleId: string;
+    }): Promise<SearchResponse<T, Record<string, AggregationsAggregate>>> {
+      if (!ruleId) {
+        throw new Error(`'ruleId' is undefined`);
+      }
+      return await retry.tryForTime(retryTimeout, async () => {
+        const response = await es.search<T>({
+          index: indexName,
+          body: {
+            query: {
+              term: {
+                'kibana.alert.rule.uuid': ruleId,
+              },
+            },
+          },
+        });
+        if (response.hits.hits.length === 0) {
+          throw new Error('No hits found');
+        }
+        return response;
+      });
+    },
+
+    async createIndexConnector({ name, indexName }: { name: string; indexName: string }) {
+      const { body } = await supertest
+        .post(`/api/actions/connector`)
+        .set('kbn-xsrf', 'foo')
+        .set('x-elastic-internal-origin', 'foo')
+        .send({
+          name,
+          config: {
+            index: indexName,
+            refresh: true,
+          },
+          connector_type_id: '.index',
+        });
+      return body.id as string;
+    },
+
+    async createRule({
+      name,
+      ruleTypeId,
+      params,
+      actions = [],
+      tags = [],
+      schedule,
+      consumer,
+    }: {
+      ruleTypeId: string;
+      name: string;
+      params: MetricThresholdParams | ThresholdParams | SloBurnRateRuleParams;
+      actions?: any[];
+      tags?: any[];
+      schedule?: { interval: string };
+      consumer: string;
+    }) {
+      const { body } = await supertest
+        .post(`/api/alerting/rule`)
+        .set('kbn-xsrf', 'foo')
+        .set('x-elastic-internal-origin', 'foo')
+        .send({
+          params,
+          consumer,
+          schedule: schedule || {
+            interval: '5m',
+          },
+          tags,
+          name,
+          rule_type_id: ruleTypeId,
+          actions,
+        });
+      return body;
+    },
+
+    async findRule(ruleId: string) {
+      if (!ruleId) {
+        throw new Error(`'ruleId' is undefined`);
+      }
+      const response = await supertest
+        .get('/api/alerting/rules/_find')
+        .set('kbn-xsrf', 'foo')
+        .set('x-elastic-internal-origin', 'foo');
+      return response.body.data.find((obj: any) => obj.id === ruleId);
+    },
+  };
+}

--- a/x-pack/test/api_integration/services/index.ts
+++ b/x-pack/test/api_integration/services/index.ts
@@ -24,6 +24,7 @@ import { IngestPipelinesProvider } from './ingest_pipelines';
 import { IndexManagementProvider } from './index_management';
 import { DataViewApiProvider } from './data_view_api';
 import { SloApiProvider } from './slo';
+import { AlertingApiProvider } from './alerting_api';
 import { SecuritySolutionApiProvider } from './security_solution_api.gen';
 
 export const services = {
@@ -44,5 +45,6 @@ export const services = {
   ingestPipelines: IngestPipelinesProvider,
   indexManagement: IndexManagementProvider,
   slo: SloApiProvider,
+  alertingApi: AlertingApiProvider,
   securitySolutionApi: SecuritySolutionApiProvider,
 };

--- a/x-pack/test_all_deployments/api_integration/ftr_provider_context.d.ts
+++ b/x-pack/test_all_deployments/api_integration/ftr_provider_context.d.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { GenericFtrProviderContext } from '@kbn/test';
+
+// eslint-disable-next-line @kbn/imports/no_boundary_crossing
+import { services } from '../../test/api_integration/services';
+
+export type FtrProviderContext = GenericFtrProviderContext<typeof services, {}>;

--- a/x-pack/test_all_deployments/api_integration/test_suites/observability/index.ts
+++ b/x-pack/test_all_deployments/api_integration/test_suites/observability/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('all deployments observability API', function () {
+    loadTestFile(require.resolve('./slo/burn_rate_rule'));
+  });
+}

--- a/x-pack/test_all_deployments/api_integration/test_suites/observability/slo/burn_rate_rule.ts
+++ b/x-pack/test_all_deployments/api_integration/test_suites/observability/slo/burn_rate_rule.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cleanup, Dataset, generate, PartialConfig } from '@kbn/data-forge';
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getService }: FtrProviderContext) {
+  const esClient = getService('es');
+  const supertest = getService('supertest');
+  const esDeleteAllIndices = getService('esDeleteAllIndices');
+  const logger = getService('log');
+  const alertingApi = getService('alertingApi');
+  const dataViewApi = getService('dataViewApi');
+  const slo = getService('slo');
+  console.log(esDeleteAllIndices, '!!esClient');
+  describe('Burn rate rule', () => {
+    const RULE_TYPE_ID = 'slo.rules.burnRate';
+    const DATA_VIEW = 'kbn-data-forge-fake_hosts.fake_hosts-*';
+    const RULE_ALERT_INDEX = '.alerts-observability.slo.alerts-default';
+
+    const ALERT_ACTION_INDEX = 'alert-action-slo';
+    const DATA_VIEW_ID = 'data-view-id';
+    let dataForgeConfig: PartialConfig;
+    let dataForgeIndices: string[];
+    let actionId: string;
+    let ruleId: string;
+
+    before(async () => {
+      dataForgeConfig = {
+        schedule: [
+          {
+            template: 'good',
+            start: 'now-15m',
+            end: 'now+5m',
+            metrics: [
+              { name: 'system.cpu.user.pct', method: 'linear', start: 2.5, end: 2.5 },
+              { name: 'system.cpu.total.pct', method: 'linear', start: 0.5, end: 0.5 },
+              { name: 'system.cpu.total.norm.pct', method: 'linear', start: 0.8, end: 0.8 },
+            ],
+          },
+        ],
+        indexing: { dataset: 'fake_hosts' as Dataset, eventsPerCycle: 1, interval: 10000 },
+      };
+      dataForgeIndices = await generate({ client: esClient, config: dataForgeConfig, logger });
+      await alertingApi.waitForDocumentInIndex({ indexName: DATA_VIEW, docCountTarget: 360 });
+      await dataViewApi.create({
+        name: DATA_VIEW,
+        id: DATA_VIEW_ID,
+        title: DATA_VIEW,
+      });
+    });
+
+    after(async () => {
+      await supertest
+        .delete(`/api/alerting/rule/${ruleId}`)
+        .set('kbn-xsrf', 'foo')
+        .set('x-elastic-internal-origin', 'foo');
+      await supertest
+        .delete(`/api/actions/connector/${actionId}`)
+        .set('kbn-xsrf', 'foo')
+        .set('x-elastic-internal-origin', 'foo');
+      await esClient.deleteByQuery({
+        index: '.kibana-event-log-*',
+        query: { term: { 'rule.id': ruleId } },
+        conflicts: 'proceed',
+      });
+      await dataViewApi.delete({
+        id: DATA_VIEW_ID,
+      });
+      await supertest
+        .delete('/api/observability/slos/my-custom-id')
+        .set('kbn-xsrf', 'foo')
+        .set('x-elastic-internal-origin', 'foo');
+
+      await esDeleteAllIndices([ALERT_ACTION_INDEX, ...dataForgeIndices]);
+      await cleanup({ client: esClient, config: dataForgeConfig, logger });
+    });
+
+    describe('Rule creation', () => {
+      it('creates rule successfully', async () => {
+        actionId = await alertingApi.createIndexConnector({
+          name: 'Index Connector: Slo Burn rate API test',
+          indexName: ALERT_ACTION_INDEX,
+        });
+
+        await slo.create({
+          id: 'my-custom-id',
+          name: 'my custom name',
+          description: 'my custom description',
+          indicator: {
+            type: 'sli.kql.custom',
+            params: {
+              index: DATA_VIEW,
+              good: 'system.cpu.total.norm.pct > 1',
+              total: 'system.cpu.total.norm.pct: *',
+              timestampField: '@timestamp',
+            },
+          },
+          timeWindow: {
+            duration: '7d',
+            type: 'rolling',
+          },
+          budgetingMethod: 'occurrences',
+          objective: {
+            target: 0.999,
+          },
+          groupBy: '*',
+        });
+
+        const dependencyRule = await alertingApi.createRule({
+          tags: ['observability'],
+          consumer: 'observability',
+          name: 'SLO Burn Rate rule - Dependency',
+          ruleTypeId: RULE_TYPE_ID,
+          schedule: {
+            interval: '1m',
+          },
+          params: {
+            sloId: 'my-custom-id',
+            windows: [
+              {
+                id: '1',
+                actionGroup: 'slo.burnRate.alert',
+                burnRateThreshold: 3.36,
+                maxBurnRateThreshold: 720,
+                longWindow: {
+                  value: 1,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 5,
+                  unit: 'm',
+                },
+              },
+              {
+                id: '2',
+                actionGroup: 'slo.burnRate.high',
+                burnRateThreshold: 1.4,
+                maxBurnRateThreshold: 120,
+                longWindow: {
+                  value: 6,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 30,
+                  unit: 'm',
+                },
+              },
+              {
+                id: '3',
+                actionGroup: 'slo.burnRate.medium',
+                burnRateThreshold: 0.7,
+                maxBurnRateThreshold: 30,
+                longWindow: {
+                  value: 24,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 120,
+                  unit: 'm',
+                },
+              },
+              {
+                id: '4',
+                actionGroup: 'slo.burnRate.low',
+                burnRateThreshold: 0.234,
+                maxBurnRateThreshold: 10,
+                longWindow: {
+                  value: 72,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 360,
+                  unit: 'm',
+                },
+              },
+            ],
+          },
+          actions: [],
+        });
+
+        const createdRule = await alertingApi.createRule({
+          tags: ['observability'],
+          consumer: 'observability',
+          name: 'SLO Burn Rate rule',
+          ruleTypeId: RULE_TYPE_ID,
+          schedule: {
+            interval: '1m',
+          },
+          params: {
+            sloId: 'my-custom-id',
+            dependencies: [
+              {
+                ruleId: dependencyRule.id,
+                actionGroupsToSuppressOn: ['slo.burnRate.alert', 'slo.burnRate.high'],
+              },
+            ],
+            windows: [
+              {
+                id: '1',
+                actionGroup: 'slo.burnRate.alert',
+                burnRateThreshold: 3.36,
+                maxBurnRateThreshold: 720,
+                longWindow: {
+                  value: 1,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 5,
+                  unit: 'm',
+                },
+              },
+              {
+                id: '2',
+                actionGroup: 'slo.burnRate.high',
+                burnRateThreshold: 1.4,
+                maxBurnRateThreshold: 120,
+                longWindow: {
+                  value: 6,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 30,
+                  unit: 'm',
+                },
+              },
+              {
+                id: '3',
+                actionGroup: 'slo.burnRate.medium',
+                burnRateThreshold: 0.7,
+                maxBurnRateThreshold: 30,
+                longWindow: {
+                  value: 24,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 120,
+                  unit: 'm',
+                },
+              },
+              {
+                id: '4',
+                actionGroup: 'slo.burnRate.low',
+                burnRateThreshold: 0.234,
+                maxBurnRateThreshold: 10,
+                longWindow: {
+                  value: 72,
+                  unit: 'h',
+                },
+                shortWindow: {
+                  value: 360,
+                  unit: 'm',
+                },
+              },
+            ],
+          },
+          actions: [],
+        });
+        ruleId = createdRule.id;
+        expect(ruleId).not.to.be(undefined);
+      });
+
+      // it('should be active', async () => {
+      //   const executionStatus = await alertingApi.waitForRuleStatus({
+      //     ruleId,
+      //     expectedStatus: 'active',
+      //   });
+      //   expect(executionStatus).to.be('active');
+      // });
+
+      // it('should set correct information in the alert document', async () => {
+      //   const resp = await alertingApi.waitForAlertInIndex({
+      //     indexName: RULE_ALERT_INDEX,
+      //     ruleId,
+      //   });
+      //   expect(resp.hits.hits[0]._source).property('kibana.alert.rule.category', 'SLO burn rate');
+      //   expect(resp.hits.hits[0]._source).property(
+      //     'kibana.alert.reason',
+      //     'SUPPRESSED - CRITICAL: The burn rate for the past 1h is 1000 and for the past 5m is 1000. Alert when above 3.36 for both windows'
+      //   );
+      // });
+
+      // it('should find the created rule with correct information about the consumer', async () => {
+      //   const match = await alertingApi.findRule(ruleId);
+      //   expect(match).not.to.be(undefined);
+      //   expect(match.consumer).to.be('observability');
+      // });
+    });
+  });
+}

--- a/x-pack/test_all_deployments/tsconfig.json
+++ b/x-pack/test_all_deployments/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "rootDirs": [".", "../test"],
+    "types": ["node", "@kbn/ambient-ftr-types"],
+  },
+  "include": [
+    "**/*",
+    "../../typings/**/*",
+    "../../packages/kbn-test/types/ftr_globals/**/*",
+  ],
+  "exclude": [
+    "target/**/*",
+    "*/plugins/**/*",
+    "*/packages/**/*",
+    "*/*/packages/**/*",
+  ],
+  "kbn_references": [
+    { "path": "../test/tsconfig.json" },
+    "@kbn/test",
+  ]
+}


### PR DESCRIPTION
## 🍒 Summary

Based on this [POC](https://github.com/elastic/kibana/pull/161574/) I am trying to write SLO tests that are deployment agnostic.

The idea is to take existing [serverless SLO burn rate](https://github.com/elastic/kibana/blob/main/x-pack/test_serverless/api_integration/test_suites/observability/burn_rate_rule/burn_rate_rule.ts) rule type tests and make them work in the new setup.

In order for this to work, all services used in the SLO tests, need to be defined under[ test/api_integration](https://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/services/index.ts). The [alerting api service](x-pack/test_serverless/api_integration/services/alerting_api.ts) needs to be moved there. 


## Status
Currently I get ` proc [kibana] [2024-05-03T12:46:22.994+02:00][ERROR][plugins.alerting] delete(): Failed to load API key to invalidate on alert undefined: Saved object [alert/undefined] not found {"service":{"node":{"roles":["background_tasks","ui"]}}}`. I'll investigate what is happening, maybe I haven't moved things properly. 

## Serverless Limitations

I am not aware of any limitations serverless environment has. I guess some services can't be the same in both environments and they need to differentiate a bit. How can we handle this? 

@pheyos Let's further discuss if what I am trying to achieve here is what you had in mind with your initial POC PR.
 