### PR TITLE
[failed-test-reporter] Include pipeline in comment

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/failed_tests_reporter_cli.ts
@@ -42,11 +42,13 @@ run(
     }
 
     let branch: string = '';
+    let pipeline: string = '';
     if (updateGithub) {
       let isPr = false;
 
       if (process.env.BUILDKITE === 'true') {
         branch = process.env.BUILDKITE_BRANCH || '';
+        pipeline = process.env.BUILDKITE_PIPELINE_SLUG || '';
         isPr = process.env.BUILDKITE_PULL_REQUEST === 'true';
         updateGithub = process.env.REPORT_FAILED_TESTS_TO_GITHUB === 'true';
       } else {
@@ -137,7 +139,8 @@ run(
               buildUrl,
               existingIssue,
               githubApi,
-              branch
+              branch,
+              pipeline
             );
             const url = existingIssue.github.htmlUrl;
             existingIssue.github.body = newBody;
@@ -150,7 +153,7 @@ run(
             continue;
           }
 
-          const newIssue = await createFailureIssue(buildUrl, failure, githubApi, branch);
+          const newIssue = await createFailureIssue(buildUrl, failure, githubApi, branch, pipeline);
           existingIssues.addNewlyCreated(failure, newIssue);
           pushMessage('Test has not failed recently on tracked branches');
           if (updateGithub) {

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.test.ts
@@ -27,7 +27,8 @@ describe('createFailureIssue()', () => {
         likelyIrrelevant: false,
       },
       api,
-      'main'
+      'main',
+      'kibana-on-merge'
     );
 
     expect(api.createIssue).toMatchInlineSnapshot(`
@@ -81,7 +82,8 @@ describe('updateFailureIssue()', () => {
         },
       },
       api,
-      'main'
+      'main',
+      'kibana-on-merge'
     );
 
     expect(api.editIssueBodyAndEnsureOpen).toMatchInlineSnapshot(`

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.test.ts
@@ -42,7 +42,7 @@ describe('createFailureIssue()', () => {
       this is the failure text
       \`\`\`
 
-      First failure: [CI Build - main](https://build-url)
+      First failure: [kibana-on-merge - main](https://build-url)
 
       <!-- kibanaCiData = {\\"failed-test\\":{\\"test.class\\":\\"some.classname\\",\\"test.name\\":\\"test name\\",\\"test.failCount\\":1}} -->",
             Array [
@@ -109,7 +109,7 @@ describe('updateFailureIssue()', () => {
         "calls": Array [
           Array [
             1234,
-            "New failure: [CI Build - main](https://build-url)",
+            "New failure: [kibana-on-merge - main](https://build-url)",
           ],
         ],
         "results": Array [

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failure.ts
@@ -15,7 +15,8 @@ export async function createFailureIssue(
   buildUrl: string,
   failure: TestFailure,
   api: GithubApi,
-  branch: string
+  branch: string,
+  pipeline: string
 ) {
   const title = `Failing test: ${failure.classname} - ${failure.name}`;
 
@@ -39,7 +40,7 @@ export async function createFailureIssue(
       failureBody,
       '```',
       '',
-      `First failure: [CI Build - ${branch}](${buildUrl})`,
+      `First failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`,
     ].join('\n'),
     {
       'test.class': failure.classname,
@@ -55,7 +56,8 @@ export async function updateFailureIssue(
   buildUrl: string,
   issue: ExistingFailedTestIssue,
   api: GithubApi,
-  branch: string
+  branch: string,
+  pipeline: string
 ) {
   // Increment failCount
   const newCount = getIssueMetadata(issue.github.body, 'test.failCount', 0) + 1;
@@ -66,7 +68,7 @@ export async function updateFailureIssue(
   await api.editIssueBodyAndEnsureOpen(issue.github.number, newBody);
   await api.addIssueComment(
     issue.github.number,
-    `New failure: [CI Build - ${branch}](${buildUrl})`
+    `New failure: [${pipeline || 'CI Build'} - ${branch}](${buildUrl})`
   );
 
   return { newBody, newCount };


### PR DESCRIPTION
Instead of the static text `CI Build` when reporting a test failure, this writes the pipeline slug.  The intention here is to enable test failure reporting for https://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote and https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify and keep the test failures consolidated in one issue.  

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->