### PR TITLE
[Search] Notebooks: add support for remote catalog fetching

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -47,3 +47,6 @@ data_visualizer.resultLinks.fileBeat.enabled: false
 
 # Search Playground
 xpack.searchPlayground.ui.enabled: true
+
+# Search Notebooks
+xpack.search.notebooks.catalog.url: https://elastic-enterprise-search.s3.us-east-2.amazonaws.com/serverless/catalog.json

--- a/x-pack/plugins/search_notebooks/common/types.ts
+++ b/x-pack/plugins/search_notebooks/common/types.ts
@@ -5,21 +5,77 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
 import { NotebookDefinition } from '@kbn/ipynb';
 
 export interface NotebookInformation {
   id: string;
   title: string;
   description: string;
+  link?: {
+    title: string;
+    url: string;
+  };
 }
 export interface NotebookCatalog {
   notebooks: NotebookInformation[];
 }
 
 export interface Notebook extends NotebookInformation {
-  link?: {
-    title: string;
-    url: string;
-  };
   notebook: NotebookDefinition;
 }
+
+export const NotebookCatalogSchema = schema.object(
+  {
+    notebooks: schema.arrayOf(
+      schema.object(
+        {
+          id: schema.string(),
+          title: schema.string(),
+          description: schema.string(),
+          url: schema.uri(),
+          link: schema.maybe(
+            schema.object({
+              title: schema.string(),
+              url: schema.uri(),
+            })
+          ),
+        },
+        {
+          unknowns: 'allow',
+        }
+      ),
+      { minSize: 1 }
+    ),
+  },
+  {
+    unknowns: 'allow',
+  }
+);
+const NotebookCellSchema = schema.object(
+  {
+    attachments: schema.maybe(schema.any()),
+    auto_number: schema.maybe(schema.number()),
+    cell_type: schema.maybe(schema.string()),
+    execution_count: schema.maybe(schema.nullable(schema.number())),
+    id: schema.maybe(schema.string()),
+    input: schema.maybe(schema.arrayOf(schema.string())),
+    metadata: schema.maybe(schema.any()),
+    outputs: schema.maybe(schema.arrayOf(schema.any())),
+    prompt_number: schema.maybe(schema.number()),
+    source: schema.maybe(schema.arrayOf(schema.string())),
+  },
+  {
+    unknowns: 'allow',
+  }
+);
+
+export const NotebookSchema = schema.object(
+  {
+    cells: schema.arrayOf(NotebookCellSchema, { minSize: 1 }),
+    metadata: schema.maybe(schema.any()),
+  },
+  {
+    unknowns: 'allow',
+  }
+);

--- a/x-pack/plugins/search_notebooks/server/config.ts
+++ b/x-pack/plugins/search_notebooks/server/config.ts
@@ -12,6 +12,13 @@ export * from './types';
 
 const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
+  catalog: schema.maybe(
+    schema.object({
+      url: schema.uri(),
+      ttl: schema.number({ defaultValue: 900 }),
+      errorTTL: schema.number({ defaultValue: 3600 }),
+    })
+  ),
 });
 
 type SearchNotebooksSchema = TypeOf<typeof configSchema>;

--- a/x-pack/plugins/search_notebooks/server/lib/notebook_catalog.test.ts
+++ b/x-pack/plugins/search_notebooks/server/lib/notebook_catalog.test.ts
@@ -10,44 +10,489 @@ import type { Logger } from '@kbn/logging';
 
 // Mocking dependencies
 jest.mock('fs/promises');
+jest.mock('node-fetch');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fetchMock = require('node-fetch') as jest.Mock;
 
 const mockLogger: Logger = {
   warn: jest.fn(),
   error: jest.fn(),
 } as Partial<Logger> as Logger;
 
-import { getNotebook, DEFAULT_NOTEBOOKS } from './notebook_catalog';
+import {
+  getNotebook,
+  getNotebookCatalog,
+  DEFAULT_NOTEBOOKS,
+  NotebookCatalogFetchOptions,
+  getNotebookMetadata,
+} from './notebook_catalog';
+import { createNotebooksCache } from '../utils';
+import { RemoteNotebookCatalog, SearchNotebooksConfig } from '../config';
+import { NotebookDefinition } from '@kbn/ipynb';
 
-describe('getNotebook', () => {
-  const options = { logger: mockLogger };
+const emptyNotebookCache = createNotebooksCache();
+const baseConfig: SearchNotebooksConfig = { enabled: true };
+const staticOptions: NotebookCatalogFetchOptions = {
+  cache: emptyNotebookCache,
+  config: baseConfig,
+  logger: mockLogger,
+};
+const dynamicOptions: NotebookCatalogFetchOptions = {
+  cache: emptyNotebookCache,
+  config: {
+    ...baseConfig,
+    catalog: {
+      url: 'http://localhost:1000/catalog.json',
+      ttl: 30,
+      errorTTL: 120,
+    },
+  },
+  logger: mockLogger,
+};
+describe('Notebook Catalog', () => {
+  const fakeNow = new Date('1999-12-31T23:59:59.999Z');
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fakeNow);
+  });
   beforeEach(() => {
     // Reset mocks and cache before each test
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    // Reset the notebook cache
+    dynamicOptions.cache = createNotebooksCache();
   });
 
-  it('throws an error if given an unknown notebook id', async () => {
-    await expect(getNotebook('some-fake-id', options)).rejects.toThrow('Unknown Notebook ID');
-    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-  });
-
-  it('throws an error if the file is not found', async () => {
-    const notebookId = DEFAULT_NOTEBOOKS.notebooks[0].id;
-    jest.mocked(fs.access).mockReset().mockRejectedValue(new Error('Boom'));
-
-    await expect(getNotebook(notebookId, options)).rejects.toThrow('Failed to fetch notebook.');
-  });
-
-  it('Reads notebook', async () => {
-    const notebookId = DEFAULT_NOTEBOOKS.notebooks[0].id;
-
-    jest.mocked(fs.access).mockReset().mockResolvedValue(undefined);
-
-    await expect(getNotebook(notebookId, options)).resolves.toMatchObject({
-      cells: expect.anything(),
-      metadata: expect.anything(),
+  describe('getNotebookCatalog', () => {
+    describe('static notebooks', () => {
+      it('returns default notebooks when theres an empty catalog config', async () => {
+        await expect(getNotebookCatalog(staticOptions)).resolves.toBe(DEFAULT_NOTEBOOKS);
+      });
     });
-    expect(mockLogger.warn).not.toHaveBeenCalled();
-    expect(mockLogger.error).not.toHaveBeenCalled();
-    expect(fs.access).toHaveBeenCalledWith(expect.stringContaining(`${notebookId}.json`), 0);
+
+    describe('remote catalog', () => {
+      it('fetches catalog from configured URL', async () => {
+        const mockCatalog: RemoteNotebookCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockCatalog),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual({
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+            },
+          ],
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(dynamicOptions.config.catalog!.url, {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      it('caches catalog on fetch', async () => {
+        const mockCatalog: RemoteNotebookCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockCatalog),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+
+        await getNotebookCatalog(dynamicOptions);
+        expect(dynamicOptions.cache.catalog).toBeDefined();
+        expect(dynamicOptions.cache.catalog).toEqual({
+          ...mockCatalog,
+          timestamp: fakeNow,
+        });
+      });
+      it('defaults to static notebooks if fetch fails with non-200', async () => {
+        const mockResp = {
+          ok: false,
+          status: 404,
+          statusText: 'NOT_FOUND',
+        };
+        fetchMock.mockResolvedValue(mockResp);
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual(DEFAULT_NOTEBOOKS);
+      });
+      it('defaults to static notebooks if fetch fails with error', async () => {
+        fetchMock.mockRejectedValue(new Error('Failed to Fetch'));
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual(DEFAULT_NOTEBOOKS);
+      });
+      it('defaults to static notebooks if fetch returns invalid catalog', async () => {
+        const mockBadCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+            },
+          ],
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockBadCatalog),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual(DEFAULT_NOTEBOOKS);
+      });
+      it('returns cached catalog if within TTL', async () => {
+        const mockCatalog: RemoteNotebookCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+        };
+        dynamicOptions.cache.catalog = {
+          ...mockCatalog,
+          timestamp: new Date('1999-12-31T23:59:58.999Z'),
+        };
+
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual({
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+            },
+          ],
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(0);
+      });
+      it('fetches catalog if cached catalog TTL is expired', async () => {
+        const mockCatalog: RemoteNotebookCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockCatalog),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+        dynamicOptions.cache.catalog = {
+          ...mockCatalog,
+          timestamp: new Date('1999-12-31T23:58:59.999Z'),
+        };
+
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual({
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+            },
+          ],
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith(dynamicOptions.config.catalog!.url, {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      it('returns cached notebooks in case of error and within error TTL', async () => {
+        const mockCatalog: RemoteNotebookCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+        };
+        dynamicOptions.cache.catalog = {
+          ...mockCatalog,
+          timestamp: new Date('1999-12-31T23:58:59.999Z'),
+        };
+        fetchMock.mockRejectedValue(new Error('Failed to Fetch'));
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual({
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+            },
+          ],
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+      it('returns static notebooks in case of error and cache outside error TTL', async () => {
+        const mockCatalog: RemoteNotebookCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+        };
+        dynamicOptions.cache.catalog = {
+          ...mockCatalog,
+          timestamp: new Date('1999-12-31T12:10:00.000Z'),
+        };
+        fetchMock.mockRejectedValue(new Error('Failed to Fetch'));
+        await expect(getNotebookCatalog(dynamicOptions)).resolves.toEqual(DEFAULT_NOTEBOOKS);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+      it('allows additional data, but removes it from results', async () => {
+        const mockCatalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+              tags: ['search', 'vector', 'ml'],
+            },
+          ],
+          categories: ['test', 'test2'],
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockCatalog),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+
+        const result = await getNotebookCatalog(dynamicOptions);
+        expect(result).toEqual({
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+            },
+          ],
+        });
+        expect(dynamicOptions.cache.catalog).toBeDefined();
+        expect(dynamicOptions.cache.catalog).toEqual({
+          ...mockCatalog,
+          timestamp: fakeNow,
+        });
+      });
+    });
+  });
+
+  describe('getNotebookMetadata', () => {
+    const fakeNotebookId = 'unit-test';
+    it('returns data from static notebooks', () => {
+      expect(getNotebookMetadata(DEFAULT_NOTEBOOKS.notebooks[0].id, staticOptions.cache)).toEqual(
+        DEFAULT_NOTEBOOKS.notebooks[0]
+      );
+    });
+    it('returns undefined for unknown static notebook id', () => {
+      expect(getNotebookMetadata(fakeNotebookId, staticOptions.cache)).toBeUndefined();
+    });
+    it('returns data from notebook catalog cache', () => {
+      dynamicOptions.cache.catalog = {
+        notebooks: [
+          {
+            id: fakeNotebookId,
+            title: 'Fake Notebook',
+            description: 'This is a fake notebook',
+            url: 'http://localhost:4000/fake_notebook.ipynb',
+          },
+        ],
+        timestamp: fakeNow,
+      };
+      expect(getNotebookMetadata(fakeNotebookId, dynamicOptions.cache)).toEqual({
+        id: fakeNotebookId,
+        title: 'Fake Notebook',
+        description: 'This is a fake notebook',
+      });
+    });
+    it('returns undefined when there is a catalog cache without notebook id', () => {
+      dynamicOptions.cache.catalog = {
+        notebooks: [
+          {
+            id: 'fake-notebook',
+            title: 'Fake Notebook',
+            description: 'This is a fake notebook',
+            url: 'http://localhost:4000/fake_notebook.ipynb',
+          },
+        ],
+        timestamp: fakeNow,
+      };
+      expect(getNotebookMetadata(fakeNotebookId, dynamicOptions.cache)).toBeUndefined();
+    });
+  });
+
+  describe('getNotebook', () => {
+    const fakeNotebookId = 'unit-test';
+
+    describe('static notebooks', () => {
+      it('throws an error if given an unknown notebook id', async () => {
+        await expect(getNotebook(fakeNotebookId, staticOptions)).rejects.toThrow(
+          'Unknown Notebook ID'
+        );
+        expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      });
+
+      it('throws an error if the file is not found', async () => {
+        const notebookId = DEFAULT_NOTEBOOKS.notebooks[0].id;
+        jest.mocked(fs.access).mockReset().mockRejectedValue(new Error('Boom'));
+
+        await expect(getNotebook(notebookId, staticOptions)).rejects.toThrow(
+          'Failed to fetch notebook.'
+        );
+      });
+
+      it('Reads notebook', async () => {
+        const notebookId = DEFAULT_NOTEBOOKS.notebooks[0].id;
+
+        jest.mocked(fs.access).mockReset().mockResolvedValue(undefined);
+
+        await expect(getNotebook(notebookId, staticOptions)).resolves.toMatchObject({
+          cells: expect.anything(),
+          metadata: expect.anything(),
+        });
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+        expect(mockLogger.error).not.toHaveBeenCalled();
+        expect(fs.access).toHaveBeenCalledWith(expect.stringContaining(`${notebookId}.json`), 0);
+      });
+    });
+    describe('remote catalog', () => {
+      beforeEach(() => {
+        fetchMock.mockReset();
+        // Reset the notebook cache
+        dynamicOptions.cache = createNotebooksCache();
+        dynamicOptions.cache.catalog = {
+          notebooks: [
+            {
+              id: 'unit-test',
+              title: 'Test',
+              description: 'Test notebook',
+              url: 'http://localhost:3000/my_notebook.ipynb',
+            },
+          ],
+          timestamp: fakeNow,
+        };
+      });
+
+      it('fetches notebook using url in cached catalog', async () => {
+        const mockNotebook: NotebookDefinition = {
+          cells: [
+            {
+              cell_type: 'markdown',
+              source: ['# Hello World'],
+            },
+          ],
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockNotebook),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+
+        await expect(getNotebook(fakeNotebookId, dynamicOptions)).resolves.toEqual(mockNotebook);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/my_notebook.ipynb', {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      it('returns notebook from cache if available', async () => {
+        const mockNotebook: NotebookDefinition = {
+          cells: [
+            {
+              cell_type: 'markdown',
+              source: ['# Hello World'],
+            },
+          ],
+        };
+        dynamicOptions.cache.notebooks[fakeNotebookId] = {
+          ...mockNotebook,
+          timestamp: new Date('1999-12-31T23:59:30.000Z'),
+        };
+
+        await expect(getNotebook(fakeNotebookId, dynamicOptions)).resolves.toEqual(mockNotebook);
+        expect(fetchMock).toHaveBeenCalledTimes(0);
+      });
+      it('fetches notebook if cached notebook ttl is expired', async () => {
+        const mockNotebook: NotebookDefinition = {
+          cells: [
+            {
+              cell_type: 'markdown',
+              source: ['# Hello World'],
+            },
+          ],
+        };
+        dynamicOptions.cache.notebooks[fakeNotebookId] = {
+          ...mockNotebook,
+          timestamp: new Date('1999-12-31T23:57:59.999Z'),
+        };
+        const mockResp = {
+          status: 200,
+          statusText: 'OK',
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockNotebook),
+        };
+        fetchMock.mockResolvedValue(mockResp);
+
+        await getNotebook(fakeNotebookId, dynamicOptions);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/my_notebook.ipynb', {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+      it("returns undefined if can't fetch notebook", async () => {
+        const mockResp = {
+          status: 404,
+          statusText: 'NOT_FOUND',
+          ok: false,
+        };
+        fetchMock.mockResolvedValue(mockResp);
+
+        await expect(getNotebook(fakeNotebookId, dynamicOptions)).resolves.toBeUndefined();
+      });
+      it("returns undefined if can't fetch notebook throws an error", async () => {
+        fetchMock.mockRejectedValue(new Error('Boom!!'));
+
+        await expect(getNotebook(fakeNotebookId, dynamicOptions)).resolves.toBeUndefined();
+      });
+    });
   });
 });

--- a/x-pack/plugins/search_notebooks/server/plugin.ts
+++ b/x-pack/plugins/search_notebooks/server/plugin.ts
@@ -13,19 +13,22 @@ import type {
   Logger,
 } from '@kbn/core/server';
 
-import { SearchNotebooksPluginSetup, SearchNotebooksPluginStart } from './types';
-import { defineRoutes } from './routes';
 import { SearchNotebooksConfig } from './config';
+import { defineRoutes } from './routes';
+import { SearchNotebooksPluginSetup, SearchNotebooksPluginStart, NotebooksCache } from './types';
+import { createNotebooksCache } from './utils';
 
 export class SearchNotebooksPlugin
   implements Plugin<SearchNotebooksPluginSetup, SearchNotebooksPluginStart>
 {
   private readonly config: SearchNotebooksConfig;
   private readonly logger: Logger;
+  private readonly notebooksCache: NotebooksCache;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<SearchNotebooksConfig>();
     this.logger = initializerContext.logger.get();
+    this.notebooksCache = createNotebooksCache();
   }
 
   public setup(core: CoreSetup) {
@@ -35,7 +38,12 @@ export class SearchNotebooksPlugin
     const router = core.http.createRouter();
 
     // Register server side APIs
-    defineRoutes(router, this.logger);
+    defineRoutes({
+      config: this.config,
+      logger: this.logger,
+      notebooksCache: this.notebooksCache,
+      router,
+    });
 
     return {};
   }

--- a/x-pack/plugins/search_notebooks/server/routes/index.ts
+++ b/x-pack/plugins/search_notebooks/server/routes/index.ts
@@ -17,6 +17,9 @@ export function defineRoutes({ config, notebooksCache, logger, router }: RouteDe
     {
       path: '/internal/search_notebooks/notebooks',
       validate: {},
+      options: {
+        access: 'internal',
+      },
     },
     async (_context, _request, response) => {
       const notebooks = await getNotebookCatalog({ cache: notebooksCache, config, logger });
@@ -35,6 +38,9 @@ export function defineRoutes({ config, notebooksCache, logger, router }: RouteDe
         params: schema.object({
           notebookId: schema.string(),
         }),
+      },
+      options: {
+        access: 'internal',
       },
     },
     async (_, request, response) => {

--- a/x-pack/plugins/search_notebooks/server/routes/index.ts
+++ b/x-pack/plugins/search_notebooks/server/routes/index.ts
@@ -6,22 +6,23 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { IRouter } from '@kbn/core/server';
-import type { Logger } from '@kbn/logging';
 import { NotebookDefinition } from '@kbn/ipynb';
 
 import { INTRODUCTION_NOTEBOOK } from '../../common/constants';
-import { DEFAULT_NOTEBOOKS, NOTEBOOKS_MAP, getNotebook } from '../lib/notebook_catalog';
+import { getNotebookCatalog, getNotebook, getNotebookMetadata } from '../lib/notebook_catalog';
+import type { RouteDependencies } from '../types';
 
-export function defineRoutes(router: IRouter, logger: Logger) {
+export function defineRoutes({ config, notebooksCache, logger, router }: RouteDependencies) {
   router.get(
     {
       path: '/internal/search_notebooks/notebooks',
       validate: {},
     },
     async (_context, _request, response) => {
+      const notebooks = await getNotebookCatalog({ cache: notebooksCache, config, logger });
+
       return response.ok({
-        body: DEFAULT_NOTEBOOKS,
+        body: notebooks,
         headers: { 'content-type': 'application/json' },
       });
     }
@@ -46,17 +47,22 @@ export function defineRoutes(router: IRouter, logger: Logger) {
         });
       }
 
-      if (!NOTEBOOKS_MAP.hasOwnProperty(notebookId)) {
+      const notebookMetadata = getNotebookMetadata(notebookId, notebooksCache);
+      if (!notebookMetadata) {
         logger.warn(`Unknown search notebook requested ${notebookId}`);
         return response.notFound();
       }
-
-      const notebookMetadata = NOTEBOOKS_MAP[notebookId];
-      let notebook: NotebookDefinition;
+      let notebook: NotebookDefinition | undefined;
       try {
-        notebook = await getNotebook(notebookId, { logger });
+        notebook = await getNotebook(notebookId, { cache: notebooksCache, config, logger });
       } catch (e) {
+        logger.warn(`Error getting search notebook ${notebookId}.`);
+        logger.warn(e);
         return response.customError(e.message);
+      }
+      if (!notebook) {
+        logger.warn(`Search notebook requested ${notebookId} not found or failed to fetch.`);
+        return response.notFound();
       }
       return response.ok({
         body: {

--- a/x-pack/plugins/search_notebooks/server/types.ts
+++ b/x-pack/plugins/search_notebooks/server/types.ts
@@ -5,7 +5,41 @@
  * 2.0.
  */
 
+import type { IRouter } from '@kbn/core/server';
+import type { NotebookDefinition } from '@kbn/ipynb';
+import type { Logger } from '@kbn/logging';
+
+import type { SearchNotebooksConfig } from './config';
+import type { NotebookCatalog, NotebookInformation } from '../common/types';
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchNotebooksPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchNotebooksPluginStart {}
+
+export interface RouteDependencies {
+  config: SearchNotebooksConfig;
+  logger: Logger;
+  notebooksCache: NotebooksCache;
+  router: IRouter;
+}
+
+export interface RemoteNotebookInformation extends NotebookInformation {
+  url: string;
+}
+
+export interface RemoteNotebookCatalog extends NotebookCatalog {
+  notebooks: RemoteNotebookInformation[];
+}
+
+export interface CachedNotebookCatalog extends RemoteNotebookCatalog {
+  timestamp: Date;
+}
+
+export interface CachedNotebook extends NotebookDefinition {
+  timestamp: Date;
+}
+export interface NotebooksCache {
+  catalog?: CachedNotebookCatalog;
+  notebooks: Record<string, CachedNotebook>;
+}

--- a/x-pack/plugins/search_notebooks/server/utils.test.ts
+++ b/x-pack/plugins/search_notebooks/server/utils.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as utils from './utils';
+
+describe('Search Notebooks Utils', () => {
+  // Party Like It's
+  const fakeNow = new Date('1999-12-31T23:59:59.999Z');
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fakeNow);
+  });
+
+  describe('dateWithinTTL', () => {
+    it('return true if value is withing TTL of now', () => {
+      expect(utils.dateWithinTTL(new Date('1999-12-31T23:59:58.999Z'), 10)).toBe(true);
+      expect(utils.dateWithinTTL(new Date('1999-12-31T23:59:49.999Z'), 10)).toBe(true);
+    });
+    it('returns false is value is older than TTL', () => {
+      expect(utils.dateWithinTTL(new Date('1999-12-31T23:59:48.999Z'), 10)).toBe(false);
+      expect(utils.dateWithinTTL(new Date('1999-12-31T23:59:39.999Z'), 10)).toBe(false);
+    });
+  });
+});

--- a/x-pack/plugins/search_notebooks/server/utils.ts
+++ b/x-pack/plugins/search_notebooks/server/utils.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { NotebookDefinition } from '@kbn/ipynb';
+import { NotebookCatalog, NotebookInformation } from '../common/types';
+import type {
+  CachedNotebook,
+  CachedNotebookCatalog,
+  NotebooksCache,
+  RemoteNotebookInformation,
+} from './types';
+
+export function createNotebooksCache(): NotebooksCache {
+  return {
+    notebooks: {},
+  };
+}
+
+export function dateWithinTTL(value: Date, ttl: number) {
+  return (Date.now() - value.getTime()) / 1000 <= ttl;
+}
+
+export function cleanCachedNotebookCatalog(catalog: CachedNotebookCatalog): NotebookCatalog {
+  const notebooks = catalog.notebooks.map(cleanNotebookMetadata);
+  return {
+    notebooks,
+  };
+}
+export function cleanCachedNotebook(notebook: CachedNotebook): NotebookDefinition {
+  const { timestamp, ...result } = notebook;
+  return result;
+}
+
+export function cleanNotebookMetadata(nb: RemoteNotebookInformation): NotebookInformation {
+  const { id, title, description, link } = nb;
+  return {
+    description,
+    id,
+    link,
+    title,
+  };
+}


### PR DESCRIPTION
## Summary

This adds a new config item for the `search_notebooks` catalog to allow fetching it from a URL instead of only serving the static notebooks packaged with Kibana. This will be used in ES3 to ensure we have the latest notebooks, but also give us the ability to change which notebooks are served without making kibana code changes.