### PR TITLE
[Security Solution] [Attack discovery] Attack discovery text updates

### DIFF
--- a/x-pack/plugins/security_solution/public/attack_discovery/attack/mini_attack_chain/translations.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/attack/mini_attack_chain/translations.ts
@@ -10,6 +10,6 @@ import { i18n } from '@kbn/i18n';
 export const ATTACK_CHAIN_TOOLTIP = (tacticsCount: number) =>
   i18n.translate('xpack.securitySolution.attackDiscovery.miniAttackChain.attackChainTooltip', {
     defaultMessage:
-      '{tacticsCount} {tacticsCount, plural, one {tactic was} other {tactics were}} identified in the analysis, providing insight into the nature of the detected violations:',
+      '{tacticsCount} {tacticsCount, plural, one {tactic was} other {tactics were}} identified in the attack:',
     values: { tacticsCount },
   });

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_prompt/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_prompt/index.tsx
@@ -11,11 +11,14 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIconTip,
   EuiLink,
   EuiSpacer,
   EuiText,
   EuiToolTip,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
 
 import { useAssistantAvailability } from '../../../assistant/use_assistant_availability';
@@ -35,6 +38,7 @@ const EmptyPromptComponent: React.FC<Props> = ({
   isDisabled = false,
   onGenerate,
 }) => {
+  const { euiTheme } = useEuiTheme();
   const { hasAssistantPrivilege } = useAssistantAvailability();
   const title = useMemo(
     () => (
@@ -51,6 +55,16 @@ const EmptyPromptComponent: React.FC<Props> = ({
 
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" direction="row" gutterSize="none">
+            <EuiFlexItem
+              css={css`
+                margin-right: ${euiTheme.size.xs};
+              `}
+              data-test-subj="upTo"
+              grow={false}
+            >
+              <span>{i18n.UP_TO}</span>
+            </EuiFlexItem>
+
             <EuiFlexItem data-test-subj="emptyPromptAnimatedCounter" grow={false}>
               <AnimatedCounter count={alertsCount} />
             </EuiFlexItem>
@@ -58,11 +72,25 @@ const EmptyPromptComponent: React.FC<Props> = ({
             <EuiFlexItem data-test-subj="emptyPromptAlertsWillBeAnalyzed" grow={false}>
               <span>{i18n.ALERTS_WILL_BE_ANALYZED(alertsCount)}</span>
             </EuiFlexItem>
+
+            <EuiFlexItem
+              css={css`
+                margin-left: ${euiTheme.size.xs};
+              `}
+              grow={false}
+            >
+              <EuiIconTip
+                content={i18n.RESPONSES_FROM_AI_SYSTEMS}
+                data-test-subj="responsesFromAiSystemsTooltip"
+                position="right"
+                type="iInCircle"
+              />
+            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
     ),
-    [alertsCount]
+    [alertsCount, euiTheme.size.xs]
   );
 
   const body = useMemo(

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_prompt/translations.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_prompt/translations.ts
@@ -30,6 +30,14 @@ export const LEARN_MORE = i18n.translate(
   }
 );
 
+export const RESPONSES_FROM_AI_SYSTEMS = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.emptyPrompt.responsesFromAiSystemsTooltip',
+  {
+    defaultMessage:
+      'Responses from AI systems may not always be entirely accurate, although they can seem convincing. For more information on the Attack Discovery feature and its usage, please reference the documentation.',
+  }
+);
+
 export const SELECT_A_CONNECTOR = i18n.translate(
   'xpack.securitySolution.attackDiscovery.pages.emptyPrompt.selectAConnectorLabel',
   {
@@ -40,6 +48,13 @@ export const SELECT_A_CONNECTOR = i18n.translate(
 export const START_GENERATING_DISCOVERIES = i18n.translate(
   'xpack.securitySolution.attackDiscovery.pages.emptyPrompt.startGeneratingDiscoveriesLabel',
   {
-    defaultMessage: 'Start generating discoveries via Elastic AI Assistant.',
+    defaultMessage: 'Start discovering attacks with the power of AI and Elastic Security.',
+  }
+);
+
+export const UP_TO = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.pages.emptyPrompt.upToTitle',
+  {
+    defaultMessage: 'Up to',
   }
 );

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/last_times_popover/translations.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/last_times_popover/translations.ts
@@ -12,7 +12,7 @@ export const AVERAGE_TIME_IS_CALCULATED = (intervals: number) =>
     'xpack.securitySolution.attackDiscovery.loadingCallout.countdown.lastTimesPopover.aiIsCurrentlyAnalyzing',
     {
       defaultMessage:
-        'Average time is calculated over the last {intervals} {intervals, plural, =1 {generation} other {generations}} on the selected connector:',
+        'Remaining time is based on the average speed of the last {intervals} {intervals, plural, =1 {time} other {times}} the same connector generated results.',
       values: { intervals },
     }
   );

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/translations.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/translations.ts
@@ -11,7 +11,7 @@ export const AI_IS_CURRENTLY_ANALYZING = (alertsCount: number) =>
   i18n.translate(
     'xpack.securitySolution.attackDiscovery.pages.loadingCallout.aiIsCurrentlyAnalyzing',
     {
-      defaultMessage: `AI is currently analyzing up to {alertsCount} {alertsCount, plural, =1 {alert} other {alerts}} in the last 24 hours to generate discoveries.`,
+      defaultMessage: `AI is analyzing up to {alertsCount} {alertsCount, plural, =1 {alert} other {alerts}} in the last 24 hours to generate discoveries.`,
       values: { alertsCount },
     }
   );


### PR DESCRIPTION
## [Security Solution] [Attack discovery] Attack discovery text updates

### Summary

This PR updates updates text in the following _Attack discovery_ views:

- Mini Attack chain tooltip
- Loading callout
- Time remaining popover
- Empty prompt

per the details in the _Before_ and _After_ screenshots of the sections below.

<https://github.com/elastic/kibana/assets/4459398/f95bbebb-7e8a-4fed-bab6-9af79dfe7549>

_Above: Updates to text in the Empty prompt (video)_

### Mini Attack chain tooltip

**Before:**

![mini_attack_chain_before](https://github.com/elastic/kibana/assets/4459398/b6b5f7c8-50a4-45d0-9283-ea1e7a787916)

**After:**

![mini_attack_chain_after](https://github.com/elastic/kibana/assets/4459398/d48bce2e-114d-431a-ad24-1b31b6ca751f)

### Loading callout

**Before:**

![loading_before](https://github.com/elastic/kibana/assets/4459398/564d794f-260c-451f-9dab-19d4744c6a8b)

**After:**

![loading_after](https://github.com/elastic/kibana/assets/4459398/23542352-43d7-4e2f-a4ec-842a526a7188)

### Time remaining popover

**Before:**

![time_remaining_before](https://github.com/elastic/kibana/assets/4459398/12c1fb26-674b-4486-81aa-874881a9abe8)

**After:**

![time_remaining_after](https://github.com/elastic/kibana/assets/4459398/6c003dc1-ef02-4410-982b-d7ebe57f5321)

### Empty prompt

**Before:**

![empty_before](https://github.com/elastic/kibana/assets/4459398/4340b87c-1878-40e5-8741-f2e1120111ea)

**After:**

![empty_after](https://github.com/elastic/kibana/assets/4459398/31119bf1-22ac-4414-ac38-911025d506ca)

![empty_info_tooltip](https://github.com/elastic/kibana/assets/4459398/3cb6ab33-b111-4260-8536-8d428a983c93)

<https://github.com/elastic/kibana/assets/4459398/f95bbebb-7e8a-4fed-bab6-9af79dfe7549>


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->