### PR TITLE
ES|QL Composer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -347,6 +347,7 @@ packages/kbn-eslint-plugin-eslint @elastic/kibana-operations
 packages/kbn-eslint-plugin-i18n @elastic/obs-knowledge-team @elastic/kibana-operations
 packages/kbn-eslint-plugin-imports @elastic/kibana-operations
 packages/kbn-eslint-plugin-telemetry @elastic/obs-knowledge-team
+packages/kbn-esql-composer @elastic/obs-ai-assistant
 packages/kbn-event-annotation-common @elastic/kibana-visualizations
 packages/kbn-event-annotation-components @elastic/kibana-visualizations
 packages/kbn-expect @elastic/kibana-operations @elastic/appex-qa

--- a/package.json
+++ b/package.json
@@ -492,6 +492,7 @@
     "@kbn/esql": "link:src/platform/plugins/shared/esql",
     "@kbn/esql-ast": "link:src/platform/packages/shared/kbn-esql-ast",
     "@kbn/esql-ast-inspector-plugin": "link:examples/esql_ast_inspector",
+    "@kbn/esql-composer": "link:packages/kbn-esql-composer",
     "@kbn/esql-datagrid": "link:src/platform/plugins/shared/esql_datagrid",
     "@kbn/esql-editor": "link:src/platform/packages/private/kbn-esql-editor",
     "@kbn/esql-utils": "link:src/platform/packages/shared/kbn-esql-utils",

--- a/packages/kbn-esql-composer/README.md
+++ b/packages/kbn-esql-composer/README.md
@@ -1,0 +1,18 @@
+# @kbn/esql-composer
+
+`@kbn/esql-composer` is a library to generate ES|QL queries in a way that is similar to Observables. Its eventual goal is to be able to create fully typed queries (with autocomplete on column names et cetera).
+
+Every query starts with a source command. Currently only `from` is available. Source commands return a `QueryPipeline`, which allows you to pipe the source data into other commands, and eventually get the ES|QL query as a raw string. Here's an example:
+
+```ts
+import { from, where, sort, keep, limit, SortOrder } from '@kbn/esql-composer';
+
+const query = from('logs-*')
+  .pipe(
+    where('@timestamp >= NOW() - 1 hour'),
+    sort({ '@timestamp': SortOrder.Desc }),
+    keep('service.name', 'log.level'),
+    limit(10)
+  )
+  .asString();
+```

--- a/packages/kbn-esql-composer/index.ts
+++ b/packages/kbn-esql-composer/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { from } from './src/commands/from';
+export { append } from './src/commands/append';
+export { drop } from './src/commands/drop';
+export { evaluate } from './src/commands/eval';
+export { keep } from './src/commands/keep';
+export { where } from './src/commands/where';
+export { stats } from './src/commands/stats';
+export { limit } from './src/commands/limit';
+export { sort, SortOrder } from './src/commands/sort';

--- a/packages/kbn-esql-composer/jest.config.js
+++ b/packages/kbn-esql-composer/jest.config.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../..',
+  roots: ['<rootDir>/packages/kbn-esql-composer'],
+};

--- a/packages/kbn-esql-composer/kibana.jsonc
+++ b/packages/kbn-esql-composer/kibana.jsonc
@@ -1,0 +1,5 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/esql-composer",
+  "owner": "@elastic/obs-ai-assistant"
+}

--- a/packages/kbn-esql-composer/package.json
+++ b/packages/kbn-esql-composer/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/esql-composer",
+  "private": true,
+  "version": "1.0.0",
+  "license": "SSPL-1.0 OR Elastic License 2.0"
+}

--- a/packages/kbn-esql-composer/src/commands/append.ts
+++ b/packages/kbn-esql-composer/src/commands/append.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Command, QueryOperator } from '../types';
+
+export function append(command: Command | string): QueryOperator {
+  return (source) => {
+    const nextCommand = typeof command === 'string' ? { body: command } : command;
+    return {
+      ...source,
+      commands: source.commands.concat(nextCommand),
+    };
+  };
+}

--- a/packages/kbn-esql-composer/src/commands/drop.test.ts
+++ b/packages/kbn-esql-composer/src/commands/drop.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { drop } from './drop';
+import { from } from './from';
+
+describe('drop', () => {
+  const source = from('logs-*');
+  it('handles single strings', () => {
+    expect(source.pipe(drop('log.level', 'service.name')).asString()).toEqual(
+      'FROM `logs-*`\n\t| DROP `log.level`, `service.name`'
+    );
+  });
+
+  it('handles arrays of strings', () => {
+    expect(source.pipe(drop(['log.level', 'service.name'])).asString()).toEqual(
+      'FROM `logs-*`\n\t| DROP `log.level`, `service.name`'
+    );
+  });
+});

--- a/packages/kbn-esql-composer/src/commands/drop.ts
+++ b/packages/kbn-esql-composer/src/commands/drop.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { escapeIdentifier } from '../utils/escape_identifier';
+import { append } from './append';
+
+export function drop(...columns: Array<string | string[]>) {
+  return append(
+    `DROP ${columns
+      .flatMap((column) => column)
+      .map((column) => escapeIdentifier(column))
+      .join(', ')}`
+  );
+}

--- a/packages/kbn-esql-composer/src/commands/eval.ts
+++ b/packages/kbn-esql-composer/src/commands/eval.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { QueryOperator } from '../types';
+import { append } from './append';
+
+export function evaluate(body: string): QueryOperator {
+  return append(`EVAL ${body}`);
+}

--- a/packages/kbn-esql-composer/src/commands/from.test.ts
+++ b/packages/kbn-esql-composer/src/commands/from.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { from } from './from';
+
+describe('from', () => {
+  it('handles single strings', () => {
+    expect(from('logs-*', 'traces-*').asString()).toEqual('FROM `logs-*`,`traces-*`');
+  });
+
+  it('handles arrays of strings', () => {
+    expect(from(['logs-*', 'traces-*']).asString()).toEqual('FROM `logs-*`,`traces-*`');
+  });
+});

--- a/packages/kbn-esql-composer/src/commands/from.ts
+++ b/packages/kbn-esql-composer/src/commands/from.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { createPipeline } from '../create_pipeline';
+import type { QueryPipeline } from '../types';
+import { escapeIdentifier } from '../utils/escape_identifier';
+
+export function from(...patterns: Array<string | string[]>): QueryPipeline {
+  const allPatterns = patterns.flatMap((pattern) => pattern);
+
+  return createPipeline({
+    commands: [
+      {
+        body: `FROM ${allPatterns.map((pattern) => escapeIdentifier(pattern)).join(',')}`,
+      },
+    ],
+  });
+}

--- a/packages/kbn-esql-composer/src/commands/keep.test.ts
+++ b/packages/kbn-esql-composer/src/commands/keep.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { from } from './from';
+import { keep } from './keep';
+
+describe('keep', () => {
+  const source = from('logs-*');
+  it('handles single strings', () => {
+    expect(source.pipe(keep('log.level', 'service.name')).asString()).toEqual(
+      'FROM `logs-*`\n\t| KEEP `log.level`, `service.name`'
+    );
+  });
+
+  it('handles arrays of strings', () => {
+    expect(source.pipe(keep(['log.level', 'service.name'])).asString()).toEqual(
+      'FROM `logs-*`\n\t| KEEP `log.level`, `service.name`'
+    );
+  });
+});

--- a/packages/kbn-esql-composer/src/commands/keep.ts
+++ b/packages/kbn-esql-composer/src/commands/keep.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { escapeIdentifier } from '../utils/escape_identifier';
+import { append } from './append';
+
+export function keep(...columns: Array<string | string[]>) {
+  return append(
+    `KEEP ${columns
+      .flatMap((column) => column)
+      .map((column) => escapeIdentifier(column))
+      .join(', ')}`
+  );
+}

--- a/packages/kbn-esql-composer/src/commands/limit.ts
+++ b/packages/kbn-esql-composer/src/commands/limit.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { append } from './append';
+
+export function limit(value: number) {
+  return append(`LIMIT ${value}`);
+}

--- a/packages/kbn-esql-composer/src/commands/sort.test.ts
+++ b/packages/kbn-esql-composer/src/commands/sort.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { from } from './from';
+import { sort, SortOrder } from './sort';
+
+describe('sort', () => {
+  const source = from('logs-*');
+
+  it('handles single strings', () => {
+    expect(source.pipe(sort('@timestamp', 'log.level')).asString()).toEqual(
+      'FROM `logs-*`\n\t| SORT @timestamp ASC, log.level ASC'
+    );
+  });
+
+  it('handles an array of strings', () => {
+    expect(source.pipe(sort(['@timestamp', 'log.level'])).asString()).toEqual(
+      'FROM `logs-*`\n\t| SORT @timestamp ASC, log.level ASC'
+    );
+  });
+
+  it('handles sort instructions', () => {
+    expect(source.pipe(sort({ '@timestamp': SortOrder.Desc })).asString()).toEqual(
+      'FROM `logs-*`\n\t| SORT @timestamp DESC'
+    );
+  });
+});

--- a/packages/kbn-esql-composer/src/commands/sort.ts
+++ b/packages/kbn-esql-composer/src/commands/sort.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { QueryOperator } from '../types';
+import { append } from './append';
+
+export enum SortOrder {
+  Asc = 'ASC',
+  Desc = 'DESC',
+}
+
+type Sort = Record<string, SortOrder>;
+
+export function sort(...sorts: Array<string | Sort | Array<string | Sort>>): QueryOperator {
+  const allSorts = sorts
+    .flatMap((sortInstruction) => sortInstruction)
+    .map((sortInstruction): { column: string; order: 'ASC' | 'DESC' } => {
+      if (typeof sortInstruction === 'string') {
+        return { column: sortInstruction, order: 'ASC' };
+      }
+      const column = Object.keys(sortInstruction)[0] as keyof typeof sortInstruction;
+
+      return {
+        column,
+        order: sortInstruction[column],
+      };
+    });
+
+  return append(
+    `SORT ${allSorts
+      .map((sortInstruction) => `${sortInstruction.column} ${sortInstruction.order}`)
+      .join(', ')}`
+  );
+}

--- a/packages/kbn-esql-composer/src/commands/stats.ts
+++ b/packages/kbn-esql-composer/src/commands/stats.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { append } from './append';
+
+export function stats(body: string) {
+  return append(`STATS ${body}`);
+}

--- a/packages/kbn-esql-composer/src/commands/where.ts
+++ b/packages/kbn-esql-composer/src/commands/where.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { QueryOperator } from '../types';
+import { append } from './append';
+
+export function where(body: string): QueryOperator {
+  return append(`WHERE ${body}`);
+}

--- a/packages/kbn-esql-composer/src/create_pipeline.ts
+++ b/packages/kbn-esql-composer/src/create_pipeline.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Query, QueryPipeline } from './types';
+
+export function createPipeline(source: Query): QueryPipeline {
+  return {
+    pipe: (...operators) => {
+      const nextSource = operators.reduce((previousQuery, operator) => {
+        return operator(previousQuery);
+      }, source);
+
+      return createPipeline(nextSource);
+    },
+    asString: () => {
+      return source.commands.map((command) => command.body).join('\n\t| ');
+    },
+  };
+}

--- a/packages/kbn-esql-composer/src/index.test.ts
+++ b/packages/kbn-esql-composer/src/index.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { from } from './commands/from';
+import { stats } from './commands/stats';
+import { where } from './commands/where';
+
+describe('composer', () => {
+  it('applies operators in order', () => {
+    expect(
+      from('logs-*')
+        .pipe(
+          where(`@timestamp <= NOW() AND @timestamp > NOW() - 24 hours`),
+          stats(`avg_duration = AVG(transaction.duration.us) BY service.name`)
+        )
+        .asString()
+    ).toEqual(
+      `FROM \`logs-*\`\n\t| WHERE @timestamp <= NOW() AND @timestamp > NOW() - 24 hours\n\t| STATS avg_duration = AVG(transaction.duration.us) BY service.name`
+    );
+  });
+});

--- a/packages/kbn-esql-composer/src/types.ts
+++ b/packages/kbn-esql-composer/src/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export interface Command {
+  body: string;
+}
+
+export interface QueryPipeline {
+  pipe: (...args: QueryOperator[]) => QueryPipeline;
+  asString: () => string;
+}
+export interface Query {
+  commands: Command[];
+}
+
+export type QueryOperator = (sourceQuery: Query) => Query;

--- a/packages/kbn-esql-composer/src/utils/escape_identifier.ts
+++ b/packages/kbn-esql-composer/src/utils/escape_identifier.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export function escapeIdentifier(identifier: string) {
+  return `\`${identifier}\``;
+}

--- a/packages/kbn-esql-composer/tsconfig.json
+++ b/packages/kbn-esql-composer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -868,6 +868,8 @@
       "@kbn/esql-ast/*": ["src/platform/packages/shared/kbn-esql-ast/*"],
       "@kbn/esql-ast-inspector-plugin": ["examples/esql_ast_inspector"],
       "@kbn/esql-ast-inspector-plugin/*": ["examples/esql_ast_inspector/*"],
+      "@kbn/esql-composer": ["packages/kbn-esql-composer"],
+      "@kbn/esql-composer/*": ["packages/kbn-esql-composer/*"],
       "@kbn/esql-datagrid": ["src/platform/plugins/shared/esql_datagrid"],
       "@kbn/esql-datagrid/*": ["src/platform/plugins/shared/esql_datagrid/*"],
       "@kbn/esql-editor": ["src/platform/packages/private/kbn-esql-editor"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5549,6 +5549,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/esql-composer@link:packages/kbn-esql-composer":
+  version "0.0.0"
+  uid ""
+
 "@kbn/esql-datagrid@link:src/platform/plugins/shared/esql_datagrid":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
Implements a library that generates ES|QL queries using piped commands. Its eventual goal is to have fully typed queries, but let's start small :).

Examples in README: https://github.com/elastic/kibana/pull/182630/files#diff-8836d5f60bbe9ced2bbe08c94f5173437d9f1d863da73b11b4926760fb8ab4cd