### PR TITLE
[fails on mki] skip x-pack/test_serverless/api_integration/test_suite…

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
@@ -24,8 +24,6 @@ export default function ({ getService }: FtrProviderContext) {
   let getDatastream: typeof helpers['getDatastream'];
 
   describe('Data streams', function () {
-    // see details: https://github.com/elastic/kibana/issues/182647
-    this.tags(['failsOnMKI']);
     before(async () => {
       ({
         datastreams: { helpers },

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
@@ -203,7 +203,10 @@ export default function ({ getService }: FtrProviderContext) {
           .send({})
           .expect(200);
 
-        expect(body).to.eql({ success: true });
+        // Providing an infinite retention might not be allowed for a given project,
+        // due to it having an existing max retention period. Because of this
+        // we will only check whether the request was recieved by ES.
+        expect(body.success).to.eql(true);
       });
 
       it('can disable lifecycle for a given policy', async () => {

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
@@ -24,6 +24,8 @@ export default function ({ getService }: FtrProviderContext) {
   let getDatastream: typeof helpers['getDatastream'];
 
   describe('Data streams', function () {
+    // see details: https://github.com/elastic/kibana/issues/182647
+    this.tags(['failsOnMKI']);
     before(async () => {
       ({
         datastreams: { helpers },


### PR DESCRIPTION
…s/common/index_management/datastreams on mki

## Summary

see details: https://github.com/elastic/kibana/issues/182647

