### PR TITLE
[Alert table] Fix Triggered column timezone and format

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/alerts_table/common/render_cell_value.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/alerts_table/common/render_cell_value.tsx
@@ -19,6 +19,7 @@ import {
   ALERT_EVALUATION_VALUES,
   ALERT_RULE_NAME,
   ALERT_RULE_CATEGORY,
+  ALERT_START,
 } from '@kbn/rule-data-utils';
 import { isEmpty } from 'lodash';
 import type { TimelineNonEcsData } from '@kbn/timelines-plugin/common';
@@ -95,6 +96,7 @@ export const getRenderCellValue = ({
       }
       return <AlertStatusIndicator alertStatus={value} />;
     case TIMESTAMP:
+    case ALERT_START:
       return <TimestampTooltip time={new Date(value ?? '').getTime()} timeUnit="milliseconds" />;
     case ALERT_DURATION:
       return asDuration(Number(value));


### PR DESCRIPTION
Partially implements #182650

## Summary

This PR fixes START_TIME timezone and format [similar to what we have in the stack management](https://github.com/elastic/kibana/blob/main/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/cells/render_cell_value.tsx#L124,L125) ([comment](https://github.com/elastic/sdh-kibana/issues/4653#issuecomment-2093845148))

|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/94c3b321-2c80-4333-bbbd-0fad6692302b)|![image](https://github.com/elastic/kibana/assets/12370520/23d2ac9d-db2b-423c-82e2-be3753b0954c)|

There are more questions to be answered in #182650, but for now, I've added this fix to have something consistent with the stack management alerts table.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->