### PR TITLE
[Security Solution][Endpoint] Undo test spec change

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -75,8 +75,7 @@ export const getCypressBaseConfig = (
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
         // TODO: undo before merge
-        specPattern:
-          'public/management/cypress/e2e/**/**/automated_response_actions.cy.{js,jsx,ts,tsx}',
+        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,


### PR DESCRIPTION
## Summary

undo test spec change introduced in

refs elastic/kibana/pull/182102

<!--ONMERGE {"backportTargets":["8.13","8.14"]} ONMERGE-->