### PR TITLE
[Security Solution][Endpoint] Enable skipped ftr tests

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/index.ts
@@ -16,8 +16,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
-  // FLAKY: https://github.com/elastic/kibana/issues/180401
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_endpoint/apps/integrations/index.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/index.ts
@@ -16,8 +16,7 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
-  // FLAKY: https://github.com/elastic/kibana/issues/174975
-  describe.skip('endpoint', function () {
+  describe('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');


### PR DESCRIPTION
## Summary

Enables skipped ftr tests

Fixes: https://github.com/elastic/kibana/issues/174975
Fixes: https://github.com/elastic/kibana/issues/180401

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->