### PR TITLE
[Index Management] Remove _source field from component template API tests on serverless

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/index_component_templates.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/index_component_templates.ts
@@ -68,9 +68,6 @@ export default function ({ getService }: FtrProviderContext) {
             },
           },
           mappings: {
-            _source: {
-              enabled: false,
-            },
             properties: {
               host_name: {
                 type: 'keyword',
@@ -140,9 +137,6 @@ export default function ({ getService }: FtrProviderContext) {
             },
           },
           mappings: {
-            _source: {
-              enabled: false,
-            },
             properties: {
               host_name: {
                 type: 'keyword',
@@ -221,9 +215,6 @@ export default function ({ getService }: FtrProviderContext) {
             },
           },
           mappings: {
-            _source: {
-              enabled: false,
-            },
             properties: {
               host_name: {
                 type: 'keyword',
@@ -381,9 +372,6 @@ export default function ({ getService }: FtrProviderContext) {
             },
           },
           mappings: {
-            _source: {
-              enabled: false,
-            },
             properties: {
               host_name: {
                 type: 'keyword',


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/181742

We need to also remove the `_source` field from the component template API integration tests on serverless, as it is not valid on serverless.