### PR TITLE
[Obs AI Assistant] E2E test for contextual insights

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant/public/components/insight/insight_base.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/public/components/insight/insight_base.tsx
@@ -138,7 +138,12 @@ export function InsightBase({
         onToggle={onToggle}
       >
         <EuiSpacer size="m" />
-        <EuiPanel hasBorder={false} hasShadow={false} color="subdued">
+        <EuiPanel
+          hasBorder={false}
+          hasShadow={false}
+          color="subdued"
+          data-test-subj="obsAiAssistantInsightResponse"
+        >
           {children}
         </EuiPanel>
       </EuiAccordion>

--- a/x-pack/test/apm_api_integration/common/config.ts
+++ b/x-pack/test/apm_api_integration/common/config.ts
@@ -21,7 +21,7 @@ import { format, UrlObject } from 'url';
 import { MachineLearningAPIProvider } from '../../functional/services/ml/api';
 import { APMFtrConfigName } from '../configs';
 import { createApmApiClient } from './apm_api_supertest';
-import { bootstrapApmSynthtrace, getApmSynthtraceKibanaClient } from './bootstrap_apm_synthtrace';
+import { getApmSynthtraceEsClient, getApmSynthtraceKibanaClient } from './bootstrap_apm_synthtrace';
 import {
   FtrProviderContext,
   InheritedFtrProviderContext,
@@ -118,7 +118,7 @@ export function createTestConfig(
         apmFtrConfig: () => config,
         registry: RegistryProvider,
         apmSynthtraceEsClient: (context: InheritedFtrProviderContext) => {
-          return bootstrapApmSynthtrace(context, synthtraceKibanaClient);
+          return getApmSynthtraceEsClient(context, synthtraceKibanaClient);
         },
         logSynthtraceEsClient: (context: InheritedFtrProviderContext) =>
           new LogsSynthtraceEsClient({

--- a/x-pack/test/observability_ai_assistant_api_integration/common/create_synthtrace_client.ts
+++ b/x-pack/test/observability_ai_assistant_api_integration/common/create_synthtrace_client.ts
@@ -10,8 +10,6 @@ import {
   createLogger,
   LogLevel,
 } from '@kbn/apm-synthtrace';
-import url from 'url';
-import { kbnTestConfig } from '@kbn/test';
 import { InheritedFtrProviderContext } from './ftr_provider_context';
 
 export async function getApmSynthtraceEsClient(
@@ -31,20 +29,4 @@ export async function getApmSynthtraceEsClient(
   });
 
   return esClient;
-}
-
-export function getApmSynthtraceKibanaClient(kibanaServerUrl: string) {
-  const kibanaServerUrlWithAuth = url
-    .format({
-      ...url.parse(kibanaServerUrl),
-      auth: `elastic:${kbnTestConfig.getUrlParts().password}`,
-    })
-    .slice(0, -1);
-
-  const kibanaClient = new ApmSynthtraceKibanaClient({
-    target: kibanaServerUrlWithAuth,
-    logger: createLogger(LogLevel.debug),
-  });
-
-  return kibanaClient;
 }

--- a/x-pack/test/observability_ai_assistant_functional/common/config.ts
+++ b/x-pack/test/observability_ai_assistant_functional/common/config.ts
@@ -10,6 +10,7 @@ import { merge } from 'lodash';
 import supertest from 'supertest';
 import { format, UrlObject } from 'url';
 import type { EBTHelpersContract } from '@kbn/analytics-ftr-helpers-plugin/common/types';
+import { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
 import {
   KibanaEBTServerProvider,
   KibanaEBTUIProvider,
@@ -39,6 +40,9 @@ export interface TestConfig extends CreateTestAPI {
       >;
       kibana_ebt_server: (context: InheritedFtrProviderContext) => EBTHelpersContract;
       kibana_ebt_ui: (context: InheritedFtrProviderContext) => EBTHelpersContract;
+      apmSynthtraceEsClient: (
+        context: InheritedFtrProviderContext
+      ) => Promise<ApmSynthtraceEsClient>;
     };
 }
 

--- a/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
+++ b/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
@@ -44,6 +44,10 @@ const pages = {
     apiKeyInput: 'secrets.apiKey-input',
     saveButton: 'create-connector-flyout-save-btn',
   },
+  contextualInsights: {
+    button: 'obsAiAssistantInsightButton',
+    text: 'obsAiAssistantInsightResponse',
+  },
 };
 
 export async function ObservabilityAIAssistantUIProvider({

--- a/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
+++ b/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
@@ -59,40 +59,36 @@ export async function ObservabilityAIAssistantUIProvider({
   const security = getService('security');
   const pageObjects = getPageObjects(['common']);
 
-  const roleName = 'observability-ai-assistant-functional-test-role';
+  const roleDefinition: Role = {
+    name: 'observability-ai-assistant-functional-test-role',
+    elasticsearch: {
+      cluster: [],
+      indices: [],
+      run_as: [],
+    },
+    kibana: [
+      {
+        spaces: ['*'],
+        base: [],
+        feature: {
+          actions: ['all'],
+          [APM_SERVER_FEATURE_ID]: ['all'],
+          [OBSERVABILITY_AI_ASSISTANT_FEATURE_ID]: ['all'],
+        },
+      },
+    ],
+  };
 
   return {
     pages,
     auth: {
       login: async () => {
         await browser.navigateTo(deployment.getHostPort());
-
-        const roleDefinition: Role = {
-          name: roleName,
-          elasticsearch: {
-            cluster: [],
-            indices: [],
-            run_as: [],
-          },
-          kibana: [
-            {
-              spaces: ['*'],
-              base: [],
-              feature: {
-                actions: ['all'],
-                [APM_SERVER_FEATURE_ID]: ['all'],
-                [OBSERVABILITY_AI_ASSISTANT_FEATURE_ID]: ['all'],
-              },
-            },
-          ],
-        };
-
-        await security.role.create(roleName, roleDefinition);
-
-        await security.testUser.setRoles([roleName, 'apm_user']); // performs a page reload
+        await security.role.create(roleDefinition.name, roleDefinition);
+        await security.testUser.setRoles([roleDefinition.name, 'apm_user', 'viewer']); // performs a page reload
       },
       logout: async () => {
-        await security.role.delete(roleName);
+        await security.role.delete(roleDefinition.name);
         await security.testUser.restoreDefaults();
       },
     },

--- a/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
@@ -89,7 +89,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
   async function navigateToError() {
     await browser.navigateTo(deployment.getHostPort());
     await common.navigateToApp('apm', {
-      hash: `/services/opbeans-go/errors?rangeFrom=now-15m&rangeTo=now`,
+      path: `/services/opbeans-go/errors`,
     });
     await testSubjects.click('errorGroupId');
   }

--- a/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
@@ -87,10 +87,8 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
   }
 
   async function navigateToError() {
-    await browser.navigateTo(deployment.getHostPort());
-    await common.navigateToApp('apm', {
-      path: `/services/opbeans-go/errors`,
-    });
+    await common.navigateToApp('apm');
+    await browser.get(`${deployment.getHostPort()}/app/apm/services/opbeans-go/errors/`);
     await testSubjects.click('errorGroupId');
   }
 

--- a/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
@@ -135,7 +135,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
       it('should show the contextual insight component on the APM error details page', async () => {
         await navigateToError();
 
-        const waitForIntercept = proxy
+        proxy
           .intercept(
             'conversation',
             (body) => !isFunctionTitleRequest(body),
@@ -149,8 +149,6 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
           const llmResponse = await testSubjects.getVisibleText(ui.pages.contextualInsights.text);
           expect(llmResponse).to.contain('This error is nothing to worry about. Have a nice day!');
         });
-
-        await waitForIntercept;
       });
     });
   });

--- a/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
@@ -21,6 +21,8 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
   const supertest = getService('supertest');
   const retry = getService('retry');
   const log = getService('log');
+  const browser = getService('browser');
+  const deployment = getService('deployment');
   const apmSynthtraceEsClient = getService('apmSynthtraceEsClient');
   const { common } = getPageObjects(['header', 'common']);
 
@@ -85,10 +87,10 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
   }
 
   async function navigateToError() {
+    await browser.navigateTo(deployment.getHostPort());
     await common.navigateToApp('apm', {
       hash: `/services/opbeans-go/errors?rangeFrom=now-15m&rangeTo=now`,
     });
-
     await testSubjects.click('errorGroupId');
   }
 

--- a/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/contextual_insights/index.spec.ts
@@ -92,7 +92,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
     await testSubjects.click('errorGroupId');
   }
 
-  describe.only('Contextual insights for APM errors', () => {
+  describe('Contextual insights for APM errors', () => {
     before(async () => {
       await Promise.all([
         deleteConnectors(), // cleanup previous connectors


### PR DESCRIPTION
This adds an e2e test for the AI Assistant Contextual Insights on the APM Error details view.

Follow-up to: https://github.com/elastic/kibana/pull/182572

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->