### PR TITLE
[8.14] [ES|QL] Add `date_diff` (#182513)

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -13,9 +13,10 @@ import { statsAggregationFunctionDefinitions } from '../definitions/aggs';
 import { chronoLiterals, timeLiterals } from '../definitions/literals';
 import { commandDefinitions } from '../definitions/commands';
 import { getUnitDuration, TRIGGER_SUGGESTION_COMMAND } from './factories';
-import { camelCase } from 'lodash';
+import { camelCase, partition } from 'lodash';
 import { getAstAndSyntaxErrors } from '@kbn/esql-ast';
 import { groupingFunctionDefinitions } from '../definitions/grouping';
+import { FunctionArgSignature } from '../definitions/types';
 
 const triggerCharacters = [',', '(', '=', ' '];
 
@@ -1115,26 +1116,35 @@ describe('autocomplete', () => {
                 i + 1 < (signature.minParams ?? 0) ||
                 signature.params.filter(({ optional }, j) => !optional && j > i).length > 0;
 
-              const allPossibleParamTypes = Array.from(
-                new Set(fn.signatures.map((s) => s.params[i].type))
+              const allParamDefs = fn.signatures.map((s) => s.params[i]);
+
+              // get all possible types for this param
+              const [constantOnlyParamDefs, acceptsFieldParamDefs] = partition(
+                allParamDefs,
+                (p) => p.constantOnly || /_literal/.test(param.type)
               );
+
+              const getTypesFromParamDefs = (paramDefs: FunctionArgSignature[]) =>
+                Array.from(new Set(paramDefs.map((p) => p.type)));
+
+              const suggestedConstants = param.literalSuggestions || param.literalOptions;
 
               testSuggestions(
                 `from a | eval ${fn.name}(${Array(i).fill('field').join(', ')}${i ? ',' : ''} )`,
-                param.literalOptions?.length
-                  ? param.literalOptions.map((option) => `"${option}"${canHaveMoreArgs ? ',' : ''}`)
+                suggestedConstants?.length
+                  ? suggestedConstants.map((option) => `"${option}"${canHaveMoreArgs ? ',' : ''}`)
                   : [
-                      ...getFieldNamesByType(allPossibleParamTypes).map((f) =>
-                        canHaveMoreArgs ? `${f},` : f
+                      ...getFieldNamesByType(getTypesFromParamDefs(acceptsFieldParamDefs)).map(
+                        (f) => (canHaveMoreArgs ? `${f},` : f)
                       ),
                       ...getFunctionSignaturesByReturnType(
                         'eval',
-                        allPossibleParamTypes,
+                        getTypesFromParamDefs(acceptsFieldParamDefs),
                         { evalMath: true },
                         undefined,
                         [fn.name]
                       ).map((l) => (canHaveMoreArgs ? `${l},` : l)),
-                      ...getLiteralsByType(allPossibleParamTypes).map((d) =>
+                      ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)).map((d) =>
                         canHaveMoreArgs ? `${d},` : d
                       ),
                     ]
@@ -1143,20 +1153,20 @@ describe('autocomplete', () => {
                 `from a | eval var0 = ${fn.name}(${Array(i).fill('field').join(', ')}${
                   i ? ',' : ''
                 } )`,
-                param.literalOptions?.length
-                  ? param.literalOptions.map((option) => `"${option}"${canHaveMoreArgs ? ',' : ''}`)
+                suggestedConstants?.length
+                  ? suggestedConstants.map((option) => `"${option}"${canHaveMoreArgs ? ',' : ''}`)
                   : [
-                      ...getFieldNamesByType(allPossibleParamTypes).map((f) =>
-                        canHaveMoreArgs ? `${f},` : f
+                      ...getFieldNamesByType(getTypesFromParamDefs(acceptsFieldParamDefs)).map(
+                        (f) => (canHaveMoreArgs ? `${f},` : f)
                       ),
                       ...getFunctionSignaturesByReturnType(
                         'eval',
-                        allPossibleParamTypes,
+                        getTypesFromParamDefs(acceptsFieldParamDefs),
                         { evalMath: true },
                         undefined,
                         [fn.name]
                       ).map((l) => (canHaveMoreArgs ? `${l},` : l)),
-                      ...getLiteralsByType(allPossibleParamTypes).map((d) =>
+                      ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)).map((d) =>
                         canHaveMoreArgs ? `${d},` : d
                       ),
                     ]

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -15,6 +15,7 @@ import type {
   ESQLFunction,
   ESQLSingleAstItem,
 } from '@kbn/esql-ast';
+import { partition } from 'lodash';
 import type { EditorContext, SuggestionRawDefinition } from './types';
 import {
   columnExists,
@@ -80,6 +81,7 @@ import {
 } from '../shared/resources_helpers';
 import { ESQLCallbacks } from '../shared/types';
 import { getFunctionsToIgnoreForStats, isAggFunctionUsedAlready } from './helper';
+import { FunctionArgSignature } from '../definitions/types';
 
 type GetSourceFn = () => Promise<SuggestionRawDefinition[]>;
 type GetFieldsByTypeFn = (
@@ -977,6 +979,9 @@ function pushItUpInTheList(suggestions: SuggestionRawDefinition[], shouldPromote
   }));
 }
 
+/**
+ * TODO — split this into distinct functions, one for fields, one for functions, one for literals
+ */
 async function getFieldsOrFunctionsSuggestions(
   types: string[],
   commandName: string,
@@ -1047,6 +1052,8 @@ async function getFieldsOrFunctionsSuggestions(
   return suggestions;
 }
 
+const addCommaIf = (condition: boolean, text: string) => (condition ? `${text},` : text);
+
 async function getFunctionArgsSuggestions(
   innerText: string,
   commands: ESQLCommand[],
@@ -1082,19 +1089,40 @@ async function getFunctionArgsSuggestions(
     argIndex -= 1;
   }
 
-  const literalOptions = fnDefinition.signatures.reduce<string[]>((acc, signature) => {
-    const literalOptionsForThisParameter = signature.params[argIndex]?.literalOptions;
-    return literalOptionsForThisParameter ? acc.concat(literalOptionsForThisParameter) : acc;
-  }, [] as string[]);
-
-  if (literalOptions.length) {
-    return buildValueDefinitions(literalOptions);
-  }
-
   const arg = node.args[argIndex];
 
   // the first signature is used as reference
   const refSignature = fnDefinition.signatures[0];
+
+  const hasMoreMandatoryArgs =
+    (refSignature.params.length >= argIndex &&
+      refSignature.params.filter(({ optional }, index) => !optional && index > argIndex).length >
+        0) ||
+    ('minParams' in refSignature && refSignature.minParams
+      ? refSignature.minParams - 1 > argIndex
+      : false);
+
+  const suggestedConstants = Array.from(
+    new Set(
+      fnDefinition.signatures.reduce<string[]>((acc, signature) => {
+        const p = signature.params[argIndex];
+        const _suggestions: string[] =
+          p && p.literalSuggestions
+            ? p.literalSuggestions
+            : p && p.literalOptions
+            ? p.literalOptions
+            : [];
+        return acc.concat(_suggestions);
+      }, [] as string[])
+    )
+  );
+
+  if (suggestedConstants.length) {
+    return buildValueDefinitions(suggestedConstants).map((suggestion) => ({
+      ...suggestion,
+      text: addCommaIf(hasMoreMandatoryArgs && fnDefinition.type !== 'builtin', suggestion.text),
+    }));
+  }
 
   const suggestions = [];
   const noArgDefined = !arg;
@@ -1106,6 +1134,9 @@ async function getFunctionArgsSuggestions(
       variables: variablesExcludingCurrentCommandOnes,
     }).hit;
   if (noArgDefined || isUnknownColumn) {
+    // ... | EVAL fn( <suggest>)
+    // ... | EVAL fn( field, <suggest>)
+
     const commandArgIndex = command.args.findIndex(
       (cmdArg) => isSingleItem(cmdArg) && cmdArg.location.max >= node.location.max
     );
@@ -1147,36 +1178,53 @@ async function getFunctionArgsSuggestions(
         return true;
       });
 
-    const supportedFieldTypes = validSignatures
-      .flatMap((signature) => {
-        if (signature.params.length > argIndex) {
-          return signature.params[argIndex].type;
-        }
-        if (signature.minParams) {
-          return signature.params[signature.params.length - 1].type;
-        }
-        return [];
-      })
+    /**
+     * Get all parameter definitions across all function signatures
+     * for the current parameter position in the given function definition,
+     */
+    const allParamDefinitionsForThisPosition = validSignatures
+      .map((signature) =>
+        signature.params.length > argIndex
+          ? signature.params[argIndex]
+          : signature.minParams
+          ? signature.params[signature.params.length - 1]
+          : null
+      )
       .filter(nonNullable);
 
-    const shouldBeConstant = validSignatures.some(
-      ({ params }) => params[argIndex]?.constantOnly || /_literal$/.test(params[argIndex]?.type)
+    // Separate the param definitions into two groups:
+    // fields should only be suggested if the param isn't constant-only,
+    // and constant suggestions should only be given if it is.
+    //
+    // TODO - consider incorporating the literalOptions into this
+    //
+    // TODO — improve this to inherit the constant flag from the outer function
+    // (e.g. if func1's first parameter is constant-only, any nested functions should
+    // inherit that constraint: func1(func2(shouldBeConstantOnly)))
+    //
+    const [constantOnlyParamDefs, paramDefsWhichSupportFields] = partition(
+      allParamDefinitionsForThisPosition,
+      (paramDef) => paramDef.constantOnly || /_literal$/.test(paramDef.type)
     );
 
-    // ... | EVAL fn( <suggest>)
-    // ... | EVAL fn( field, <suggest>)
+    const getTypesFromParamDefs = (paramDefs: FunctionArgSignature[]) => {
+      return Array.from(new Set(paramDefs.map(({ type }) => type)));
+    };
+
+    suggestions.push(
+      ...getCompatibleLiterals(command.name, getTypesFromParamDefs(constantOnlyParamDefs))
+    );
+
     suggestions.push(
       ...(await getFieldsOrFunctionsSuggestions(
-        supportedFieldTypes,
+        getTypesFromParamDefs(paramDefsWhichSupportFields),
         command.name,
         option?.name,
         getFieldsByType,
         {
-          // @TODO: improve this to inherit the constant flag from the outer function
-          functions: !shouldBeConstant,
-          fields: !shouldBeConstant,
+          functions: true,
+          fields: true,
           variables: variablesExcludingCurrentCommandOnes,
-          literals: shouldBeConstant,
         },
         // do not repropose the same function as arg
         // i.e. avoid cases like abs(abs(abs(...))) with suggestions
@@ -1186,14 +1234,6 @@ async function getFunctionArgsSuggestions(
       ))
     );
   }
-
-  const hasMoreMandatoryArgs =
-    (refSignature.params.length >= argIndex &&
-      refSignature.params.filter(({ optional }, index) => !optional && index > argIndex).length >
-        0) ||
-    ('minParams' in refSignature && refSignature.minParams
-      ? refSignature.minParams - 1 > argIndex
-      : false);
 
   // for eval and row commands try also to complete numeric literals with time intervals where possible
   if (arg) {
@@ -1237,7 +1277,7 @@ async function getFunctionArgsSuggestions(
 
   return suggestions.map(({ text, ...rest }) => ({
     ...rest,
-    text: hasMoreMandatoryArgs && fnDefinition.type !== 'builtin' ? `${text},` : text,
+    text: addCommaIf(hasMoreMandatoryArgs && fnDefinition.type !== 'builtin', text),
   }));
 }
 

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -36,6 +36,69 @@ const validateLogFunctions = (fnDef: ESQLFunction) => {
   return messages;
 };
 
+const dateDiffSuggestions = [
+  'year',
+  'quarter',
+  'month',
+  'week',
+  'day',
+  'hour',
+  'minute',
+  'second',
+  'millisecond',
+  'microsecond',
+  'nanosecond',
+];
+
+const dateDiffOptions = [
+  'year',
+  'years',
+  'yy',
+  'yyyy',
+  'quarter',
+  'quarters',
+  'qq',
+  'q',
+  'month',
+  'months',
+  'mm',
+  'm',
+  'dayofyear',
+  'dy',
+  'y',
+  'day',
+  'days',
+  'dd',
+  'd',
+  'week',
+  'weeks',
+  'wk',
+  'ww',
+  'weekday',
+  'weekdays',
+  'dw',
+  'hour',
+  'hours',
+  'hh',
+  'minute',
+  'minutes',
+  'mi',
+  'n',
+  'second',
+  'seconds',
+  'ss',
+  's',
+  'millisecond',
+  'milliseconds',
+  'ms',
+  'microsecond',
+  'microseconds',
+  'mcs',
+  'nanosecond',
+  'nanoseconds',
+  'ns',
+];
+
 export const evalFunctionsDefinitions: FunctionDefinition[] = [
   {
     name: 'round',
@@ -520,6 +583,70 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
         examples: [
           `ROW date = DATE_PARSE("yyyy-MM-dd", "2022-05-06") | EVAL year = DATE_EXTRACT("year", date)`,
         ],
+      },
+    ],
+  },
+  {
+    name: 'date_diff',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.dateDiffDoc', {
+      defaultMessage: `Subtracts the startTimestamp from the endTimestamp and returns the difference in multiples of unit. If startTimestamp is later than the endTimestamp, negative values are returned.`,
+    }),
+    signatures: [
+      {
+        params: [
+          {
+            name: 'unit',
+            type: 'string',
+            literalOptions: dateDiffOptions,
+            literalSuggestions: dateDiffSuggestions,
+          },
+          { name: 'startTimestamp', type: 'date' },
+          { name: 'endTimestamp', type: 'date' },
+        ],
+        returnType: 'number',
+        examples: [],
+      },
+      {
+        params: [
+          {
+            name: 'unit',
+            type: 'string',
+            literalOptions: dateDiffOptions,
+            literalSuggestions: dateDiffSuggestions,
+          },
+          { name: 'startTimestamp', type: 'string', constantOnly: true },
+          { name: 'endTimestamp', type: 'date' },
+        ],
+        returnType: 'number',
+        examples: [],
+      },
+      {
+        params: [
+          {
+            name: 'unit',
+            type: 'string',
+            literalOptions: dateDiffOptions,
+            literalSuggestions: dateDiffSuggestions,
+          },
+          { name: 'startTimestamp', type: 'date' },
+          { name: 'endTimestamp', type: 'string', constantOnly: true },
+        ],
+        returnType: 'number',
+        examples: [],
+      },
+      {
+        params: [
+          {
+            name: 'unit',
+            type: 'string',
+            literalOptions: dateDiffOptions,
+            literalSuggestions: dateDiffSuggestions,
+          },
+          { name: 'startTimestamp', type: 'string', constantOnly: true },
+          { name: 'endTimestamp', type: 'string', constantOnly: true },
+        ],
+        returnType: 'number',
+        examples: [],
       },
     ],
   },

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -39,6 +39,17 @@ export interface FunctionDefinition {
        * matches one of the options prior to runtime.
        */
       literalOptions?: string[];
+      /**
+       * Must only be included _in addition to_ literalOptions.
+       *
+       * If provided this is the list of suggested values that
+       * will show up in the autocomplete. If omitted, the literalOptions
+       * will be used as suggestions.
+       *
+       * This is useful for functions that accept
+       * values that we don't want to show as suggestions.
+       */
+      literalSuggestions?: string[];
     }>;
     minParams?: number;
     returnType: string;

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -16242,6 +16242,11 @@
       "warning": []
     },
     {
+      "query": "from a_index | sort date_diff(\"year\", dateField, dateField)",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | sort date_extract(\"ALIGNED_DAY_OF_WEEK_IN_MONTH\", dateField)",
       "error": [],
       "warning": []
@@ -16951,6 +16956,52 @@
     {
       "query": "from a_index | eval round(numberField) + 1 | eval `round(numberField) + 1` + 1 | eval ```round(numberField) + 1`` + 1` + 1 | eval ```````round(numberField) + 1```` + 1`` + 1` + 1 | eval ```````````````round(numberField) + 1```````` + 1```` + 1`` + 1` + 1 | keep ```````````````````````````````round(numberField) + 1```````````````` + 1```````` + 1```` + 1`` + 1`",
       "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = date_diff(\"month\", \"2023-12-02T11:00:00.000Z\", \"2023-12-02T11:00:00.000Z\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = date_diff(\"mm\", \"2023-12-02T11:00:00.000Z\", \"2023-12-02T11:00:00.000Z\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = date_diff(\"bogus\", \"2023-12-02T11:00:00.000Z\", \"2023-12-02T11:00:00.000Z\")",
+      "error": [],
+      "warning": [
+        "Invalid option [\"bogus\"] for date_diff. Supported options: [\"year\", \"years\", \"yy\", \"yyyy\", \"quarter\", \"quarters\", \"qq\", \"q\", \"month\", \"months\", \"mm\", \"m\", \"dayofyear\", \"dy\", \"y\", \"day\", \"days\", \"dd\", \"d\", \"week\", \"weeks\", \"wk\", \"ww\", \"weekday\", \"weekdays\", \"dw\", \"hour\", \"hours\", \"hh\", \"minute\", \"minutes\", \"mi\", \"n\", \"second\", \"seconds\", \"ss\", \"s\", \"millisecond\", \"milliseconds\", \"ms\", \"microsecond\", \"microseconds\", \"mcs\", \"nanosecond\", \"nanoseconds\", \"ns\"]."
+      ]
+    },
+    {
+      "query": "from a_index | eval date_diff(stringField, \"2023-12-02T11:00:00.000Z\", \"2023-12-02T11:00:00.000Z\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval date_diff(\"month\", dateField, \"2023-12-02T11:00:00.000Z\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval date_diff(\"month\", \"2023-12-02T11:00:00.000Z\", dateField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval date_diff(\"month\", stringField, dateField)",
+      "error": [
+        "Argument of [date_diff] must be [date], found value [stringField] type [string]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval date_diff(\"month\", dateField, stringField)",
+      "error": [
+        "Argument of [date_diff] must be [date], found value [stringField] type [string]"
+      ],
       "warning": []
     }
   ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ES|QL] Add `date_diff` (#182513)](https://github.com/elastic/kibana/pull/182513)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2024-05-03T14:29:36Z","message":"[ES|QL] Add `date_diff` (#182513)\n\n## Summary\r\n\r\nAdds validation and autocomplete support for\r\n[`date_diff`](https://www.elastic.co/guide/en/elasticsearch/reference/8.14/esql-functions-operators.html#esql-date_diff).\r\nWhew — just me or does this get trickier every time? 😅\r\n\r\n## First param\r\n\r\n### We only suggest the main time unit options\r\n\r\n<img width=\"910\" alt=\"Screenshot 2024-05-02 at 1 19 32 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/ecf7f602-0934-4f2c-8c38-df7cdbd9da28\">\r\n\r\n\r\n### But the validator accepts all the options including abbreviations\r\n\r\n<img width=\"897\" alt=\"Screenshot 2024-05-02 at 1 42 19 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/7a523a8e-a1a4-4abc-b318-a2d2a0ddf11c\">\r\n\r\n### But still warns if it's a totally funky value\r\n\r\n<img width=\"782\" alt=\"Screenshot 2024-05-02 at 1 19 17 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/ff8955d9-e7a2-4e7a-b64c-aad2ba2aee0e\">\r\n\r\n### And it does accept string fields\r\n\r\n<img width=\"918\" alt=\"Screenshot 2024-05-02 at 1 39 57 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/b76a4343-a88a-44e0-8324-54cad4d3b53d\">\r\n\r\n## Second and third params\r\n\r\n### We suggest date-based fields and functions\r\n \r\n<img width=\"955\" alt=\"Screenshot 2024-05-02 at 1 51 14 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/39927314-b93e-4289-9d14-aecbaab644d9\">\r\n\r\n### But date strings are also 👍 because of auto-casting\r\n\r\n<img width=\"844\" alt=\"Screenshot 2024-05-02 at 1 51 47 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/1d826fa4-5604-453f-95fe-a03612a9c4cf\">\r\n\r\n### But string fields are 👎 \r\n\r\n<img width=\"872\" alt=\"Screenshot 2024-05-02 at 1 52 13 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/4f7f3220-ccd3-4592-b034-579a31f0c88c\">\r\n\r\n\r\n\r\n## Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"df0949469a4a4142692204153b69b728b6969ce5","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","Feature:ES|QL","v8.14.0","Team:ESQL","v8.15.0"],"number":182513,"url":"https://github.com/elastic/kibana/pull/182513","mergeCommit":{"message":"[ES|QL] Add `date_diff` (#182513)\n\n## Summary\r\n\r\nAdds validation and autocomplete support for\r\n[`date_diff`](https://www.elastic.co/guide/en/elasticsearch/reference/8.14/esql-functions-operators.html#esql-date_diff).\r\nWhew — just me or does this get trickier every time? 😅\r\n\r\n## First param\r\n\r\n### We only suggest the main time unit options\r\n\r\n<img width=\"910\" alt=\"Screenshot 2024-05-02 at 1 19 32 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/ecf7f602-0934-4f2c-8c38-df7cdbd9da28\">\r\n\r\n\r\n### But the validator accepts all the options including abbreviations\r\n\r\n<img width=\"897\" alt=\"Screenshot 2024-05-02 at 1 42 19 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/7a523a8e-a1a4-4abc-b318-a2d2a0ddf11c\">\r\n\r\n### But still warns if it's a totally funky value\r\n\r\n<img width=\"782\" alt=\"Screenshot 2024-05-02 at 1 19 17 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/ff8955d9-e7a2-4e7a-b64c-aad2ba2aee0e\">\r\n\r\n### And it does accept string fields\r\n\r\n<img width=\"918\" alt=\"Screenshot 2024-05-02 at 1 39 57 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/b76a4343-a88a-44e0-8324-54cad4d3b53d\">\r\n\r\n## Second and third params\r\n\r\n### We suggest date-based fields and functions\r\n \r\n<img width=\"955\" alt=\"Screenshot 2024-05-02 at 1 51 14 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/39927314-b93e-4289-9d14-aecbaab644d9\">\r\n\r\n### But date strings are also 👍 because of auto-casting\r\n\r\n<img width=\"844\" alt=\"Screenshot 2024-05-02 at 1 51 47 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/1d826fa4-5604-453f-95fe-a03612a9c4cf\">\r\n\r\n### But string fields are 👎 \r\n\r\n<img width=\"872\" alt=\"Screenshot 2024-05-02 at 1 52 13 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/4f7f3220-ccd3-4592-b034-579a31f0c88c\">\r\n\r\n\r\n\r\n## Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"df0949469a4a4142692204153b69b728b6969ce5"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/182513","number":182513,"mergeCommit":{"message":"[ES|QL] Add `date_diff` (#182513)\n\n## Summary\r\n\r\nAdds validation and autocomplete support for\r\n[`date_diff`](https://www.elastic.co/guide/en/elasticsearch/reference/8.14/esql-functions-operators.html#esql-date_diff).\r\nWhew — just me or does this get trickier every time? 😅\r\n\r\n## First param\r\n\r\n### We only suggest the main time unit options\r\n\r\n<img width=\"910\" alt=\"Screenshot 2024-05-02 at 1 19 32 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/ecf7f602-0934-4f2c-8c38-df7cdbd9da28\">\r\n\r\n\r\n### But the validator accepts all the options including abbreviations\r\n\r\n<img width=\"897\" alt=\"Screenshot 2024-05-02 at 1 42 19 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/7a523a8e-a1a4-4abc-b318-a2d2a0ddf11c\">\r\n\r\n### But still warns if it's a totally funky value\r\n\r\n<img width=\"782\" alt=\"Screenshot 2024-05-02 at 1 19 17 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/ff8955d9-e7a2-4e7a-b64c-aad2ba2aee0e\">\r\n\r\n### And it does accept string fields\r\n\r\n<img width=\"918\" alt=\"Screenshot 2024-05-02 at 1 39 57 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/b76a4343-a88a-44e0-8324-54cad4d3b53d\">\r\n\r\n## Second and third params\r\n\r\n### We suggest date-based fields and functions\r\n \r\n<img width=\"955\" alt=\"Screenshot 2024-05-02 at 1 51 14 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/39927314-b93e-4289-9d14-aecbaab644d9\">\r\n\r\n### But date strings are also 👍 because of auto-casting\r\n\r\n<img width=\"844\" alt=\"Screenshot 2024-05-02 at 1 51 47 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/1d826fa4-5604-453f-95fe-a03612a9c4cf\">\r\n\r\n### But string fields are 👎 \r\n\r\n<img width=\"872\" alt=\"Screenshot 2024-05-02 at 1 52 13 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/4f7f3220-ccd3-4592-b034-579a31f0c88c\">\r\n\r\n\r\n\r\n## Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"df0949469a4a4142692204153b69b728b6969ce5"}}]}] BACKPORT-->