### PR TITLE
[Serverless ]Fix Playground in Serverless

### DIFF
--- a/x-pack/plugins/search_playground/kibana.jsonc
+++ b/x-pack/plugins/search_playground/kibana.jsonc
@@ -20,7 +20,8 @@
       "triggersActionsUi",
     ],
     "optionalPlugins": [
-      "cloud"
+      "cloud",
+      "usageCollection",
     ],
     "requiredBundles": [
       "kibanaReact"

--- a/x-pack/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/chat.tsx
@@ -68,13 +68,13 @@ export const Chat = () => {
         data: buildFormData(data),
       }
     );
-    usageTracker.click(AnalyticsEvents.chatQuestionSent);
+    usageTracker?.click(AnalyticsEvents.chatQuestionSent);
 
     resetField(ChatFormFields.question);
   };
   const handleStopRequest = () => {
     stopRequest();
-    usageTracker.click(AnalyticsEvents.chatRequestStopped);
+    usageTracker?.click(AnalyticsEvents.chatRequestStopped);
   };
   const chatMessages = useMemo(
     () => [
@@ -101,15 +101,15 @@ export const Chat = () => {
     });
     setIsRegenerating(false);
 
-    usageTracker.click(AnalyticsEvents.chatRegenerateMessages);
+    usageTracker?.click(AnalyticsEvents.chatRegenerateMessages);
   };
   const handleClearChat = () => {
     setMessages([]);
-    usageTracker.click(AnalyticsEvents.chatCleared);
+    usageTracker?.click(AnalyticsEvents.chatCleared);
   };
 
   useEffect(() => {
-    usageTracker.load(AnalyticsEvents.chatPageLoaded);
+    usageTracker?.load(AnalyticsEvents.chatPageLoaded);
   }, [usageTracker]);
 
   return (

--- a/x-pack/plugins/search_playground/public/components/edit_context/edit_context_flyout.tsx
+++ b/x-pack/plugins/search_playground/public/components/edit_context/edit_context_flyout.tsx
@@ -65,23 +65,23 @@ export const EditContextFlyout: React.FC<EditContextFlyoutProps> = ({ onClose })
       ...tempSourceFields,
       [index]: [field],
     });
-    usageTracker.click(AnalyticsEvents.editContextFieldToggled);
+    usageTracker?.click(AnalyticsEvents.editContextFieldToggled);
   };
 
   const saveSourceFields = () => {
-    usageTracker.click(AnalyticsEvents.editContextSaved);
+    usageTracker?.click(AnalyticsEvents.editContextSaved);
     onChangeSourceFields(tempSourceFields);
     onChangeSize(docSize);
     onClose();
   };
 
   const handleDocSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    usageTracker.click(AnalyticsEvents.editContextDocSizeChanged);
+    usageTracker?.click(AnalyticsEvents.editContextDocSizeChanged);
     setDocSize(Number(e.target.value));
   };
 
   useEffect(() => {
-    usageTracker.load(AnalyticsEvents.editContextFlyoutOpened);
+    usageTracker?.load(AnalyticsEvents.editContextFlyoutOpened);
   }, [usageTracker]);
 
   return (

--- a/x-pack/plugins/search_playground/public/components/message_list/citations_table.tsx
+++ b/x-pack/plugins/search_playground/public/components/message_list/citations_table.tsx
@@ -32,12 +32,12 @@ export const CitationsTable: React.FC<CitationsTableProps> = ({ citations }) => 
     if (itemIdToExpandedRowMapValues[citation.metadata._id]) {
       delete itemIdToExpandedRowMapValues[citation.metadata._id];
 
-      usageTracker.click(AnalyticsEvents.citationDetailsCollapsed);
+      usageTracker?.click(AnalyticsEvents.citationDetailsCollapsed);
     } else {
       itemIdToExpandedRowMapValues[citation.metadata._id] = (
         <EuiText size="s">{citation.content}</EuiText>
       );
-      usageTracker.click(AnalyticsEvents.citationDetailsExpanded);
+      usageTracker?.click(AnalyticsEvents.citationDetailsExpanded);
     }
 
     setItemIdToExpandedRowMap(itemIdToExpandedRowMapValues);

--- a/x-pack/plugins/search_playground/public/components/message_list/retrieval_docs_flyout.tsx
+++ b/x-pack/plugins/search_playground/public/components/message_list/retrieval_docs_flyout.tsx
@@ -81,7 +81,7 @@ export const RetrievalDocsFlyout: React.FC<RetrievalDocsFlyoutProps> = ({
   ];
 
   useEffect(() => {
-    usageTracker.load(AnalyticsEvents.retrievalDocsFlyoutOpened);
+    usageTracker?.load(AnalyticsEvents.retrievalDocsFlyoutOpened);
   }, [usageTracker]);
 
   return (

--- a/x-pack/plugins/search_playground/public/components/set_up_connector_panel_for_start_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/set_up_connector_panel_for_start_chat.tsx
@@ -36,19 +36,19 @@ export const SetUpConnectorPanelForStartChat: React.FC = () => {
     setConnectorFlyoutOpen(false);
   };
   const handleSetupGenAiConnector = () => {
-    usageTracker.click(AnalyticsEvents.genAiConnectorCreated);
+    usageTracker?.click(AnalyticsEvents.genAiConnectorCreated);
     setConnectorFlyoutOpen(true);
   };
 
   useEffect(() => {
     if (connectors?.length) {
       if (showCallout) {
-        usageTracker.load(AnalyticsEvents.genAiConnectorAdded);
+        usageTracker?.load(AnalyticsEvents.genAiConnectorAdded);
       } else {
-        usageTracker.load(AnalyticsEvents.genAiConnectorExists);
+        usageTracker?.load(AnalyticsEvents.genAiConnectorExists);
       }
     } else {
-      usageTracker.load(AnalyticsEvents.genAiConnectorSetup);
+      usageTracker?.load(AnalyticsEvents.genAiConnectorSetup);
     }
   }, [connectors?.length, showCallout, usageTracker]);
 

--- a/x-pack/plugins/search_playground/public/components/set_up_connector_panel_for_start_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/set_up_connector_panel_for_start_chat.tsx
@@ -82,6 +82,7 @@ export const SetUpConnectorPanelForStartChat: React.FC = () => {
             defaultMessage="You need to connect to a large-language model to use this feature. Start by adding connection details for your LLM provider."
           />
         }
+        dataTestSubj="connectToLLMChatPanel"
       >
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>

--- a/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.tsx
@@ -35,6 +35,7 @@ export const SourcesPanelForStartChat: React.FC = () => {
           "Select the Elasticsearch indices you'd like to query, providing additional context for the LLM.",
       })}
       isValid={!!selectedIndices.length}
+      dataTestSubj="selectIndicesChatPanel"
     >
       {!!selectedIndices?.length && (
         <EuiFlexItem>

--- a/x-pack/plugins/search_playground/public/components/start_chat_panel.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_chat_panel.tsx
@@ -22,6 +22,7 @@ interface StartChatPanelProps {
   title: string;
   description: string | React.ReactNode;
   isValid?: boolean;
+  dataTestSubj: string;
 }
 
 export const StartChatPanel: FC<PropsWithChildren<StartChatPanelProps>> = ({
@@ -29,8 +30,9 @@ export const StartChatPanel: FC<PropsWithChildren<StartChatPanelProps>> = ({
   description,
   children,
   isValid,
+  dataTestSubj,
 }) => (
-  <EuiPanel hasBorder paddingSize="l">
+  <EuiPanel hasBorder paddingSize="l" data-test-subj={dataTestSubj}>
     <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
       <EuiTitle size="xs">
         <h5>{title}</h5>

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
@@ -37,7 +37,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
   const usageTracker = useUsageTracker();
 
   useEffect(() => {
-    usageTracker.load(AnalyticsEvents.startNewChatPageLoaded);
+    usageTracker?.load(AnalyticsEvents.startNewChatPageLoaded);
   }, [usageTracker]);
 
   return (

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
@@ -85,7 +85,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
           <SourcesPanelForStartChat />
         </EuiFlexItem>
 
-        <EuiFlexGroup justifyContent="flexEnd">
+        <EuiFlexGroup justifyContent="flexEnd" data-test-subj="startChatButton">
           <EuiButton
             fill
             iconType="arrowRight"

--- a/x-pack/plugins/search_playground/public/components/summarization_panel/include_citations_field.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/include_citations_field.tsx
@@ -23,7 +23,7 @@ export const IncludeCitationsField: React.FC<IncludeCitationsFieldProps> = ({
   const usageTracker = useUsageTracker();
   const handleChange = (value: boolean) => {
     onChange(value);
-    usageTracker.click(`${AnalyticsEvents.includeCitations}_${String(value)}`);
+    usageTracker?.click(`${AnalyticsEvents.includeCitations}_${String(value)}`);
   };
 
   return (

--- a/x-pack/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
@@ -29,7 +29,7 @@ export const InstructionsField: React.FC<InstructionsFieldProps> = ({ value, onC
   };
   const handleBlur = () => {
     if (baseValue !== value) {
-      usageTracker.click(AnalyticsEvents.instructionsFieldChanged);
+      usageTracker?.click(AnalyticsEvents.instructionsFieldChanged);
     }
     setBaseValue('');
   };

--- a/x-pack/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
@@ -97,7 +97,7 @@ export const SummarizationModel: React.FC<SummarizationModelProps> = ({
   );
 
   useEffect(() => {
-    usageTracker.click(
+    usageTracker?.click(
       `${AnalyticsEvents.modelSelected}_${selectedModel.value || selectedModel.connectorType}`
     );
   }, [usageTracker, selectedModel]);

--- a/x-pack/plugins/search_playground/public/components/toolbar.tsx
+++ b/x-pack/plugins/search_playground/public/components/toolbar.tsx
@@ -13,7 +13,7 @@ import { EditContextAction } from './edit_context/edit_context_action';
 
 export const Toolbar: React.FC = () => {
   return (
-    <EuiFlexGroup gutterSize="s">
+    <EuiFlexGroup gutterSize="s" data-test-subj="playground-header-actions">
       <EditContextAction />
       <ViewQueryAction />
       <ViewCodeAction />

--- a/x-pack/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
+++ b/x-pack/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
@@ -70,11 +70,11 @@ export const ViewCodeFlyout: React.FC<ViewCodeFlyoutProps> = ({ onClose }) => {
   };
 
   useEffect(() => {
-    usageTracker.load(AnalyticsEvents.viewCodeFlyoutOpened);
+    usageTracker?.load(AnalyticsEvents.viewCodeFlyoutOpened);
   }, [usageTracker]);
 
   useEffect(() => {
-    usageTracker.click(`${AnalyticsEvents.viewCodeLanguageChange}_${selectedLanguage}`);
+    usageTracker?.click(`${AnalyticsEvents.viewCodeLanguageChange}_${selectedLanguage}`);
   }, [usageTracker, selectedLanguage]);
 
   return (

--- a/x-pack/plugins/search_playground/public/components/view_query/view_query_flyout.tsx
+++ b/x-pack/plugins/search_playground/public/components/view_query/view_query_flyout.tsx
@@ -106,7 +106,7 @@ export const ViewQueryFlyout: React.FC<ViewQueryFlyoutProps> = ({ onClose }) => 
       ...tempQueryFields,
       [index]: newFields,
     });
-    usageTracker.count(AnalyticsEvents.viewQueryFieldsUpdated, newFields.length);
+    usageTracker?.count(AnalyticsEvents.viewQueryFieldsUpdated, newFields.length);
   };
 
   const saveQuery = () => {
@@ -117,12 +117,12 @@ export const ViewQueryFlyout: React.FC<ViewQueryFlyoutProps> = ({ onClose }) => 
     const groupedQueryFields = groupTypeQueryFields(fields, tempQueryFields);
 
     groupedQueryFields.forEach((typeQueryFields) =>
-      usageTracker.click(`${AnalyticsEvents.viewQuerySaved}_${typeQueryFields}`)
+      usageTracker?.click(`${AnalyticsEvents.viewQuerySaved}_${typeQueryFields}`)
     );
   };
 
   useEffect(() => {
-    usageTracker.load(AnalyticsEvents.viewQueryFlyoutOpened);
+    usageTracker?.load(AnalyticsEvents.viewQueryFlyoutOpened);
   }, [usageTracker]);
 
   return (

--- a/x-pack/plugins/search_playground/public/hooks/use_source_indices_field.ts
+++ b/x-pack/plugins/search_playground/public/hooks/use_source_indices_field.ts
@@ -91,7 +91,10 @@ export const useSourceIndicesFields = () => {
 
       onElasticsearchQueryChange(createQuery(defaultFields, fields));
       onSourceFieldsChange(defaultSourceFields);
-      usageTracker.count(AnalyticsEvents.sourceFieldsLoaded, Object.values(fields)?.flat()?.length);
+      usageTracker?.count(
+        AnalyticsEvents.sourceFieldsLoaded,
+        Object.values(fields)?.flat()?.length
+      );
     } else {
       setNoFieldsIndicesWarning(null);
     }
@@ -103,14 +106,14 @@ export const useSourceIndicesFields = () => {
     const newIndices = [...selectedIndices, newIndex];
     setLoading(true);
     onIndicesChange(newIndices);
-    usageTracker.count(AnalyticsEvents.sourceIndexUpdated, newIndices.length);
+    usageTracker?.count(AnalyticsEvents.sourceIndexUpdated, newIndices.length);
   };
 
   const removeIndex = (index: IndexName) => {
     const newIndices = selectedIndices.filter((indexName: string) => indexName !== index);
     setLoading(true);
     onIndicesChange(newIndices);
-    usageTracker.count(AnalyticsEvents.sourceIndexUpdated, newIndices.length);
+    usageTracker?.count(AnalyticsEvents.sourceIndexUpdated, newIndices.length);
   };
 
   return {

--- a/x-pack/plugins/search_playground/public/hooks/use_usage_tracker.test.ts
+++ b/x-pack/plugins/search_playground/public/hooks/use_usage_tracker.test.ts
@@ -30,15 +30,15 @@ describe('useUsageTracker', () => {
   it('returns bound functions for tracking usage', () => {
     const { result } = renderHook(() => useUsageTracker());
 
-    expect(typeof result.current.click).toBe('function');
-    expect(typeof result.current.count).toBe('function');
-    expect(typeof result.current.load).toBe('function');
+    expect(typeof result.current?.click).toBe('function');
+    expect(typeof result.current?.count).toBe('function');
+    expect(typeof result.current?.load).toBe('function');
   });
 
   it('calls reportUiCounter with correct arguments for click', () => {
     const { result } = renderHook(() => useUsageTracker());
 
-    result.current.click('button_click');
+    result.current?.click('button_click');
 
     expect(reportUiCounter).toHaveBeenCalledWith('search_playground', 'click', 'button_click');
   });
@@ -46,7 +46,7 @@ describe('useUsageTracker', () => {
   it('calls reportUiCounter with correct arguments for count', () => {
     const { result } = renderHook(() => useUsageTracker());
 
-    result.current.count('item_count');
+    result.current?.count('item_count');
 
     expect(reportUiCounter).toHaveBeenCalledWith('search_playground', 'count', 'item_count');
   });
@@ -54,8 +54,21 @@ describe('useUsageTracker', () => {
   it('calls reportUiCounter with correct arguments for load', () => {
     const { result } = renderHook(() => useUsageTracker());
 
-    result.current.load('page_loaded');
+    result.current?.load('page_loaded');
 
     expect(reportUiCounter).toHaveBeenCalledWith('search_playground', 'loaded', 'page_loaded');
+  });
+
+  it('does not  reportUiCounter if usageCollection is not loaded properly', () => {
+    reportUiCounter = jest.fn();
+    (useKibana as jest.Mock).mockReturnValue({
+      services: { usageCollection: undefined },
+    });
+
+    const { result } = renderHook(() => useUsageTracker());
+
+    result.current?.load('page_loaded');
+
+    expect(reportUiCounter).toHaveBeenCalledTimes(0);
   });
 });

--- a/x-pack/plugins/search_playground/public/hooks/use_usage_tracker.ts
+++ b/x-pack/plugins/search_playground/public/hooks/use_usage_tracker.ts
@@ -14,24 +14,25 @@ const APP_TRACKER_NAME = 'search_playground';
 export const useUsageTracker = () => {
   const { usageCollection } = useKibana().services;
 
-  return useMemo(
-    () => ({
-      click: usageCollection.reportUiCounter.bind(
-        usageCollection,
-        APP_TRACKER_NAME,
-        METRIC_TYPE.CLICK
-      ),
-      count: usageCollection.reportUiCounter.bind(
-        usageCollection,
-        APP_TRACKER_NAME,
-        METRIC_TYPE.COUNT
-      ),
-      load: usageCollection.reportUiCounter.bind(
-        usageCollection,
-        APP_TRACKER_NAME,
-        METRIC_TYPE.LOADED
-      ),
-    }),
-    [usageCollection]
-  );
+  return useMemo(() => {
+    if (usageCollection) {
+      return {
+        click: usageCollection.reportUiCounter.bind(
+          usageCollection,
+          APP_TRACKER_NAME,
+          METRIC_TYPE.CLICK
+        ),
+        count: usageCollection.reportUiCounter.bind(
+          usageCollection,
+          APP_TRACKER_NAME,
+          METRIC_TYPE.COUNT
+        ),
+        load: usageCollection.reportUiCounter.bind(
+          usageCollection,
+          APP_TRACKER_NAME,
+          METRIC_TYPE.LOADED
+        ),
+      };
+    }
+  }, [usageCollection]);
 };

--- a/x-pack/plugins/search_playground/public/types.ts
+++ b/x-pack/plugins/search_playground/public/types.ts
@@ -40,7 +40,7 @@ export interface SearchPlaygroundPluginStart {
 
 export interface AppPluginStartDependencies {
   history: AppMountParameters['history'];
-  usageCollection: UsageCollectionStart;
+  usageCollection?: UsageCollectionStart;
   navigation: NavigationPublicPluginStart;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
   share: SharePluginStart;
@@ -52,7 +52,7 @@ export interface AppServicesContext {
   share: SharePluginStart;
   cloud?: CloudSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
-  usageCollection: UsageCollectionStart;
+  usageCollection?: UsageCollectionStart;
 }
 
 export enum ChatFormFields {

--- a/x-pack/test_serverless/functional/page_objects/index.ts
+++ b/x-pack/test_serverless/functional/page_objects/index.ts
@@ -21,6 +21,7 @@ import { SvlRuleDetailsPageProvider } from './svl_rule_details_ui_page';
 import { SvlSearchConnectorsPageProvider } from './svl_search_connectors_page';
 import { SvlManagementPageProvider } from './svl_management_page';
 import { SvlIngestPipelines } from './svl_ingest_pipelines';
+import { SvlPlaygroundPageProvider } from './svl_playground_page';
 
 export const pageObjects = {
   ...xpackFunctionalPageObjects,
@@ -38,4 +39,5 @@ export const pageObjects = {
   svlRuleDetailsUI: SvlRuleDetailsPageProvider,
   svlManagementPage: SvlManagementPageProvider,
   svlIngestPipelines: SvlIngestPipelines,
+  svlPlaygroundUI: SvlPlaygroundPageProvider,
 };

--- a/x-pack/test_serverless/functional/page_objects/svl_playground_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_playground_page.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function SvlPlaygroundPageProvider({ getService }: FtrProviderContext) {
+  const testSubjects = getService('testSubjects');
+  return {
+    PlaygrounStartChatPage: {
+      async expectPlaygroundStartChatPageComponentsToExist() {
+        await testSubjects.existOrFail('chat-playground-home-page-title');
+        await testSubjects.existOrFail('selectIndicesChatPanel');
+        await testSubjects.existOrFail('startChatButton');
+      },
+
+      async expectPlaygroundHeaderComponentsToExist() {
+        await testSubjects.existOrFail('playground-header-actions');
+        await testSubjects.existOrFail('playground-documentation-link');
+      },
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -70,6 +70,15 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await expectNoPageReload();
     });
 
+    it('navigate to playground from side nav', async () => {
+      await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
+      await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts(['Build', 'Playground']);
+
+      await svlCommonNavigation.sidenav.expectLinkActive({ deepLinkId: 'searchPlayground' });
+
+      expect(await browser.getCurrentUrl()).contain('/app/search_playground/chat');
+    });
+
     it("management apps from the sidenav hide the 'stack management' root from the breadcrumbs", async () => {
       await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'management:index_management' });
       await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts([

--- a/x-pack/test_serverless/functional/test_suites/search/playground_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/playground_overview.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getPageObjects }: FtrProviderContext) {
+  const pageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation', 'svlPlaygroundUI']);
+  describe('Playground', function () {
+    before(async () => {
+      await pageObjects.svlCommonPage.login();
+      await pageObjects.svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
+    });
+
+    after(async () => {
+      await pageObjects.svlCommonPage.forceLogout();
+    });
+
+    it('playground app is loaded', async () => {
+      await pageObjects.svlPlaygroundUI.PlaygrounStartChatPage.expectPlaygroundStartChatPageComponentsToExist();
+      await pageObjects.svlPlaygroundUI.PlaygrounStartChatPage.expectPlaygroundHeaderComponentsToExist();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

We encountered an issue in Serverless
```core.entry.js:16 TypeError: Cannot read properties of undefined (reading 'reportUiCounter')
    at searchPlayground.chunk.0.js:3:27662
    at Object.useMemo (kbn-ui-shared-deps-npm.dll.js:425:65135)
    at t.useMemo (kbn-ui-shared-deps-npm.dll.js:401:5744)
    at u (searchPlayground.chunk.0.js:3:27646)
    at pe (searchPlayground.chunk.1.js:3:48026)
    at la (kbn-ui-shared-deps-npm.dll.js:425:59212)
    at ec (kbn-ui-shared-deps-npm.dll.js:425:114853)
    at Pc (kbn-ui-shared-deps-npm.dll.js:425:99713)
    at Nc (kbn-ui-shared-deps-npm.dll.js:425:99563)
    at Dc (kbn-ui-shared-deps-npm.dll.js:425:99396)
```

This PR includes:
- Fix Playground loading issue
- Added Functional testing


## UX
![Screenshot 2024-05-06 at 2 15 42 PM](https://github.com/elastic/kibana/assets/150824886/27e47cc9-a556-4c61-9b2e-3a327984181b)

![Screenshot 2024-05-06 at 2 15 51 PM](https://github.com/elastic/kibana/assets/150824886/f21d22e0-40d2-4a9b-bd68-d673a30e147d)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->