### PR TITLE
[ES|QL] bucket as an aggregation

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -109,6 +109,8 @@ function getFunctionSignaturesByReturnType(
   const list = [];
   if (agg) {
     list.push(...statsAggregationFunctionDefinitions);
+    // right now all grouping functions are agg functions too
+    list.push(...groupingFunctionDefinitions);
   }
   if (grouping) {
     list.push(...groupingFunctionDefinitions);
@@ -120,7 +122,10 @@ function getFunctionSignaturesByReturnType(
   if (builtin) {
     list.push(...builtinFunctions.filter(({ name }) => (skipAssign ? name !== '=' : true)));
   }
-  return list
+
+  const deduped = Array.from(new Set(list));
+
+  return deduped
     .filter(({ signatures, ignoreAsSuggestion, supportedCommands, supportedOptions, name }) => {
       if (ignoreAsSuggestion) {
         return false;
@@ -732,7 +737,7 @@ describe('autocomplete', () => {
     testSuggestions(
       'from a | stats round(',
       [
-        ...getFunctionSignaturesByReturnType('stats', 'number', { agg: true }),
+        ...getFunctionSignaturesByReturnType('stats', 'number', { agg: true, grouping: true }),
         ...getFieldNamesByType('number'),
         ...getFunctionSignaturesByReturnType('eval', 'number', { evalMath: true }, undefined, [
           'round',

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -1106,12 +1106,16 @@ async function getFunctionArgsSuggestions(
     new Set(
       fnDefinition.signatures.reduce<string[]>((acc, signature) => {
         const p = signature.params[argIndex];
-        const _suggestions: string[] =
-          p && p.literalSuggestions
-            ? p.literalSuggestions
-            : p && p.literalOptions
-            ? p.literalOptions
-            : [];
+        if (!p) {
+          return acc;
+        }
+
+        const _suggestions: string[] = p.literalSuggestions
+          ? p.literalSuggestions
+          : p.literalOptions
+          ? p.literalOptions
+          : [];
+
         return acc.concat(_suggestions);
       }, [] as string[])
     )

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -136,7 +136,7 @@ export const commandDefinitions: CommandDefinition[] = [
         function checkAggExistence(arg: ESQLFunction): boolean {
           // TODO the grouping function check may not
           // hold true for all future cases
-          if (isAggFunction(arg) || isGroupingFunction(arg)) {
+          if (isAggFunction(arg)) {
             return true;
           }
           if (isOtherFunction(arg)) {
@@ -176,7 +176,7 @@ export const commandDefinitions: CommandDefinition[] = [
           function checkFunctionContent(arg: ESQLFunction) {
             // TODO the grouping function check may not
             // hold true for all future cases
-            if (isAggFunction(arg) || isGroupingFunction(arg)) {
+            if (isAggFunction(arg)) {
               return true;
             }
             return (arg as ESQLFunction).args.every(

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -129,12 +129,17 @@ export const commandDefinitions: CommandDefinition[] = [
         function isAggFunction(arg: ESQLAstItem): arg is ESQLFunction {
           return isFunctionItem(arg) && getFunctionDefinition(arg.name)?.type === 'agg';
         }
+        function isGroupingFunction(arg: ESQLAstItem): arg is ESQLFunction {
+          return isFunctionItem(arg) && getFunctionDefinition(arg.name)?.type === 'grouping';
+        }
         function isOtherFunction(arg: ESQLAstItem): arg is ESQLFunction {
           return isFunctionItem(arg) && getFunctionDefinition(arg.name)?.type !== 'agg';
         }
 
         function checkAggExistence(arg: ESQLFunction): boolean {
-          if (isAggFunction(arg)) {
+          // TODO the grouping function check may not
+          // hold true for all future cases
+          if (isAggFunction(arg) || isGroupingFunction(arg)) {
             return true;
           }
           if (isOtherFunction(arg)) {
@@ -172,7 +177,9 @@ export const commandDefinitions: CommandDefinition[] = [
           // * or if it's a builtin function, then all operands are agg functions or literals
           // * or if it's a eval function then all arguments are agg functions or literals
           function checkFunctionContent(arg: ESQLFunction) {
-            if (isAggFunction(arg)) {
+            // TODO the grouping function check may not
+            // hold true for all future cases
+            if (isAggFunction(arg) || isGroupingFunction(arg)) {
               return true;
             }
             return (arg as ESQLFunction).args.every(

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -129,9 +129,6 @@ export const commandDefinitions: CommandDefinition[] = [
         function isAggFunction(arg: ESQLAstItem): arg is ESQLFunction {
           return isFunctionItem(arg) && getFunctionDefinition(arg.name)?.type === 'agg';
         }
-        function isGroupingFunction(arg: ESQLAstItem): arg is ESQLFunction {
-          return isFunctionItem(arg) && getFunctionDefinition(arg.name)?.type === 'grouping';
-        }
         function isOtherFunction(arg: ESQLAstItem): arg is ESQLFunction {
           return isFunctionItem(arg) && getFunctionDefinition(arg.name)?.type !== 'agg';
         }

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/grouping.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/grouping.ts
@@ -16,8 +16,9 @@ export const groupingFunctionDefinitions: FunctionDefinition[] = [
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.autoBucketDoc', {
       defaultMessage: `Automatically bucket dates based on a given range and bucket target.`,
     }),
-    type: 'grouping',
-    supportedCommands: [],
+    // type agg because it can also be used as an aggregation...
+    type: 'agg',
+    supportedCommands: ['stats'],
     supportedOptions: ['by'],
     signatures: [
       {
@@ -31,7 +32,7 @@ export const groupingFunctionDefinitions: FunctionDefinition[] = [
       {
         params: [
           { name: 'field', type: 'number' },
-          { name: 'buckets', type: 'time_literal', constantOnly: true },
+          { name: 'buckets', type: 'number', constantOnly: true },
         ],
         returnType: 'number',
         examples: ['from index | eval hd = bucket(bytes, 1 hour)'],

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -9,7 +9,7 @@
 import type { ESQLCommand, ESQLCommandOption, ESQLFunction, ESQLMessage } from '@kbn/esql-ast';
 
 export interface FunctionDefinition {
-  type: 'builtin' | 'agg' | 'eval' | 'grouping';
+  type: 'builtin' | 'agg' | 'eval';
   ignoreAsSuggestion?: boolean;
   name: string;
   alias?: string[];

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -15778,17 +15778,19 @@
       "warning": []
     },
     {
-      "query": "from a_index | stats by bucket(numberField, 1 year)",
+      "query": "from a_index | stats by bucket(numberField, 5)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats by bucket(numberField, 1 year)",
-      "error": [],
+      "query": "from a_index | stats by bucket(numberField, numberField)",
+      "error": [
+        "Argument of [bucket] must be a constant, received [numberField]"
+      ],
       "warning": []
     },
     {
-      "query": "from a_index | stats by bin(numberField, 1 year)",
+      "query": "from a_index | stats by bin(numberField, 5)",
       "error": [],
       "warning": []
     },


### PR DESCRIPTION
## Summary

This PR adds validation and autocomplete support for the `bucket` function to be used in both the `stats` clause and the `by` clause in accordance with [the docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-functions-operators.html#esql-bucket):

<img width="1100" alt="Screenshot 2024-05-06 at 10 45 03 AM" src="https://github.com/elastic/kibana/assets/315764/716a9f5a-fdc2-4d67-b0e9-9362354074da">

It also fixes the short-hand signature of `bucket(numberField, number)` which was incorrectly configured as `bucket(numberField, time_literal)`.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->