### PR TITLE
[Infra] Dashboards: Change the `NEW` icon with the beta badge

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/common/asset_details_config/asset_details_tabs.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/common/asset_details_config/asset_details_tabs.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBadge } from '@elastic/eui';
+import { EuiBetaBadge } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { ContentTabIds, type Tab } from '../../components/asset_details/types';
@@ -65,11 +65,21 @@ export const commonFlyoutTabs: Tab[] = [
       defaultMessage: 'Dashboards',
     }),
     append: (
-      <EuiBadge color="accent">
-        {i18n.translate('xpack.infra.customDashboards.newLabel', {
-          defaultMessage: 'NEW',
+      <EuiBetaBadge
+        label={i18n.translate('xpack.infra.customDashboards.technicalPreviewBadgeLabel', {
+          defaultMessage: 'Technical preview',
         })}
-      </EuiBadge>
+        tooltipContent={i18n.translate(
+          'xpack.infra.customDashboards.technicalPreviewBadgeDescription',
+          {
+            defaultMessage:
+              'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
+          }
+        )}
+        iconType="beaker"
+        size="s"
+        style={{ verticalAlign: 'middle' }}
+      />
     ),
   },
 ];


### PR DESCRIPTION
Closes #182703 

## Summary

This PR changes the badge next to the new dashboards tab from `NEW` to the technical preview icon/tooltip

![image](https://github.com/elastic/kibana/assets/14139027/bb77cb82-72d6-481e-bfb8-889bca4341f8)

## Testing

- Enable the dashboards feature from advanced settings
<img width="1654" alt="image" src="https://github.com/elastic/kibana/assets/14139027/0af29c80-fb33-4467-9585-50efcb0694a9">

- Select a host and check the dashboards tab title (should look like the APM tab title and use the same badge)
   - Infra: 
   - ![image](https://github.com/elastic/kibana/assets/14139027/11a62236-8255-4508-a733-9e7e7ca1d49e)
   
   - APM:
   - ![image](https://github.com/elastic/kibana/assets/14139027/c689a40c-e5bc-42f4-9eed-2ccfaf288850)
