### PR TITLE
[Security Solution] Skips `Investigation fields actions` tests on MKI environments.

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -578,7 +578,8 @@ describe('Detection rules, bulk edit', { tags: ['@ess', '@serverless'] }, () => 
     });
   });
 
-  describe('Investigation fields actions', () => {
+  // https://github.com/elastic/kibana/issues/182834
+  describe('Investigation fields actions', { tags: ['@skipInServerlessMKI'] }, () => {
     it('Add investigation fields to custom rules', () => {
       getRulesManagementTableRows().then((rows) => {
         const fieldsToBeAdded = ['source.ip', 'destination.ip'];


### PR DESCRIPTION
## Summary

The `Investigation fields actions` actions tests are failing on MKI environments because they need a FF to be activated (bulkCustomHighlightedFieldsEnabled).

As we currently not support FF on MKI environments, the test has been skipped by adding the `skipInServerlessMKI` label.

i.e.: https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/114