### PR TITLE
[Onboarding] Scroll to the top on the page when navigating to a quick start view

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/experimental_onboarding_flow.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/experimental_onboarding_flow.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Route, Routes } from '@kbn/shared-ux-router';
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { EuiButtonEmpty, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
@@ -22,6 +22,13 @@ import { CustomLogsPanel } from './quickstart_flows/custom_logs';
 const queryClient = new QueryClient();
 
 export function ExperimentalOnboardingFlow() {
+  const mainContentRef = useRef<HTMLDivElement | null>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [location.pathname]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <EuiPageTemplate.Section
@@ -40,19 +47,21 @@ export function ExperimentalOnboardingFlow() {
         <Header />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section paddingSize="xl" color="subdued" restrictWidth>
-        <Routes>
-          <Route path="/systemLogs">
-            <BackButton />
-            <SystemLogsPanel />
-          </Route>
-          <Route path="/customLogs">
-            <BackButton />
-            <CustomLogsPanel />
-          </Route>
-          <Route>
-            <OnboardingFlowForm />
-          </Route>
-        </Routes>
+        <div ref={mainContentRef}>
+          <Routes>
+            <Route path="/systemLogs">
+              <BackButton />
+              <SystemLogsPanel />
+            </Route>
+            <Route path="/customLogs">
+              <BackButton />
+              <CustomLogsPanel />
+            </Route>
+            <Route>
+              <OnboardingFlowForm />
+            </Route>
+          </Routes>
+        </div>
         <EuiSpacer size="xl" />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section paddingSize="xl" grow={false} restrictWidth>

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/experimental_onboarding_flow.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/experimental_onboarding_flow.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { Route, Routes } from '@kbn/shared-ux-router';
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { EuiButtonEmpty, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
@@ -22,12 +22,11 @@ import { CustomLogsPanel } from './quickstart_flows/custom_logs';
 const queryClient = new QueryClient();
 
 export function ExperimentalOnboardingFlow() {
-  const mainContentRef = useRef<HTMLDivElement | null>(null);
-  const location = useLocation();
+  const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [location.pathname]);
+    window.scrollTo(0, 0);
+  }, [pathname]);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -47,21 +46,19 @@ export function ExperimentalOnboardingFlow() {
         <Header />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section paddingSize="xl" color="subdued" restrictWidth>
-        <div ref={mainContentRef}>
-          <Routes>
-            <Route path="/systemLogs">
-              <BackButton />
-              <SystemLogsPanel />
-            </Route>
-            <Route path="/customLogs">
-              <BackButton />
-              <CustomLogsPanel />
-            </Route>
-            <Route>
-              <OnboardingFlowForm />
-            </Route>
-          </Routes>
-        </div>
+        <Routes>
+          <Route path="/systemLogs">
+            <BackButton />
+            <SystemLogsPanel />
+          </Route>
+          <Route path="/customLogs">
+            <BackButton />
+            <CustomLogsPanel />
+          </Route>
+          <Route>
+            <OnboardingFlowForm />
+          </Route>
+        </Routes>
         <EuiSpacer size="xl" />
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section paddingSize="xl" grow={false} restrictWidth>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/182157

- Adds a hook to watch for location path updates reset the page's scroll position