### PR TITLE
[Security Solution][Timeline] - fix ESQL tab full screen showing unwanted UI elements

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/esql/styles.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/esql/styles.tsx
@@ -21,4 +21,9 @@ export const TimelineESQLGlobalStyles = createGlobalStyle`
   body:has(.timeline-portal-overlay-mask) .DiscoverFlyout {
     z-index: 1002; // For its usage in the Security Solution timeline, we need Discover flyout to be above the timeline flyout (which has a z-index of 1001)
   }
+
+  // TODO this should be removed when we change the ES|QL tab to be our own component instead of Discover (hopefully 8.15)
+  .unifiedDataTable__fullScreen .dscPageBody * {
+    z-index: unset !important;
+  }
 `;


### PR DESCRIPTION
## Summary

This PR fixes a small issue when going to full screen mode on the new ES|QL tab.

The `kbn-unified-data-table` forces to unset `z-index` values (see [here](https://github.com/elastic/kibana/blob/main/packages/kbn-unified-data-table/src/components/data_table.scss#L173)) but this is not applied to EUI portals which Timeline is.
The small change added in this PR focuses on adding this back to the `dscPageBody` class which is in our case is within the Timeline ES|QL tab.

Before fix

https://github.com/elastic/kibana/assets/17276605/a0d3fb52-8982-48ca-8a43-ab4406cdcf1f

After fix

https://github.com/elastic/kibana/assets/17276605/a16c1d2b-0c79-48df-a530-f1be0afb6274

I also verified that this didn't break the Discover page in Security Solution running in Serverless

https://github.com/elastic/kibana/assets/17276605/dfd850c3-faf5-4998-93c3-8fc121f46fff

https://github.com/elastic/kibana/issues/182812

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->