### PR TITLE
[Detection Engine][FTR] Get exceptions tests in MKI green

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exception_comments_serverless.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/exception_comments_serverless.ts
@@ -26,7 +26,8 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  describe('@serverless exception item comments - serverless specific behavior', () => {
+  // Skipping in MKI due to roles testing not yet being available
+  describe('@serverless @skipInServerlessMKI exception item comments - serverless specific behavior', () => {
     // FLAKY: https://github.com/elastic/kibana/issues/181507
     describe.skip('Rule Exceptions', () => {
       afterEach(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/prebuilt_rules.ts
@@ -37,7 +37,9 @@ export default ({ getService }: FtrProviderContext) => {
   const log = getService('log');
   const es = getService('es');
 
-  describe('@serverless @ess exceptions workflows for prebuilt rules', () => {
+  // See https://github.com/elastic/kibana/issues/182889 for details
+  // on skipping in MKI
+  describe('@serverless @ess @skipInServerlessMKI exceptions workflows for prebuilt rules', () => {
     describe('creating rules with exceptions', () => {
       beforeEach(async () => {
         await createAlertsIndex(supertest, log);


### PR DESCRIPTION
## Summary

This PR:

- Ensures we have the correct tags for the FTR tests within `detection_engine/exceptions` 
- Adds ticket references or comments where we need to skip a test in MKI

### Flakey test runner
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5887
