### PR TITLE
[Lens] Fix overriding title when using inline Lens vis editor

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -230,7 +230,6 @@ export function LensEditConfigurationFlyout({
       },
       references,
       visualizationType: visualization.activeId,
-      title: (attributes.title || visualization.activeId) ?? '',
     };
     if (savedObjectId) {
       saveByRef?.(attrs);

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -230,7 +230,7 @@ export function LensEditConfigurationFlyout({
       },
       references,
       visualizationType: visualization.activeId,
-      title: visualization.activeId ?? '',
+      title: (attributes.title || visualization.activeId) ?? '',
     };
     if (savedObjectId) {
       saveByRef?.(attrs);


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Lens on-the-fly popover editor, in which a visualization title would be overridden to `InsXY`.

fixes #182896

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->