### PR TITLE
Skip serverless playground UI tests for MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -70,15 +70,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await expectNoPageReload();
     });
 
-    it('navigate to playground from side nav', async () => {
-      await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
-      await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts(['Build', 'Playground']);
-
-      await svlCommonNavigation.sidenav.expectLinkActive({ deepLinkId: 'searchPlayground' });
-
-      expect(await browser.getCurrentUrl()).contain('/app/search_playground/chat');
-    });
-
     it("management apps from the sidenav hide the 'stack management' root from the breadcrumbs", async () => {
       await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'management:index_management' });
       await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts([

--- a/x-pack/test_serverless/functional/test_suites/search/playground_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/playground_overview.ts
@@ -5,21 +5,41 @@
  * 2.0.
  */
 
+import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getPageObjects }: FtrProviderContext) {
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const pageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation', 'svlPlaygroundUI']);
+  const browser = getService('browser');
+
   describe('Playground', function () {
+    // playground UI is currently disabled in MKI
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await pageObjects.svlCommonPage.login();
-      await pageObjects.svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
     });
 
     after(async () => {
       await pageObjects.svlCommonPage.forceLogout();
     });
 
+    it('navigate to playground from side nav', async () => {
+      await pageObjects.svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
+      await pageObjects.svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts([
+        'Build',
+        'Playground',
+      ]);
+
+      await pageObjects.svlCommonNavigation.sidenav.expectLinkActive({
+        deepLinkId: 'searchPlayground',
+      });
+
+      expect(await browser.getCurrentUrl()).contain('/app/search_playground/chat');
+    });
+
     it('playground app is loaded', async () => {
+      await pageObjects.svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'searchPlayground' });
       await pageObjects.svlPlaygroundUI.PlaygrounStartChatPage.expectPlaygroundStartChatPageComponentsToExist();
       await pageObjects.svlPlaygroundUI.PlaygrounStartChatPage.expectPlaygroundHeaderComponentsToExist();
     });


### PR DESCRIPTION
## Summary

This PR skips the playground UI tests for MKI runs since that feature has temporarily been disabled in that environment.

### Details

This PR will be reverted once the fix #182739 is rolled out to MKI and the playground UI has been reenabled there.

The navigation test could not be skipped for MKI separately (tags are only available on suite level and we don't want to skip the whole navigation suite for MKI). So this test has been temporarily moved to the playground overview suite, where it could be disabled for MKI runs but continues to run locally / on CI.
