### PR TITLE
Add await on deletion queries that are blowing up in FTR tests

### DIFF
--- a/x-pack/test/cloud_security_posture_api/routes/vulnerabilities_dashboard.ts
+++ b/x-pack/test/cloud_security_posture_api/routes/vulnerabilities_dashboard.ts
@@ -155,7 +155,7 @@ export default function ({ getService }: FtrProviderContext) {
       const indexExists = await es.indices.exists({ index: VULNERABILITIES_LATEST_INDEX });
 
       if (indexExists) {
-        es.deleteByQuery({
+        await es.deleteByQuery({
           index: VULNERABILITIES_LATEST_INDEX,
           query: { match_all: {} },
           refresh: true,
@@ -167,7 +167,7 @@ export default function ({ getService }: FtrProviderContext) {
       const indexExists = await es.indices.exists({ index: BENCHMARK_SCORES_INDEX });
 
       if (indexExists) {
-        es.deleteByQuery({
+        await es.deleteByQuery({
           index: BENCHMARK_SCORES_INDEX,
           query: { match_all: {} },
           refresh: true,


### PR DESCRIPTION
## Summary
We've seen several cases of FTR tests dying of unhandled promise rejections. (https://buildkite.com/elastic/kibana-on-merge/builds/44936#018f56c3-184a-4cd6-98fc-4342d713e52a)

I've managed to locate the place where these requests come from - ideally with this addition, the tests should fail earlier, and not way after the test have been marked successful.

Further problems/questions:
 - [ ] The FTR runner should not mark these runs successful if there are unhandled promise rejections, rather wait for the promises to settle before concluding
 - [ ] Why did this call suddenly start to fail?