### PR TITLE
Add * as default value for 3 more native connectors

### DIFF
--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -2605,7 +2605,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         type: FieldType.LIST,
         ui_restrictions: [],
         validations: [],
-        value: '',
+        value: '*',
       },
       ssl_enabled: {
         default_value: false,
@@ -3142,7 +3142,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         type: FieldType.LIST,
         ui_restrictions: [],
         validations: [],
-        value: '',
+        value: '*',
       },
       fetch_size: {
         default_value: 50,
@@ -4279,7 +4279,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         type: FieldType.LIST,
         ui_restrictions: [],
         validations: [],
-        value: '',
+        value: '*',
       },
       use_text_extraction_service: {
         default_value: false,


### PR DESCRIPTION
## Summary

This PR adds "*" as default value for 3 more native connector fields that specify comma-separate values:

- MySQL connector field "tables"
- Oracle connector field "tables"
- Sharepoint Online field "site_collections"

Similar PR in connectors:
https://github.com/elastic/connectors/pull/2532


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->