### PR TITLE
[Security Solution][Timeline] - fix host and user details flyout not using the correct time for requests when open from Timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
@@ -17,7 +17,7 @@ import { Direction, NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../common/se
 import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from '..';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
-import { isActiveTimeline } from '../../../../helpers';
+import { getSourcererScopeId, isActiveTimeline } from '../../../../helpers';
 
 export const useObservedHost = (
   hostName: string,
@@ -31,7 +31,7 @@ export const useObservedHost = (
   const { to, from } = isActiveTimelines ? timelineTime : globalTime;
   const { isInitializing, setQuery, deleteQuery } = globalTime;
 
-  const { selectedPatterns } = useSourcererDataView();
+  const { selectedPatterns } = useSourcererDataView(getSourcererScopeId(scopeId));
 
   const [isLoading, { hostDetails, inspect: inspectObservedHost }, refetch] = useHostDetails({
     endDate: to,

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_observed_host.ts
@@ -6,6 +6,8 @@
  */
 
 import { useMemo } from 'react';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { inputsSelectors } from '../../../../common/store';
 import { useHostDetails } from '../../../../explore/hosts/containers/hosts/details';
 import { useFirstLastSeen } from '../../../../common/containers/use_first_last_seen';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -15,11 +17,20 @@ import { Direction, NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../common/se
 import { HOST_PANEL_OBSERVED_HOST_QUERY_ID, HOST_PANEL_RISK_SCORE_QUERY_ID } from '..';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
+import { isActiveTimeline } from '../../../../helpers';
 
 export const useObservedHost = (
-  hostName: string
+  hostName: string,
+  scopeId: string
 ): Omit<ObservedEntityData<HostItem>, 'anomalies'> => {
-  const { to, from, isInitializing, setQuery, deleteQuery } = useGlobalTime();
+  const timelineTime = useDeepEqualSelector((state) =>
+    inputsSelectors.timelineTimeRangeSelector(state)
+  );
+  const globalTime = useGlobalTime();
+  const isActiveTimelines = isActiveTimeline(scopeId);
+  const { to, from } = isActiveTimelines ? timelineTime : globalTime;
+  const { isInitializing, setQuery, deleteQuery } = globalTime;
+
   const { selectedPatterns } = useSourcererDataView();
 
   const [isLoading, { hostDetails, inspect: inspectObservedHost }, refetch] = useHostDetails({

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/index.tsx
@@ -112,7 +112,7 @@ export const HostPanel = ({ contextID, scopeId, hostName, isDraggable }: HostPan
   );
 
   const openDefaultPanel = useCallback(() => openTabPanel(), [openTabPanel]);
-  const observedHost = useObservedHost(hostName);
+  const observedHost = useObservedHost(hostName, scopeId);
 
   if (observedHost.isLoading) {
     return <FlyoutLoading />;

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
@@ -6,6 +6,8 @@
  */
 
 import { useMemo } from 'react';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { inputsSelectors } from '../../../../common/store';
 import { useQueryInspector } from '../../../../common/components/page/manage_query';
 import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
 import { useObservedUserDetails } from '../../../../explore/users/containers/users/observed_details';
@@ -14,12 +16,21 @@ import { Direction, NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../common/se
 import { useSourcererDataView } from '../../../../common/containers/sourcerer';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useFirstLastSeen } from '../../../../common/containers/use_first_last_seen';
+import { isActiveTimeline } from '../../../../helpers';
 
 export const useObservedUser = (
-  userName: string
+  userName: string,
+  scopeId: string
 ): Omit<ObservedEntityData<UserItem>, 'anomalies'> => {
+  const timelineTime = useDeepEqualSelector((state) =>
+    inputsSelectors.timelineTimeRangeSelector(state)
+  );
+  const globalTime = useGlobalTime();
+  const isActiveTimelines = isActiveTimeline(scopeId);
+  const { to, from } = isActiveTimelines ? timelineTime : globalTime;
+  const { isInitializing, setQuery, deleteQuery } = globalTime;
+
   const { selectedPatterns } = useSourcererDataView();
-  const { to, from, isInitializing, deleteQuery, setQuery } = useGlobalTime();
 
   const [loadingObservedUser, { userDetails: observedUserDetails, inspect, refetch, id: queryId }] =
     useObservedUserDetails({

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user.ts
@@ -16,7 +16,7 @@ import { Direction, NOT_EVENT_KIND_ASSET_FILTER } from '../../../../../common/se
 import { useSourcererDataView } from '../../../../common/containers/sourcerer';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useFirstLastSeen } from '../../../../common/containers/use_first_last_seen';
-import { isActiveTimeline } from '../../../../helpers';
+import { getSourcererScopeId, isActiveTimeline } from '../../../../helpers';
 
 export const useObservedUser = (
   userName: string,
@@ -30,7 +30,7 @@ export const useObservedUser = (
   const { to, from } = isActiveTimelines ? timelineTime : globalTime;
   const { isInitializing, setQuery, deleteQuery } = globalTime;
 
-  const { selectedPatterns } = useSourcererDataView();
+  const { selectedPatterns } = useSourcererDataView(getSourcererScopeId(scopeId));
 
   const [loadingObservedUser, { userDetails: observedUserDetails, inspect, refetch, id: queryId }] =
     useObservedUserDetails({

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/index.tsx
@@ -67,7 +67,7 @@ export const UserPanel = ({ contextID, scopeId, userName, isDraggable }: UserPan
   const { inspect, refetch, loading } = riskScoreState;
   const { to, from, isInitializing, setQuery, deleteQuery } = useGlobalTime();
 
-  const observedUser = useObservedUser(userName);
+  const observedUser = useObservedUser(userName, scopeId);
   const email = observedUser.details.user?.email;
   const managedUser = useManagedUser(userName, email, observedUser.isLoading);
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the user and host detail flyouts (the new ones using the expandable flyout framework). When those flyouts are open from Timeline, the request made to query their data is using the `from` and `to` values from the global query, meaning the date interval selected in the alerts page.
They should be instead using the date interval from Timeline.

Before fix

https://github.com/elastic/kibana/assets/17276605/84685de8-402d-4dc9-85e9-3e78f50e520f

After fix

https://github.com/elastic/kibana/assets/17276605/ad365303-f0a9-4a90-9e46-8bd742df8db6

https://github.com/elastic/kibana/issues/182967

### Notes

I did not add any unit tests for this, as the cutoff for the last BC is happening very soon, and also because no tests existed for these 2 hooks. Let me know if that is ok with you for now @machadoum 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->