### PR TITLE
[8.13] [Lens] Fix overriding title when using inline Lens vis editor (#182897)

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -228,7 +228,6 @@ export function LensEditConfigurationFlyout({
       },
       references,
       visualizationType: visualization.activeId,
-      title: visualization.activeId ?? '',
     };
     if (savedObjectId) {
       saveByRef?.(attrs);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Lens] Fix overriding title when using inline Lens vis editor (#182897)](https://github.com/elastic/kibana/pull/182897)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nick Partridge","email":"nicholas.partridge@elastic.co"},"sourceCommit":{"committedDate":"2024-05-08T19:45:26Z","message":"[Lens] Fix overriding title when using inline Lens vis editor (#182897)\n\n## Summary\r\n\r\nThis PR fixes an issue in the Lens on-the-fly popover editor, in which a\r\nvisualization title would be overridden to `InsXY`.\r\n\r\nfixes #182896","sha":"44f458be5a4fd5104be5c709747e8c55eaf88760","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","v8.15.0","v8.13.4"],"number":182897,"url":"https://github.com/elastic/kibana/pull/182897","mergeCommit":{"message":"[Lens] Fix overriding title when using inline Lens vis editor (#182897)\n\n## Summary\r\n\r\nThis PR fixes an issue in the Lens on-the-fly popover editor, in which a\r\nvisualization title would be overridden to `InsXY`.\r\n\r\nfixes #182896","sha":"44f458be5a4fd5104be5c709747e8c55eaf88760"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/182897","number":182897,"mergeCommit":{"message":"[Lens] Fix overriding title when using inline Lens vis editor (#182897)\n\n## Summary\r\n\r\nThis PR fixes an issue in the Lens on-the-fly popover editor, in which a\r\nvisualization title would be overridden to `InsXY`.\r\n\r\nfixes #182896","sha":"44f458be5a4fd5104be5c709747e8c55eaf88760"}},{"branch":"8.13","label":"v8.13.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/182993","number":182993,"branch":"8.14","state":"OPEN"}]}] BACKPORT-->