### PR TITLE
[Security Solution] [Attack discovery] Fixes attack discovery cache issues

### DIFF
--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/session_storage/index.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/session_storage/index.ts
@@ -6,7 +6,9 @@
  */
 
 import type { Replacements } from '@kbn/elastic-assistant-common';
-import type { AttackDiscovery } from '../../types';
+import { isEmpty } from 'lodash/fp';
+
+import type { AttackDiscovery, GenerationInterval } from '../../types';
 
 export interface CachedAttackDiscoveries {
   connectorId: string;
@@ -19,7 +21,7 @@ export const encodeCachedAttackDiscoveries = (
   cachedAttackDiscoveries: Record<string, CachedAttackDiscoveries>
 ): string | null => {
   try {
-    return JSON.stringify(cachedAttackDiscoveries, null, 2);
+    return JSON.stringify(cachedAttackDiscoveries);
   } catch {
     return null;
   }
@@ -32,5 +34,77 @@ export const decodeCachedAttackDiscoveries = (
     return JSON.parse(cachedAttackDiscoveries);
   } catch {
     return null;
+  }
+};
+
+export const getSessionStorageCachedAttackDiscoveries = (
+  key: string
+): Record<string, CachedAttackDiscoveries> | null => {
+  if (!isEmpty(key)) {
+    return decodeCachedAttackDiscoveries(sessionStorage.getItem(key) ?? '');
+  }
+
+  return null;
+};
+
+export const setSessionStorageCachedAttackDiscoveries = ({
+  key,
+  cachedAttackDiscoveries,
+}: {
+  key: string;
+  cachedAttackDiscoveries: Record<string, CachedAttackDiscoveries>;
+}) => {
+  if (!isEmpty(key)) {
+    const encoded = encodeCachedAttackDiscoveries(cachedAttackDiscoveries);
+
+    if (encoded != null) {
+      sessionStorage.setItem(key, encoded);
+    }
+  }
+};
+
+export const encodeGenerationIntervals = (
+  generationIntervals: Record<string, GenerationInterval[]>
+): string | null => {
+  try {
+    return JSON.stringify(generationIntervals);
+  } catch {
+    return null;
+  }
+};
+
+export const decodeGenerationIntervals = (
+  generationIntervals: string
+): Record<string, GenerationInterval[]> | null => {
+  try {
+    return JSON.parse(generationIntervals);
+  } catch {
+    return null;
+  }
+};
+
+export const getLocalStorageGenerationIntervals = (
+  key: string
+): Record<string, GenerationInterval[]> | null => {
+  if (!isEmpty(key)) {
+    return decodeGenerationIntervals(sessionStorage.getItem(key) ?? '');
+  }
+
+  return null;
+};
+
+export const setLocalStorageGenerationIntervals = ({
+  key,
+  generationIntervals,
+}: {
+  key: string;
+  generationIntervals: Record<string, GenerationInterval[]>;
+}) => {
+  if (!isEmpty(key)) {
+    const encoded = encodeGenerationIntervals(generationIntervals);
+
+    if (encoded != null) {
+      localStorage.setItem(key, encoded);
+    }
   }
 };


### PR DESCRIPTION
## [Security Solution] [Attack discovery] Fixes attack discovery cache issues

### Summary

This PR fixes an issue where cached attack discoveries (for the same connector) in session storage were available in the same browser when switching spaces.

### Test setup

- Configure at least two generative AI connectors (e.g. one OpenAI and one Claude (Sonnet))
- Create another space to switch to during testing
  - Make sure the other space has alerts in the last 24 hours

### Desk testing

1. Clear the browser's local storage

2. Close all open browser tabs connected to Kibana, to clear the browser's session storage

3. Open the browser, and Navigate to Security > Attack discovery

4. Select a connector

5. Click `Generate`

**Expected results**

- A loading countdown is NOT displayed for the current connector during loading (because it's the first run for the selected connector)
- Attack discoveries are generated for the connector

6. Once again, click `Generate`

**Expected result**

- A loading countdown is displayed for the current connector

7. Click on the loading countdown's (i) icon

**Expected result**

- The tooltip displays the timing for the previous run
- Attack discoveries are (once again) generated for the connector

8. Select a different connector

**Expected result**

- The `Up to 20 alerts will be analyzed` empty state is displayed

9. Click the `Generate` button

**Expected results**

- A loading countdown is NOT displayed for the newly-selected connector during loading (because it's the first run for the newly-selected connector)
- Attack discoveries are generated for the connector
- The header displays the text `Generated a few seconds ago`

10. Once again, select the first connector

**Expected results**

- The previous connector's results are displayed
- The header displays the text `Generated: 3 minutes ago`

11. Navigate to Security > Cases

12. Navigate back to Security > Attack discovery

**Expected results**

- The previous connector's results are displayed
- The header displays the text `Generated: 4 minutes ago`

13. Once again, select the other connector

**Expected results**

- The other connector's results are displayed
- The header displays the text `Generated: n minutes ago` that's different than the previously-selected connector

14. Change to another space

15. Navgiate to Security > Attack discovery

16. Select a connector

**Expected results**

- The results from the other space (for the selected connector) are NOT displayed

17. Once again, select the _other_ connector

**Expected results**

- Once again, the results from the other space (for the selected connector) are NOT displayed

18. Click the `Generate` button

**Expected results**

- A loading countdown is NOT displayed for the newly-selected connector during loading (because it's the first run for the newly-selected connector in this Space)
- Attack discoveries are generated for the connector

19. Once again, click the `Generate` button

**Expected results**

- A loading countdown is displayed for the current connector
- Attack discoveries are once again generated
- The header displays the text `Generated a few seconds ago`

20. Navigate back to the original space

21. Navigate to Security > Attack discovery in the orignal space

23. Re-select the previous connector

**Expected results**

- The (much older) attack discovery results from the original space are displayed


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->