### PR TITLE
[8.14] [Security Solution] [Attack discovery] Removes the Attack discovery feature flag (#182975)

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant-common/impl/capabilities/index.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/capabilities/index.ts
@@ -15,5 +15,4 @@ export type AssistantFeatures = { [K in keyof typeof defaultAssistantFeatures]: 
  */
 export const defaultAssistantFeatures = Object.freeze({
   assistantModelEvaluation: false,
-  attackDiscoveryEnabled: false,
 });

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
@@ -19,5 +19,4 @@ import { z } from 'zod';
 export type GetCapabilitiesResponse = z.infer<typeof GetCapabilitiesResponse>;
 export const GetCapabilitiesResponse = z.object({
   assistantModelEvaluation: z.boolean(),
-  attackDiscoveryEnabled: z.boolean(),
 });

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
@@ -21,11 +21,8 @@ paths:
                 properties:
                   assistantModelEvaluation:
                     type: boolean
-                  attackDiscoveryEnabled:
-                    type: boolean
                 required:
                   - assistantModelEvaluation
-                  - attackDiscoveryEnabled
         '400':
           description: Generic Error
           content:

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api/capabilities/use_capabilities.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api/capabilities/use_capabilities.test.tsx
@@ -16,7 +16,6 @@ import { API_VERSIONS } from '@kbn/elastic-assistant-common';
 const statusResponse = {
   assistantModelEvaluation: true,
   assistantStreamingEnabled: false,
-  attackDiscoveryEnabled: false,
 };
 
 const http = {

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -277,7 +277,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
 
   // Fetch assistant capabilities
   const { data: capabilities } = useCapabilities({ http, toasts });
-  const { assistantModelEvaluation: modelEvaluatorEnabled, attackDiscoveryEnabled } =
+  const { assistantModelEvaluation: modelEvaluatorEnabled } =
     capabilities ?? defaultAssistantFeatures;
 
   const value = useMemo(
@@ -286,7 +286,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       alertsIndexPattern,
       assistantAvailability,
       assistantTelemetry,
-      attackDiscoveryEnabled,
       augmentMessageCodeBlocks,
       allQuickPrompts: localStorageQuickPrompts ?? [],
       allSystemPrompts: localStorageSystemPrompts ?? [],
@@ -326,7 +325,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       alertsIndexPattern,
       assistantAvailability,
       assistantTelemetry,
-      attackDiscoveryEnabled,
       augmentMessageCodeBlocks,
       localStorageQuickPrompts,
       localStorageSystemPrompts,

--- a/x-pack/plugins/elastic_assistant/server/routes/attack_discovery/helpers.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/attack_discovery/helpers.ts
@@ -16,7 +16,7 @@ import { ActionsClientLlm } from '@kbn/elastic-assistant-common/impl/language_mo
 import { AnonymizationFieldResponse } from '@kbn/elastic-assistant-common/impl/schemas/anonymization_fields/bulk_crud_anonymization_fields_route.gen';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AssistantToolParams, ElasticAssistantApiRequestHandlerContext } from '../../types';
+import { AssistantToolParams } from '../../types';
 
 export const REQUIRED_FOR_ATTACK_DISCOVERY: AnonymizationFieldResponse[] = [
   {
@@ -68,15 +68,3 @@ export const getAssistantToolParams = ({
   request,
   size,
 });
-
-export const isAttackDiscoveryFeatureEnabled = ({
-  assistantContext,
-  pluginName,
-}: {
-  assistantContext: ElasticAssistantApiRequestHandlerContext;
-  pluginName: string;
-}): boolean => {
-  const registeredFeatures = assistantContext.getRegisteredFeatures(pluginName);
-
-  return registeredFeatures.attackDiscoveryEnabled === true;
-};

--- a/x-pack/plugins/elastic_assistant/server/routes/attack_discovery/post_attack_discovery.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/attack_discovery/post_attack_discovery.ts
@@ -17,7 +17,7 @@ import {
 import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { ATTACK_DISCOVERY } from '../../../common/constants';
-import { getAssistantToolParams, isAttackDiscoveryFeatureEnabled } from './helpers';
+import { getAssistantToolParams } from './helpers';
 import { DEFAULT_PLUGIN_NAME, getPluginNameFromRequest } from '../helpers';
 import { getLangSmithTracer } from '../evaluate/utils';
 import { buildResponse } from '../../lib/build_response';
@@ -62,16 +62,6 @@ export const postAttackDiscoveryRoute = (
             defaultPluginName: DEFAULT_PLUGIN_NAME,
             logger,
           });
-
-          // feature flag check:
-          const attackDiscoveryFeatureEnabled = isAttackDiscoveryFeatureEnabled({
-            assistantContext,
-            pluginName,
-          });
-
-          if (!attackDiscoveryFeatureEnabled) {
-            return response.notFound();
-          }
 
           // get parameters from the request body
           const alertsIndexPattern = decodeURIComponent(request.body.alertsIndexPattern);

--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.test.ts
@@ -46,7 +46,6 @@ describe('Post Evaluate Route', () => {
     it('returns a 404 if evaluate feature is not registered', async () => {
       context.elasticAssistant.getRegisteredFeatures.mockReturnValueOnce({
         assistantModelEvaluation: false,
-        attackDiscoveryEnabled: false,
       });
 
       const response = await server.inject(

--- a/x-pack/plugins/elastic_assistant/server/services/app_context.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/services/app_context.test.ts
@@ -54,7 +54,6 @@ describe('AppContextService', () => {
       appContextService.start(mockAppContext);
       appContextService.registerFeatures('super', {
         assistantModelEvaluation: true,
-        attackDiscoveryEnabled: false,
       });
       appContextService.stop();
 
@@ -104,7 +103,6 @@ describe('AppContextService', () => {
       const pluginName = 'pluginName';
       const features: AssistantFeatures = {
         assistantModelEvaluation: true,
-        attackDiscoveryEnabled: false,
       };
 
       appContextService.start(mockAppContext);
@@ -119,12 +117,10 @@ describe('AppContextService', () => {
       const pluginOne = 'plugin1';
       const featuresOne: AssistantFeatures = {
         assistantModelEvaluation: true,
-        attackDiscoveryEnabled: false,
       };
       const pluginTwo = 'plugin2';
       const featuresTwo: AssistantFeatures = {
         assistantModelEvaluation: false,
-        attackDiscoveryEnabled: false,
       };
 
       appContextService.start(mockAppContext);
@@ -139,11 +135,9 @@ describe('AppContextService', () => {
       const pluginName = 'pluginName';
       const featuresOne: AssistantFeatures = {
         assistantModelEvaluation: true,
-        attackDiscoveryEnabled: false,
       };
       const featuresTwo: AssistantFeatures = {
         assistantModelEvaluation: false,
-        attackDiscoveryEnabled: false,
       };
 
       appContextService.start(mockAppContext);

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -119,11 +119,6 @@ export const allowedExperimentalValues = Object.freeze({
   alertsPageFiltersEnabled: true,
 
   /**
-   * Enables the Attack discovery feature and API endpoint
-   */
-  attackDiscoveryEnabled: false,
-
-  /**
    * Enables the Assistant Model Evaluation advanced setting and API endpoint, introduced in `8.11.0`.
    */
   assistantModelEvaluation: false,

--- a/x-pack/plugins/security_solution/public/app/solution_navigation/categories.ts
+++ b/x-pack/plugins/security_solution/public/app/solution_navigation/categories.ts
@@ -24,6 +24,7 @@ export const CATEGORIES: Array<SeparatorLinkCategory<SolutionPageName>> = [
     linkIds: [
       SecurityPageName.rulesLanding,
       SecurityPageName.alerts,
+      SecurityPageName.attackDiscovery,
       SecurityPageName.cloudSecurityPostureFindings,
       SecurityPageName.case,
     ],

--- a/x-pack/plugins/security_solution/public/attack_discovery/index.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/index.ts
@@ -11,9 +11,9 @@ import { routes } from './routes';
 export class AttackDiscovery {
   public setup() {}
 
-  public start(isEnabled = false): SecuritySubPlugin {
+  public start(): SecuritySubPlugin {
     return {
-      routes: isEnabled ? routes : [],
+      routes,
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/attack_discovery/links.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/links.ts
@@ -13,7 +13,6 @@ import type { LinkItem } from '../common/links/types';
 
 export const links: LinkItem = {
   capabilities: [`${SERVER_APP_ID}.show`],
-  experimentalKey: 'attackDiscoveryEnabled',
   globalNavPosition: 4,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.attackDiscovery', {

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
@@ -50,7 +50,6 @@ jest.mock(
 jest.mock('../../common/links', () => ({
   useLinkInfo: jest.fn().mockReturnValue({
     capabilities: ['siem.show'],
-    experimentalKey: 'attackDiscoveryEnabled',
     globalNavPosition: 4,
     globalSearchKeywords: ['Attack discovery'],
     id: 'attack_discovery',

--- a/x-pack/plugins/security_solution/public/attack_discovery/tour/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/tour/index.tsx
@@ -97,7 +97,12 @@ const AttackDiscoveryTourComp = () => {
 
   const isElementAtCurrentStepMounted = useIsElementMounted(attackDiscoveryTourStepOne?.anchor);
 
+  const isTestAutomation =
+    window.Cypress != null || // TODO: temporary workaround to disable the tour when running in Cypress, because the tour breaks other projects Cypress tests
+    navigator.webdriver === true; // TODO: temporary workaround to disable the tour when running in the FTR, because the tour breaks other projects FTR tests
+
   if (
+    isTestAutomation ||
     !tourState.isTourActive ||
     (tourState.currentTourStep === 1 && !isElementAtCurrentStepMounted)
   ) {

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -338,9 +338,7 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     const subPlugins = await this.createSubPlugins();
     return {
       alerts: subPlugins.alerts.start(storage),
-      attackDiscovery: subPlugins.attackDiscovery.start(
-        this.experimentalFeatures.attackDiscoveryEnabled
-      ),
+      attackDiscovery: subPlugins.attackDiscovery.start(),
       cases: subPlugins.cases.start(),
       cloudDefend: subPlugins.cloudDefend.start(),
       cloudSecurityPosture: subPlugins.cloudSecurityPosture.start(),

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -559,7 +559,6 @@ export class Plugin implements ISecuritySolutionPlugin {
     plugins.elasticAssistant.registerTools(APP_UI_ID, getAssistantTools());
     plugins.elasticAssistant.registerFeatures(APP_UI_ID, {
       assistantModelEvaluation: config.experimentalFeatures.assistantModelEvaluation,
-      attackDiscoveryEnabled: config.experimentalFeatures.attackDiscoveryEnabled,
     });
     plugins.elasticAssistant.registerFeatures('management', {
       assistantModelEvaluation: config.experimentalFeatures.assistantModelEvaluation,

--- a/x-pack/test/plugin_functional/test_suites/global_search/global_search_providers.ts
+++ b/x-pack/test/plugin_functional/test_suites/global_search/global_search_providers.ts
@@ -87,7 +87,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     describe('Applications provider', function () {
       it('can search for root-level applications', async () => {
         const results = await findResultsWithApi('discover');
-        expect(results.length).to.be(1);
+        expect(results.length).to.be(2);
         expect(results[0].title).to.be('Discover');
       });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Security Solution] [Attack discovery] Removes the Attack discovery feature flag (#182975)](https://github.com/elastic/kibana/pull/182975)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Andrew Macri","email":"andrew.macri@elastic.co"},"sourceCommit":{"committedDate":"2024-05-09T07:48:10Z","message":"[Security Solution] [Attack discovery] Removes the Attack discovery feature flag (#182975)\n\n## [Security Solution] [Attack discovery] Removes the Attack discovery feature flag\r\n\r\n### Summary\r\n\r\nThis PR removes the feature flag required to enable the _Attack discovery_ feature.\r\n\r\nIt (always) enables the Attack discovery feature in both self managed and serverless deployments.\r\n\r\n### Desk testing\r\n\r\n1. REMOVE the `attackDiscoveryEnabled` feature flag if it was previously enabled in `kibana.dev.yml`:\r\n\r\n```\r\n# xpack.securitySolution.enableExperimental: ['attackDiscoveryEnabled']\r\n```\r\n\r\n2. Restart Kibana\r\n\r\n3. Navigate to Security > Attack discovery\r\n\r\n**Expected results**\r\n\r\n- `Attack discovery` appears in the global navigation, below `Alerts`\r\n- The contents of the `Attack discovery` page are displayed, per the self managed and serverless examples in the screenshots below:\r\n\r\n![self_managed](https://github.com/elastic/kibana/assets/4459398/40d9c23c-af67-476b-997b-fca0ac1c5467)\r\n\r\n_Above: Attack discovery in self managed_\r\n\r\n![attack_discovery_serverless](https://github.com/elastic/kibana/assets/4459398/1dadcf1a-8a46-4bd5-8b78-df1135e5933f)\r\n\r\n_Above: Attack discovery in serverless_","sha":"39fe68e8fac20228d5edd417359bd144bb7c532f","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Security Generative AI","v8.14.0","v8.15.0","Feature:Attack Discovery"],"number":182975,"url":"https://github.com/elastic/kibana/pull/182975","mergeCommit":{"message":"[Security Solution] [Attack discovery] Removes the Attack discovery feature flag (#182975)\n\n## [Security Solution] [Attack discovery] Removes the Attack discovery feature flag\r\n\r\n### Summary\r\n\r\nThis PR removes the feature flag required to enable the _Attack discovery_ feature.\r\n\r\nIt (always) enables the Attack discovery feature in both self managed and serverless deployments.\r\n\r\n### Desk testing\r\n\r\n1. REMOVE the `attackDiscoveryEnabled` feature flag if it was previously enabled in `kibana.dev.yml`:\r\n\r\n```\r\n# xpack.securitySolution.enableExperimental: ['attackDiscoveryEnabled']\r\n```\r\n\r\n2. Restart Kibana\r\n\r\n3. Navigate to Security > Attack discovery\r\n\r\n**Expected results**\r\n\r\n- `Attack discovery` appears in the global navigation, below `Alerts`\r\n- The contents of the `Attack discovery` page are displayed, per the self managed and serverless examples in the screenshots below:\r\n\r\n![self_managed](https://github.com/elastic/kibana/assets/4459398/40d9c23c-af67-476b-997b-fca0ac1c5467)\r\n\r\n_Above: Attack discovery in self managed_\r\n\r\n![attack_discovery_serverless](https://github.com/elastic/kibana/assets/4459398/1dadcf1a-8a46-4bd5-8b78-df1135e5933f)\r\n\r\n_Above: Attack discovery in serverless_","sha":"39fe68e8fac20228d5edd417359bd144bb7c532f"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/182975","number":182975,"mergeCommit":{"message":"[Security Solution] [Attack discovery] Removes the Attack discovery feature flag (#182975)\n\n## [Security Solution] [Attack discovery] Removes the Attack discovery feature flag\r\n\r\n### Summary\r\n\r\nThis PR removes the feature flag required to enable the _Attack discovery_ feature.\r\n\r\nIt (always) enables the Attack discovery feature in both self managed and serverless deployments.\r\n\r\n### Desk testing\r\n\r\n1. REMOVE the `attackDiscoveryEnabled` feature flag if it was previously enabled in `kibana.dev.yml`:\r\n\r\n```\r\n# xpack.securitySolution.enableExperimental: ['attackDiscoveryEnabled']\r\n```\r\n\r\n2. Restart Kibana\r\n\r\n3. Navigate to Security > Attack discovery\r\n\r\n**Expected results**\r\n\r\n- `Attack discovery` appears in the global navigation, below `Alerts`\r\n- The contents of the `Attack discovery` page are displayed, per the self managed and serverless examples in the screenshots below:\r\n\r\n![self_managed](https://github.com/elastic/kibana/assets/4459398/40d9c23c-af67-476b-997b-fca0ac1c5467)\r\n\r\n_Above: Attack discovery in self managed_\r\n\r\n![attack_discovery_serverless](https://github.com/elastic/kibana/assets/4459398/1dadcf1a-8a46-4bd5-8b78-df1135e5933f)\r\n\r\n_Above: Attack discovery in serverless_","sha":"39fe68e8fac20228d5edd417359bd144bb7c532f"}}]}] BACKPORT-->