### PR TITLE
[jest_integration] Reduce --max-old-space-size, add --trace-warnings

### DIFF
--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -57,7 +57,10 @@ echo "
 while read -r config; do
   echo "--- $ node scripts/jest --config $config"
 
-  cmd="NODE_OPTIONS=\"--max-old-space-size=14336\" node ./scripts/jest --config=\"$config\" $parallelism --coverage=false --passWithNoTests"
+  # --trace-warnings to debug
+  # Node.js process-warning detected:
+  # Warning: Closing file descriptor 24 on garbage collection
+  cmd="NODE_OPTIONS=\"--max-old-space-size=12288 --trace-warnings\" node ./scripts/jest --config=\"$config\" $parallelism --coverage=false --passWithNoTests"
   echo "actual full command is:"
   echo "$cmd"
   echo ""


### PR DESCRIPTION
We're seeing a process closed on garbage collection, with the subsequent warning terminating Node.js.  This adds the trace-warnings flag to jest tests.  This also reduces the max-old-space-size - there's 1.5gb allocated to the OS and up to 3 elasticsearch nodes, which is not enough.

https://buildkite.com/elastic/kibana-on-merge/builds/45020#018f5bd0-04c0-4427-b897-c398b9c29550