### PR TITLE
[ci/on-merge] Security solution tests depend on quick_checks

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -96,7 +96,9 @@ steps:
     label: 'Serverless Entity Analytics - Security Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -108,7 +110,9 @@ steps:
     label: 'Serverless Explore - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -120,7 +124,9 @@ steps:
     label: 'Serverless Investigations - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -132,7 +138,9 @@ steps:
     label: 'Serverless Rule Management - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -144,7 +152,9 @@ steps:
     label: 'Serverless Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -156,7 +166,9 @@ steps:
     label: 'Rule Management - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 4
     retry:
@@ -168,7 +180,9 @@ steps:
     label: 'Rule Management - Prebuilt Rules - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 6
     retry:
@@ -180,7 +194,9 @@ steps:
     label: 'Serverless Detection Engine - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -192,7 +208,9 @@ steps:
     label: 'Serverless Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 6
     retry:
@@ -204,7 +222,9 @@ steps:
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 5
     retry:
@@ -216,7 +236,9 @@ steps:
     label: 'Detection Engine - Exceptions - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 6
     retry:
@@ -228,7 +250,9 @@ steps:
     label: 'Serverless AI Assistant - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -240,7 +264,9 @@ steps:
     label: 'AI Assistant - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -252,7 +278,9 @@ steps:
     label: 'Entity Analytics - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 2
     retry:
@@ -264,7 +292,9 @@ steps:
     label: 'Explore - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 3
     retry:
@@ -276,7 +306,9 @@ steps:
     label: 'Investigations - Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 7
     retry:
@@ -288,7 +320,9 @@ steps:
     label: 'Threat Intelligence Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 1
     retry:
@@ -300,7 +334,9 @@ steps:
     label: 'Osquery Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -312,7 +348,9 @@ steps:
     label: 'Serverless Osquery Cypress Tests'
     agents:
       queue: n2-4-spot
-    depends_on: build
+    depends_on:
+      - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 8
     retry:
@@ -326,6 +364,7 @@ steps:
       queue: n2-4-virt
     depends_on:
       - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 20
     retry:
@@ -339,6 +378,7 @@ steps:
       queue: n2-4-virt
     depends_on:
       - build
+      - quick_checks
     timeout_in_minutes: 60
     parallelism: 14
     retry:
@@ -351,6 +391,7 @@ steps:
     timeout_in_minutes: 10
     depends_on:
       - build
+      - quick_checks
     agents:
       queue: 'kibana-default'
 


### PR DESCRIPTION
Currently, if quick checks fail, security solution tests will continue to run.  We want to skip running the extended test suite.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->