### PR TITLE
[IM] Fix broken index settings page in serverless

### DIFF
--- a/x-pack/plugins/index_management/server/routes/api/settings/register_load_route.ts
+++ b/x-pack/plugins/index_management/server/routes/api/settings/register_load_route.ts
@@ -30,7 +30,6 @@ export function registerLoadRoute({ router, lib: { handleEsError } }: RouteDepen
       const params = {
         expand_wildcards: 'none' as const,
         flat_settings: false,
-        local: false,
         include_defaults: true,
         index: indexName,
       };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/183038

## Summary

This PR fixes the broken index settings details page by removing the `local` parameter from the Es request for fetching index settings (since this parameter is not available in serverless). This change will also remove the parameter in stateful, but this shouldn't cause issues since the parameter's default value is `false` anyway (as per the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html#get-index-settings-api-query-params)).

To test in a serverless project on Cloud:
1. If you haven't done yet, configure Vault locally (https://docs.elastic.dev/ci/using-secrets#installing-vault).
2. Run `export VAULT_ADDR=https://secrets.elastic.co:8200`
3. Log into Vault: `vault login --method github`
4. Obtain the credentials: `vault read secret/kibana-issues/dev/cloud-deploy/kibana-pr-183044-elasticsearch`
5. Access the CI Cloud serverless project for this PR: https://kibana-pr-183044-elasticsearch-b33339.kb.eu-west-1.aws.qa.elastic.cloud/login
6. Log in with the obtained credentials.
7. Go to Stack Management -> Index Management.
8. Switch the hidden indices toggle and click on one of the indices to open the index details page.
9. Navigate to the Settings tab and verify that the page is loading correctly.

<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->
