### PR TITLE
[i18n] Identify renamed methods

### DIFF
--- a/src/dev/i18n/extract_default_translations.js
+++ b/src/dev/i18n/extract_default_translations.js
@@ -48,7 +48,7 @@ See .i18nrc.json for the list of supported namespaces.`)
   }
 }
 
-export async function matchEntriesWithExctractors(inputPath, options = {}) {
+export async function matchEntriesWithExtractors(inputPath, options = {}) {
   const { additionalIgnore = [], mark = false, absolute = false } = options;
   const ignore = [
     '**/node_modules/**',
@@ -77,7 +77,7 @@ export async function matchEntriesWithExctractors(inputPath, options = {}) {
 }
 
 export async function extractMessagesFromPathToMap(inputPath, targetMap, config, reporter) {
-  const { entries, extractFunction } = await matchEntriesWithExctractors(inputPath);
+  const { entries, extractFunction } = await matchEntriesWithExtractors(inputPath);
 
   const files = await Promise.all(
     filterEntries(entries, config.exclude).map(async (entry) => {

--- a/src/dev/i18n/index.ts
+++ b/src/dev/i18n/index.ts
@@ -9,7 +9,7 @@
 // @ts-ignore
 export { extractMessagesFromPathToMap } from './extract_default_translations';
 // @ts-ignore
-export { matchEntriesWithExctractors } from './extract_default_translations';
+export { matchEntriesWithExtractors } from './extract_default_translations';
 export { arrayify, writeFileAsync, readFileAsync, normalizePath, ErrorReporter } from './utils';
 export { serializeToJson, serializeToJson5 } from './serializers';
 export type { I18nConfig } from './config';

--- a/src/dev/i18n/tasks/extract_untracked_translations.ts
+++ b/src/dev/i18n/tasks/extract_untracked_translations.ts
@@ -7,7 +7,7 @@
  */
 
 import { createFailError } from '@kbn/dev-cli-errors';
-import { matchEntriesWithExctractors } from '../extract_default_translations';
+import { matchEntriesWithExtractors } from '../extract_default_translations';
 import { I18nConfig } from '../config';
 import { normalizePath, readFileAsync, ErrorReporter } from '../utils';
 import { I18nCheckTaskContext } from '../types';
@@ -42,7 +42,7 @@ export async function extractUntrackedMessagesTask({
     '**/dist/**',
   ]);
   for (const inputPath of inputPaths) {
-    const { entries, extractFunction } = await matchEntriesWithExctractors(inputPath, {
+    const { entries, extractFunction } = await matchEntriesWithExtractors(inputPath, {
       additionalIgnore: ignore,
       mark: true,
       absolute: true,

--- a/src/dev/i18n/utils/utils.test.js
+++ b/src/dev/i18n/utils/utils.test.js
@@ -20,18 +20,6 @@ import {
   extractMessageValueFromNode,
 } from './utils';
 
-const i18nTranslateSources = ['i18n', 'i18n.translate'].map(
-  (callee) => `
-${callee}('plugin_1.id_1', {
-  values: {
-    key: 'value',
-  },
-  defaultMessage: 'Message text',
-  description: 'Message description'
-});
-`
-);
-
 const objectPropertySource = `
 const object = {
   id: 'value',
@@ -51,21 +39,25 @@ describe('i18n utils', () => {
     ).toMatchSnapshot();
   });
 
-  test('should detect i18n translate function call', () => {
-    let source = i18nTranslateSources[0];
-    let expressionStatementNode = [...traverseNodes(parse(source).program.body)].find((node) =>
-      isExpressionStatement(node)
-    );
+  test.each(['i18n', 'i18n.translate', 't.translate', 'kbni18n.translate', 'I18N.translate'])(
+    'should detect %s() translate function call',
+    (callee) => {
+      const source = `
+${callee}('plugin_1.id_1', {
+  values: {
+    key: 'value',
+  },
+  defaultMessage: 'Message text',
+  description: 'Message description'
+});
+`;
+      const expressionStatementNode = [...traverseNodes(parse(source).program.body)].find((node) =>
+        isExpressionStatement(node)
+      );
 
-    expect(isI18nTranslateFunction(expressionStatementNode.expression)).toBe(true);
-
-    source = i18nTranslateSources[1];
-    expressionStatementNode = [...traverseNodes(parse(source).program.body)].find((node) =>
-      isExpressionStatement(node)
-    );
-
-    expect(isI18nTranslateFunction(expressionStatementNode.expression)).toBe(true);
-  });
+      expect(isI18nTranslateFunction(expressionStatementNode.expression)).toBe(true);
+    }
+  );
 
   test('should detect object property with defined key', () => {
     const objectExpresssionNode = [...traverseNodes(parse(objectPropertySource).program.body)].find(

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/legacy_url_conflict_callout.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/legacy_url_conflict_callout.tsx
@@ -27,7 +27,7 @@ export const LegacyUrlConflictCallOut = React.memo<LegacyUrlConflictCallOutProps
           <EuiSpacer />
           {spacesApi.ui.components.getLegacyUrlConflict({
             objectNoun: i18nTranslate.translate(
-              'xpack.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
+              'xpack.securitySolution.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
               {
                 defaultMessage: 'rule',
               }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/use_redirect_legacy_url.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/use_redirect_legacy_url.ts
@@ -26,7 +26,7 @@ export const useLegacyUrlRedirect = ({ rule, spacesApi }: UseLegacyUrlRedirectPa
           path,
           aliasPurpose: rule.alias_purpose,
           objectNoun: i18nTranslate.translate(
-            'xpack.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
+            'xpack.securitySolution.triggersActionsUI.sections.ruleDetails.redirectObjectNoun',
             { defaultMessage: 'rule' }
           ),
         });


### PR DESCRIPTION
## Summary

Resolves #181771

### How to test

Running the command below updates the file `x-pack/plugins/translations/translations/en.json` and we can see the missing translations are showing up.

```Shell
node scripts/i18n_extract.js --output-dir x-pack/plugins/translations/translations
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| There could be other usages like `const t = i18n.translate; t('message-id', ...)`. | Low | High | We may want to change the script to be TS-aware, so that it can find all the references to the function instead of looking for usage patterns. But that's a quite large effort. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

#### Backport strategy

I figured we don't want to backport this because we won't likely translate any missing keys for past releases. Should we backport anyway?
