### PR TITLE
[ML] Single Metric Viewer embeddable in dashboards: ensures edit to different job works as expected

### DIFF
--- a/x-pack/plugins/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
+++ b/x-pack/plugins/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
@@ -282,7 +282,8 @@ export const getSingleMetricViewerEmbeddableFactory = (
                       >
                         {singleMetricViewerData !== undefined &&
                           autoZoomDuration !== undefined &&
-                          jobsLoaded && (
+                          jobsLoaded &&
+                          selectedJobId === selectedJob?.job_id && (
                             <TimeSeriesExplorerEmbeddableChart
                               chartWidth={chartWidth - containerPadding}
                               dataViewsService={services[1].data.dataViews}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/pull/182756#issuecomment-2102400873

This PR ensures the loaded job and the selected job id are synced to ensure the chart loads correctly.

After:


https://github.com/elastic/kibana/assets/6446462/4c80bdd6-54cd-4404-8fa4-8930aca1b3f9




<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->