### PR TITLE
Re-enable saved query security tests except Maps

### DIFF
--- a/x-pack/test/functional/apps/saved_query_management/feature_controls/security.ts
+++ b/x-pack/test/functional/apps/saved_query_management/feature_controls/security.ts
@@ -10,14 +10,7 @@ import { getSavedQuerySecurityUtils } from '../utils/saved_query_security';
 
 type AppName = 'discover' | 'dashboard' | 'maps' | 'visualize';
 
-const apps: AppName[] = [
-  'discover',
-  'dashboard',
-  // Commenting out maps to due to test flakiness, re-enable to resolve
-  // https://github.com/elastic/kibana/issues/183066
-  // 'maps',
-  'visualize',
-];
+const apps: AppName[] = ['discover', 'dashboard', 'maps', 'visualize'];
 
 export default function (ctx: FtrProviderContext) {
   const { getPageObjects, getService } = ctx;

--- a/x-pack/test/functional/apps/saved_query_management/feature_controls/security.ts
+++ b/x-pack/test/functional/apps/saved_query_management/feature_controls/security.ts
@@ -10,7 +10,14 @@ import { getSavedQuerySecurityUtils } from '../utils/saved_query_security';
 
 type AppName = 'discover' | 'dashboard' | 'maps' | 'visualize';
 
-const apps: AppName[] = ['discover', 'dashboard', 'maps', 'visualize'];
+const apps: AppName[] = [
+  'discover',
+  'dashboard',
+  // Commenting out maps to due to test flakiness, re-enable to resolve
+  // https://github.com/elastic/kibana/issues/183066
+  // 'maps',
+  'visualize',
+];
 
 export default function (ctx: FtrProviderContext) {
   const { getPageObjects, getService } = ctx;
@@ -91,8 +98,7 @@ export default function (ctx: FtrProviderContext) {
     }
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/183066
-  describe.skip('Security: App vs Global privilege', () => {
+  describe('Security: App vs Global privilege', () => {
     apps.forEach((appName) => {
       before(async () => {
         await kibanaServer.savedObjects.cleanStandardList();


### PR DESCRIPTION
## Summary

This PR unskips the saved query security tests aside from the Maps tests, which are the flaky ones and appear to be failing for reasons unrelated to these tests (see https://github.com/elastic/kibana/issues/183066#issuecomment-2103285491 for more details).

**Update:** the issue was an update to the Maps service causing a temporary outage and Kibana failing to load base maps, resulting in these test failures. The outage has now been resolved and these tests should pass as expected now.

Resolves #183066.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)