### PR TITLE
Revert "skip failing test suite (#183067)"

### DIFF
--- a/x-pack/test/functional/apps/maps/group4/add_layer_panel.js
+++ b/x-pack/test/functional/apps/maps/group4/add_layer_panel.js
@@ -12,8 +12,7 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['maps']);
   const security = getService('security');
 
-  // Failing: See https://github.com/elastic/kibana/issues/183067
-  describe.skip('Add layer panel', () => {
+  describe('Add layer panel', () => {
     before(async () => {
       await security.testUser.setRoles(['global_maps_all', 'test_logstash_reader']);
       await PageObjects.maps.openNewMap();


### PR DESCRIPTION
## Summary

Re-enable functional test in 8.14 branch. The test failed likely due to a brief service interruption in Elastic Maps Service as the basemaps failed to load.

[Flaky test runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5922)