### PR TITLE
[ML] Anomaly Detection: Fix API integration tests for field caps.

### DIFF
--- a/x-pack/test/api_integration/apis/ml/indices/field_caps.ts
+++ b/x-pack/test/api_integration/apis/ml/indices/field_caps.ts
@@ -30,10 +30,7 @@ export default ({ getService }: FtrProviderContext) => {
     return body;
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/182837
-  describe.skip('field_caps', function () {
-    // Failing ES Forward Compatibility: https://github.com/elastic/kibana/issues/182514
-    this.onlyEsVersion('>=8');
+  describe('field_caps', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
     });
@@ -64,9 +61,16 @@ export default ({ getService }: FtrProviderContext) => {
         `Expected number of indices to be 1, but got ${indices.length}`
       );
       const fieldsLength = Object.keys(fields).length;
+
+      // The number of fields returned by the field caps API is different across
+      // ES versions in forward compatibility tests. In ES 8.15.0, the `_ignored_source`
+      // field was added (https://github.com/elastic/elasticsearch/pull/107567).
+      const esVersion = getService('esVersion');
+      const expectedFieldsLength = esVersion.matchRange('>=8.15') ? 22 : 21;
+
       expect(fieldsLength).to.eql(
-        21,
-        `Expected number of fields to be 21, but got ${fieldsLength}`
+        expectedFieldsLength,
+        `Expected number of fields to be ${expectedFieldsLength}, but got ${fieldsLength}`
       );
     });
   });


### PR DESCRIPTION
## Summary

Fixes #182837.
Fixes #182514.

The number of fields returned by the field caps API is different across ES versions in forward compatibility tests. In ES 8.15.0, the `_ignored_source` field was added (https://github.com/elastic/elasticsearch/pull/107567). This fixes the API integration test for field caps to assert the correct number of fields across versions. Note that in Kibana `8.15` we refactored away from using fields caps directly in this way and removed the corresponding API endpoint and tests (https://github.com/elastic/kibana/pull/182588), that's why there's this dedicated `7.17` PR to just fix the assertions on the existing test.

To test this locally, the following commands for the functional tests server and runner can be used to run the tests in different forward compatibility scenarios:

```
# 7.17 tests server
node scripts/functional_tests_server.js --config x-pack/test/api_integration/config.ts
# 7.17 tests runner
node scripts/functional_test_runner --config x-pack/test/api_integration/config.ts

# 8.14 tests server
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.14.0/manifest-latest-verified.json" node scripts/functional_tests_server.js  --config x-pack/test/api_integration/config.ts
# 8.14 tests runner
node scripts/functional_test_runner --config x-pack/test/api_integration/config.ts --es-version=8.14.0-SNAPSHOT

# 8.15 tests server
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.15.0/manifest-latest-verified.json" node scripts/functional_tests_server.js  --config x-pack/test/api_integration/config.ts
# 8.15 tests runner
node scripts/functional_test_runner --config x-pack/test/api_integration/config.ts --es-version=8.15.0-SNAPSHOT
```

Note in `7.17` the API integration tests are not split up yet into several configs so the commands above will run ALL Kibana API integration tests.

The command to run the tests server for a specific ES version is also shared in the buildkite reports, for example: https://buildkite.com/elastic/kibana-7-dot-17-es-8-dot-15-forward-compatibility/builds/20#annotation-es-snapshot-manifest

The versions the compatibility tests will currently run against can be found here: https://github.com/elastic/kibana/blob/main/versions.json

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
