### PR TITLE
Serverless search tests - recreate default data view

### DIFF
--- a/x-pack/test_serverless/api_integration/services/index.ts
+++ b/x-pack/test_serverless/api_integration/services/index.ts
@@ -11,7 +11,6 @@ import { services as svlSharedServices } from '../../shared/services';
 
 import { AlertingApiProvider } from './alerting_api';
 import { SamlToolsProvider } from './saml_tools';
-import { DataViewApiProvider } from './data_view_api';
 import { SvlCasesServiceProvider } from './svl_cases';
 import { SloApiProvider } from './slo_api';
 import { TransformProvider } from './transform';
@@ -24,7 +23,6 @@ export const services = {
   ...svlSharedServices,
   alertingApi: AlertingApiProvider,
   samlTools: SamlToolsProvider,
-  dataViewApi: DataViewApiProvider,
   svlCases: SvlCasesServiceProvider,
   sloApi: SloApiProvider,
   transform: TransformProvider,

--- a/x-pack/test_serverless/functional/test_suites/search/default_dataview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/default_dataview.ts
@@ -12,18 +12,26 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const svlCommonNavigation = getPageObject('svlCommonNavigation');
   const svlCommonPage = getPageObject('svlCommonPage');
+  const dataViewApi = getService('dataViewApi');
 
   describe('default dataView', function () {
     before(async () => {
       await svlCommonPage.login();
       await svlSearchNavigation.navigateToLandingPage();
+
+      // re-create the default data view in case it has been cleaned up by another test
+      await dataViewApi.create({
+        id: 'default_all_data_id',
+        name: 'default:all-data',
+        title: '*,-.*',
+      });
     });
 
     after(async () => {
       await svlCommonPage.forceLogout();
     });
 
-    it('should show dashboard but with no data', async () => {
+    it('should show discover but with no data', async () => {
       await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'discover' });
       await testSubjects.existOrFail('~breadcrumb-deepLinkId-discover');
       await testSubjects.existOrFail('discover-dataView-switch-link');

--- a/x-pack/test_serverless/shared/services/data_view_api.ts
+++ b/x-pack/test_serverless/shared/services/data_view_api.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../ftr_provider_context';
+import { FtrProviderContext } from '../../functional/ftr_provider_context';
 
 export function DataViewApiProvider({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');

--- a/x-pack/test_serverless/shared/services/index.ts
+++ b/x-pack/test_serverless/shared/services/index.ts
@@ -9,6 +9,7 @@ import { SupertestProvider, SupertestWithoutAuthProvider } from './supertest';
 import { SvlCommonApiServiceProvider } from './svl_common_api';
 import { SvlReportingServiceProvider } from './svl_reporting';
 import { SvlUserManagerProvider } from './svl_user_manager';
+import { DataViewApiProvider } from './data_view_api';
 
 export type { RoleCredentials } from './svl_user_manager';
 
@@ -18,4 +19,5 @@ export const services = {
   svlCommonApi: SvlCommonApiServiceProvider,
   svlReportingApi: SvlReportingServiceProvider,
   svlUserManager: SvlUserManagerProvider,
+  dataViewApi: DataViewApiProvider,
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue with serverless search tests when running against MKI. Due to a different test run order there, the search project default data view does not necessarily exist anymore when the test runs (as another test might have cleaned it up already). To fix this, the default data view is re-created during `before` of the default data view test suite.

As part of this PR, the `data_view_api` service is moved from the `api_integration` services to the `shared` services, so it can be used from functional tests as well.
