### PR TITLE
[artifacts/package-testing] Fix rpm install

### DIFF
--- a/test/package/Vagrantfile
+++ b/test/package/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
     rpm.vm.box = 'almalinux/9'
     # `rpm -i` is broken in 9.4 when installing from a shared folder
     # alternative workaround is to copy /packages/kibana.tar.gz to the cwd
-    rpm.box_version = '9.3.20231118'
+    rpm.vm.box_version = '9.3.20231118'
     rpm.vm.provision "ansible" do |ansible|
       ansible.playbook = "rpm.yml"
     end

--- a/test/package/Vagrantfile
+++ b/test/package/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure("2") do |config|
       vb.cpus = 2
     end
     rpm.vm.box = 'almalinux/9'
+    # `rpm -i` is broken in 9.4 when installing from a shared folder
+    # alternative workaround is to copy /packages/kibana.tar.gz to the cwd
+    rpm.box_version = '9.3.20231118'
     rpm.vm.provision "ansible" do |ansible|
       ansible.playbook = "rpm.yml"
     end


### PR DESCRIPTION
The version of rpm installed with almalinux 9.4 isn't able to install from a shared folder.  This downgrades to 9.3 while we wait for a fix.

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4281

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->