### PR TITLE
[Search] [Playground] fix token history issue for chat

### DIFF
--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.ts
@@ -130,7 +130,7 @@ class ConversationalChainFn {
         question: (input) => input.question,
       },
       prompt,
-      this.options.model,
+      this.options.model.withConfig({ metadata: { type: 'question_answer_qa' } }),
     ]);
 
     const conversationalRetrievalQAChain = RunnableSequence.from([
@@ -140,11 +140,7 @@ class ConversationalChainFn {
       },
       answerChain,
       new BytesOutputParser(),
-    ]).withConfig({
-      metadata: {
-        type: 'conversational_retrieval_qa',
-      },
-    });
+    ]);
 
     const stream = await conversationalRetrievalQAChain.stream(
       {
@@ -163,7 +159,7 @@ class ConversationalChainFn {
               tags,
               metadata: Record<string, string>
             ) {
-              if (metadata?.type === 'conversational_retrieval_qa') {
+              if (metadata?.type === 'question_answer_qa') {
                 data.appendMessageAnnotation({
                   type: 'prompt_token_count',
                   count: getTokenEstimateFromMessages(msg),


### PR DESCRIPTION
Issue was that previously using withConfig on the parent chain. This meant all runs, including the standalone_question chain was `conversational_retrieval_qa`

Moving the metadata type to the ChatModel responsible for the QA part, this means only the QA chain and not the standalone_question chain counted the prompt tokens. 

Verified on both stateful and serverless


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->