### PR TITLE
[8.13] Revert "skip failing test suite (#183067)" (#183093)

### DIFF
--- a/x-pack/test/functional/apps/maps/group4/add_layer_panel.js
+++ b/x-pack/test/functional/apps/maps/group4/add_layer_panel.js
@@ -12,8 +12,7 @@ export default function ({ getService, getPageObjects }) {
   const PageObjects = getPageObjects(['maps']);
   const security = getService('security');
 
-  // Failing: See https://github.com/elastic/kibana/issues/183067
-  describe.skip('Add layer panel', () => {
+  describe('Add layer panel', () => {
     before(async () => {
       await security.testUser.setRoles(['global_maps_all', 'test_logstash_reader']);
       await PageObjects.maps.openNewMap();


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.14` to `8.13`:
 - [Revert "skip failing test suite (#183067)" (#183093)](https://github.com/elastic/kibana/pull/183093)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2024-05-10T12:49:29Z","message":"Revert \"skip failing test suite (#183067)\" (#183093)\n\n## Summary\r\n\r\nRe-enable functional test in 8.14 branch. The test failed likely due to\r\na brief service interruption in Elastic Maps Service as the basemaps\r\nfailed to load.\r\n\r\n[Flaky test\r\nrunner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5922)","sha":"687cb8d1b4938cf8be77d97902ef7a22a6f113d3","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip"],"number":183093,"url":"https://github.com/elastic/kibana/pull/183093","mergeCommit":{"message":"Revert \"skip failing test suite (#183067)\" (#183093)\n\n## Summary\r\n\r\nRe-enable functional test in 8.14 branch. The test failed likely due to\r\na brief service interruption in Elastic Maps Service as the basemaps\r\nfailed to load.\r\n\r\n[Flaky test\r\nrunner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5922)","sha":"687cb8d1b4938cf8be77d97902ef7a22a6f113d3"}},"sourceBranch":"8.14","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->