### PR TITLE
[Search] [Playground] Improve view code examples

### DIFF
--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_lang_client.test.tsx.snap
@@ -10,41 +10,41 @@ from openai import OpenAI
 
 
 es_client = Elasticsearch(
-  \\"http://my-local-cloud-instance\\",
-  api_key=os.environ[\\"ES_API_KEY\\"]
+    \\"http://my-local-cloud-instance\\",
+    api_key=os.environ[\\"ES_API_KEY\\"]
 )
       
 
 openai_client = OpenAI(
-  api_key=os.environ[\\"OPENAI_API_KEY\\"],
+    api_key=os.environ[\\"OPENAI_API_KEY\\"],
 )
 
 index_source_fields = {
-  \\"index1\\": [
-    \\"field1\\"
-  ],
-  \\"index2\\": [
-    \\"field2\\"
-  ]
+    \\"index1\\": [
+        \\"field1\\"
+    ],
+    \\"index2\\": [
+        \\"field2\\"
+    ]
 }
 
 def get_elasticsearch_results(query):
-  es_query = {
-    \\"query\\": {},
-    \\"size\\": 10
-  }
+    es_query = {
+        \\"query\\": {},
+        \\"size\\": 10
+    }
 
-  result = es.search(index=\\"index1,index2\\", body=es_query)
-  return result[\\"hits\\"][\\"hits\\"]
+    result = es_client.search(index=\\"index1,index2\\", body=es_query)
+    return result[\\"hits\\"][\\"hits\\"]
 
 def create_openai_prompt(question, results):
-  context = \\"\\"
-  for hit in results:
-    source_field = index_source_fields.get(hit[\\"_index\\"])[0]
-    hit_context = hit[\\"_source\\"][source_field]
-    context += f\\"{hit_context}\\\\n\\"
+    context = \\"\\"
+    for hit in results:
+      source_field = index_source_fields.get(hit[\\"_index\\"])[0]
+      hit_context = hit[\\"_source\\"][source_field]
+      context += f\\"{hit_context}\\\\n\\"
 
-  prompt = f\\"\\"\\"
+    prompt = f\\"\\"\\"
   Instructions:
   
   - Your prompt
@@ -62,25 +62,25 @@ def create_openai_prompt(question, results):
   Answer:
   \\"\\"\\"
 
-  return prompt
+    return prompt
 
 def generate_openai_completion(user_prompt):
-  response = openai_client.chat.completions.create(
-    model=\\"gpt-3.5-turbo\\",
-    messages=[
-      {\\"role\\": \\"system\\", \\"content\\": \\"You are an assistant for question-answering tasks.\\"},
-      {\\"role\\": \\"user\\", \\"content\\": user_prompt},
-    ]
-  )
+    response = openai_client.chat.completions.create(
+        model=\\"gpt-3.5-turbo\\",
+        messages=[
+            {\\"role\\": \\"system\\", \\"content\\": \\"You are an assistant for question-answering tasks.\\"},
+            {\\"role\\": \\"user\\", \\"content\\": user_prompt},
+        ]
+    )
 
-  return response.choices[0].message.content
+    return response.choices[0].message.content
 
 if __name__ == \\"__main__\\":
-  question = \\"my question\\"
-  elasticsearch_results = get_elasticsearch_results(question)
-  context_prompt = create_openai_prompt(question, elasticsearch_results)
-  openai_completion = generate_openai_completion(context_prompt)
-  print(openai_completion)
+    question = \\"my question\\"
+    elasticsearch_results = get_elasticsearch_results(question)
+    context_prompt = create_openai_prompt(question, elasticsearch_results)
+    openai_completion = generate_openai_completion(context_prompt)
+    print(openai_completion)
 
 "
 `;

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/__snapshots__/py_langchain_python.test.tsx.snap
@@ -14,36 +14,32 @@ from langchain.prompts.prompt import PromptTemplate
 import os
 
 es_client = Elasticsearch(
-  \\"http://my-local-cloud-instance\\",
-  api_key=os.environ[\\"ES_API_KEY\\"]
+    \\"http://my-local-cloud-instance\\",
+    api_key=os.environ[\\"ES_API_KEY\\"]
 )
       
 
 def build_query(query):
-  return {
-    \\"query\\": {}
-  }
+    return {
+        \\"query\\": {}
+    }
 
 index_source_fields = {
-  \\"index1\\": [
-    \\"field1\\"
-  ],
-  \\"index2\\": [
-    \\"field2\\"
-  ]
+    \\"index1\\": \\"field1\\",
+    \\"index2\\": \\"field2\\"
 }
 
 retriever = ElasticsearchRetriever(
-  index_name=\\"index1,index2\\",
-  body_func=build_query,
-  content_field=index_source_fields,
-  es_client=es_client
+    index_name=\\"index1,index2\\",
+    body_func=build_query,
+    content_field=index_source_fields,
+    es_client=es_client
 )
 
 model = ChatOpenAI(openai_api_key=os.environ[\\"OPENAI_API_KEY\\"], model_name=\\"gpt-3.5-turbo\\")
 
 ANSWER_PROMPT = ChatPromptTemplate.from_template(
-  f\\"\\"\\"
+    \\"\\"\\"
   Instructions:
   
   - Your prompt
@@ -65,14 +61,14 @@ ANSWER_PROMPT = ChatPromptTemplate.from_template(
 DEFAULT_DOCUMENT_PROMPT = PromptTemplate.from_template(template=\\"{page_content}\\")
 
 def _combine_documents(
-  docs, document_prompt=DEFAULT_DOCUMENT_PROMPT, document_separator=\\"\\\\n\\\\n\\"
+    docs, document_prompt=DEFAULT_DOCUMENT_PROMPT, document_separator=\\"\\\\n\\\\n\\"
 ):
-  doc_strings = [format_document(doc, document_prompt) for doc in docs]
-  return document_separator.join(doc_strings)
+    doc_strings = [format_document(doc, document_prompt) for doc in docs]
+    return document_separator.join(doc_strings)
 
 _context = {
-  \\"context\\": retriever | _combine_documents,
-  \\"question\\": RunnablePassthrough(),
+    \\"context\\": retriever | _combine_documents,
+    \\"question\\": RunnablePassthrough(),
 }
 
 chain = _context | ANSWER_PROMPT | model | StrOutputParser()

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
@@ -23,52 +23,52 @@ from openai import OpenAI
 ${clientDetails}
 
 openai_client = OpenAI(
-  api_key=os.environ["OPENAI_API_KEY"],
+    api_key=os.environ["OPENAI_API_KEY"],
 )
 
-index_source_fields = ${JSON.stringify(formValues.source_fields, null, 2)}
+index_source_fields = ${JSON.stringify(formValues.source_fields, null, 4)}
 
 def get_elasticsearch_results(query):
-  es_query = ${getESQuery({
-    ...formValues.elasticsearch_query,
-    size: formValues.doc_size,
-  })}
+    es_query = ${getESQuery({
+      ...formValues.elasticsearch_query,
+      size: formValues.doc_size,
+    })}
 
-  result = es.search(index="${formValues.indices.join(',')}", body=es_query)
-  return result["hits"]["hits"]
+    result = es_client.search(index="${formValues.indices.join(',')}", body=es_query)
+    return result["hits"]["hits"]
 
 def create_openai_prompt(question, results):
-  context = ""
-  for hit in results:
-    source_field = index_source_fields.get(hit["_index"])[0]
-    hit_context = hit["_source"][source_field]
-    context += f"{hit_context}\\n"
+    context = ""
+    for hit in results:
+      source_field = index_source_fields.get(hit["_index"])[0]
+      hit_context = hit["_source"][source_field]
+      context += f"{hit_context}\\n"
 
-  prompt = f"""${Prompt(formValues.prompt, {
-    context: true,
-    citations: formValues.citations,
-    type: 'openai',
-  })}"""
+    prompt = f"""${Prompt(formValues.prompt, {
+      context: true,
+      citations: formValues.citations,
+      type: 'openai',
+    })}"""
 
-  return prompt
+    return prompt
 
 def generate_openai_completion(user_prompt):
-  response = openai_client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    messages=[
-      {"role": "system", "content": "You are an assistant for question-answering tasks."},
-      {"role": "user", "content": user_prompt},
-    ]
-  )
+    response = openai_client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": "You are an assistant for question-answering tasks."},
+            {"role": "user", "content": user_prompt},
+        ]
+    )
 
-  return response.choices[0].message.content
+    return response.choices[0].message.content
 
 if __name__ == "__main__":
-  question = "my question"
-  elasticsearch_results = get_elasticsearch_results(question)
-  context_prompt = create_openai_prompt(question, elasticsearch_results)
-  openai_completion = generate_openai_completion(context_prompt)
-  print(openai_completion)
+    question = "my question"
+    elasticsearch_results = get_elasticsearch_results(question)
+    context_prompt = create_openai_prompt(question, elasticsearch_results)
+    openai_completion = generate_openai_completion(context_prompt)
+    print(openai_completion)
 
 `}
   </EuiCodeBlock>

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/utils.test.ts
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/utils.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getESQuery } from './utils';
+
+describe('getESQuery', () => {
+  it('should stringify and format the query correctly', () => {
+    const query = {
+      query: {
+        bool: {
+          should: [
+            {
+              match: {
+                field: '{query}',
+              },
+            },
+            {
+              match: {
+                field: '{query}',
+              },
+            },
+          ],
+        },
+      },
+    };
+    const expectedResult = `{
+  "query": {
+    "match": {
+      "field": query
+    }
+  }
+}`;
+    expect(getESQuery(query)).toEqual(expectedResult);
+  });
+
+  it('should handle invalid input gracefully', () => {
+    // Test when invalid input is provided
+    const invalidQuery = 'not a valid query';
+    // In this case, since the input is invalid, it should return an empty object
+    expect(getESQuery(invalidQuery)).toEqual('{}');
+  });
+
+  it('should handle empty input gracefully', () => {
+    // Test when empty input is provided
+    const emptyQuery = {};
+    // In this case, since the input is empty, it should return an empty object
+    expect(getESQuery(emptyQuery)).toEqual('{}');
+  });
+});

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/utils.test.ts
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/utils.test.ts
@@ -27,27 +27,25 @@ describe('getESQuery', () => {
         },
       },
     };
-    const expectedResult = `{
-  "query": {
-    "match": {
-      "field": query
-    }
-  }
-}`;
-    expect(getESQuery(query)).toEqual(expectedResult);
-  });
-
-  it('should handle invalid input gracefully', () => {
-    // Test when invalid input is provided
-    const invalidQuery = 'not a valid query';
-    // In this case, since the input is invalid, it should return an empty object
-    expect(getESQuery(invalidQuery)).toEqual('{}');
-  });
-
-  it('should handle empty input gracefully', () => {
-    // Test when empty input is provided
-    const emptyQuery = {};
-    // In this case, since the input is empty, it should return an empty object
-    expect(getESQuery(emptyQuery)).toEqual('{}');
+    expect(getESQuery(query)).toMatchInlineSnapshot(`
+      "{
+              \\"query\\": {
+                  \\"bool\\": {
+                      \\"should\\": [
+                          {
+                              \\"match\\": {
+                                  \\"field\\": query
+                              }
+                          },
+                          {
+                              \\"match\\": {
+                                  \\"field\\": query
+                              }
+                          }
+                      ]
+                  }
+              }
+          }"
+    `);
   });
 });

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
@@ -7,10 +7,10 @@
 
 export const getESQuery = (query: any) => {
   try {
-    return JSON.stringify(query, null, 2)
+    return JSON.stringify(query, null, 4)
       .replace(/"{query}"/g, 'query')
       .split('\n')
-      .map((line) => `  ${line}`)
+      .map((line) => `    ${line}`)
       .join('\n')
       .trim();
   } catch (e) {

--- a/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
+++ b/x-pack/plugins/search_playground/public/components/view_code/examples/utils.ts
@@ -8,7 +8,7 @@
 export const getESQuery = (query: any) => {
   try {
     return JSON.stringify(query, null, 2)
-      .replace('"{query}"', 'query')
+      .replace(/"{query}"/g, 'query')
       .split('\n')
       .map((line) => `  ${line}`)
       .join('\n')

--- a/x-pack/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
+++ b/x-pack/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
@@ -37,15 +37,15 @@ export const ES_CLIENT_DETAILS = (cloud: CloudSetup | undefined) => {
   if (cloud) {
     return `
 es_client = Elasticsearch(
-  "${cloud.elasticsearchUrl}",
-  api_key=os.environ["ES_API_KEY"]
+    "${cloud.elasticsearchUrl}",
+    api_key=os.environ["ES_API_KEY"]
 )
       `;
   }
 
   return `
 es_client = Elasticsearch(
-  "<your-elasticsearch-url>"
+    "<your-elasticsearch-url>"
 )
   `;
 };

--- a/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
+++ b/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
@@ -25,7 +25,7 @@ export const PlaygroundProvider: FC<PropsWithChildren<PlaygroundProviderProps>> 
     defaultValues: {
       prompt: 'You are an assistant for question-answering tasks.',
       doc_size: 3,
-      source_fields: [],
+      source_fields: {},
       indices: defaultValues?.indices || [],
     },
   });

--- a/x-pack/plugins/search_playground/public/types.ts
+++ b/x-pack/plugins/search_playground/public/types.ts
@@ -74,7 +74,7 @@ export interface ChatForm {
   [ChatFormFields.indices]: string[];
   [ChatFormFields.summarizationModel]: LLMModel;
   [ChatFormFields.elasticsearchQuery]: { query: QueryDslQueryContainer };
-  [ChatFormFields.sourceFields]: string[];
+  [ChatFormFields.sourceFields]: { [index: string]: string[] };
   [ChatFormFields.docSize]: number;
   [ChatFormFields.queryFields]: { [index: string]: string[] };
 }


### PR DESCRIPTION
## Summary

Improves couple of typos which prevented the example to run without modifications. Also updated the indenting.

Checked in stateful and es3.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->