### PR TITLE
[Discover][ES|QL] Show field stats per records instead of per values

### DIFF
--- a/packages/kbn-unified-field-list/src/components/field_stats/field_stats.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_stats/field_stats.tsx
@@ -567,7 +567,7 @@ function getCountsElement(
 ): JSX.Element {
   const dataTestSubjDocsCount = 'unifiedFieldStats-statsFooter-docsCount';
   const { fieldFormats } = services;
-  const { totalDocuments, sampledValues, sampledDocuments, topValues } = state;
+  const { totalDocuments, sampledDocuments } = state;
 
   if (!totalDocuments) {
     return <></>;
@@ -576,7 +576,7 @@ function getCountsElement(
   let labelElement;
 
   if (isTextBased) {
-    labelElement = topValues?.areExamples ? (
+    labelElement = (
       <FormattedMessage
         id="unifiedFieldList.fieldStats.calculatedFromSampleRecordsLabel"
         defaultMessage="Calculated from {sampledDocumentsFormatted} sample {sampledDocuments, plural, one {record} other {records}}."
@@ -587,21 +587,6 @@ function getCountsElement(
               {fieldFormats
                 .getDefaultInstance(KBN_FIELD_TYPES.NUMBER, [ES_FIELD_TYPES.INTEGER])
                 .convert(sampledDocuments)}
-            </strong>
-          ),
-        }}
-      />
-    ) : (
-      <FormattedMessage
-        id="unifiedFieldList.fieldStats.calculatedFromSampleValuesLabel"
-        defaultMessage="Calculated from {sampledValuesFormatted} sample {sampledValues, plural, one {value} other {values}}."
-        values={{
-          sampledValues,
-          sampledValuesFormatted: (
-            <strong data-test-subj={dataTestSubjDocsCount}>
-              {fieldFormats
-                .getDefaultInstance(KBN_FIELD_TYPES.NUMBER, [ES_FIELD_TYPES.INTEGER])
-                .convert(sampledValues)}
             </strong>
           ),
         }}

--- a/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.test.ts
+++ b/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.test.ts
@@ -76,7 +76,7 @@ describe('fieldStatsUtilsTextBased', function () {
       expect(searchHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           query:
-            'from logs* | limit 1000\n| WHERE `message` IS NOT NULL\n    | STATS `message_terms` = count(`message`) BY `message`\n    | SORT `message_terms` DESC\n    | LIMIT 10',
+            'from logs* | limit 1000\n| WHERE `message` IS NOT NULL\n    | STATS `message_terms` = count(mv_min(`message`)) BY `message`\n    | SORT `message_terms` DESC\n    | LIMIT 10',
         })
       );
     });

--- a/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.ts
+++ b/packages/kbn-unified-field-list/src/services/field_stats_text_based/field_stats_utils_text_based.ts
@@ -80,7 +80,7 @@ export async function getStringTopValues(
   const esqlQuery = appendToESQLQuery(
     esqlBaseQuery,
     `| WHERE ${safeEsqlFieldName} IS NOT NULL
-    | STATS ${safeEsqlFieldNameTerms} = count(${safeEsqlFieldName}) BY ${safeEsqlFieldName}
+    | STATS ${safeEsqlFieldNameTerms} = count(mv_min(${safeEsqlFieldName})) BY ${safeEsqlFieldName}
     | SORT ${safeEsqlFieldNameTerms} DESC
     | LIMIT ${size}`
   );
@@ -92,7 +92,7 @@ export async function getStringTopValues(
     return {};
   }
 
-  const sampledValues = values?.reduce((acc: number, row) => acc + row[0], 0);
+  const sampledDocuments = values?.reduce((acc: number, row) => acc + row[0], 0);
 
   const topValues = {
     buckets: values.map((value) => ({
@@ -102,9 +102,9 @@ export async function getStringTopValues(
   };
 
   return {
-    totalDocuments: sampledValues,
-    sampledDocuments: sampledValues,
-    sampledValues,
+    totalDocuments: sampledDocuments,
+    sampledDocuments,
+    sampledValues: sampledDocuments,
     topValues,
   };
 }

--- a/test/functional/apps/discover/group6/_sidebar_field_stats.ts
+++ b/test/functional/apps/discover/group6/_sidebar_field_stats.ts
@@ -165,7 +165,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const topValuesRows = await testSubjects.findAll('dscFieldStats-topValues-bucket');
         expect(topValuesRows.length).to.eql(10);
         expect(await testSubjects.getVisibleText('dscFieldStats-statsFooter')).to.contain(
-          '42 sample values'
+          '42 sample records'
         );
 
         await PageObjects.unifiedFieldList.clickFieldListPlusFilter('bytes', '0');
@@ -186,7 +186,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await testSubjects.missingOrFail('unifiedFieldStats-buttonGroup');
         await testSubjects.missingOrFail('unifiedFieldStats-histogram');
         expect(await testSubjects.getVisibleText('dscFieldStats-statsFooter')).to.contain(
-          '500 sample values'
+          '500 sample records'
         );
 
         await PageObjects.unifiedFieldList.clickFieldListPlusFilter('extension.raw', 'css');
@@ -208,7 +208,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await testSubjects.missingOrFail('unifiedFieldStats-buttonGroup');
         await testSubjects.missingOrFail('unifiedFieldStats-histogram');
         expect(await testSubjects.getVisibleText('dscFieldStats-statsFooter')).to.contain(
-          '32 sample values'
+          '32 sample records'
         );
 
         await PageObjects.unifiedFieldList.clickFieldListPlusFilter('clientip', '216.126.255.31');
@@ -230,7 +230,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await testSubjects.missingOrFail('unifiedFieldStats-buttonGroup');
         await testSubjects.missingOrFail('unifiedFieldStats-histogram');
         expect(await testSubjects.getVisibleText('dscFieldStats-statsFooter')).to.contain(
-          '500 sample values'
+          '500 sample records'
         );
         await PageObjects.unifiedFieldList.closeFieldPopover();
       });
@@ -310,7 +310,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const topValuesRows = await testSubjects.findAll('dscFieldStats-topValues-bucket');
         expect(topValuesRows.length).to.eql(3);
         expect(await testSubjects.getVisibleText('dscFieldStats-statsFooter')).to.contain(
-          '3 sample values'
+          '3 sample records'
         );
 
         await PageObjects.unifiedFieldList.clickFieldListPlusFilter('avg(bytes)', '5453');
@@ -339,7 +339,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'true\n100%'
         );
         expect(await testSubjects.getVisibleText('dscFieldStats-statsFooter')).to.contain(
-          '1 sample value'
+          '1 sample record'
         );
 
         await PageObjects.unifiedFieldList.clickFieldListMinusFilter('enabled', 'true');


### PR DESCRIPTION
## Summary

Aligning with ML work in https://github.com/elastic/kibana/pull/180849. Relevant for fields with multiple values.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
