### PR TITLE
[Cloud Experiments] Catch errors in the Metadata service

### DIFF
--- a/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/common/metadata_service/metadata_service.test.ts
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { fakeSchedulers } from 'rxjs-marbles/jest';
 import { firstValueFrom } from 'rxjs';
 import { MetadataService } from './metadata_service';
+import { loggerMock, type MockedLogger } from '@kbn/logging-mocks';
 
 jest.mock('rxjs', () => {
   const RxJs = jest.requireActual('rxjs');
@@ -23,9 +24,14 @@ describe('MetadataService', () => {
   jest.useFakeTimers({ legacyFakeTimers: true });
 
   let metadataService: MetadataService;
+  let logger: MockedLogger;
 
   beforeEach(() => {
-    metadataService = new MetadataService({ metadata_refresh_interval: moment.duration(1, 's') });
+    logger = loggerMock.create();
+    metadataService = new MetadataService(
+      { metadata_refresh_interval: moment.duration(1, 's') },
+      logger
+    );
   });
 
   afterEach(() => {
@@ -86,6 +92,48 @@ describe('MetadataService', () => {
 
         // After scheduler kicks in...
         advance(1); // The timer kicks in first on 0 (but let's give us 1ms so the trial is expired)
+        await new Promise((resolve) => process.nextTick(resolve)); // The timer triggers a promise, so we need to skip to the next tick
+        await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual({
+          ...initialMetadata,
+          hasData: true,
+        });
+      })
+    );
+
+    test(
+      'handles errors in hasDataFetcher',
+      fakeSchedulers(async (advance) => {
+        let count = 0;
+        metadataService.start({
+          hasDataFetcher: async () => {
+            if (count++ > 0) {
+              return { hasData: true };
+            } else {
+              throw new Error('Something went wrong');
+            }
+          },
+        });
+
+        // Still equals initialMetadata
+        await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual(
+          initialMetadata
+        );
+
+        // After scheduler kicks in...
+        advance(1); // The timer kicks in first on 0 (but let's give us 1ms so the trial is expired)
+        await new Promise((resolve) => process.nextTick(resolve)); // The timer triggers a promise, so we need to skip to the next tick
+
+        // Still equals initialMetadata
+        await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual(
+          initialMetadata
+        );
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn.mock.calls[0][0]).toMatchInlineSnapshot(
+          `"Failed to update metadata because Error: Something went wrong"`
+        );
+
+        // After scheduler kicks in...
+        advance(1_001);
         await new Promise((resolve) => process.nextTick(resolve)); // The timer triggers a promise, so we need to skip to the next tick
         await expect(firstValueFrom(metadataService.userMetadata$)).resolves.toStrictEqual({
           ...initialMetadata,

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/public/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/public/plugin.ts
@@ -55,9 +55,10 @@ export class CloudExperimentsPlugin
       metadata_refresh_interval: string;
     }>();
 
-    this.metadataService = new MetadataService({
-      metadata_refresh_interval: duration(config.metadata_refresh_interval),
-    });
+    this.metadataService = new MetadataService(
+      { metadata_refresh_interval: duration(config.metadata_refresh_interval) },
+      this.logger.get('metadata')
+    );
 
     if (config.flag_overrides) {
       this.flagOverrides = config.flag_overrides;

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/server/plugin.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/server/plugin.ts
@@ -50,9 +50,10 @@ export class CloudExperimentsPlugin
     this.logger = initializerContext.logger.get();
     const config = initializerContext.config.get<CloudExperimentsConfigType>();
 
-    this.metadataService = new MetadataService({
-      metadata_refresh_interval: config.metadata_refresh_interval,
-    });
+    this.metadataService = new MetadataService(
+      { metadata_refresh_interval: config.metadata_refresh_interval },
+      this.logger.get('metadata')
+    );
 
     if (config.flag_overrides) {
       this.flagOverrides = config.flag_overrides;


### PR DESCRIPTION
## Summary

It looks like `RxJs.exhaustMap` doesn't handle errors nicely.

This PR adds an explicit `try...catch` block to the promise that we run inside the Cloud Experiments' Metadata service.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
