### PR TITLE
[8.14] [SLO] synthetics add fields to temp document (#181843)

### DIFF
--- a/x-pack/plugins/observability_solution/slo/server/services/__snapshots__/create_slo.test.ts.snap
+++ b/x-pack/plugins/observability_solution/slo/server/services/__snapshots__/create_slo.test.ts.snap
@@ -182,6 +182,16 @@ Array [
       "goodEvents": 0,
       "isTempDoc": true,
       "kibanaUrl": "http://myhost.com/mock-server-basepath",
+      "monitor": Object {
+        "config_id": null,
+        "name": null,
+      },
+      "observer": Object {
+        "geo": Object {
+          "name": null,
+        },
+        "name": null,
+      },
       "service": Object {
         "environment": "irrelevant",
         "name": "irrelevant",

--- a/x-pack/plugins/observability_solution/slo/server/services/__snapshots__/reset_slo.test.ts.snap
+++ b/x-pack/plugins/observability_solution/slo/server/services/__snapshots__/reset_slo.test.ts.snap
@@ -469,6 +469,16 @@ exports[`ResetSLO resets all associated resources 11`] = `
           "goodEvents": 0,
           "isTempDoc": true,
           "kibanaUrl": "http://myhost.com/mock-server-basepath",
+          "monitor": Object {
+            "config_id": null,
+            "name": null,
+          },
+          "observer": Object {
+            "geo": Object {
+              "name": null,
+            },
+            "name": null,
+          },
           "service": Object {
             "environment": "irrelevant",
             "name": "irrelevant",

--- a/x-pack/plugins/observability_solution/slo/server/services/summary_transform_generator/helpers/create_temp_summary.ts
+++ b/x-pack/plugins/observability_solution/slo/server/services/summary_transform_generator/helpers/create_temp_summary.ts
@@ -11,6 +11,7 @@ import * as t from 'io-ts';
 import { Indicator, IndicatorTypes, SLODefinition, Status } from '../../../domain/models';
 
 export interface EsSummaryDocument {
+  // apm specific fields
   service: {
     environment: string | null;
     name: string | null;
@@ -19,6 +20,18 @@ export interface EsSummaryDocument {
     name: string | null;
     type: string | null;
   };
+  // synthetics specific fields
+  monitor: {
+    config_id: string | null;
+    name: string | null;
+  };
+  observer: {
+    geo: {
+      name: string | null;
+    };
+    name: string | null;
+  };
+  // common fields
   slo: {
     // >= 8.14: Add indicator.params on the temporary summary as well as real summary through summary pipeline
     indicator: { type: IndicatorTypes } | Indicator;
@@ -58,6 +71,7 @@ export function createTempSummaryDocument(
   const apmParams = 'environment' in slo.indicator.params ? slo.indicator.params : null;
 
   const doc = {
+    // apm specific fields
     service: {
       environment: apmParams?.environment ?? null,
       name: apmParams?.service ?? null,
@@ -65,6 +79,17 @@ export function createTempSummaryDocument(
     transaction: {
       name: apmParams?.transactionName ?? null,
       type: apmParams?.transactionType ?? null,
+    },
+    // synthetics specific fields
+    monitor: {
+      name: null,
+      config_id: null,
+    },
+    observer: {
+      name: null,
+      geo: {
+        name: null,
+      },
     },
     slo: {
       // 8.14 adds indicator.params through transform summary pipeline, i.e. indicator.params might be undefined

--- a/x-pack/plugins/observability_solution/slo/server/services/unsafe_federated/remote_summary_doc_to_slo.test.ts
+++ b/x-pack/plugins/observability_solution/slo/server/services/unsafe_federated/remote_summary_doc_to_slo.test.ts
@@ -28,6 +28,16 @@ describe('FromRemoteSummaryDocToSlo', () => {
             name: null,
             type: null,
           },
+          monitor: {
+            name: null,
+            config_id: null,
+          },
+          observer: {
+            name: null,
+            geo: {
+              name: null,
+            },
+          },
           slo: {
             indicator: {
               type: 'sli.kql.custom',
@@ -81,6 +91,16 @@ describe('FromRemoteSummaryDocToSlo', () => {
           transaction: {
             name: null,
             type: null,
+          },
+          monitor: {
+            name: null,
+            config_id: null,
+          },
+          observer: {
+            name: null,
+            geo: {
+              name: null,
+            },
           },
           slo: {
             indicator: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[SLO] synthetics add fields to temp document (#181843)](https://github.com/elastic/kibana/pull/181843)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dominique Clarke","email":"dominique.clarke@elastic.co"},"sourceCommit":{"committedDate":"2024-05-09T19:16:24Z","message":"[SLO] synthetics add fields to temp document (#181843)\n\n## Summary\r\n\r\nAdds synthetics fields to the temp SLO document.","sha":"6ce1e1d57a31f7498233935ff3564f46c09b62b5","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Feature:SLO","ci:project-deploy-observability","Team:obs-ux-management","v8.14.0","v8.15.0"],"number":181843,"url":"https://github.com/elastic/kibana/pull/181843","mergeCommit":{"message":"[SLO] synthetics add fields to temp document (#181843)\n\n## Summary\r\n\r\nAdds synthetics fields to the temp SLO document.","sha":"6ce1e1d57a31f7498233935ff3564f46c09b62b5"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181843","number":181843,"mergeCommit":{"message":"[SLO] synthetics add fields to temp document (#181843)\n\n## Summary\r\n\r\nAdds synthetics fields to the temp SLO document.","sha":"6ce1e1d57a31f7498233935ff3564f46c09b62b5"}}]}] BACKPORT-->