### PR TITLE
[ES|QL] `bucket` no longer suggests `bucket`

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -732,6 +732,16 @@ describe('autocomplete', () => {
       ...allEvaFunctions,
       ...allGroupingFunctions,
     ]);
+
+    // expect "bucket" NOT to be suggested for its own parameter
+    testSuggestions(
+      'from a | stats by bucket(',
+      [
+        ...getFieldNamesByType(['number', 'date']),
+        ...getFunctionSignaturesByReturnType('eval', ['date', 'number'], { evalMath: true }),
+      ].map((field) => `${field},`)
+    );
+
     testSuggestions('from a | stats avg(b) by numberField % 2 ', [',', '|']);
 
     testSuggestions(

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -1151,9 +1151,14 @@ async function getFunctionArgsSuggestions(
         ? Math.max(command.args.length - 1, 0)
         : commandArgIndex;
 
+    const finalCommandArg = command.args[finalCommandArgIndex];
+
     const fnToIgnore = [];
     // just ignore the current function
-    if (command.name !== 'stats') {
+    if (
+      command.name !== 'stats' ||
+      (isOptionItem(finalCommandArg) && finalCommandArg.name === 'by')
+    ) {
       fnToIgnore.push(node.name);
     } else {
       fnToIgnore.push(


### PR DESCRIPTION
## Summary

This fixes a bug where `bucket` gets suggested for the first parameter of the `bucket` function.


https://github.com/elastic/kibana/assets/315764/9c17180b-3f5d-42f9-904f-8c8b5848d22a



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->