### PR TITLE
[8.14] [ML] Fix transform health rule failure with a long list of continuous transforms  (#183153)

### DIFF
--- a/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.test.ts
+++ b/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { transformHealthServiceProvider } from './transform_health_service';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { RulesClient } from '@kbn/alerting-plugin/server';
+import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { rulesClientMock } from '@kbn/alerting-plugin/server/rules_client.mock';
+import type {
+  TransformGetTransformResponse,
+  TransformGetTransformStatsResponse,
+} from '@elastic/elasticsearch/lib/api/types';
+
+describe('transformHealthServiceProvider', () => {
+  let esClient: jest.Mocked<ElasticsearchClient>;
+  let rulesClient: jest.Mocked<RulesClient>;
+  let fieldFormatsRegistry: jest.Mocked<FieldFormatsRegistry>;
+
+  beforeEach(() => {
+    esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+    (esClient.transform.getTransform as jest.Mock).mockResolvedValue({
+      count: 3,
+      transforms: [
+        // Mock continuous transforms
+        ...new Array(102).fill(null).map((_, i) => ({
+          id: `transform${i}`,
+          sync: true,
+        })),
+        {
+          id: 'transform102',
+          sync: false,
+        },
+      ],
+    } as unknown as TransformGetTransformResponse);
+    (esClient.transform.getTransformStats as jest.Mock).mockResolvedValue({
+      count: 2,
+      transforms: [{}],
+    } as unknown as TransformGetTransformStatsResponse);
+
+    rulesClient = rulesClientMock.create();
+    fieldFormatsRegistry = {
+      deserialize: jest.fn(),
+    } as unknown as jest.Mocked<FieldFormatsRegistry>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch transform stats by transform IDs if the length does not exceed the URL limit', async () => {
+    const service = transformHealthServiceProvider({ esClient, rulesClient, fieldFormatsRegistry });
+    const result = await service.getHealthChecksResults({
+      includeTransforms: ['*'],
+      excludeTransforms: ['transform4', 'transform6', 'transform62'],
+      testsConfig: null,
+    });
+
+    expect(esClient.transform.getTransform).toHaveBeenCalledWith({
+      allow_no_match: true,
+      size: 1000,
+    });
+    expect(esClient.transform.getTransformStats).toHaveBeenCalledTimes(1);
+    expect(esClient.transform.getTransformStats).toHaveBeenNthCalledWith(1, {
+      basic: true,
+      transform_id:
+        'transform0,transform1,transform2,transform3,transform5,transform7,transform8,transform9,transform10,transform11,transform12,transform13,transform14,transform15,transform16,transform17,transform18,transform19,transform20,transform21,transform22,transform23,transform24,transform25,transform26,transform27,transform28,transform29,transform30,transform31,transform32,transform33,transform34,transform35,transform36,transform37,transform38,transform39,transform40,transform41,transform42,transform43,transform44,transform45,transform46,transform47,transform48,transform49,transform50,transform51,transform52,transform53,transform54,transform55,transform56,transform57,transform58,transform59,transform60,transform61,transform63,transform64,transform65,transform66,transform67,transform68,transform69,transform70,transform71,transform72,transform73,transform74,transform75,transform76,transform77,transform78,transform79,transform80,transform81,transform82,transform83,transform84,transform85,transform86,transform87,transform88,transform89,transform90,transform91,transform92,transform93,transform94,transform95,transform96,transform97,transform98,transform99,transform100,transform101',
+    });
+
+    expect(result).toBeDefined();
+  });
+
+  it('should fetch all transform stats and filter by transform IDs if the length exceeds the URL limit', async () => {
+    const transformIdPrefix = 'transform_with_a_very_long_id_that_result_in_long_url_for_sure_';
+
+    (esClient.transform.getTransform as jest.Mock).mockResolvedValue({
+      count: 3,
+      transforms: [
+        // Mock continuous transforms
+        ...new Array(102).fill(null).map((_, i) => ({
+          id: `${transformIdPrefix}${i}`,
+          sync: true,
+        })),
+        {
+          id: 'transform102',
+          sync: false,
+        },
+      ],
+    } as unknown as TransformGetTransformResponse);
+
+    (esClient.transform.getTransformStats as jest.Mock).mockResolvedValue({
+      count: 2,
+      transforms: [
+        ...new Array(200).fill(null).map((_, i) => ({
+          id: `${transformIdPrefix}${i}`,
+          transform_state: 'stopped',
+        })),
+      ],
+    } as unknown as TransformGetTransformStatsResponse);
+
+    const service = transformHealthServiceProvider({ esClient, rulesClient, fieldFormatsRegistry });
+    const result = await service.getHealthChecksResults({
+      includeTransforms: ['*'],
+      excludeTransforms: new Array(50).fill(null).map((_, i) => `${transformIdPrefix}${i + 60}`),
+      testsConfig: null,
+    });
+
+    expect(esClient.transform.getTransform).toHaveBeenCalledWith({
+      allow_no_match: true,
+      size: 1000,
+    });
+    expect(esClient.transform.getTransformStats).toHaveBeenCalledTimes(1);
+    expect(esClient.transform.getTransformStats).toHaveBeenNthCalledWith(1, {
+      basic: true,
+    });
+
+    const notStarted = result[0];
+
+    expect(notStarted.context.message).toEqual(
+      'Transform transform_with_a_very_long_id_that_result_in_long_url_for_sure_0, transform_with_a_very_long_id_that_result_in_long_url_for_sure_1, transform_with_a_very_long_id_that_result_in_long_url_for_sure_2, transform_with_a_very_long_id_that_result_in_long_url_for_sure_3, transform_with_a_very_long_id_that_result_in_long_url_for_sure_4, transform_with_a_very_long_id_that_result_in_long_url_for_sure_5, transform_with_a_very_long_id_that_result_in_long_url_for_sure_6, transform_with_a_very_long_id_that_result_in_long_url_for_sure_7, transform_with_a_very_long_id_that_result_in_long_url_for_sure_8, transform_with_a_very_long_id_that_result_in_long_url_for_sure_9, transform_with_a_very_long_id_that_result_in_long_url_for_sure_10, transform_with_a_very_long_id_that_result_in_long_url_for_sure_11, transform_with_a_very_long_id_that_result_in_long_url_for_sure_12, transform_with_a_very_long_id_that_result_in_long_url_for_sure_13, transform_with_a_very_long_id_that_result_in_long_url_for_sure_14, transform_with_a_very_long_id_that_result_in_long_url_for_sure_15, transform_with_a_very_long_id_that_result_in_long_url_for_sure_16, transform_with_a_very_long_id_that_result_in_long_url_for_sure_17, transform_with_a_very_long_id_that_result_in_long_url_for_sure_18, transform_with_a_very_long_id_that_result_in_long_url_for_sure_19, transform_with_a_very_long_id_that_result_in_long_url_for_sure_20, transform_with_a_very_long_id_that_result_in_long_url_for_sure_21, transform_with_a_very_long_id_that_result_in_long_url_for_sure_22, transform_with_a_very_long_id_that_result_in_long_url_for_sure_23, transform_with_a_very_long_id_that_result_in_long_url_for_sure_24, transform_with_a_very_long_id_that_result_in_long_url_for_sure_25, transform_with_a_very_long_id_that_result_in_long_url_for_sure_26, transform_with_a_very_long_id_that_result_in_long_url_for_sure_27, transform_with_a_very_long_id_that_result_in_long_url_for_sure_28, transform_with_a_very_long_id_that_result_in_long_url_for_sure_29, transform_with_a_very_long_id_that_result_in_long_url_for_sure_30, transform_with_a_very_long_id_that_result_in_long_url_for_sure_31, transform_with_a_very_long_id_that_result_in_long_url_for_sure_32, transform_with_a_very_long_id_that_result_in_long_url_for_sure_33, transform_with_a_very_long_id_that_result_in_long_url_for_sure_34, transform_with_a_very_long_id_that_result_in_long_url_for_sure_35, transform_with_a_very_long_id_that_result_in_long_url_for_sure_36, transform_with_a_very_long_id_that_result_in_long_url_for_sure_37, transform_with_a_very_long_id_that_result_in_long_url_for_sure_38, transform_with_a_very_long_id_that_result_in_long_url_for_sure_39, transform_with_a_very_long_id_that_result_in_long_url_for_sure_40, transform_with_a_very_long_id_that_result_in_long_url_for_sure_41, transform_with_a_very_long_id_that_result_in_long_url_for_sure_42, transform_with_a_very_long_id_that_result_in_long_url_for_sure_43, transform_with_a_very_long_id_that_result_in_long_url_for_sure_44, transform_with_a_very_long_id_that_result_in_long_url_for_sure_45, transform_with_a_very_long_id_that_result_in_long_url_for_sure_46, transform_with_a_very_long_id_that_result_in_long_url_for_sure_47, transform_with_a_very_long_id_that_result_in_long_url_for_sure_48, transform_with_a_very_long_id_that_result_in_long_url_for_sure_49, transform_with_a_very_long_id_that_result_in_long_url_for_sure_50, transform_with_a_very_long_id_that_result_in_long_url_for_sure_51, transform_with_a_very_long_id_that_result_in_long_url_for_sure_52, transform_with_a_very_long_id_that_result_in_long_url_for_sure_53, transform_with_a_very_long_id_that_result_in_long_url_for_sure_54, transform_with_a_very_long_id_that_result_in_long_url_for_sure_55, transform_with_a_very_long_id_that_result_in_long_url_for_sure_56, transform_with_a_very_long_id_that_result_in_long_url_for_sure_57, transform_with_a_very_long_id_that_result_in_long_url_for_sure_58, transform_with_a_very_long_id_that_result_in_long_url_for_sure_59 are not started.'
+    );
+  });
+});

--- a/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.ts
+++ b/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.ts
@@ -13,21 +13,21 @@ import type { RulesClient } from '@kbn/alerting-plugin/server';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
 import { FIELD_FORMAT_IDS } from '@kbn/field-formats-plugin/common';
 import type { TransformStats } from '../../../../common/types/transform_stats';
-import { TRANSFORM_HEALTH_STATUS } from '../../../../common/constants';
-import type { TransformHealthRuleParams } from './schema';
 import {
-  mapEsHealthStatus2TransformHealthStatus,
   ALL_TRANSFORMS_SELECTION,
+  mapEsHealthStatus2TransformHealthStatus,
   TRANSFORM_HEALTH_CHECK_NAMES,
+  TRANSFORM_HEALTH_STATUS,
   TRANSFORM_NOTIFICATIONS_INDEX,
   TRANSFORM_RULE_TYPE,
   TRANSFORM_STATE,
 } from '../../../../common/constants';
+import type { TransformHealthRuleParams } from './schema';
 import { getResultTestConfig } from '../../../../common/utils/alerts';
 import type {
   ErrorMessagesTransformResponse,
-  TransformStateReportResponse,
   TransformHealthAlertContext,
+  TransformStateReportResponse,
 } from './register_transform_health_rule_type';
 import type { TransformHealthAlertRule } from '../../../../common/types/alerting';
 import { isContinuousTransform } from '../../../../common/types/transform';
@@ -46,6 +46,8 @@ type Transform = estypes.TransformGetTransformTransformSummary & {
 
 type TransformWithAlertingRules = Transform & { alerting_rules: TransformHealthAlertRule[] };
 
+const maxPathComponentLength = 2000;
+
 export function transformHealthServiceProvider({
   esClient,
   rulesClient,
@@ -58,7 +60,7 @@ export function transformHealthServiceProvider({
   const transformsDict = new Map<string, Transform>();
 
   /**
-   * Resolves result transform selection.
+   * Resolves result transform selection. Only continuously running transforms are included.
    * @param includeTransforms
    * @param excludeTransforms
    * @param skipIDsCheck
@@ -67,7 +69,7 @@ export function transformHealthServiceProvider({
     includeTransforms: string[],
     excludeTransforms: string[] | null,
     skipIDsCheck = false
-  ): Promise<string[]> => {
+  ): Promise<Set<string>> => {
     const includeAll = includeTransforms.some((id) => id === ALL_TRANSFORMS_SELECTION);
 
     let resultTransformIds: string[] = [];
@@ -86,6 +88,7 @@ export function transformHealthServiceProvider({
 
       transformsResponse.forEach((t) => {
         transformsDict.set(t.id, t);
+        // Include only continuously running transforms.
         if (t.sync) {
           resultTransformIds.push(t.id);
         }
@@ -97,16 +100,34 @@ export function transformHealthServiceProvider({
       resultTransformIds = resultTransformIds.filter((id) => !excludeIdsSet.has(id));
     }
 
-    return resultTransformIds;
+    return new Set(resultTransformIds);
   };
 
-  const getTransformStats = memoize(async (transformIds: string[]): Promise<TransformStats[]> => {
-    return (
-      await esClient.transform.getTransformStats({
-        transform_id: transformIds.join(','),
-      })
-    ).transforms as TransformStats[];
-  });
+  const getTransformStats = memoize(
+    async (transformIds: Set<string>): Promise<TransformStats[]> => {
+      const transformIdsString = Array.from(transformIds).join(',');
+
+      if (transformIdsString.length < maxPathComponentLength) {
+        return (
+          await esClient.transform.getTransformStats({
+            transform_id: transformIdsString,
+            // @ts-expect-error `basic` query option not yet in @elastic/elasticsearch
+            basic: true,
+          })
+        ).transforms as TransformStats[];
+      } else {
+        // Fetch all transforms and filter out the ones that are not in the list.
+        return (
+          (
+            await esClient.transform.getTransformStats({
+              // @ts-expect-error `basic` query option not yet in @elastic/elasticsearch
+              basic: true,
+            })
+          ).transforms as TransformStats[]
+        ).filter((t) => transformIds.has(t.id));
+      }
+    }
+  );
 
   function baseTransformAlertResponseFormatter(
     transformStats: TransformStats
@@ -144,7 +165,7 @@ export function transformHealthServiceProvider({
      * @return - Partitions with not started and started transforms
      */
     async getTransformsStateReport(
-      transformIds: string[]
+      transformIds: Set<string>
     ): Promise<[TransformStateReportResponse[], TransformStateReportResponse[]]> {
       const transformsStats = await getTransformStats(transformIds);
 
@@ -161,7 +182,7 @@ export function transformHealthServiceProvider({
      * @param transformIds
      */
     async getErrorMessagesReport(
-      transformIds: string[]
+      transformIds: Set<string>
     ): Promise<ErrorMessagesTransformResponse[]> {
       interface TransformErrorsBucket {
         key: string;
@@ -185,7 +206,7 @@ export function transformHealthServiceProvider({
               },
               {
                 terms: {
-                  transform_id: transformIds,
+                  transform_id: Array.from(transformIds),
                 },
               },
             ],
@@ -195,7 +216,7 @@ export function transformHealthServiceProvider({
           by_transform: {
             terms: {
               field: 'transform_id',
-              size: transformIds.length,
+              size: transformIds.size,
             },
             aggs: {
               error_messages: {
@@ -212,11 +233,7 @@ export function transformHealthServiceProvider({
       });
 
       // If transform contains errors, it's in a failed state
-      const transformsStats = (
-        await esClient.transform.getTransformStats({
-          transform_id: transformIds.join(','),
-        })
-      ).transforms;
+      const transformsStats = await getTransformStats(transformIds);
       const failedTransforms = new Set(
         transformsStats.filter((t) => t.state === TRANSFORM_STATE.FAILED).map((t) => t.id)
       );
@@ -235,7 +252,7 @@ export function transformHealthServiceProvider({
      * @param transformIds
      */
     async getUnhealthyTransformsReport(
-      transformIds: string[]
+      transformIds: Set<string>
     ): Promise<TransformStateReportResponse[]> {
       const transformsStats = await getTransformStats(transformIds);
 
@@ -314,7 +331,7 @@ export function transformHealthServiceProvider({
                   {
                     defaultMessage:
                       'No errors in the {count, plural, one {transform} other {transforms}} messages.',
-                    values: { count: transformIds.length },
+                    values: { count: transformIds.size },
                   }
                 )
               : i18n.translate('xpack.transform.alertTypes.transformHealth.errorMessagesMessage', {
@@ -380,7 +397,7 @@ export function transformHealthServiceProvider({
 
       for (const ruleInstance of transformAlertingRules.data) {
         // Retrieve result transform IDs
-        const resultTransformIds: string[] = await getResultsTransformIds(
+        const resultTransformIds = await getResultsTransformIds(
           ruleInstance.params.includeTransforms.includes(ALL_TRANSFORMS_SELECTION)
             ? Object.keys(transformMap)
             : ruleInstance.params.includeTransforms,

--- a/x-pack/plugins/transform/tsconfig.json
+++ b/x-pack/plugins/transform/tsconfig.json
@@ -74,7 +74,10 @@
     "@kbn/ml-creation-wizard-utils",
     "@kbn/alerts-as-data-utils",
     "@kbn/code-editor",
-    "@kbn/rule-data-utils"
+    "@kbn/rule-data-utils",
+    "@kbn/react-kibana-context-render",
+    "@kbn/search-types",
+    "@kbn/core-elasticsearch-server-mocks"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/plugins/transform/tsconfig.json
+++ b/x-pack/plugins/transform/tsconfig.json
@@ -75,8 +75,6 @@
     "@kbn/alerts-as-data-utils",
     "@kbn/code-editor",
     "@kbn/rule-data-utils",
-    "@kbn/react-kibana-context-render",
-    "@kbn/search-types",
     "@kbn/core-elasticsearch-server-mocks"
   ],
   "exclude": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ML] Fix transform health rule failure with a long list of continuous transforms  (#183153)](https://github.com/elastic/kibana/pull/183153)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dima Arnautov","email":"dmitrii.arnautov@elastic.co"},"sourceCommit":{"committedDate":"2024-05-10T20:41:05Z","message":"[ML] Fix transform health rule failure with a long list of continuous transforms  (#183153)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/182942\r\n\r\nChecks if the\r\n[`_stats`](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html)\r\nrequest URL exceeds the limit and retrieves `_all` stats if necessary.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"4c8e67bccb1a2f9cfbe978305b2178ea711e912e","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:Transforms","Feature:Alerting/RuleTypes","Team:ML","v8.14.0","v8.15.0"],"number":183153,"url":"https://github.com/elastic/kibana/pull/183153","mergeCommit":{"message":"[ML] Fix transform health rule failure with a long list of continuous transforms  (#183153)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/182942\r\n\r\nChecks if the\r\n[`_stats`](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html)\r\nrequest URL exceeds the limit and retrieves `_all` stats if necessary.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"4c8e67bccb1a2f9cfbe978305b2178ea711e912e"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183153","number":183153,"mergeCommit":{"message":"[ML] Fix transform health rule failure with a long list of continuous transforms  (#183153)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/182942\r\n\r\nChecks if the\r\n[`_stats`](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-stats.html)\r\nrequest URL exceeds the limit and retrieves `_all` stats if necessary.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"4c8e67bccb1a2f9cfbe978305b2178ea711e912e"}}]}] BACKPORT-->