### PR TITLE
Initial try to improve SearchSource consumtion in alerting rules

### DIFF
--- a/packages/kbn-es-query/index.ts
+++ b/packages/kbn-es-query/index.ts
@@ -6,6 +6,9 @@
  * Side Public License, v 1.
  */
 
+import { compact } from 'lodash';
+import { KueryNode } from './src/kuery/types';
+
 export type {
   BoolQuery,
   DataViewBase,
@@ -127,3 +130,21 @@ export {
 } from './src/utils';
 
 export type { ExecutionContextSearch } from './src/expressions/types';
+
+export function getKueryFields(nodes: KueryNode[]): string[] {
+  const allFields = nodes
+    .map((node) => {
+      const {
+        arguments: [fieldNameArg],
+      } = node;
+
+      if (fieldNameArg.type === 'function') {
+        return getKueryFields(node.arguments);
+      }
+
+      return fieldNameArg.value;
+    })
+    .flat();
+
+  return compact(allFields);
+}

--- a/src/plugins/data/common/search/search_source/create_search_source.ts
+++ b/src/plugins/data/common/search/search_source/create_search_source.ts
@@ -80,7 +80,6 @@ export const createSearchSource = (
       searchSource.setField('query', migrateLegacyQuery(query));
     }
     if (useDataViewLazy) {
-      console.log('useDataViewLazy', useDataViewLazy);
       await searchSource.loadDataViewFields();
     }
 

--- a/src/plugins/data/common/search/search_source/normalize_sort_request.ts
+++ b/src/plugins/data/common/search/search_source/normalize_sort_request.ts
@@ -7,7 +7,7 @@
  */
 
 import { estypes } from '@elastic/elasticsearch';
-import type { DataView } from '@kbn/data-views-plugin/common';
+import { DataView, DataViewLazy } from '@kbn/data-views-plugin/common';
 import { EsQuerySortValue } from './types';
 
 type FieldSortOptions = estypes.FieldSort &
@@ -19,9 +19,10 @@ type FieldSortOptions = estypes.FieldSort &
 
 export function normalizeSortRequest(
   sortObject: EsQuerySortValue | EsQuerySortValue[],
-  indexPattern: DataView | string | undefined,
+  indexPattern: DataView | DataViewLazy | string | undefined,
   defaultSortOptions: FieldSortOptions | string = {}
 ) {
+  console.log('normalizeSortRequest', sortObject, defaultSortOptions);
   const sortArray: EsQuerySortValue[] = Array.isArray(sortObject) ? sortObject : [sortObject];
   return sortArray.map(function (sortable) {
     return normalize(sortable, indexPattern, defaultSortOptions);
@@ -35,14 +36,14 @@ export function normalizeSortRequest(
  */
 function normalize(
   sortable: EsQuerySortValue,
-  indexPattern: DataView | string | undefined,
+  indexPattern: DataView | DataViewLazy | string | undefined,
   defaultSortOptions: FieldSortOptions | string
 ) {
   const [[sortField, sortOrder]] = Object.entries(sortable);
   const order = typeof sortOrder === 'object' ? sortOrder : { order: sortOrder };
 
   if (indexPattern && typeof indexPattern !== 'string') {
-    const indexField = indexPattern.fields.find(({ name }) => name === sortField);
+    const indexField = indexPattern.fields?.find(({ name }) => name === sortField);
     if (indexField && indexField.scripted && indexField.sortable) {
       return {
         _script: {

--- a/src/plugins/data/common/search/search_source/normalize_sort_request.ts
+++ b/src/plugins/data/common/search/search_source/normalize_sort_request.ts
@@ -22,7 +22,6 @@ export function normalizeSortRequest(
   indexPattern: DataView | DataViewLazy | string | undefined,
   defaultSortOptions: FieldSortOptions | string = {}
 ) {
-  console.log('normalizeSortRequest', sortObject, defaultSortOptions);
   const sortArray: EsQuerySortValue[] = Array.isArray(sortObject) ? sortObject : [sortObject];
   return sortArray.map(function (sortable) {
     return normalize(sortable, indexPattern, defaultSortOptions);

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -805,21 +805,16 @@ export class SearchSource {
     }
     // eslint-disable-next-line no-console
     console.log('loadDataViewFields because of DataViewLazy');
-    const sort1 = this.getField('sort');
-    console.log(sort1);
     const request = this.mergeProps(this, { body: {} }, ['query', 'filter']);
     let fields = dataView.timeFieldName ? [dataView.timeFieldName] : [];
     const sort = this.getField('sort');
-    console.log(sort);
     if (sort) {
       const sortArr = Array.isArray(sort) ? sort : [sort];
       for (const s of sortArr) {
         const keys = Object.keys(s);
-        console.log({ keys });
         fields = fields.concat(keys);
       }
     }
-    console.log('fields after sort', fields);
     for (const query of request.query) {
       if (query.query) {
         const nodes = fromKueryExpression(query.query);
@@ -827,7 +822,6 @@ export class SearchSource {
         fields = fields.concat(queryFields);
       }
     }
-    console.log('fields after query', fields);
     const filters = request.filters;
     if (filters) {
       const filtersArr = Array.isArray(filters) ? filters : [filters];
@@ -836,14 +830,11 @@ export class SearchSource {
       }
     }
     fields = fields.filter((f) => Boolean(f));
-    console.log('fields after query', fields);
 
     if (dataView.getSourceFiltering() && dataView.getSourceFiltering().excludes.length) {
       // if source filtering is enabled, we need to fetch all the fields
       await dataView.getFields({ fieldName: ['*'] });
     } else if (fields.length) {
-      // eslint-disable-next-line no-console
-      console.log('loadDataViewFields fields:', fields);
       const fieldSpec = await dataView.getFields({
         fieldName: fields,
         // fieldTypes: ['date', 'date_nanos'],
@@ -986,7 +977,6 @@ export class SearchSource {
     } else {
       body.fields = filteredDocvalueFields;
     }
-    console.log('body.fields', body.fields);
     // @ts-ignore
     body.fields = body.fields.filter((field) => Boolean(field));
 

--- a/src/plugins/data/common/search/search_source/search_source_service.ts
+++ b/src/plugins/data/common/search/search_source/search_source_service.ts
@@ -61,6 +61,10 @@ export class SearchSourceService {
        * creates searchsource based on serialized search source fields
        */
       create: createSearchSource(indexPatterns, dependencies),
+      createLazy: (searchSourceFields: SerializedSearchSourceFields = {}) => {
+        const fn = createSearchSource(indexPatterns, dependencies);
+        return fn(searchSourceFields, true);
+      },
       /**
        * creates an enpty search source
        */

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -13,7 +13,7 @@ import { SerializableRecord } from '@kbn/utility-types';
 import { PersistableStateService } from '@kbn/kibana-utils-plugin/common';
 import type { Filter } from '@kbn/es-query';
 import { ISearchOptions } from '@kbn/search-types';
-import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import { DataView, DataViewLazy, DataViewSpec } from '@kbn/data-views-plugin/common';
 import type { AggConfigSerialized, IAggConfigs } from '../../../public';
 import type { SearchSource } from './search_source';
 
@@ -34,6 +34,8 @@ export interface ISearchStartSearchSource
    * @param fields
    */
   create: (fields?: SerializedSearchSourceFields) => Promise<ISearchSource>;
+
+  createLazy: (fields?: SerializedSearchSourceFields) => Promise<ISearchSource>;
   /**
    * creates empty {@link SearchSource}
    */
@@ -110,7 +112,7 @@ export interface SearchSourceFields {
   /**
    * {@link IndexPatternService}
    */
-  index?: DataView;
+  index?: DataView | DataViewLazy;
   timeout?: string;
   terminate_after?: number;
   searchAfter?: estypes.SortResults;

--- a/src/plugins/data_views/common/data_views/abstract_data_views.ts
+++ b/src/plugins/data_views/common/data_views/abstract_data_views.ts
@@ -27,7 +27,7 @@ import type {
 import { removeFieldAttrs } from './utils';
 import { metaUnitsToFormatter } from './meta_units_to_formatter';
 
-import type { DataViewAttributes, FieldAttrs, FieldAttrSet, IIndexPatternFieldList} from '..';
+import type { DataViewAttributes, FieldAttrs, FieldAttrSet, IIndexPatternFieldList } from '..';
 
 import type { DataViewField } from '../fields';
 

--- a/src/plugins/data_views/common/data_views/abstract_data_views.ts
+++ b/src/plugins/data_views/common/data_views/abstract_data_views.ts
@@ -22,11 +22,12 @@ import type {
   SourceFilter,
   TypeMeta,
   RuntimeField,
+  DataViewFieldMap,
 } from '../types';
 import { removeFieldAttrs } from './utils';
 import { metaUnitsToFormatter } from './meta_units_to_formatter';
 
-import type { DataViewAttributes, FieldAttrs, FieldAttrSet } from '..';
+import type { DataViewAttributes, FieldAttrs, FieldAttrSet, IIndexPatternFieldList} from '..';
 
 import type { DataViewField } from '../fields';
 
@@ -68,6 +69,10 @@ export abstract class AbstractDataView {
    * Only used by rollup indices, used by rollup specific endpoint to load field list.
    */
   public typeMeta?: TypeMeta;
+  /**
+   * Field list, in extended array format
+   */
+  public fields?: IIndexPatternFieldList & { toSpec: () => DataViewFieldMap };
 
   /**
    * Timestamp field name


### PR DESCRIPTION
## Summary

This is a quick POC evaluating how we could make use of DataViewLazy to reduce field_caps requests without having to rewrite a ton of code. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
