### PR TITLE
[Playground] Fix Context field extraction

### DIFF
--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -179,6 +179,7 @@ describe('conversational chain', () => {
           body: { query: { match: { field: 'what is the work from home policy?' } }, size: 3 },
         },
       ],
+      // @ts-ignore
       { index: ['field'], website: ['body_content'] }
     );
   });

--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -19,7 +19,8 @@ describe('conversational chain', () => {
     expectedFinalAnswer: string,
     expectedDocs: any,
     expectedTokens: any,
-    expectedSearchRequest: any
+    expectedSearchRequest: any,
+    contentField?: Record<string, string>
   ) => {
     const searchMock = jest.fn().mockImplementation(() => {
       return {
@@ -69,7 +70,7 @@ describe('conversational chain', () => {
             },
           },
         }),
-        content_field: { index: 'field', website: 'body_content' },
+        content_field: contentField ?? { index: 'field', website: 'body_content' },
         size: 3,
       },
       prompt: 'you are a QA bot',
@@ -144,6 +145,41 @@ describe('conversational chain', () => {
           body: { query: { match: { field: 'what is the work from home policy?' } }, size: 3 },
         },
       ]
+    );
+  });
+
+  it('should be able to create a conversational chain with field as array type', async () => {
+    await createTestChain(
+      ['the final answer'],
+      [
+        {
+          id: '1',
+          role: 'user',
+          content: 'what is the work from home policy?',
+        },
+      ],
+      'the final answer',
+      [
+        {
+          documents: [
+            { metadata: { _id: '1', _index: 'index' }, pageContent: 'value' },
+            { metadata: { _id: '1', _index: 'website' }, pageContent: 'value2' },
+          ],
+          type: 'retrieved_docs',
+        },
+      ],
+      [
+        { type: 'context_token_count', count: 15 },
+        { type: 'prompt_token_count', count: 5 },
+      ],
+      [
+        {
+          method: 'POST',
+          path: '/index,website/_search',
+          body: { query: { match: { field: 'what is the work from home policy?' } }, size: 3 },
+        },
+      ],
+      { index: ['field'], website: ['body_content'] }
     );
   });
 

--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -38,6 +38,9 @@ describe('conversational chain', () => {
               _id: '1',
               _source: {
                 body_content: 'value2',
+                metadata: {
+                  source: 'value3',
+                },
               },
             },
           ],
@@ -148,7 +151,7 @@ describe('conversational chain', () => {
     );
   });
 
-  it('should be able to create a conversational chain with field as array type', async () => {
+  it('should be able to create a conversational chain with nested field', async () => {
     await createTestChain(
       ['the final answer'],
       [
@@ -163,7 +166,7 @@ describe('conversational chain', () => {
         {
           documents: [
             { metadata: { _id: '1', _index: 'index' }, pageContent: 'value' },
-            { metadata: { _id: '1', _index: 'website' }, pageContent: 'value2' },
+            { metadata: { _id: '1', _index: 'website' }, pageContent: 'value3' },
           ],
           type: 'retrieved_docs',
         },
@@ -180,7 +183,7 @@ describe('conversational chain', () => {
         },
       ],
       // @ts-ignore
-      { index: ['field'], website: ['body_content'] }
+      { index: 'field', website: 'metadata.source' }
     );
   });
 

--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -20,7 +20,7 @@ describe('conversational chain', () => {
     expectedDocs: any,
     expectedTokens: any,
     expectedSearchRequest: any,
-    contentField?: Record<string, string>
+    contentField: Record<string, string> = { index: 'field', website: 'body_content' }
   ) => {
     const searchMock = jest.fn().mockImplementation(() => {
       return {
@@ -73,7 +73,7 @@ describe('conversational chain', () => {
             },
           },
         }),
-        content_field: contentField ?? { index: 'field', website: 'body_content' },
+        content_field: contentField,
         size: 3,
       },
       prompt: 'you are a QA bot',
@@ -182,7 +182,6 @@ describe('conversational chain', () => {
           body: { query: { match: { field: 'what is the work from home policy?' } }, size: 3 },
         },
       ],
-      // @ts-ignore
       { index: 'field', website: 'metadata.source' }
     );
   });

--- a/x-pack/plugins/search_playground/server/lib/elasticsearch_retriever.ts
+++ b/x-pack/plugins/search_playground/server/lib/elasticsearch_retriever.ts
@@ -13,6 +13,7 @@ import {
   SearchHit,
   SearchResponse,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { getValueForSelectedField } from '../utils/get_value_for_selected_field';
 
 export interface ElasticsearchRetrieverInput extends BaseRetrieverInput {
   /**
@@ -85,10 +86,13 @@ export class ElasticsearchRetriever extends BaseRetriever {
         const pageContentFieldKey =
           typeof this.content_field === 'string'
             ? this.content_field
-            : this.content_field[hit._index as string];
+            : this.content_field[hit._index as string][0];
+
+        // we need to iterate over the _source object to get the value of complex key definition such as metadata.source
+        const valueForSelectedField = getValueForSelectedField(hit._source, pageContentFieldKey);
 
         return new Document({
-          pageContent: hit._source[pageContentFieldKey],
+          pageContent: valueForSelectedField,
           metadata: {
             _score: hit._score,
             _id: hit._id,

--- a/x-pack/plugins/search_playground/server/lib/elasticsearch_retriever.ts
+++ b/x-pack/plugins/search_playground/server/lib/elasticsearch_retriever.ts
@@ -83,10 +83,15 @@ export class ElasticsearchRetriever extends BaseRetriever {
 
       // default elasticsearch doc to LangChain doc
       let mapper: HitDocMapper = (hit: SearchHit<any>) => {
-        const pageContentFieldKey =
+        let pageContentFieldKey =
           typeof this.content_field === 'string'
             ? this.content_field
-            : this.content_field[hit._index as string][0];
+            : this.content_field[hit._index as string];
+
+        // field values can be a single item array or plain text, that is why needed to check the types before accessing the field
+        pageContentFieldKey = Array.isArray(pageContentFieldKey)
+          ? pageContentFieldKey[0]
+          : pageContentFieldKey;
 
         // we need to iterate over the _source object to get the value of complex key definition such as metadata.source
         const valueForSelectedField = getValueForSelectedField(hit._source, pageContentFieldKey);

--- a/x-pack/plugins/search_playground/server/lib/elasticsearch_retriever.ts
+++ b/x-pack/plugins/search_playground/server/lib/elasticsearch_retriever.ts
@@ -83,15 +83,10 @@ export class ElasticsearchRetriever extends BaseRetriever {
 
       // default elasticsearch doc to LangChain doc
       let mapper: HitDocMapper = (hit: SearchHit<any>) => {
-        let pageContentFieldKey =
+        const pageContentFieldKey =
           typeof this.content_field === 'string'
             ? this.content_field
             : this.content_field[hit._index as string];
-
-        // field values can be a single item array or plain text, that is why needed to check the types before accessing the field
-        pageContentFieldKey = Array.isArray(pageContentFieldKey)
-          ? pageContentFieldKey[0]
-          : pageContentFieldKey;
 
         // we need to iterate over the _source object to get the value of complex key definition such as metadata.source
         const valueForSelectedField = getValueForSelectedField(hit._source, pageContentFieldKey);

--- a/x-pack/plugins/search_playground/server/routes.ts
+++ b/x-pack/plugins/search_playground/server/routes.ts
@@ -109,6 +109,11 @@ export function defineRoutes({
 
       try {
         sourceFields = JSON.parse(data.source_fields);
+        sourceFields = Object.keys(sourceFields).reduce((acc, key) => {
+          // @ts-ignore
+          acc[key] = sourceFields[key][0];
+          return acc;
+        }, {});
       } catch (e) {
         logger.error('Failed to parse the source fields', e);
         throw Error(e);

--- a/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.test.ts
+++ b/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getValueForSelectedField } from './get_value_for_selected_field';
+
+describe('getValueForSelectedField', () => {
+  test('should return for simple key', () => {
+    const hit = {
+      _index: 'sample-index',
+      _id: '8jSNY48B6iHEi98DL1C-',
+      _score: 0.7789394,
+      _source: {
+        test: 'The Shawshank Redemption',
+        metadata: {
+          source:
+            'Over the course of several years, two convicts form a friendship, seeking consolation and, eventually, redemption through basic compassion',
+        },
+      },
+    };
+
+    expect(getValueForSelectedField(hit._source, 'test')).toEqual('The Shawshank Redemption');
+  });
+
+  test('should return for combined key', () => {
+    const hit = {
+      _index: 'sample-index',
+      _id: '8jSNY48B6iHEi98DL1C-',
+      _score: 0.7789394,
+      _source: {
+        test: 'The Shawshank Redemption',
+        metadata: {
+          source:
+            'Over the course of several years, two convicts form a friendship, seeking consolation and, eventually, redemption through basic compassion',
+        },
+      },
+    };
+
+    expect(getValueForSelectedField(hit._source, 'metadata.source')).toEqual(
+      'Over the course of several years, two convicts form a friendship, seeking consolation and, eventually, redemption through basic compassion'
+    );
+  });
+
+  test('should return undefined for missing key', () => {
+    const hit = {
+      _index: 'sample-index',
+      _id: '8jSNY48B6iHEi98DL1C-',
+      _score: 0.7789394,
+      _source: {
+        test: 'The Shawshank Redemption',
+        metadata: {
+          source:
+            'Over the course of several years, two convicts form a friendship, seeking consolation and, eventually, redemption through basic compassion',
+        },
+      },
+    };
+
+    expect(getValueForSelectedField(hit._source, 'metadata.sources')).toBeUndefined();
+  });
+});

--- a/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.ts
+++ b/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// @ts-ignore
+export const getValueForSelectedField = (source, path: string): string => {
+  return path.split('.').reduce((acc, key) => acc[key], source);
+};


### PR DESCRIPTION
## Summary

Currently, Nested fields are not being parsed correctly. Due to that, `context` is showing empty in list of the documents retrieved flyout.

This PR includes a fix for the nested fields parsing issue. 

### UI (Stack):

<img width="1507" alt="Screenshot 2024-05-10 at 2 51 53 PM" src="https://github.com/elastic/kibana/assets/150824886/d298a673-595c-41b7-a7d6-600cfca0ea1b">
<img width="1512" alt="Screenshot 2024-05-10 at 2 52 09 PM" src="https://github.com/elastic/kibana/assets/150824886/6d4cf8f4-73e4-47f3-bed7-77f7f8863726">

### UI (Serverless):
![Screenshot 2024-05-12 at 1 02 43 PM](https://github.com/elastic/kibana/assets/150824886/f0a31056-64dc-409e-80cf-7ad15452a579)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->