### PR TITLE
[EDR Workflows] Fix flaky osquery alerts_response_actions_form.cy.ts test

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_response_actions_form.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_response_actions_form.cy.ts
@@ -138,7 +138,7 @@ describe('Alert Event Details - Response Actions Form', { tags: ['@ess', '@serve
         inputQuery('select * from uptime');
         cy.contains('Query is a required field').should('not.exist');
         cy.contains('Advanced').click();
-        typeInECSFieldInput('{downArrow}{enter}');
+        typeInECSFieldInput('label{downArrow}{enter}');
         cy.getBySel('osqueryColumnValueSelect').type('days{downArrow}{enter}');
       })
       .clickOutside();

--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_response_actions_form.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_response_actions_form.cy.ts
@@ -24,229 +24,227 @@ import {
 import { clickRuleName, inputQuery, typeInECSFieldInput } from '../../tasks/live_query';
 import { closeDateTabIfVisible, closeToastIfVisible } from '../../tasks/integrations';
 
-// Failing: See https://github.com/elastic/kibana/issues/169785
-describe.skip(
-  'Alert Event Details - Response Actions Form',
-  { tags: ['@ess', '@serverless'] },
-  () => {
-    let multiQueryPackId: string;
-    let multiQueryPackName: string;
-    let ruleId: string;
-    let ruleName: string;
-    let packId: string;
-    let packName: string;
-    const packData = packFixture();
-    const multiQueryPackData = multiQueryPackFixture();
-    before(() => {
-      initializeDataViews();
+describe('Alert Event Details - Response Actions Form', { tags: ['@ess', '@serverless'] }, () => {
+  let multiQueryPackId: string;
+  let multiQueryPackName: string;
+  let ruleId: string;
+  let ruleName: string;
+  let packId: string;
+  let packName: string;
+  const packData = packFixture();
+  const multiQueryPackData = multiQueryPackFixture();
+  before(() => {
+    initializeDataViews();
+  });
+  beforeEach(() => {
+    loadPack(packData).then((data) => {
+      packId = data.saved_object_id;
+      packName = data.name;
     });
-    beforeEach(() => {
-      loadPack(packData).then((data) => {
-        packId = data.saved_object_id;
-        packName = data.name;
-      });
-      loadPack(multiQueryPackData).then((data) => {
-        multiQueryPackId = data.saved_object_id;
-        multiQueryPackName = data.name;
-      });
-      loadRule().then((data) => {
-        ruleId = data.id;
-        ruleName = data.name;
-      });
+    loadPack(multiQueryPackData).then((data) => {
+      multiQueryPackId = data.saved_object_id;
+      multiQueryPackName = data.name;
     });
-    afterEach(() => {
-      cleanupPack(packId);
-      cleanupPack(multiQueryPackId);
-      cleanupRule(ruleId);
+    loadRule().then((data) => {
+      ruleId = data.id;
+      ruleName = data.name;
+    });
+  });
+  afterEach(() => {
+    cleanupPack(packId);
+    cleanupPack(multiQueryPackId);
+    cleanupRule(ruleId);
+  });
+
+  it('adds response actions with osquery with proper validation and form values', () => {
+    cy.visit('/app/security/rules');
+    clickRuleName(ruleName);
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+    cy.getBySel('editRuleSettingsLink').click();
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+    closeDateTabIfVisible();
+    cy.getBySel('edit-rule-actions-tab').click();
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+    cy.contains('Response actions are run on each rule execution.');
+    cy.getBySel(OSQUERY_RESPONSE_ACTION_ADD_BUTTON).click();
+
+    cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
+      cy.contains('Query is a required field');
+      cy.contains('The timeout value must be 60 seconds or higher.').should('not.exist');
     });
 
-    it('adds response actions with osquery with proper validation and form values', () => {
-      cy.visit('/app/security/rules');
-      clickRuleName(ruleName);
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-      cy.getBySel('editRuleSettingsLink').click();
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-      closeDateTabIfVisible();
-      cy.getBySel('edit-rule-actions-tab').click();
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-      cy.contains('Response actions are run on each rule execution.');
-      cy.getBySel(OSQUERY_RESPONSE_ACTION_ADD_BUTTON).click();
+    // check if changing error state of one input doesn't clear other errors - START
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.contains('Advanced').click();
+      cy.getBySel('timeout-input').clear();
+      cy.contains('The timeout value must be 60 seconds or higher.');
+    });
 
-      cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
+    cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
+      cy.contains('Query is a required field');
+      cy.contains('The timeout value must be 60 seconds or higher.');
+    });
+
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.getBySel('timeout-input').type('6');
+      cy.contains('The timeout value must be 60 seconds or higher.');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
+      cy.contains('Query is a required field');
+      cy.contains('The timeout value must be 60 seconds or higher.');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.getBySel('timeout-input').type('6');
+      cy.contains('The timeout value must be 60 seconds or higher.').should('not.exist');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
+      cy.contains('Query is a required field');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.getBySel('timeout-input').type('6');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
+      cy.contains('Query is a required field');
+      cy.contains('The timeout value must be 60 seconds or higher.').should('not.exist');
+    });
+    // check if changing error state of one input doesn't clear other errors - END
+
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.contains('Query is a required field');
+      inputQuery('select * from uptime1');
+    });
+    cy.getBySel(OSQUERY_RESPONSE_ACTION_ADD_BUTTON).click();
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
+      cy.contains('Run a set of queries in a pack').click();
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ERRORS)
+      .within(() => {
+        cy.contains('Pack is a required field');
+      })
+      .should('exist');
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
+      cy.contains('Pack is a required field');
+      cy.getBySel('comboBoxInput').click();
+      cy.getBySel('comboBoxInput').type(`${packName}`);
+      cy.contains(`doesn't match any options`).should('not.exist');
+      cy.getBySel('comboBoxInput').type('{downArrow}{enter}');
+    });
+
+    cy.getBySel(OSQUERY_RESPONSE_ACTION_ADD_BUTTON).click();
+
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_2)
+      .within(() => {
         cy.contains('Query is a required field');
-        cy.contains('The timeout value must be 60 seconds or higher.').should('not.exist');
-      });
-
-      // check if changing error state of one input doesn't clear other errors - START
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+        inputQuery('select * from uptime');
+        cy.contains('Query is a required field').should('not.exist');
         cy.contains('Advanced').click();
-        cy.getBySel('timeout-input').clear();
-        cy.contains('The timeout value must be 60 seconds or higher.');
-      });
+        typeInECSFieldInput('{downArrow}{enter}');
+        cy.getBySel('osqueryColumnValueSelect').type('days{downArrow}{enter}');
+      })
+      .clickOutside();
 
-      cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
-        cy.contains('Query is a required field');
-        cy.contains('The timeout value must be 60 seconds or higher.');
-      });
+    cy.getBySel('ruleEditSubmitButton').click();
+    cy.contains(`${ruleName} was saved`).should('exist');
+    closeToastIfVisible();
 
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
-        cy.getBySel('timeout-input').type('6');
-        cy.contains('The timeout value must be 60 seconds or higher.');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
-        cy.contains('Query is a required field');
-        cy.contains('The timeout value must be 60 seconds or higher.');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
-        cy.getBySel('timeout-input').type('6');
-        cy.contains('The timeout value must be 60 seconds or higher.').should('not.exist');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
-        cy.contains('Query is a required field');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
-        cy.getBySel('timeout-input').type('6');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ERRORS).within(() => {
-        cy.contains('Query is a required field');
-        cy.contains('The timeout value must be 60 seconds or higher.').should('not.exist');
-      });
-      // check if changing error state of one input doesn't clear other errors - END
-
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
-        cy.contains('Query is a required field');
-        inputQuery('select * from uptime1');
-      });
-      cy.getBySel(OSQUERY_RESPONSE_ACTION_ADD_BUTTON).click();
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
-        cy.contains('Run a set of queries in a pack').click();
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ERRORS)
-        .within(() => {
-          cy.contains('Pack is a required field');
-        })
-        .should('exist');
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+    cy.getBySel('editRuleSettingsLink').click();
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+    cy.getBySel('edit-rule-actions-tab').click();
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.contains('select * from uptime1');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_2).within(() => {
+      cy.contains('select * from uptime');
+      cy.contains('Custom key/value pairs. e.g. {"application":"foo-bar","env":"production"}');
+      cy.contains('Days of uptime');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
+      cy.getBySel('comboBoxSearchInput').should('have.value', packName);
+      cy.getBySel('comboBoxInput').type('{selectall}{backspace}{enter}');
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
+      cy.contains('select * from uptime1');
+      cy.getBySel('remove-response-action').click();
+    });
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0)
+      .within(() => {
+        cy.getBySel('comboBoxSearchInput').click();
+        cy.contains('Search for a pack to run');
         cy.contains('Pack is a required field');
         cy.getBySel('comboBoxInput').type(`${packName}{downArrow}{enter}`);
-      });
-
-      cy.getBySel(OSQUERY_RESPONSE_ACTION_ADD_BUTTON).click();
-
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_2)
-        .within(() => {
-          cy.contains('Query is a required field');
-          inputQuery('select * from uptime');
-          cy.contains('Query is a required field').should('not.exist');
-          cy.contains('Advanced').click();
-          typeInECSFieldInput('{downArrow}{enter}');
-          cy.getBySel('osqueryColumnValueSelect').type('days{downArrow}{enter}');
-        })
-        .clickOutside();
-
-      cy.getBySel('ruleEditSubmitButton').click();
-      cy.contains(`${ruleName} was saved`).should('exist');
-      closeToastIfVisible();
-
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-      cy.getBySel('editRuleSettingsLink').click();
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-      cy.getBySel('edit-rule-actions-tab').click();
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
-        cy.contains('select * from uptime1');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_2).within(() => {
-        cy.contains('select * from uptime');
-        cy.contains('Custom key/value pairs. e.g. {"application":"foo-bar","env":"production"}');
-        cy.contains('Days of uptime');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
-        cy.getBySel('comboBoxSearchInput').should('have.value', packName);
-        cy.getBySel('comboBoxInput').type('{selectall}{backspace}{enter}');
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0).within(() => {
-        cy.contains('select * from uptime1');
-        cy.getBySel('remove-response-action').click();
-      });
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0)
-        .within(() => {
-          cy.getBySel('comboBoxSearchInput').click();
-          cy.contains('Search for a pack to run');
-          cy.contains('Pack is a required field');
-          cy.getBySel('comboBoxInput').type(`${packName}{downArrow}{enter}`);
-          cy.contains(packName);
-        })
-        .clickOutside();
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
-        cy.contains('select * from uptime');
-        cy.contains('Custom key/value pairs. e.g. {"application":"foo-bar","env":"production"}');
-        cy.contains('Days of uptime');
-      });
-
-      cy.intercept('PUT', '/api/detection_engine/rules').as('saveRuleSingleQuery');
-
-      cy.getBySel('ruleEditSubmitButton').click();
-      cy.wait('@saveRuleSingleQuery', { timeout: 15000 }).should(({ request }) => {
-        const oneQuery = [
-          {
-            interval: 3600,
-            query: 'select * from uptime;',
-            id: Object.keys(packData.queries)[0],
-          },
-        ];
-        expect(request.body.response_actions[0].params.queries).to.deep.equal(oneQuery);
-      });
-
-      cy.contains(`${ruleName} was saved`).should('exist');
-      closeToastIfVisible();
-
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-      cy.getBySel('editRuleSettingsLink').click();
-      cy.getBySel('globalLoadingIndicator').should('not.exist');
-
-      cy.getBySel('edit-rule-actions-tab').click();
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_0)
-        .within(() => {
-          cy.getBySel('comboBoxSearchInput').should('have.value', packName);
-          cy.getBySel('comboBoxInput').type(
-            `{selectall}{backspace}${multiQueryPackName}{downArrow}{enter}`
-          );
-          cy.contains('SELECT * FROM memory_info;');
-          cy.contains('SELECT * FROM system_info;');
-        })
-        .clickOutside();
-
-      cy.getBySel(RESPONSE_ACTIONS_ITEM_1)
-        .within(() => {
-          cy.contains('select * from uptime');
-          cy.contains('Custom key/value pairs. e.g. {"application":"foo-bar","env":"production"}');
-          cy.contains('Days of uptime');
-        })
-        .clickOutside();
-      cy.intercept('PUT', '/api/detection_engine/rules').as('saveRuleMultiQuery');
-
-      cy.contains('Save changes').click();
-      cy.wait('@saveRuleMultiQuery', { timeout: 15000 }).should(({ request }) => {
-        const threeQueries = [
-          {
-            interval: 3600,
-            query: 'SELECT * FROM memory_info;',
-            platform: 'linux',
-            id: Object.keys(multiQueryPackData.queries)[0],
-          },
-          {
-            interval: 3600,
-            query: 'SELECT * FROM system_info;',
-            id: Object.keys(multiQueryPackData.queries)[1],
-          },
-          {
-            interval: 10,
-            query: 'select opera_extensions.* from users join opera_extensions using (uid);',
-            id: Object.keys(multiQueryPackData.queries)[2],
-          },
-        ];
-        expect(request.body.response_actions[0].params.queries).to.deep.equal(threeQueries);
-      });
+        cy.contains(packName);
+      })
+      .clickOutside();
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_1).within(() => {
+      cy.contains('select * from uptime');
+      cy.contains('Custom key/value pairs. e.g. {"application":"foo-bar","env":"production"}');
+      cy.contains('Days of uptime');
     });
-  }
-);
+
+    cy.intercept('PUT', '/api/detection_engine/rules').as('saveRuleSingleQuery');
+
+    cy.getBySel('ruleEditSubmitButton').click();
+    cy.wait('@saveRuleSingleQuery', { timeout: 15000 }).should(({ request }) => {
+      const oneQuery = [
+        {
+          interval: 3600,
+          query: 'select * from uptime;',
+          id: Object.keys(packData.queries)[0],
+        },
+      ];
+      expect(request.body.response_actions[0].params.queries).to.deep.equal(oneQuery);
+    });
+
+    cy.contains(`${ruleName} was saved`).should('exist');
+    closeToastIfVisible();
+
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+    cy.getBySel('editRuleSettingsLink').click();
+    cy.getBySel('globalLoadingIndicator').should('not.exist');
+
+    cy.getBySel('edit-rule-actions-tab').click();
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_0)
+      .within(() => {
+        cy.getBySel('comboBoxSearchInput').should('have.value', packName);
+        cy.getBySel('comboBoxInput').type(
+          `{selectall}{backspace}${multiQueryPackName}{downArrow}{enter}`
+        );
+        cy.contains('SELECT * FROM memory_info;');
+        cy.contains('SELECT * FROM system_info;');
+      })
+      .clickOutside();
+
+    cy.getBySel(RESPONSE_ACTIONS_ITEM_1)
+      .within(() => {
+        cy.contains('select * from uptime');
+        cy.contains('Custom key/value pairs. e.g. {"application":"foo-bar","env":"production"}');
+        cy.contains('Days of uptime');
+      })
+      .clickOutside();
+    cy.intercept('PUT', '/api/detection_engine/rules').as('saveRuleMultiQuery');
+
+    cy.contains('Save changes').click();
+    cy.wait('@saveRuleMultiQuery', { timeout: 15000 }).should(({ request }) => {
+      const threeQueries = [
+        {
+          interval: 3600,
+          query: 'SELECT * FROM memory_info;',
+          platform: 'linux',
+          id: Object.keys(multiQueryPackData.queries)[0],
+        },
+        {
+          interval: 3600,
+          query: 'SELECT * FROM system_info;',
+          id: Object.keys(multiQueryPackData.queries)[1],
+        },
+        {
+          interval: 10,
+          query: 'select opera_extensions.* from users join opera_extensions using (uid);',
+          id: Object.keys(multiQueryPackData.queries)[2],
+        },
+      ];
+      expect(request.body.response_actions[0].params.queries).to.deep.equal(threeQueries);
+    });
+  });
+});

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -67,11 +67,8 @@ export const checkResults = () => {
   });
 };
 
-export const typeInECSFieldInput = (text: string, index = 0) => {
-  cy.getBySel('ECS-field-input').eq(index).click();
-  cy.getBySel('globalLoadingIndicator').should('not.exist');
+export const typeInECSFieldInput = (text: string, index = 0) =>
   cy.getBySel('ECS-field-input').eq(index).type(text);
-};
 
 export const typeInOsqueryFieldInput = (text: string, index = 0) =>
   cy

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -75,6 +75,7 @@ export const typeInOsqueryFieldInput = (text: string, index = 0) =>
     .eq(index)
     .within(() => {
       cy.getBySel('comboBoxInput').click();
+      cy.getBySel('globalLoadingIndicator').should('not.exist');
       cy.getBySel('comboBoxInput').type(text);
     });
 

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -67,8 +67,12 @@ export const checkResults = () => {
   });
 };
 
-export const typeInECSFieldInput = (text: string, index = 0) =>
+export const typeInECSFieldInput = (text: string, index = 0) => {
+  cy.getBySel('ECS-field-input').eq(index).click();
+  cy.getBySel('globalLoadingIndicator').should('not.exist');
   cy.getBySel('ECS-field-input').eq(index).type(text);
+};
+
 export const typeInOsqueryFieldInput = (text: string, index = 0) =>
   cy
     .getBySel('osqueryColumnValueSelect')

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -74,6 +74,7 @@ export const typeInOsqueryFieldInput = (text: string, index = 0) =>
     .getBySel('osqueryColumnValueSelect')
     .eq(index)
     .within(() => {
+      cy.getBySel('comboBoxInput').click();
       cy.getBySel('comboBoxInput').type(text);
     });
 

--- a/x-pack/plugins/osquery/package.json
+++ b/x-pack/plugins/osquery/package.json
@@ -12,7 +12,7 @@
     "cypress:run": "yarn cypress run",
     "cypress:serverless": "NODE_OPTIONS=--openssl-legacy-provider node ../security_solution/scripts/start_cypress_parallel --config-file ../osquery/cypress/serverless_cypress.config.ts --ftr-config-file ../../../x-pack/test/osquery_cypress/serverless_cli_config",
     "cypress:serverless:open": "yarn cypress:serverless open",
-    "cypress:serverless:run": "yarn cypress:serverless run",
+    "cypress:serverless:run": "yarn cypress:serverless run --spec ./cypress/e2e/all/alerts_response_actions_form.cy.ts",
     "nyc": "../../../node_modules/.bin/nyc report --reporter=text-summary",
     "junit:merge": "../../../node_modules/.bin/mochawesome-merge ../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../target/kibana-osquery/cypress/results/output.json && ../../../node_modules/.bin/marge ../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../target/junit && cp ../../../target/kibana-osquery/cypress/results/*.xml ../../../target/junit/",
     "junit:transform": "node ../security_solution/scripts/junit_transformer --pathPattern '../../../target/kibana-osquery/cypress/results/*.xml' --rootDirectory ../../../ --reportName 'Osquery Cypress' --writeInPlace",

--- a/x-pack/plugins/osquery/package.json
+++ b/x-pack/plugins/osquery/package.json
@@ -12,7 +12,7 @@
     "cypress:run": "yarn cypress run",
     "cypress:serverless": "NODE_OPTIONS=--openssl-legacy-provider node ../security_solution/scripts/start_cypress_parallel --config-file ../osquery/cypress/serverless_cypress.config.ts --ftr-config-file ../../../x-pack/test/osquery_cypress/serverless_cli_config",
     "cypress:serverless:open": "yarn cypress:serverless open",
-    "cypress:serverless:run": "yarn cypress:serverless run --spec ./cypress/e2e/all/alerts_response_actions_form.cy.ts",
+    "cypress:serverless:run": "yarn cypress:serverless run",
     "nyc": "../../../node_modules/.bin/nyc report --reporter=text-summary",
     "junit:merge": "../../../node_modules/.bin/mochawesome-merge ../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../target/kibana-osquery/cypress/results/output.json && ../../../node_modules/.bin/marge ../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../target/junit && cp ../../../target/kibana-osquery/cypress/results/*.xml ../../../target/junit/",
     "junit:transform": "node ../security_solution/scripts/junit_transformer --pathPattern '../../../target/kibana-osquery/cypress/results/*.xml' --rootDirectory ../../../ --reportName 'Osquery Cypress' --writeInPlace",


### PR DESCRIPTION
This PR fixes a flaky test.
<img width="1758" alt="Zrzut ekranu 2024-05-14 o 14 14 01" src="https://github.com/elastic/kibana/assets/16632552/943fcb6a-9714-497c-95e3-69cab05d0d33">

- https://buildkite.com/elastic/kibana-on-merge/builds/45125#018f63d3-6e61-4d4b-9cf5-bc7e70466f96

The issue didn't appear in the flaky test runs, although there were some other fails. 
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5966
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5968

Closes: https://github.com/elastic/kibana/issues/169785

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->