### PR TITLE
[EDR Workflows] Fix flaky osquery pack_integration test

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/packs_integration.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/packs_integration.cy.ts
@@ -104,8 +104,7 @@ describe('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
     }
   );
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176543
-  describe.skip('Load prebuilt packs', { tags: ['@ess', '@serverless'] }, () => {
+  describe('Load prebuilt packs', { tags: ['@ess', '@serverless'] }, () => {
     afterEach(() => {
       cleanupAllPrebuiltPacks();
     });
@@ -161,9 +160,11 @@ describe('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
 
       it('should be able to run live prebuilt pack', () => {
         navigateTo('/app/osquery/live_queries');
+
         cy.contains('New live query').click();
         cy.contains('Run a set of queries in a pack.').click();
         cy.getBySel(LIVE_QUERY_EDITOR).should('not.exist');
+        cy.getBySel('globalLoadingIndicator').should('not.exist');
         cy.getBySel('select-live-pack').click().type('osquery-monitoring{downArrow}{enter}');
         selectAllAgents();
         submitQuery();

--- a/x-pack/plugins/osquery/cypress/e2e/all/packs_integration.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/packs_integration.cy.ts
@@ -160,7 +160,6 @@ describe('ALL - Packs', { tags: ['@ess', '@serverless'] }, () => {
 
       it('should be able to run live prebuilt pack', () => {
         navigateTo('/app/osquery/live_queries');
-
         cy.contains('New live query').click();
         cy.contains('Run a set of queries in a pack.').click();
         cy.getBySel(LIVE_QUERY_EDITOR).should('not.exist');

--- a/x-pack/plugins/osquery/package.json
+++ b/x-pack/plugins/osquery/package.json
@@ -12,7 +12,7 @@
     "cypress:run": "yarn cypress run",
     "cypress:serverless": "NODE_OPTIONS=--openssl-legacy-provider node ../security_solution/scripts/start_cypress_parallel --config-file ../osquery/cypress/serverless_cypress.config.ts --ftr-config-file ../../../x-pack/test/osquery_cypress/serverless_cli_config",
     "cypress:serverless:open": "yarn cypress:serverless open",
-    "cypress:serverless:run": "yarn cypress:serverless run --spec ./cypress/e2e/all/packs_integration.cy.ts",
+    "cypress:serverless:run": "yarn cypress:serverless run",
     "nyc": "../../../node_modules/.bin/nyc report --reporter=text-summary",
     "junit:merge": "../../../node_modules/.bin/mochawesome-merge ../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../target/kibana-osquery/cypress/results/output.json && ../../../node_modules/.bin/marge ../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../target/junit && cp ../../../target/kibana-osquery/cypress/results/*.xml ../../../target/junit/",
     "junit:transform": "node ../security_solution/scripts/junit_transformer --pathPattern '../../../target/kibana-osquery/cypress/results/*.xml' --rootDirectory ../../../ --reportName 'Osquery Cypress' --writeInPlace",

--- a/x-pack/plugins/osquery/package.json
+++ b/x-pack/plugins/osquery/package.json
@@ -12,7 +12,7 @@
     "cypress:run": "yarn cypress run",
     "cypress:serverless": "NODE_OPTIONS=--openssl-legacy-provider node ../security_solution/scripts/start_cypress_parallel --config-file ../osquery/cypress/serverless_cypress.config.ts --ftr-config-file ../../../x-pack/test/osquery_cypress/serverless_cli_config",
     "cypress:serverless:open": "yarn cypress:serverless open",
-    "cypress:serverless:run": "yarn cypress:serverless run",
+    "cypress:serverless:run": "yarn cypress:serverless run --spec ./cypress/e2e/all/packs_integration.cy.ts",
     "nyc": "../../../node_modules/.bin/nyc report --reporter=text-summary",
     "junit:merge": "../../../node_modules/.bin/mochawesome-merge ../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../target/kibana-osquery/cypress/results/output.json && ../../../node_modules/.bin/marge ../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../target/junit && cp ../../../target/kibana-osquery/cypress/results/*.xml ../../../target/junit/",
     "junit:transform": "node ../security_solution/scripts/junit_transformer --pathPattern '../../../target/kibana-osquery/cypress/results/*.xml' --rootDirectory ../../../ --reportName 'Osquery Cypress' --writeInPlace",


### PR DESCRIPTION
This PR fixes a flaky test.
- example fail: https://buildkite.com/elastic/kibana-on-merge/builds/42302#018e1da4-aee8-49e0-9f6e-aeef18401bc2
- 99/99 ✅ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5950

Closes: #176543

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->