### PR TITLE
[7.17] Backport #183140 

### DIFF
--- a/.buildkite/pipelines/es_snapshots/build.yml
+++ b/.buildkite/pipelines/es_snapshots/build.yml
@@ -4,7 +4,7 @@ steps:
     timeout_in_minutes: 30
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       localSsds: 1
       localSsdInterface: nvme

--- a/.buildkite/pipelines/es_snapshots/promote.yml
+++ b/.buildkite/pipelines/es_snapshots/promote.yml
@@ -12,6 +12,6 @@ steps:
     command: .buildkite/scripts/steps/es_snapshots/promote.sh
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/es_snapshots/verify.yml
+++ b/.buildkite/pipelines/es_snapshots/verify.yml
@@ -16,7 +16,7 @@ steps:
     timeout_in_minutes: 10
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
 
@@ -26,7 +26,7 @@ steps:
     label: Build Kibana Distribution and Plugins
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: c2-standard-16
       preemptible: true
@@ -39,7 +39,7 @@ steps:
     parallelism: 27
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
     depends_on: build
@@ -54,7 +54,7 @@ steps:
     label: 'Docker CI Group'
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
     depends_on: build
@@ -70,7 +70,7 @@ steps:
     parallelism: 11
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
@@ -87,7 +87,7 @@ steps:
     parallelism: 3
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-4
     timeout_in_minutes: 120
@@ -101,7 +101,7 @@ steps:
     label: 'API Integration Tests'
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
     timeout_in_minutes: 120
@@ -112,7 +112,7 @@ steps:
     timeout_in_minutes: 10
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2
     depends_on:
@@ -130,6 +130,6 @@ steps:
     timeout_in_minutes: 10
     agents:
       image: family/kibana-ubuntu-2004
-      imageProject: elastic-images-qa
+      imageProject: elastic-images-prod
       provider: gcp
       machineType: n2-standard-2

--- a/.buildkite/pipelines/flaky_tests/pipeline.js
+++ b/.buildkite/pipelines/flaky_tests/pipeline.js
@@ -27,7 +27,7 @@ const getAgentRule = (queueName = 'n2-4-spot') => {
     return {
       provider: 'gcp',
       image: 'family/kibana-ubuntu-2004',
-      imageProject: 'elastic-images-qa',
+      imageProject: 'elastic-images-prod',
       machineType: `${kind}-standard-${cores}`,
       ...additionalProps,
     };

--- a/.buildkite/pipelines/flaky_tests/runner.js
+++ b/.buildkite/pipelines/flaky_tests/runner.js
@@ -27,7 +27,7 @@ const getAgentRule = (queueName = 'n2-4-spot') => {
     return {
       provider: 'gcp',
       image: 'family/kibana-ubuntu-2004',
-      imageProject: 'elastic-images-qa',
+      imageProject: 'elastic-images-prod',
       machineType: `${kind}-standard-${cores}`,
       ...additionalProps,
     };


### PR DESCRIPTION
## Summary
Manual backport of #183140, simply replacing `elastic-images-qa` => `elastic-images-prod`