### PR TITLE
[ci] Refactor docker login

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -20,7 +20,6 @@ echo "> node scripts/build" "${BUILD_ARGS[@]}"
 node scripts/build "${BUILD_ARGS[@]}"
 
 if is_pr_with_label "ci:build-cloud-image"; then
-  echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
   node scripts/build \
   --skip-initialize \
   --skip-generic-folders \
@@ -35,7 +34,6 @@ if is_pr_with_label "ci:build-cloud-image"; then
   --skip-docker-ubuntu \
   --skip-docker-serverless \
   --skip-docker-contexts
-  docker logout docker.elastic.co
 
   CLOUD_IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" docker.elastic.co/kibana-ci/kibana-cloud)
   cat << EOF | buildkite-agent annotate --style "info" --context kibana-cloud-image

--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -8,7 +8,6 @@ if [[ "$(type -t vault_get)" != "function" ]]; then
   source .buildkite/scripts/common/vault_fns.sh
 fi
 
-
 # Set up general-purpose tokens and credentials
 {
   BUILDKITE_TOKEN="$(vault_get buildkite-ci buildkite_token_all_jobs)"

--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -20,8 +20,6 @@ fi
   export KIBANA_CI_GITHUB_TOKEN
 
   KIBANA_DOCKER_USERNAME="$(vault_get container-registry username)"
-  export KIBANA_DOCKER_USERNAME
-
   KIBANA_DOCKER_PASSWORD="$(vault_get container-registry password)"
   echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
 }

--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -8,6 +8,7 @@ if [[ "$(type -t vault_get)" != "function" ]]; then
   source .buildkite/scripts/common/vault_fns.sh
 fi
 
+
 # Set up general-purpose tokens and credentials
 {
   BUILDKITE_TOKEN="$(vault_get buildkite-ci buildkite_token_all_jobs)"
@@ -23,7 +24,7 @@ fi
   export KIBANA_DOCKER_USERNAME
 
   KIBANA_DOCKER_PASSWORD="$(vault_get container-registry password)"
-  export KIBANA_DOCKER_PASSWORD
+  echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
 }
 
 # Set up a custom ES Snapshot Manifest if one has been specified for this build

--- a/.buildkite/scripts/pipelines/security_solution_quality_gate/create_periodic_test_docker_image.sh
+++ b/.buildkite/scripts/pipelines/security_solution_quality_gate/create_periodic_test_docker_image.sh
@@ -17,9 +17,6 @@ KIBANA_BASE_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless"
 export KIBANA_IMAGE="$KIBANA_BASE_IMAGE:$KIBANA_IMAGE_TAG"
 
 echo "--- Verify manifest does not already exist"
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-trap 'docker logout docker.elastic.co' EXIT
-
 echo "Checking manifest for $KIBANA_IMAGE"
 if docker manifest inspect $KIBANA_IMAGE &> /dev/null; then
   echo "Manifest already exists, exiting"
@@ -69,8 +66,6 @@ if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]] && [[ "${BUILDKITE_PULL_RE
     --amend "$KIBANA_IMAGE-amd64"
   docker manifest push "$KIBANA_BASE_IMAGE:latest"
 fi
-
-docker logout docker.elastic.co
 
 cat << EOF | buildkite-agent annotate --style "info" --context image
   ### Serverless Images

--- a/.buildkite/scripts/pipelines/security_solution_quality_gate/upload_image_metadata.sh
+++ b/.buildkite/scripts/pipelines/security_solution_quality_gate/upload_image_metadata.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
 
 KIBANA_BASE_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless"
 KIBANA_LATEST=${KIBANA_BASE_IMAGE}:latest

--- a/.buildkite/scripts/steps/artifacts/cloud.sh
+++ b/.buildkite/scripts/steps/artifacts/cloud.sh
@@ -20,16 +20,11 @@ KIBANA_TEST_IMAGE="docker.elastic.co/kibana-ci/kibana-cloud:$TAG"
 # docker.elastic.co/kibana-ci/kibana-cloud:$FULL_VERSION -> :$FULL_VERSION-$GIT_COMMIT
 docker tag "$KIBANA_BASE_IMAGE" "$KIBANA_TEST_IMAGE"
 
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-trap 'docker logout docker.elastic.co' EXIT
-
 if  docker manifest inspect $KIBANA_TEST_IMAGE &> /dev/null; then
   echo "Cloud image already exists, skipping docker push"
 else
   docker image push "$KIBANA_TEST_IMAGE"
 fi
-
-docker logout docker.elastic.co
 
 echo "--- Create deployment"
 CLOUD_DEPLOYMENT_NAME="kibana-artifacts-$TAG"

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -17,9 +17,6 @@ KIBANA_BASE_IMAGE="docker.elastic.co/kibana-ci/kibana-serverless"
 export KIBANA_IMAGE="$KIBANA_BASE_IMAGE:$KIBANA_IMAGE_TAG"
 
 echo "--- Verify manifest does not already exist"
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-trap 'docker logout docker.elastic.co' EXIT
-
 echo "Checking manifest for $KIBANA_IMAGE"
 if docker manifest inspect $KIBANA_IMAGE &> /dev/null; then
   echo "Manifest already exists, exiting"
@@ -67,8 +64,6 @@ if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]] && [[ "${BUILDKITE_PULL_RE
     --amend "$KIBANA_IMAGE-amd64"
   docker manifest push "$KIBANA_BASE_IMAGE:latest"
 fi
-
-docker logout docker.elastic.co
 
 cat << EOF | buildkite-agent annotate --style "info" --context image
   ### Serverless Images

--- a/.buildkite/scripts/steps/artifacts/publish.sh
+++ b/.buildkite/scripts/steps/artifacts/publish.sh
@@ -49,8 +49,6 @@ chmod -R a+r target/*
 chmod -R a+w target
 
 echo "--- Pull latest Release Manager CLI"
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-trap 'docker logout docker.elastic.co' EXIT
 docker pull docker.elastic.co/infra/release-manager:latest
 
 echo "--- Publish artifacts"

--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -24,7 +24,6 @@ ELASTICSEARCH_CLOUD_IMAGE="docker.elastic.co/kibana-ci/elasticsearch-cloud:$VERS
 KIBANA_CLOUD_IMAGE="docker.elastic.co/kibana-ci/kibana-cloud:$VERSION-$GIT_COMMIT"
 CLOUD_DEPLOYMENT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST"
 
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
 set +e
 DISTRIBUTION_EXISTS=$(docker manifest inspect $KIBANA_CLOUD_IMAGE &> /dev/null; echo $?)
 set -e
@@ -47,8 +46,6 @@ else
     --skip-docker-serverless \
     --skip-docker-contexts
 fi
-
-docker logout docker.elastic.co
 
 if is_pr_with_label "ci:cloud-redeploy"; then
   echo "--- Shutdown Previous Deployment"

--- a/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
+++ b/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
@@ -25,8 +25,6 @@ fi
 
 echo "Re-tagging $SOURCE_IMAGE -> $TARGET_IMAGE"
 
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-
 docker manifest inspect "$SOURCE_IMAGE" | tee manifests.json
 
 ARM_64_DIGEST=$(jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest' manifests.json)
@@ -59,7 +57,6 @@ docker manifest inspect "$TARGET_IMAGE"
 ORIG_IMG_DATA=$(docker inspect "$SOURCE_IMAGE@$ARM_64_DIGEST")
 ELASTIC_COMMIT_HASH=$(echo $ORIG_IMG_DATA | jq -r '.[].Config.Labels["org.opencontainers.image.revision"]')
 
-docker logout docker.elastic.co
 
 echo "Image push to $TARGET_IMAGE successful."
 echo "Promotion successful! Henceforth, thou shall be named Sir $TARGET_IMAGE"

--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -93,8 +93,6 @@ set +e
   echo $ES_CLOUD_ID $ES_CLOUD_VERSION $KIBANA_ES_CLOUD_VERSION $KIBANA_ES_CLOUD_IMAGE
   docker tag "$ES_CLOUD_ID" "$KIBANA_ES_CLOUD_IMAGE"
 
-  echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-  trap 'docker logout docker.elastic.co' EXIT
   docker image push "$KIBANA_ES_CLOUD_IMAGE"
 
   export ELASTICSEARCH_CLOUD_IMAGE="$KIBANA_ES_CLOUD_IMAGE"

--- a/.buildkite/scripts/steps/fips/build.sh
+++ b/.buildkite/scripts/steps/fips/build.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 source .buildkite/scripts/steps/artifacts/env.sh
 
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
 mkdir -p target
 download_artifact "kibana-$FULL_VERSION-linux-x86_64.tar.gz" ./target --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
@@ -27,8 +26,6 @@ node scripts/build \
     --skip-docker-cloud \
     --skip-docker-serverless \
     --skip-docker-contexts
-
-docker logout docker.elastic.co
 
 # Moving to `target/` first will keep `buildkite-agent` from including directories in the artifact name
 cd "$KIBANA_DIR/target"

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -22,6 +22,3 @@ fi
 
 is_test_execution_step
 
-# logins into docker as a common step for functional tests
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-trap 'docker logout docker.elastic.co' EXIT

--- a/.buildkite/scripts/steps/test/jest_integration.sh
+++ b/.buildkite/scripts/steps/test/jest_integration.sh
@@ -8,9 +8,5 @@ is_test_execution_step
 
 .buildkite/scripts/bootstrap.sh
 
-echo '--- Docker login'
-echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
-trap 'docker logout docker.elastic.co' EXIT
-
 echo '--- Jest Integration Tests'
 .buildkite/scripts/steps/test/jest_parallel.sh jest.integration.config.js


### PR DESCRIPTION
Originally `docker login` was localized to a single step and was managed only in that step.  Over time, this has expanded most pipelines and steps.  This changes the pattern to authenticate once during pre command.

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->