### PR TITLE
update sentinelone connector schema

### DIFF
--- a/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
@@ -66,7 +66,7 @@ export const SentinelOneGetAgentsResponseSchema = schema.object({
         registeredAt: schema.string(),
         lastIpToMgmt: schema.string(),
         storageName: schema.nullable(schema.string()),
-        osUsername: schema.string(),
+        osUsername: schema.nullable(schema.string()),
         groupIp: schema.string(),
         createdAt: schema.string(),
         remoteProfilingState: schema.string(),


### PR DESCRIPTION
## Summary

Updates the sentinel one connector schema so it is less strict on osUsername values that may not be present for some hosts with sentinel one integration. Without this, the agent status API that uses the connector logic fails at schema  validation level and consequently breaks the alerts details agent status UX.

closes elastic/kibana/issues/182330

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->