### PR TITLE
[Search] [Playground] hide create index action when locator doesn't exist

### DIFF
--- a/x-pack/plugins/search_playground/public/components/sources_panel/create_index_callout.test.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/create_index_callout.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC, PropsWithChildren } from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { CreateIndexCallout } from './create_index_callout';
+import { useKibana } from '../../hooks/use_kibana';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+// Mocking the useKibana hook
+jest.mock('../../hooks/use_kibana', () => ({
+  useKibana: jest.fn(() => ({
+    services: {
+      application: {
+        navigateToUrl: jest.fn(),
+      },
+      share: {
+        url: {
+          locators: {
+            get: jest.fn().mockReturnValue(undefined),
+          },
+        },
+      },
+    },
+  })),
+}));
+
+const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  return (
+    <>
+      <IntlProvider locale="en">{children}</IntlProvider>
+    </>
+  );
+};
+
+describe('CreateIndexCallout', () => {
+  it('renders correctly when there is no locator', async () => {
+    const { queryByTestId } = render(<CreateIndexCallout />, { wrapper: Wrapper });
+
+    expect(queryByTestId('createIndexButton')).not.toBeInTheDocument();
+  });
+
+  it('renders correctly when there is a locator', async () => {
+    const navigateToUrl = jest.fn();
+
+    (useKibana as unknown as jest.Mock).mockImplementation(() => ({
+      services: {
+        application: {
+          navigateToUrl,
+        },
+        share: {
+          url: {
+            locators: {
+              get: jest.fn().mockReturnValue({
+                getUrl: jest.fn().mockReturnValue('mock-create-index-url'),
+              }),
+            },
+          },
+        },
+      },
+    }));
+
+    const { getByTestId } = render(<CreateIndexCallout />, { wrapper: Wrapper });
+
+    const createIndexButton = getByTestId('createIndexButton');
+    expect(createIndexButton).toBeInTheDocument();
+
+    fireEvent.click(createIndexButton);
+
+    await waitFor(() => {
+      expect(navigateToUrl).toHaveBeenCalledWith('mock-create-index-url');
+    });
+  });
+});

--- a/x-pack/plugins/search_playground/public/components/sources_panel/create_index_callout.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/create_index_callout.tsx
@@ -45,18 +45,21 @@ export const CreateIndexCallout: React.FC = () => {
         </p>
       </EuiText>
       <EuiSpacer size="l" />
-      <EuiButton
-        color="primary"
-        iconType="plusInCircle"
-        fill
-        size="s"
-        onClick={handleNavigateToIndex}
-      >
-        <FormattedMessage
-          id="xpack.searchPlayground.sources.createIndexCallout."
-          defaultMessage="Create an index"
-        />
-      </EuiButton>
+      {createIndexLocator && (
+        <EuiButton
+          color="primary"
+          iconType="plusInCircle"
+          fill
+          size="s"
+          onClick={handleNavigateToIndex}
+          data-test-subj="createIndexButton"
+        >
+          <FormattedMessage
+            id="xpack.searchPlayground.sources.createIndexCallout."
+            defaultMessage="Create an index"
+          />
+        </EuiButton>
+      )}
     </EuiCallOut>
   );
 };


### PR DESCRIPTION
## Summary

On serverless, the locator for create index doesn't exist. Check to see if the locator exist before displaying the action. For now serverless will hide the action until we build the UI for this screen.

**Serverless**
![Screenshot 2024-05-13 at 13 38 40](https://github.com/elastic/kibana/assets/49480/ac89431d-9100-4396-bcf6-b23d0a4eca79)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->