### PR TITLE
[Embeddable] Expose getReactEmbeddableSavedObjects on the embeddable start contract

### DIFF
--- a/src/plugins/embeddable/public/index.ts
+++ b/src/plugins/embeddable/public/index.ts
@@ -25,7 +25,6 @@ export {
   EmbeddableStateTransfer,
   ErrorEmbeddable,
   genericEmbeddableInputIsEqual,
-  getReactEmbeddableSavedObjects,
   isContextMenuTriggerContext,
   isEmbeddable,
   isErrorEmbeddable,

--- a/src/plugins/embeddable/public/lib/embeddable_saved_object_registry/embeddable_saved_object_registry.ts
+++ b/src/plugins/embeddable/public/lib/embeddable_saved_object_registry/embeddable_saved_object_registry.ts
@@ -26,25 +26,6 @@ export type ReactEmbeddableSavedObject<
 
 const registry: Map<string, ReactEmbeddableSavedObject<any>> = new Map();
 
-/**
- * Register an embeddable API saved object with the Add from library flyout.
- *
- * @example
- *  registerReactEmbeddableSavedObject({
- *    onAdd: (container, savedObject) => {
- *      container.addNewPanel({
- *        panelType: CONTENT_ID,
- *        initialState: savedObject.attributes,
- *      });
- *    },
- *    embeddableType: CONTENT_ID,
- *    savedObjectType: MAP_SAVED_OBJECT_TYPE,
- *    savedObjectName: i18n.translate('xpack.maps.mapSavedObjectLabel', {
- *      defaultMessage: 'Map',
- *    }),
- *    getIconForSavedObject: () => APP_ICON,
- *  });
- */
 export const registerReactEmbeddableSavedObject = <
   TSavedObjectAttributes extends FinderAttributes
 >({

--- a/src/plugins/embeddable/public/mocks.tsx
+++ b/src/plugins/embeddable/public/mocks.tsx
@@ -116,6 +116,7 @@ const createSetupContract = (): Setup => {
 const createStartContract = (): Start => {
   const startContract: Start = {
     reactEmbeddableRegistryHasKey: jest.fn().mockImplementation(reactEmbeddableRegistryHasKey),
+    getReactEmbeddableSavedObjects: jest.fn(),
     getEmbeddableFactories: jest.fn(),
     getEmbeddableFactory: jest.fn(),
     telemetry: jest.fn(),

--- a/src/plugins/embeddable/public/plugin.tsx
+++ b/src/plugins/embeddable/public/plugin.tsx
@@ -24,6 +24,7 @@ import { migrateToLatest, PersistableStateService } from '@kbn/kibana-utils-plug
 import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
 import type { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
+import { FinderAttributes } from '@kbn/saved-objects-finder-plugin/common';
 import {
   EmbeddableFactoryRegistry,
   EmbeddableFactoryProvider,
@@ -40,6 +41,8 @@ import {
   IEmbeddable,
   SavedObjectEmbeddableInput,
   registerReactEmbeddableSavedObject,
+  ReactEmbeddableSavedObject,
+  getReactEmbeddableSavedObjects,
 } from './lib';
 import { EmbeddableFactoryDefinition } from './lib/embeddables/embeddable_factory_definition';
 import { EmbeddableStateTransfer } from './lib/state_transfer';
@@ -76,7 +79,30 @@ export interface EmbeddableStartDependencies {
 }
 
 export interface EmbeddableSetup {
+  /**
+   * Register an embeddable API saved object with the Add from library flyout.
+   *
+   * @example
+   *  registerReactEmbeddableSavedObject({
+   *    onAdd: (container, savedObject) => {
+   *      container.addNewPanel({
+   *        panelType: CONTENT_ID,
+   *        initialState: savedObject.attributes,
+   *      });
+   *    },
+   *    embeddableType: CONTENT_ID,
+   *    savedObjectType: MAP_SAVED_OBJECT_TYPE,
+   *    savedObjectName: i18n.translate('xpack.maps.mapSavedObjectLabel', {
+   *      defaultMessage: 'Map',
+   *    }),
+   *    getIconForSavedObject: () => APP_ICON,
+   *  });
+   */
   registerReactEmbeddableSavedObject: typeof registerReactEmbeddableSavedObject;
+
+  /**
+   * @deprecated React embeddables should register their saved objects with {@link registerReactEmbeddableSavedObject}.
+   */
   registerSavedObjectToPanelMethod: typeof registerSavedObjectToPanelMethod;
 
   /**
@@ -116,6 +142,14 @@ export interface EmbeddableStart extends PersistableStateService<EmbeddableState
    * Checks if a {@link ReactEmbeddableFactory} has been registered using {@link registerReactEmbeddableFactory}
    */
   reactEmbeddableRegistryHasKey: (type: string) => boolean;
+
+  /**
+   *
+   * @returns An iterator over all {@link ReactEmbeddableSavedObject}s that have been registered using {@link registerReactEmbeddableSavedObject}.
+   */
+  getReactEmbeddableSavedObjects: <
+    TSavedObjectAttributes extends FinderAttributes
+  >() => IterableIterator<[string, ReactEmbeddableSavedObject<TSavedObjectAttributes>]>;
 
   /**
    * @deprecated use {@link registerReactEmbeddableFactory} instead.
@@ -217,6 +251,7 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
 
     const embeddableStart: EmbeddableStart = {
       reactEmbeddableRegistryHasKey,
+      getReactEmbeddableSavedObjects,
 
       getEmbeddableFactory: this.getEmbeddableFactory,
       getEmbeddableFactories: this.getEmbeddableFactories,

--- a/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.component.tsx
+++ b/x-pack/plugins/canvas/public/components/embeddable_flyout/flyout.component.tsx
@@ -11,11 +11,7 @@ import { i18n } from '@kbn/i18n';
 
 import { SavedObjectFinder, SavedObjectMetaData } from '@kbn/saved-objects-finder-plugin/public';
 import { FinderAttributes } from '@kbn/saved-objects-finder-plugin/common';
-import {
-  EmbeddableFactory,
-  ReactEmbeddableSavedObject,
-  getReactEmbeddableSavedObjects,
-} from '@kbn/embeddable-plugin/public';
+import { EmbeddableFactory, ReactEmbeddableSavedObject } from '@kbn/embeddable-plugin/public';
 import { useEmbeddablesService, usePlatformService } from '../../services';
 
 const strings = {
@@ -51,7 +47,7 @@ export const AddEmbeddableFlyout: FC<Props> = ({
 }) => {
   const embeddablesService = useEmbeddablesService();
   const platformService = usePlatformService();
-  const { getEmbeddableFactories } = embeddablesService;
+  const { getEmbeddableFactories, getReactEmbeddableSavedObjects } = embeddablesService;
   const { getContentManagement, getUISettings } = platformService;
 
   const legacyFactoriesBySavedObjectType: LegacyFactoryMap = useMemo(() => {
@@ -78,7 +74,7 @@ export const AddEmbeddableFlyout: FC<Props> = ({
         };
         return acc;
       }, {} as FactoryMap);
-  }, []);
+  }, [getReactEmbeddableSavedObjects]);
 
   const metaData = useMemo(
     () =>

--- a/x-pack/plugins/canvas/public/services/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/embeddables.ts
@@ -5,10 +5,18 @@
  * 2.0.
  */
 
-import { EmbeddableFactory, EmbeddableStateTransfer } from '@kbn/embeddable-plugin/public';
+import {
+  EmbeddableFactory,
+  type EmbeddableStateTransfer,
+  ReactEmbeddableSavedObject,
+} from '@kbn/embeddable-plugin/public';
+import { FinderAttributes } from '@kbn/saved-objects-finder-plugin/common';
 
 export interface CanvasEmbeddablesService {
   reactEmbeddableRegistryHasKey: (key: string) => boolean;
+  getReactEmbeddableSavedObjects: <
+    TSavedObjectAttributes extends FinderAttributes
+  >() => IterableIterator<[string, ReactEmbeddableSavedObject<TSavedObjectAttributes>]>;
   getEmbeddableFactories: () => IterableIterator<EmbeddableFactory>;
   getStateTransfer: () => EmbeddableStateTransfer;
 }

--- a/x-pack/plugins/canvas/public/services/kibana/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/kibana/embeddables.ts
@@ -16,6 +16,7 @@ export type EmbeddablesServiceFactory = KibanaPluginServiceFactory<
 
 export const embeddablesServiceFactory: EmbeddablesServiceFactory = ({ startPlugins }) => ({
   reactEmbeddableRegistryHasKey: startPlugins.embeddable.reactEmbeddableRegistryHasKey,
+  getReactEmbeddableSavedObjects: startPlugins.embeddable.getReactEmbeddableSavedObjects,
   getEmbeddableFactories: startPlugins.embeddable.getEmbeddableFactories,
   getStateTransfer: startPlugins.embeddable.getStateTransfer,
 });

--- a/x-pack/plugins/canvas/public/services/stubs/embeddables.ts
+++ b/x-pack/plugins/canvas/public/services/stubs/embeddables.ts
@@ -14,6 +14,7 @@ const noop = (..._args: any[]): any => {};
 
 export const embeddablesServiceFactory: EmbeddablesServiceFactory = () => ({
   reactEmbeddableRegistryHasKey: noop,
+  getReactEmbeddableSavedObjects: noop,
   getEmbeddableFactories: noop,
   getStateTransfer: noop,
 });


### PR DESCRIPTION
## Summary

Adds the `getReactEmbeddableSavedObjects` method to the Embeddable plugin's Start contract.

Exposing this method is necessary for Canvas to populate its custom Add from library flyout.
