### PR TITLE
[Connectors] [Jira] Fixed bug in additional fields 

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/jira/jira_params.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/jira/jira_params.test.tsx
@@ -12,7 +12,7 @@ import { useGetFieldsByIssueType } from './use_get_fields_by_issue_type';
 import { useGetIssues } from './use_get_issues';
 import { useGetSingleIssue } from './use_get_single_issue';
 import { ActionConnector } from '@kbn/triggers-actions-ui-plugin/public/types';
-import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, waitFor, within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 jest.mock('@kbn/triggers-actions-ui-plugin/public/common/lib/kibana');
@@ -487,6 +487,16 @@ describe('JiraParamsFields renders', () => {
       });
 
       expect(editAction.mock.calls[0][1].incident.otherFields).toEqual(TEST_VALUE);
+    });
+
+    it('updating additional fields with an empty string sets its value to null', async () => {
+      render(<JiraParamsFields {...defaultProps} />);
+      const otherFields = await screen.findByTestId('otherFieldsJsonEditor');
+
+      userEvent.paste(otherFields, 'foobar');
+      userEvent.clear(otherFields);
+
+      expect(editAction.mock.calls[1][1].incident.otherFields).toEqual(null);
     });
 
     it('Clears any left behind priority when issueType changes and hasPriority becomes false', async () => {

--- a/x-pack/plugins/stack_connectors/public/connector_types/jira/jira_params.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/jira/jira_params.tsx
@@ -424,7 +424,7 @@ const JiraParamsFields: React.FunctionComponent<ActionParamsProps<JiraActionPara
               </>
             }
             onDocumentsChange={(json: string) => {
-              editSubActionProperty('otherFields', json);
+              editSubActionProperty('otherFields', json === '' ? null : json);
             }}
           />
         </EuiFormRow>


### PR DESCRIPTION
Fixes #183163

## Summary

In this scenario, the API was being called with `otherFields: ''`.

The backend expects `otherFields: schema.nullable(schema.recordOf(...))`.

Initially, I thought about setting the value to `{}` when the user cleared the form but we had that behavior in the past in another field and I had to change it. 😅 

Now I set the value to `null` and the API is called with valid values.


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->