### PR TITLE
[8.14] [Stack Monitoring] Fix broken KQL filter for Cluster Health rule (#183259)

### DIFF
--- a/x-pack/plugins/monitoring/public/components/kuery_bar/autocomplete_field.tsx
+++ b/x-pack/plugins/monitoring/public/components/kuery_bar/autocomplete_field.tsx
@@ -9,6 +9,7 @@ import { EuiFieldSearch, EuiOutsideClickDetector, EuiPanel } from '@elastic/eui'
 import React from 'react';
 import { QuerySuggestion } from '@kbn/unified-search-plugin/public';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import { euiThemeVars } from '@kbn/ui-theme';
 import { composeStateUpdaters } from '../../lib/typed_react';
 import { SuggestionItem } from './suggestion_item';
 
@@ -311,6 +312,6 @@ const SuggestionsPanel = euiStyled(EuiPanel).attrs(() => ({
   margin-top: 2px;
   overflow-x: hidden;
   overflow-y: scroll;
-  z-index: ${(props) => props.theme.eui.euiZLevel1};
+  z-index: ${euiThemeVars.euiZLevel1};
   max-height: 322px;
 `;

--- a/x-pack/plugins/monitoring/tsconfig.json
+++ b/x-pack/plugins/monitoring/tsconfig.json
@@ -46,6 +46,7 @@
     "@kbn/rule-data-utils",
     "@kbn/react-kibana-mount",
     "@kbn/react-kibana-context-render",
+    "@kbn/ui-theme",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Stack Monitoring] Fix broken KQL filter for Cluster Health rule (#183259)](https://github.com/elastic/kibana/pull/183259)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Antonio Ghiani","email":"marcoantonio.ghiani01@gmail.com"},"sourceCommit":{"committedDate":"2024-05-13T13:58:33Z","message":"[Stack Monitoring] Fix broken KQL filter for Cluster Health rule (#183259)\n\n## 📓 Summary\r\n\r\nWhen creating a cluster health rule in Stack Monitoring, typing on the\r\nfilter input bar was broken due to an inaccessible theme variable.\r\n\r\nThe fix accesses the variable from a static enum, fixing the reference\r\nerror when accessing the variable.\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/34506779/b364d509-21b1-4448-bf1c-9cbe8bc97b05\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"590d381db1eddbeb806dc1680cd42d5d438525cb","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Monitoring","Feature:Stack Monitoring","backport:prev-minor","v8.15.0"],"number":183259,"url":"https://github.com/elastic/kibana/pull/183259","mergeCommit":{"message":"[Stack Monitoring] Fix broken KQL filter for Cluster Health rule (#183259)\n\n## 📓 Summary\r\n\r\nWhen creating a cluster health rule in Stack Monitoring, typing on the\r\nfilter input bar was broken due to an inaccessible theme variable.\r\n\r\nThe fix accesses the variable from a static enum, fixing the reference\r\nerror when accessing the variable.\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/34506779/b364d509-21b1-4448-bf1c-9cbe8bc97b05\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"590d381db1eddbeb806dc1680cd42d5d438525cb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183259","number":183259,"mergeCommit":{"message":"[Stack Monitoring] Fix broken KQL filter for Cluster Health rule (#183259)\n\n## 📓 Summary\r\n\r\nWhen creating a cluster health rule in Stack Monitoring, typing on the\r\nfilter input bar was broken due to an inaccessible theme variable.\r\n\r\nThe fix accesses the variable from a static enum, fixing the reference\r\nerror when accessing the variable.\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/34506779/b364d509-21b1-4448-bf1c-9cbe8bc97b05\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"590d381db1eddbeb806dc1680cd42d5d438525cb"}}]}] BACKPORT-->