### PR TITLE
[Search] [Playground] Semantic search: input_output inference support

### DIFF
--- a/x-pack/plugins/search_playground/__mocks__/fetch_query_source_fields.mock.ts
+++ b/x-pack/plugins/search_playground/__mocks__/fetch_query_source_fields.mock.ts
@@ -45,6 +45,110 @@ export const ELSER_PASSAGE_CHUNKED_TWO_INDICES_DOCS = [
   },
 ];
 
+export const DENSE_INPUT_OUTPUT_ONE_INDEX = [
+  {
+    _index: 'index2',
+    _id: 'KQ6Wco8BO787m9kIp1Ug',
+    _score: 1,
+    _source: {
+      text_embedding: [0.03889123350381851],
+      text: 'hello there',
+      model_id: '.multilingual-e5-small',
+    },
+  },
+];
+
+export const SPARSE_INPUT_OUTPUT_ONE_INDEX = [
+  {
+    _index: 'index',
+    _id: 'Iw6Bco8BO787m9kIa1Wo',
+    _score: 1,
+    _source: {
+      text_embedding: {
+        interview: 0.42307013,
+      },
+      text: 'hello there',
+      model_id: '.elser_model_2',
+    },
+  },
+];
+
+export const SPARSE_INPUT_OUTPUT_ONE_INDEX_FIELD_CAPS = {
+  indices: ['index'],
+  fields: {
+    text_embedding: {
+      sparse_vector: {
+        type: 'sparse_vector',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    text: {
+      text: {
+        type: 'text',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    model_id: {
+      text: {
+        type: 'text',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    'model_id.keyword': {
+      keyword: {
+        type: 'keyword',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: true,
+      },
+    },
+  },
+};
+
+export const DENSE_INPUT_OUTPUT_ONE_INDEX_FIELD_CAPS = {
+  indices: ['index2'],
+  fields: {
+    text_embedding: {
+      dense_vector: {
+        type: 'dense_vector',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    text: {
+      text: {
+        type: 'text',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    model_id: {
+      text: {
+        type: 'text',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    'model_id.keyword': {
+      keyword: {
+        type: 'keyword',
+        metadata_field: false,
+        searchable: true,
+        aggregatable: true,
+      },
+    },
+  },
+};
+
 export const DENSE_VECTOR_DOCUMENT_FIRST = [
   {
     _index: 'workplace_index_nested',

--- a/x-pack/plugins/search_playground/server/lib/fetch_query_source_fields.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/fetch_query_source_fields.test.ts
@@ -14,6 +14,10 @@ import {
   ELSER_PASSAGE_CHUNKED_TWO_INDICES,
   ELSER_PASSAGE_CHUNKED_TWO_INDICES_DOCS,
   SPARSE_DOC_SINGLE_INDEX,
+  DENSE_INPUT_OUTPUT_ONE_INDEX,
+  DENSE_INPUT_OUTPUT_ONE_INDEX_FIELD_CAPS,
+  SPARSE_INPUT_OUTPUT_ONE_INDEX,
+  SPARSE_INPUT_OUTPUT_ONE_INDEX_FIELD_CAPS,
 } from '../../__mocks__/fetch_query_source_fields.mock';
 import { parseFieldsCapabilities } from './fetch_query_source_fields';
 
@@ -192,6 +196,58 @@ describe('fetch_query_source_fields', () => {
             'metadata.content',
           ],
           skipped_fields: 18,
+        },
+      });
+    });
+
+    it('should return the correct fields for dense vector using input_output configuration', () => {
+      expect(
+        parseFieldsCapabilities(DENSE_INPUT_OUTPUT_ONE_INDEX_FIELD_CAPS, [
+          {
+            index: 'index2',
+            doc: DENSE_INPUT_OUTPUT_ONE_INDEX[0],
+          },
+        ])
+      ).toEqual({
+        index2: {
+          bm25_query_fields: ['text'],
+          dense_vector_query_fields: [
+            {
+              field: 'text_embedding',
+              indices: ['index2'],
+              model_id: '.multilingual-e5-small',
+              nested: false,
+            },
+          ],
+          elser_query_fields: [],
+          source_fields: ['text'],
+          skipped_fields: 2,
+        },
+      });
+    });
+
+    it('should return the correct fields for sparse vector using input_output configuration', () => {
+      expect(
+        parseFieldsCapabilities(SPARSE_INPUT_OUTPUT_ONE_INDEX_FIELD_CAPS, [
+          {
+            index: 'index',
+            doc: SPARSE_INPUT_OUTPUT_ONE_INDEX[0],
+          },
+        ])
+      ).toEqual({
+        index: {
+          bm25_query_fields: ['text'],
+          elser_query_fields: [
+            {
+              field: 'text_embedding',
+              indices: ['index'],
+              model_id: '.elser_model_2',
+              nested: false,
+            },
+          ],
+          dense_vector_query_fields: [],
+          source_fields: ['text'],
+          skipped_fields: 2,
         },
       });
     });


### PR DESCRIPTION
## Summary

This allows semantic sparse_vector and dense_vector fields to be used which were setup with the input_output configuration in the inference processor. model_id is top level rather than object field level. This PR checks whether model_id is present in either the object or in the top level. 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->