### PR TITLE
[BK] Fix pipeline resources post-merge

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -21,7 +21,7 @@ spec:
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 8.14 8.13 7.17
+      branch_configuration: main 8.14 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts.yml
@@ -48,10 +48,6 @@ spec:
           cronline: 0 7 * * * America/New_York
           message: Daily build
           branch: main
-        Daily build (8.13):
-          cronline: 0 7 * * * America/New_York
-          message: Daily build
-          branch: '8.13'
         Daily build (8.14):
           cronline: 0 7 * * * America/New_York
           message: Daily build

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -22,7 +22,7 @@ spec:
         RELEASE_BUILD: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: 7.17 8.13 8.14
+      branch_configuration: 7.17 8.14
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts.yml
       skip_intermediate_builds: false
@@ -44,10 +44,6 @@ spec:
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
       schedules:
-        Daily build (8.13):
-          cronline: 0 7 * * * America/New_York
-          message: Daily build
-          branch: '8.13'
         Daily build (8.14):
           cronline: 0 7 * * * America/New_York
           message: Daily build

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
@@ -22,7 +22,7 @@ spec:
         RELEASE_BUILD: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: '8.13 8.14'
+      branch_configuration: '8.14'
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts_trigger.yml
@@ -45,10 +45,6 @@ spec:
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
       schedules:
-        Daily build (8.13):
-          cronline: 0 */2 * * * America/New_York
-          message: Daily build
-          branch: '8.13'
         Daily build (8.14):
           cronline: 0 */2 * * * America/New_York
           message: Daily build


### PR DESCRIPTION
## Summary
8.13-related builds/schedules should be removed from the pipelines, because that branch has been deactivated since then