### PR TITLE
[Semantic Text UI] Adapt inference endpoint calls to new API spec

### DIFF
--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -69,7 +69,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
   jsonData,
   refetchMapping,
   showAboutMappings,
-  isSemanticTextEnabled = false,
+  isSemanticTextEnabled = true,
 }) => {
   const {
     services: { extensionsService },

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -69,7 +69,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
   jsonData,
   refetchMapping,
   showAboutMappings,
-  isSemanticTextEnabled = true,
+  isSemanticTextEnabled = false,
 }) => {
   const {
     services: { extensionsService },

--- a/x-pack/plugins/index_management/server/routes/api/inference_models/register_get_route.ts
+++ b/x-pack/plugins/index_management/server/routes/api/inference_models/register_get_route.ts
@@ -21,15 +21,15 @@ export function registerGetAllRoute({ router, lib: { handleEsError } }: RouteDep
 
       // TODO: Use the client's built-in function rather than the transport when it's available
       try {
-        const { models } = await client.asCurrentUser.transport.request<{
-          models: InferenceAPIConfigResponse[];
+        const { endpoints } = await client.asCurrentUser.transport.request<{
+          endpoints: InferenceAPIConfigResponse[];
         }>({
           method: 'GET',
           path: `/_inference/_all`,
         });
 
         return response.ok({
-          body: models,
+          body: endpoints,
         });
       } catch (error) {
         return handleEsError({ error, response });

--- a/x-pack/test/api_integration/apis/management/index_management/index.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/index.ts
@@ -15,6 +15,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./stats'));
     loadTestFile(require.resolve('./data_streams'));
     loadTestFile(require.resolve('./templates'));
+    loadTestFile(require.resolve('./inference_endpoints'));
     loadTestFile(require.resolve('./component_templates'));
     loadTestFile(require.resolve('./cluster_nodes'));
     loadTestFile(require.resolve('./index_details'));

--- a/x-pack/test/api_integration/apis/management/index_management/inference_endpoints.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/inference_endpoints.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const API_BASE_PATH = '/api/index_management';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const log = getService('log');
+  const ml = getService('ml');
+  const inferenceId = 'my-elser-model';
+  const taskType = 'sparse_embedding';
+  const service = 'elser';
+
+  describe('Inference endpoints', function () {
+    before(async () => {
+      log.debug(`Creating inference endpoint`);
+      try {
+        await ml.api.createInferenceEndpoint(inferenceId, taskType, {
+          service,
+          service_settings: {
+            num_allocations: 1,
+            num_threads: 1,
+          },
+        });
+      } catch (err) {
+        log.debug('[Setup error] Error creating inference endpoint');
+        throw err;
+      }
+    });
+
+    after(async () => {
+      // Cleanup inference endpoints created for testing purposes
+      try {
+        log.debug(`Deleting inference endpoint`);
+        await ml.api.deleteInferenceEndpoint(inferenceId, taskType);
+      } catch (err) {
+        log.debug('[Cleanup error] Error deleting inference endpoint');
+        throw err;
+      }
+    });
+
+    describe('get inference endpoints', () => {
+      it('returns the existing inference endpoints', async () => {
+        const { body: inferenceEndpoints } = await supertest
+          .get(`${API_BASE_PATH}/inference/all`)
+          .set('kbn-xsrf', 'xxx')
+          .set('x-elastic-internal-origin', 'xxx')
+          .expect(200);
+
+        expect(inferenceEndpoints).to.be.ok();
+        expect(inferenceEndpoints[0].model_id).to.eql(inferenceId);
+      });
+    });
+  });
+}

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -226,6 +226,32 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
       );
     },
 
+    async getInferenceEndpoint(inferenceId: string) {
+      const { status } = await esSupertest.get(`/_inference/${inferenceId}`);
+      return status === 200;
+    },
+
+    async createInferenceEndpoint(inferenceId: string, taskType: string, requestBody: object) {
+      const found = await this.getInferenceEndpoint(inferenceId);
+      if (found) {
+        log.debug(`Inference endpoint '${inferenceId}' already exists. Nothing to create.`);
+        return;
+      }
+      const { body, status } = await esSupertest
+        .put(`/_inference/${taskType}/${inferenceId}`)
+        .send(requestBody);
+      this.assertResponseStatusCode(200, status, body);
+
+      return body;
+    },
+
+    async deleteInferenceEndpoint(inferenceId: string, taskType: string) {
+      const { body, status } = await esSupertest.delete(`/_inference/${taskType}/${inferenceId}`);
+      this.assertResponseStatusCode(200, status, body);
+
+      return body;
+    },
+
     async createIndex(
       indices: string,
       mappings?: Record<string, estypes.MappingTypeMapping> | estypes.MappingTypeMapping,

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/index.ts
@@ -13,6 +13,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
 
     loadTestFile(require.resolve('./index_templates'));
     loadTestFile(require.resolve('./indices'));
+    loadTestFile(require.resolve('./inference_endpoints'));
     loadTestFile(require.resolve('./enrich_policies'));
     loadTestFile(require.resolve('./create_enrich_policies'));
     loadTestFile(require.resolve('./index_component_templates'));

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/inference_endpoints.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/inference_endpoints.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const API_BASE_PATH = '/api/index_management';
+
+export default function ({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const log = getService('log');
+  const ml = getService('ml');
+  const inferenceId = 'my-elser-model';
+  const taskType = 'sparse_embedding';
+  const service = 'elser';
+
+  describe('Inference endpoints', function () {
+    before(async () => {
+      log.debug(`Creating inference endpoint`);
+      try {
+        await ml.api.createInferenceEndpoint(inferenceId, taskType, {
+          service,
+          service_settings: {
+            num_allocations: 1,
+            num_threads: 1,
+          },
+        });
+      } catch (err) {
+        log.debug('[Setup error] Error creating inference endpoint');
+        throw err;
+      }
+    });
+
+    after(async () => {
+      // Cleanup inference endpoints created for testing purposes
+      try {
+        log.debug(`Deleting inference endpoint`);
+        await ml.api.deleteInferenceEndpoint(inferenceId, taskType);
+      } catch (err) {
+        log.debug('[Cleanup error] Error deleting inference endpoint');
+        throw err;
+      }
+    });
+
+    describe('get inference endpoints', () => {
+      it('returns the existing inference endpoints', async () => {
+        const { body: inferenceEndpoints } = await supertest
+          .get(`${API_BASE_PATH}/inference/all`)
+          .set('kbn-xsrf', 'xxx')
+          .set('x-elastic-internal-origin', 'xxx')
+          .expect(200);
+
+        expect(inferenceEndpoints).to.be.ok();
+        expect(inferenceEndpoints[0].model_id).to.eql(inferenceId);
+      });
+    });
+  });
+}


### PR DESCRIPTION
The inference endpoint API spec has changed. Now, we need to refer to 'endpoints' property instead of the 'models' property while gathering the inference_endpoints informations using _inference/_all