### PR TITLE
[Security Solution[Telemetry] Apply copyAllowlistedFields to events

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/send_telemetry_events.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/send_telemetry_events.ts
@@ -10,6 +10,7 @@ import type { TelemetryEvent } from '../../../telemetry/types';
 import type { IRuleExecutionLogForExecutors } from '../../rule_monitoring';
 import type { SignalSource, SignalSourceHit } from '../types';
 import { TelemetryChannel } from '../../../telemetry/types';
+import { copyAllowlistedFields, filterList } from '../../../telemetry/filterlists';
 
 interface SearchResultSource {
   _source: SignalSource;
@@ -71,7 +72,11 @@ export function sendAlertTelemetryEvents(
     selectedEvents = enrichEndpointAlertsSignalID(selectedEvents, signalIdMap);
   }
   try {
-    eventsTelemetry.sendAsync(TelemetryChannel.ENDPOINT_ALERTS, selectedEvents);
+    const filtered = selectedEvents.map(
+      (event: TelemetryEvent): TelemetryEvent =>
+        copyAllowlistedFields(filterList.endpointAlerts, event)
+    );
+    eventsTelemetry.sendAsync(TelemetryChannel.ENDPOINT_ALERTS, filtered);
   } catch (exc) {
     ruleExecutionLogger.error(`Queuing telemetry events failed: ${exc}`);
   }


### PR DESCRIPTION
## Summary

Apply the filterlist automatically before sending events since `AsyncTelemetrySender::sendAsync` doesn't do it like `TelemetryEventsSender::queueTelemetryEvents` did.

Related PR: https://github.com/elastic/kibana/pull/174577



<!--ONMERGE {"backportTargets":["8.13","8.14"]} ONMERGE-->