### PR TITLE
[Observability AI Assistant] Correctly reset title to previously saved title when canceling edit action

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_header.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_header.tsx
@@ -138,8 +138,8 @@ export function ChatHeader({
                 onSaveTitle(e);
               }
             }}
-            onCancel={(previousTitle: string) => {
-              setNewTitle(previousTitle);
+            onCancel={() => {
+              setNewTitle(title);
             }}
           />
         </EuiFlexItem>


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/176499

## Summary

This correctly resets the title to the previously saved one when cancelling the edit action.