### PR TITLE
[CI] Avoid docker login if docker is not running

### DIFF
--- a/.buildkite/scripts/common/setup_job_env.sh
+++ b/.buildkite/scripts/common/setup_job_env.sh
@@ -21,7 +21,7 @@ fi
 
   KIBANA_DOCKER_USERNAME="$(vault_get container-registry username)"
   KIBANA_DOCKER_PASSWORD="$(vault_get container-registry password)"
-  if command -v docker &> /dev/null; then
+  if (command -v docker && docker version) &> /dev/null; then
     echo "$KIBANA_DOCKER_PASSWORD" | docker login -u "$KIBANA_DOCKER_USERNAME" --password-stdin docker.elastic.co
   fi
 }


### PR DESCRIPTION
## Summary
We've found that the command tries to log in to docker in cases when the `docker` binary is available (installed) but not running on the devices. This can happen, for example, on a device that's set up a bit differently than our normal CI executors (e.g.: [bare metal executors](https://buildkite.com/elastic/kibana-single-user-performance/builds/13383)).

This PR makes it sure that we only interact with docker in that step, if it's running. 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->