### PR TITLE
[CI] Fix issues related to publish

### DIFF
--- a/.buildkite/scripts/common/vault_fns.sh
+++ b/.buildkite/scripts/common/vault_fns.sh
@@ -65,3 +65,23 @@ vault_kv_set() {
 
   vault kv put "$VAULT_KV_PREFIX/$kv_path" "${fields[@]}"
 }
+
+function get_vault_role_id() {
+  if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
+    VAULT_ROLE_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-role-id)"
+  else
+    VAULT_ROLE_ID="$(vault_get kibana-buildkite-vault-credentials role-id)"
+  fi
+
+  echo "$VAULT_ROLE_ID"
+}
+
+function get_vault_secret_id() {
+    if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
+      VAULT_SECRET_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-secret-id)"
+    else
+      VAULT_SECRET_ID="$(vault_get kibana-buildkite-vault-credentials secret-id)"
+    fi
+
+    echo "$VAULT_SECRET_ID"
+}

--- a/.buildkite/scripts/steps/artifacts/publish.sh
+++ b/.buildkite/scripts/steps/artifacts/publish.sh
@@ -53,8 +53,8 @@ docker pull docker.elastic.co/infra/release-manager:latest
 
 echo "--- Publish artifacts"
 if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]]; then
-  export VAULT_ROLE_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-role-id)"
-  export VAULT_SECRET_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-secret-id)"
+  export VAULT_ROLE_ID="$(get_vault_role_id)"
+  export VAULT_SECRET_ID="$(get_vault_secret_id)"
   export VAULT_ADDR="https://secrets.elastic.co:8200"
 
   download_artifact beats_manifest.json /tmp --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"

--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -80,16 +80,18 @@ if [ -z "${CLOUD_DEPLOYMENT_ID}" ] || [ "${CLOUD_DEPLOYMENT_ID}" = 'null' ]; the
   CLOUD_DEPLOYMENT_STATUS_MESSAGES=$(jq --slurp '[.[]|select(.resources == null)]' "$ECCTL_LOGS")
 
   echo "Writing to vault..."
-  VAULT_ROLE_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-role-id)"
-  VAULT_SECRET_ID="$(retry 5 15 gcloud secrets versions access latest --secret=kibana-buildkite-vault-secret-id)"
-  VAULT_TOKEN=$(retry 5 30 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
-  retry 5 30 vault login -no-print "$VAULT_TOKEN"
 
   # TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
   if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
+    VAULT_ROLE_ID="$(get_vault_role_id)"
+    VAULT_SECRET_ID="$(get_vault_secret_id)"
+    VAULT_TOKEN=$(retry 5 30 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+    retry 5 30 vault login -no-print "$VAULT_TOKEN"
     vault_set "cloud-deploy/$CLOUD_DEPLOYMENT_NAME" username="$CLOUD_DEPLOYMENT_USERNAME" password="$CLOUD_DEPLOYMENT_PASSWORD"
+    VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
   else
     vault_kv_set "cloud-deploy/$CLOUD_DEPLOYMENT_NAME" username="$CLOUD_DEPLOYMENT_USERNAME" password="$CLOUD_DEPLOYMENT_PASSWORD"
+    VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
   fi
 
   echo "Enabling Stack Monitoring..."
@@ -124,13 +126,6 @@ fi
 
 CLOUD_DEPLOYMENT_KIBANA_URL=$(ecctl deployment show "$CLOUD_DEPLOYMENT_ID" | jq -r '.resources.kibana[0].info.metadata.aliased_url')
 CLOUD_DEPLOYMENT_ELASTICSEARCH_URL=$(ecctl deployment show "$CLOUD_DEPLOYMENT_ID" | jq -r '.resources.elasticsearch[0].info.metadata.aliased_url')
-
-# TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
-if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
-  VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
-else
-  VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
-fi
 
 cat << EOF | buildkite-agent annotate --style "info" --context cloud
   ### Cloud Deployment

--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -88,10 +88,8 @@ if [ -z "${CLOUD_DEPLOYMENT_ID}" ] || [ "${CLOUD_DEPLOYMENT_ID}" = 'null' ]; the
     VAULT_TOKEN=$(retry 5 30 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
     retry 5 30 vault login -no-print "$VAULT_TOKEN"
     vault_set "cloud-deploy/$CLOUD_DEPLOYMENT_NAME" username="$CLOUD_DEPLOYMENT_USERNAME" password="$CLOUD_DEPLOYMENT_PASSWORD"
-    VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
   else
     vault_kv_set "cloud-deploy/$CLOUD_DEPLOYMENT_NAME" username="$CLOUD_DEPLOYMENT_USERNAME" password="$CLOUD_DEPLOYMENT_PASSWORD"
-    VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
   fi
 
   echo "Enabling Stack Monitoring..."
@@ -122,6 +120,13 @@ else
 
   echo "Updating deployment..."
   ecctl deployment update "$CLOUD_DEPLOYMENT_ID" --track --output json --file /tmp/deploy.json > "$ECCTL_LOGS"
+fi
+
+# TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
+if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
+  VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
+else
+  VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$CLOUD_DEPLOYMENT_NAME"
 fi
 
 CLOUD_DEPLOYMENT_KIBANA_URL=$(ecctl deployment show "$CLOUD_DEPLOYMENT_ID" | jq -r '.resources.kibana[0].info.metadata.aliased_url')

--- a/.buildkite/scripts/steps/serverless/deploy.sh
+++ b/.buildkite/scripts/steps/serverless/deploy.sh
@@ -97,10 +97,8 @@ deploy() {
       VAULT_TOKEN=$(retry 5 30 vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
       retry 5 30 vault login -no-print "$VAULT_TOKEN"
       vault_set "cloud-deploy/$VAULT_KEY_NAME" username="$PROJECT_USERNAME" password="$PROJECT_PASSWORD" id="$PROJECT_ID"
-      VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$VAULT_KEY_NAME"
     else
       vault_kv_set "cloud-deploy/$VAULT_KEY_NAME" username="$PROJECT_USERNAME" password="$PROJECT_PASSWORD" id="$PROJECT_ID"
-      VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$VAULT_KEY_NAME"
     fi
 
   else
@@ -115,6 +113,13 @@ deploy() {
   PROJECT_KIBANA_URL=$(jq -r --slurp '.[1].endpoints.kibana' $DEPLOY_LOGS)
   PROJECT_KIBANA_LOGIN_URL="${PROJECT_KIBANA_URL}/login"
   PROJECT_ELASTICSEARCH_URL=$(jq -r --slurp '.[1].endpoints.elasticsearch' $DEPLOY_LOGS)
+
+  # TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
+  if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
+    VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$VAULT_KEY_NAME"
+  else
+    VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$VAULT_KEY_NAME"
+  fi
 
   cat << EOF | buildkite-agent annotate --style "info" --context "project-$PROJECT_TYPE"
 ### $PROJECT_TYPE_LABEL Deployment


### PR DESCRIPTION
## Summary
On the new infra, the publish step will still require legacy vault credentials and login. (https://buildkite.com/elastic/kibana-artifacts-staging/builds/3513#018f7691-73c8-4e6f-862b-328b05d9de3b)

As a fix: this PR digs up the credentials from the vault instead of gcloud secrets on the new infra. 

Also, other usages of role-id/secret-id is used are moved in the legacy-vault usages, plus minor code re-org, to reduce branching, and future cleanup.

Fix after: https://github.com/elastic/kibana/pull/182582

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->