### PR TITLE
[EDR Workflows] Unskip Jest Protection Updates test

### DIFF
--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -562,16 +562,13 @@ describe('ingest_integration tests ', () => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/183348
-    describe.skip('when the license is at least enterprise', () => {
+    describe('when the license is at least enterprise', () => {
       const soClient = savedObjectsClientMock.create();
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
       beforeEach(() => {
         licenseEmitter.next(Enterprise); // set license level to enterprise
       });
-
-      const validDateYesterday = moment.utc().subtract(1, 'day');
 
       it('should throw if endpointProtectionUpdates productFeature is disabled and user modifies global_manifest_version', async () => {
         productFeaturesService = createProductFeaturesServiceMock(
@@ -611,21 +608,23 @@ describe('ingest_integration tests ', () => {
         },
         {
           date: '2100-10-01',
-          message: `Global manifest version cannot be in the future. Latest selectable date is ${validDateYesterday.format(
-            'MMMM DD, YYYY'
-          )} UTC time.`,
+          message: `Global manifest version cannot be in the future. Latest selectable date is ${moment
+            .utc()
+            .subtract(1, 'day')
+            .format('MMMM DD, YYYY')} UTC time.`,
         },
         {
-          date: validDateYesterday.clone().add(1, 'day').format('YYYY-MM-DD'),
-          message: `Global manifest version cannot be in the future. Latest selectable date is ${validDateYesterday.format(
-            'MMMM DD, YYYY'
-          )} UTC time.`,
+          date: moment.utc().format('YYYY-MM-DD'),
+          message: `Global manifest version cannot be in the future. Latest selectable date is ${moment
+            .utc()
+            .subtract(1, 'day')
+            .format('MMMM DD, YYYY')} UTC time.`,
         },
         {
           date: 'latest',
         },
         {
-          date: validDateYesterday.format('YYYY-MM-DD'), // Correct date
+          date: moment.utc().subtract(1, 'day').format('YYYY-MM-DD'), // Correct date
         },
       ])(
         'should return bad request for invalid endpoint package policy global manifest values',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/183348

Move date object creation to single test execution instead of defining it beforehand. This way we minimize the probability of assertion being run a day after the test was picked up by CI runner (11:59:59 pm vs 00:00:00 am).