### PR TITLE
[FTR] Session Concurrency Test

### DIFF
--- a/x-pack/test/security_api_integration/session_concurrent_limit.config.ts
+++ b/x-pack/test/security_api_integration/session_concurrent_limit.config.ts
@@ -45,6 +45,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
         `--plugin-path=${testEndpointsPlugin}`,
         '--xpack.security.session.concurrentSessions.maxSessions=2',
+        '--xpack.security.session.cleanupInterval=5h',
         `--xpack.security.authc.providers=${JSON.stringify({
           basic: { basic1: { order: 0 } },
           saml: { saml1: { order: 1, realm: 'saml1' } },


### PR DESCRIPTION
## Summary
Set `security.session.cleanupInterval` to 5h for session concurrency test.

### **Prerequisites**

- Task for session cleanup with [default schedule set to 1h](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security/server/config.ts#L222).
- Task polling interval is set to [3000ms](https://github.com/elastic/kibana/blob/main/x-pack/plugins/task_manager/server/config.ts#L13).
- We override `scheduledAt` once we make a request in [runCleanupTaskSoon](https://github.com/elastic/kibana/blob/main/x-pack/test/security_api_integration/tests/session_concurrent_limit/cleanup.ts#L145).

### **Hypothesis**

Taking into consideration that:

- `session_cleanup` task is not the only one scheduled during test run.
- There is sort of an exponential backoff implemented for task polling if there are too many retries.
- Clock jitter.

I had a hypothesis that if our whole test run exceeds 1h or polling interval gets adjusted because of retries we might end up executing the scheduled cleanup before we trigger `runCleanupTaskSoon` (this is there we drop 1 session already).

### **FTR runs (x55 each)**

- `cleanupInterval` set to 5h: [#1](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5986) :green_circle:, [#2](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5987) :green_circle:
- `cleanupInterval` set to default 1h: [#1](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5983) :green_circle:, [#2](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5982) :red_circle: (has 2 failures out of 55)


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

__Fixes: https://github.com/elastic/kibana/issues/149091__