### PR TITLE
[Observability] [Alert] Open source links in same tab

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/alert_details_app_section.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/alert_details_app_section.test.tsx
@@ -136,7 +136,6 @@ describe('AlertDetailsAppSection', () => {
               <EuiLink
                 data-test-subj="o11yCustomThresholdAlertDetailsViewRelatedLogs"
                 href="/view-in-app-url"
-                target="_blank"
               >
                 View related logs
               </EuiLink>

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/alert_details_app_section.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/alert_details_app_section.tsx
@@ -167,7 +167,6 @@ export default function AlertDetailsAppSection({
               <EuiLink
                 data-test-subj="o11yCustomThresholdAlertDetailsViewRelatedLogs"
                 href={viewInAppUrl}
-                target="_blank"
               >
                 {i18n.translate(
                   'xpack.observability.alertDetailsAppSection.a.viewRelatedLogsLabel',

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/groups.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/groups.tsx
@@ -60,7 +60,6 @@ export function Groups({ groups, timeRange }: { groups: Group[]; timeRange: Time
                 <EuiLink
                   data-test-subj="o11yCustomThresholdAlertSourceLink"
                   href={sourceLinks[group.field]}
-                  target="_blank"
                 >
                   {group.value}
                 </EuiLink>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/183439

Opens source links in Alert detail pages and alert flyout in the "same" tab.

### Alert details page
<img width="1232" alt="Screenshot 2024-05-14 at 21 14 04" src="https://github.com/elastic/kibana/assets/69037875/d8023a2e-4098-47dc-9c5b-4902ee5e7057">

### Alert flyout
<img width="728" alt="Screenshot 2024-05-14 at 21 13 32" src="https://github.com/elastic/kibana/assets/69037875/daf9f290-6f70-454b-bffa-028d71484b30">




<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->