### PR TITLE
[Security Solution][Detection Engine] Skip flaky Cypress step related to Related Integrations UI

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows.cy.ts
@@ -67,7 +67,8 @@ describe('Common rule creation flows', { tags: ['@ess', '@serverless'] }, () => 
   it('Creates and enables a rule', function () {
     cy.log('Filling define section');
     importSavedQuery(this.timelineId);
-    fillRelatedIntegrations();
+    // The following step is flaky due to a recent EUI upgrade. There is not currently a ticket for the underlying EUI issue, but when there is it will be linked on the test-failure ticket: https://github.com/elastic/kibana/issues/183437
+    // fillRelatedIntegrations();
     cy.get(DEFINE_CONTINUE_BUTTON).click();
 
     cy.log('Filling about section');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows.cy.ts
@@ -33,7 +33,6 @@ import {
   fillMaxSignals,
   fillNote,
   fillReferenceUrls,
-  fillRelatedIntegrations,
   fillRiskScore,
   fillRuleName,
   fillRuleTags,


### PR DESCRIPTION
This was made flaky in a recent EUI upgrade. The related test failure ticket is https://github.com/elastic/kibana/issues/183437.