### PR TITLE
[Discover] Fix JSON view height in DocViewer

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
@@ -36,7 +36,7 @@ interface SourceViewerProps {
 // inline limitation was necessary to enable virtualized scrolling, which improves performance
 export const MAX_LINES_CLASSIC_TABLE = 500;
 // Displayed margin of the code editor to the window bottom when rendered in the document explorer flyout
-export const MARGIN_BOTTOM = 80;
+export const MARGIN_BOTTOM = 80; // DocViewer flyout has a footer
 // Minimum height for the source content to guarantee minimum space when the flyout is scrollable.
 export const MIN_HEIGHT = 400;
 

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
@@ -36,7 +36,7 @@ interface SourceViewerProps {
 // inline limitation was necessary to enable virtualized scrolling, which improves performance
 export const MAX_LINES_CLASSIC_TABLE = 500;
 // Displayed margin of the code editor to the window bottom when rendered in the document explorer flyout
-export const MARGIN_BOTTOM = 80; // DocViewer flyout has a footer
+export const MARGIN_BOTTOM = 25;
 // Minimum height for the source content to guarantee minimum space when the flyout is scrollable.
 export const MIN_HEIGHT = 400;
 

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
@@ -36,7 +36,7 @@ interface SourceViewerProps {
 // inline limitation was necessary to enable virtualized scrolling, which improves performance
 export const MAX_LINES_CLASSIC_TABLE = 500;
 // Displayed margin of the code editor to the window bottom when rendered in the document explorer flyout
-export const MARGIN_BOTTOM = 25;
+export const MARGIN_BOTTOM = 80;
 // Minimum height for the source content to guarantee minimum space when the flyout is scrollable.
 export const MIN_HEIGHT = 400;
 
@@ -54,7 +54,7 @@ export const DocViewerSource = ({
   const [jsonValue, setJsonValue] = useState<string>('');
   const { uiSettings } = getUnifiedDocViewerServices();
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
-  const useDocExplorer = isLegacyTableEnabled({
+  const useDocExplorer = !isLegacyTableEnabled({
     uiSettings,
     isTextBasedQueryMode: Array.isArray(textBasedHits),
   });


### PR DESCRIPTION
- A fix after https://github.com/elastic/kibana/pull/180370/files#diff-ed350967c6564d64f0123a2d55700b1ddc7f5d6fcb3786384fb7ae25334fe9eaL672

## Summary

This PR fixes the height of JSON block in DocViewer. ~Also it reduces the available height as the flyout now has a footer with Close button.~



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->