### PR TITLE
[7.17] [BK] Migrate batch 1 (Artifact builds) (#182582)

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -6,7 +6,7 @@ steps:
       imageProject: elastic-images-qa
       provider: gcp
       machineType: c2-standard-16
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -2,7 +2,10 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/build.sh
     label: Build Kibana Artifacts
     agents:
-      queue: c2-16
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      machineType: c2-standard-16
     timeout_in_minutes: 60
     retry:
       automatic:
@@ -14,7 +17,13 @@ steps:
   - command: TEST_PACKAGE=deb .buildkite/scripts/steps/package_testing/test.sh
     label: Artifact Testing
     agents:
-      queue: n2-4-virt
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      enableNestedVirtualization: true
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-4
     timeout_in_minutes: 30
     retry:
       automatic:
@@ -24,7 +33,13 @@ steps:
   - command: TEST_PACKAGE=rpm .buildkite/scripts/steps/package_testing/test.sh
     label: Artifact Testing
     agents:
-      queue: n2-4-virt
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      enableNestedVirtualization: true
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-4
     timeout_in_minutes: 30
     retry:
       automatic:
@@ -34,7 +49,13 @@ steps:
   - command: TEST_PACKAGE=docker .buildkite/scripts/steps/package_testing/test.sh
     label: Artifact Testing
     agents:
-      queue: n2-4-virt
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      enableNestedVirtualization: true
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-4
     timeout_in_minutes: 30
     retry:
       automatic:
@@ -44,7 +65,12 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=default .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      queue: n2-2
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-2
     timeout_in_minutes: 30
     retry:
       automatic:
@@ -54,7 +80,12 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=ubi .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      queue: n2-2
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-2
     timeout_in_minutes: 30
     retry:
       automatic:
@@ -64,7 +95,12 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=ironbank .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      queue: n2-2
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-2
     timeout_in_minutes: 30
     retry:
       automatic:
@@ -76,5 +112,10 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/publish.sh
     label: 'Publish Kibana Artifacts'
     agents:
-      queue: n2-2
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      localSsds: 1
+      localSsdInterface: nvme
+      machineType: n2-standard-2
     timeout_in_minutes: 30


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[BK] Migrate batch 1 (Artifact builds) (#182582)](https://github.com/elastic/kibana/pull/182582)

It's supposed to fix: https://buildkite.com/elastic/kibana-artifacts-snapshot/builds?branch=7.17

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2024-05-13T14:06:55Z","message":"[BK] Migrate batch 1 (Artifact builds) (#182582)\n\n## Summary\r\nMigrates batch 1 - artifact builds. The upload aspect wasn't tested,\r\nbecause it's programmed only to run from `main`, and we didn't want to\r\ninterfere with the ongoing releases. This can be tested after the merge.\r\n\r\nVerification:\r\n- [x] RREs tested locally\r\n- [x] kibana / artifacts trigger\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/87)\r\n- [x] kibana / artifacts container image\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/86)\r\n- [x] kibana / artifacts snapshot\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/88)\r\n- [x] kibana / artifacts staging\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/88)\r\n- [x] 8.13 / 8.14 / 7.17 verification (only a few jobs need to work\r\nhere)\r\n\r\nOriginals:\r\n- kibana / artifacts trigger\r\n[kibana-artifacts-trigger.yml](https://buildkite.com/elastic/kibana-artifacts-trigger)\r\n- kibana / artifacts container image\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-container-image)\r\n- kibana / artifacts snapshot\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-snapshot)\r\n- kibana / artifacts staging\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-staging)\r\n\r\nBackports:\r\n - https://github.com/elastic/kibana/pull/182781\r\n - https://github.com/elastic/kibana/pull/182780\r\n \r\nThe backports don't need to have the pipeline resource definition files,\r\nhowever, we forked 8.14 off from main, where we already had the\r\nresources. I'll remove all the unnecessary resource defs from the legacy\r\nbranches, once we finalize the state (simply to save a little\r\ninconvenience on future backports.)","sha":"d5362fdaf7da5dd60f26da2ce4c64313c5930317","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:prev-MAJOR","v8.15.0","v7.17.22"],"number":182582,"url":"https://github.com/elastic/kibana/pull/182582","mergeCommit":{"message":"[BK] Migrate batch 1 (Artifact builds) (#182582)\n\n## Summary\r\nMigrates batch 1 - artifact builds. The upload aspect wasn't tested,\r\nbecause it's programmed only to run from `main`, and we didn't want to\r\ninterfere with the ongoing releases. This can be tested after the merge.\r\n\r\nVerification:\r\n- [x] RREs tested locally\r\n- [x] kibana / artifacts trigger\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/87)\r\n- [x] kibana / artifacts container image\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/86)\r\n- [x] kibana / artifacts snapshot\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/88)\r\n- [x] kibana / artifacts staging\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/88)\r\n- [x] 8.13 / 8.14 / 7.17 verification (only a few jobs need to work\r\nhere)\r\n\r\nOriginals:\r\n- kibana / artifacts trigger\r\n[kibana-artifacts-trigger.yml](https://buildkite.com/elastic/kibana-artifacts-trigger)\r\n- kibana / artifacts container image\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-container-image)\r\n- kibana / artifacts snapshot\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-snapshot)\r\n- kibana / artifacts staging\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-staging)\r\n\r\nBackports:\r\n - https://github.com/elastic/kibana/pull/182781\r\n - https://github.com/elastic/kibana/pull/182780\r\n \r\nThe backports don't need to have the pipeline resource definition files,\r\nhowever, we forked 8.14 off from main, where we already had the\r\nresources. I'll remove all the unnecessary resource defs from the legacy\r\nbranches, once we finalize the state (simply to save a little\r\ninconvenience on future backports.)","sha":"d5362fdaf7da5dd60f26da2ce4c64313c5930317"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/182582","number":182582,"mergeCommit":{"message":"[BK] Migrate batch 1 (Artifact builds) (#182582)\n\n## Summary\r\nMigrates batch 1 - artifact builds. The upload aspect wasn't tested,\r\nbecause it's programmed only to run from `main`, and we didn't want to\r\ninterfere with the ongoing releases. This can be tested after the merge.\r\n\r\nVerification:\r\n- [x] RREs tested locally\r\n- [x] kibana / artifacts trigger\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/87)\r\n- [x] kibana / artifacts container image\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/86)\r\n- [x] kibana / artifacts snapshot\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/88)\r\n- [x] kibana / artifacts staging\r\n(https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/88)\r\n- [x] 8.13 / 8.14 / 7.17 verification (only a few jobs need to work\r\nhere)\r\n\r\nOriginals:\r\n- kibana / artifacts trigger\r\n[kibana-artifacts-trigger.yml](https://buildkite.com/elastic/kibana-artifacts-trigger)\r\n- kibana / artifacts container image\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-container-image)\r\n- kibana / artifacts snapshot\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-snapshot)\r\n- kibana / artifacts staging\r\n[kibana-artifacts.yml](https://buildkite.com/elastic/kibana-artifacts-staging)\r\n\r\nBackports:\r\n - https://github.com/elastic/kibana/pull/182781\r\n - https://github.com/elastic/kibana/pull/182780\r\n \r\nThe backports don't need to have the pipeline resource definition files,\r\nhowever, we forked 8.14 off from main, where we already had the\r\nresources. I'll remove all the unnecessary resource defs from the legacy\r\nbranches, once we finalize the state (simply to save a little\r\ninconvenience on future backports.)","sha":"d5362fdaf7da5dd60f26da2ce4c64313c5930317"}},{"branch":"7.17","label":"v7.17.22","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->