### PR TITLE
[CI] Increase artifact build timeout

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -6,7 +6,7 @@ steps:
       imageProject: elastic-images-qa
       provider: gcp
       machineType: c2-standard-16
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
## Summary
Increases step timeout for building the whole artifact collection by 15m. 

With some recent additions ([chainguard build](https://github.com/elastic/kibana/pull/183200) adds ~7m) and the new infra overhead, we've gone from ~50-52 minutes to ~57-60 minutes (this one timed out exactly on the last bit: https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4295#018f7b4c-3629-4c4f-8d80-85b2552a43c4)

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->