### PR TITLE
[Lens] Provide a way to intercept and rewrite user messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1554,6 +1554,7 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "abab": "^2.0.4",
     "aggregate-error": "^3.1.0",
+    "apache-arrow": "16.1.0",
     "apidoc-markdown": "^7.3.0",
     "argsplit": "^1.0.5",
     "autoprefixer": "^10.4.7",

--- a/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/form_based.tsx
@@ -100,6 +100,7 @@ import { isColumnOfType } from './operations/definitions/helpers';
 import { LayerSettingsPanel } from './layer_settings';
 import { FormBasedLayer, LastValueIndexPatternColumn } from '../..';
 import { filterAndSortUserMessages } from '../../app_plugin/get_application_user_messages';
+import { UM_LENS_FORM_BASED_LAYER_DIMENSION } from '../../user_messages_types';
 export type { OperationType, GenericIndexPatternColumn } from './operations';
 export { deleteColumn } from './operations';
 
@@ -770,34 +771,35 @@ export function getFormBasedDatasource({
         }
       );
 
-      const warningMessages = [
-        ...[
-          ...(getStateTimeShiftWarningMessages(data.datatableUtilities, state, framePublicAPI) ||
-            []),
-        ].map((longMessage) => {
-          const message: UserMessage = {
-            severity: 'warning',
-            fixableInEditor: true,
-            displayLocations: [{ id: 'toolbar' }],
-            shortMessage: '',
-            longMessage,
-          };
+      const timeShiftWarningMessages = getStateTimeShiftWarningMessages(
+        data.datatableUtilities,
+        state,
+        framePublicAPI
+      );
 
-          return message;
-        }),
-        ...getPrecisionErrorWarningMessages(
-          data.datatableUtilities,
-          state,
-          framePublicAPI,
-          core.docLinks,
-          setState
-        ),
-        ...getUnsupportedOperationsWarningMessage(state, framePublicAPI, core.docLinks),
-      ];
+      const precisionErrorWarningMessages = getPrecisionErrorWarningMessages(
+        data.datatableUtilities,
+        state,
+        framePublicAPI,
+        core.docLinks,
+        setState
+      );
+
+      const unsupporteOpsWarningMessages = getUnsupportedOperationsWarningMessage(
+        state,
+        framePublicAPI,
+        core.docLinks
+      );
 
       const infoMessages = getNotifiableFeatures(state, framePublicAPI, visualizationInfo);
 
-      return layerErrorMessages.concat(dimensionErrorMessages, warningMessages, infoMessages);
+      return layerErrorMessages.concat(
+        dimensionErrorMessages,
+        timeShiftWarningMessages,
+        precisionErrorWarningMessages,
+        unsupporteOpsWarningMessages,
+        infoMessages
+      );
     },
 
     getSearchWarningMessages: (state, warning, request, response) => {
@@ -1024,6 +1026,8 @@ function getInvalidDimensionErrorMessages(
 
         if (!isValidColumn(layerId, columnId)) {
           messages.push({
+            type: UM_LENS_FORM_BASED_LAYER_DIMENSION,
+            name: 'InvalidConfiguration',
             severity: 'error',
             displayLocations: [{ id: 'dimensionButton', dimensionId: columnId }],
             fixableInEditor: true,

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/formula.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/formula.tsx
@@ -68,16 +68,23 @@ export const formulaOperation: OperationDefinition<FormulaIndexPatternColumn, 'm
     getDisabledStatus(indexPattern: IndexPattern) {
       return undefined;
     },
-    getErrorMessage(layer, columnId, indexPattern, dateRange, operationDefinitionMap, targetBars) {
+    getErrorMessage(
+      layer,
+      columnId,
+      indexPattern,
+      dateRange,
+      operationDefinitionMap,
+      targetBars
+    ): FieldBasedOperationErrorMessage[] {
       const column = layer.columns[columnId] as FormulaIndexPatternColumn;
       if (!column.params.formula || !operationDefinitionMap) {
-        return;
+        return [];
       }
 
       const visibleOperationsMap = filterByVisibleOperation(operationDefinitionMap);
       const { root, error } = tryToParse(column.params.formula, visibleOperationsMap);
       if (error || root == null) {
-        return error?.message ? [error.message] : [];
+        return error?.message ? [{ message: error.message }] : [];
       }
 
       const errors = runASTValidation(
@@ -94,7 +101,7 @@ export const formulaOperation: OperationDefinition<FormulaIndexPatternColumn, 'm
         return uniqBy(errors, ({ message }) => message).map(({ type, message, extraInfo }) =>
           type === 'missingField' && extraInfo?.missingFields
             ? generateMissingFieldMessage(extraInfo.missingFields, columnId)
-            : message
+            : { message }
         );
       }
 
@@ -149,7 +156,7 @@ export const formulaOperation: OperationDefinition<FormulaIndexPatternColumn, 'm
         });
       }
 
-      return innerErrors.length ? innerErrors : undefined;
+      return innerErrors;
     },
     getPossibleOperation() {
       return {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
@@ -28,9 +28,9 @@ export function getInvalidFieldMessage(
   layer: FormBasedLayer,
   columnId: string,
   indexPattern?: IndexPattern
-): FieldBasedOperationErrorMessage[] | undefined {
+): FieldBasedOperationErrorMessage[] {
   if (!indexPattern) {
-    return;
+    return [];
   }
 
   const column = layer.columns[columnId] as FieldBasedIndexPatternColumn;
@@ -77,19 +77,21 @@ export function getInvalidFieldMessage(
       const wrongTypeFields =
         operationDefinition?.getNonTransferableFields?.(column, indexPattern) ?? fieldNames;
       return [
-        i18n.translate('xpack.lens.indexPattern.fieldsWrongType', {
-          defaultMessage:
-            '{count, plural, one {Field} other {Fields}} {invalidFields} {count, plural, one {is} other {are}} of the wrong type',
-          values: {
-            count: wrongTypeFields.length,
-            invalidFields: wrongTypeFields.join(', '),
-          },
-        }),
+        {
+          message: i18n.translate('xpack.lens.indexPattern.fieldsWrongType', {
+            defaultMessage:
+              '{count, plural, one {Field} other {Fields}} {invalidFields} {count, plural, one {is} other {are}} of the wrong type',
+            values: {
+              count: wrongTypeFields.length,
+              invalidFields: wrongTypeFields.join(', '),
+            },
+          }),
+        },
       ];
     }
   }
 
-  return undefined;
+  return [];
 }
 
 export const generateMissingFieldMessage = (
@@ -123,10 +125,9 @@ export const generateMissingFieldMessage = (
 });
 
 export function combineErrorMessages(
-  errorMessages: Array<FieldBasedOperationErrorMessage[] | undefined>
-): FieldBasedOperationErrorMessage[] | undefined {
-  const messages = (errorMessages.filter(Boolean) as FieldBasedOperationErrorMessage[][]).flat();
-  return messages.length ? messages : undefined;
+  errorMessages: FieldBasedOperationErrorMessage[][]
+): FieldBasedOperationErrorMessage[] {
+  return errorMessages.flat();
 }
 
 export function getSafeName(name: string, indexPattern: IndexPattern | undefined): string {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/index.ts
@@ -324,7 +324,7 @@ interface BaseOperationDefinitionProps<
     dateRange?: DateRange,
     operationDefinitionMap?: Record<string, GenericOperationDefinition>,
     targetBars?: number
-  ) => FieldBasedOperationErrorMessage[] | undefined;
+  ) => FieldBasedOperationErrorMessage[];
 
   /*
    * Flag whether this operation can be scaled by time unit if a date histogram is available.
@@ -463,21 +463,19 @@ interface FilterParams {
   lucene?: string;
 }
 
-export type FieldBasedOperationErrorMessage =
-  | {
-      message: string | React.ReactNode;
-      displayLocations?: UserMessage['displayLocations'];
-      fixAction?: {
-        label: string;
-        newState: (
-          data: DataPublicPluginStart,
-          core: CoreStart,
-          frame: FramePublicAPI,
-          layerId: string
-        ) => Promise<FormBasedLayer>;
-      };
-    }
-  | string;
+export interface FieldBasedOperationErrorMessage {
+  message: string | React.ReactNode;
+  displayLocations?: UserMessage['displayLocations'];
+  fixAction?: {
+    label: string;
+    newState: (
+      data: DataPublicPluginStart,
+      core: CoreStart,
+      frame: FramePublicAPI,
+      layerId: string
+    ) => Promise<FormBasedLayer>;
+  };
+}
 interface FieldlessOperationDefinition<C extends BaseIndexPatternColumn, P = {}> {
   input: 'none';
 
@@ -581,7 +579,7 @@ interface FieldBasedOperationDefinition<C extends BaseIndexPatternColumn, P = {}
     columnId: string,
     indexPattern: IndexPattern,
     operationDefinitionMap?: Record<string, GenericOperationDefinition>
-  ) => FieldBasedOperationErrorMessage[] | undefined;
+  ) => FieldBasedOperationErrorMessage[];
 }
 
 export interface RequiredReference {

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/last_value.tsx
@@ -93,10 +93,12 @@ function getInvalidSortFieldMessage(
     };
   }
   if (field.type !== 'date') {
-    return i18n.translate('xpack.lens.indexPattern.lastValue.invalidTypeSortField', {
-      defaultMessage: 'Field {invalidField} is not a date field and cannot be used for sorting',
-      values: { invalidField: sortField },
-    });
+    return {
+      message: i18n.translate('xpack.lens.indexPattern.lastValue.invalidTypeSortField', {
+        defaultMessage: 'Field {invalidField} is not a date field and cannot be used for sorting',
+        values: { invalidField: sortField },
+      }),
+    };
   }
 }
 
@@ -228,7 +230,7 @@ export const lastValueOperation: OperationDefinition<
     }
 
     errorMessages.push(...(getColumnReducedTimeRangeError(layer, columnId, indexPattern) || []));
-    return errorMessages.length ? errorMessages : undefined;
+    return errorMessages;
   },
   buildColumn({ field, previousColumn, indexPattern }, columnParams) {
     const lastValueParams = columnParams as LastValueIndexPatternColumn['params'];

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/layer_helpers.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/layer_helpers.ts
@@ -1557,7 +1557,7 @@ export function getErrorMessages(
   layerId: string,
   core: CoreStart,
   data: DataPublicPluginStart
-): LayerErrorMessage[] | undefined {
+): LayerErrorMessage[] {
   const columns = Object.entries(layer.columns);
   const visibleManagedReferences = columns.filter(
     ([columnId, column]) =>
@@ -1608,7 +1608,7 @@ export function getErrorMessages(
     // remove the undefined values
     .filter((v) => v != null) as LayerErrorMessage[];
 
-  return errors.length ? errors : undefined;
+  return errors;
 }
 
 export function isReferenced(layer: FormBasedLayer, columnId: string): boolean {

--- a/x-pack/plugins/lens/public/datasources/form_based/reduced_time_range_utils.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/reduced_time_range_utils.tsx
@@ -57,33 +57,38 @@ export function getColumnReducedTimeRangeError(
   layer: FormBasedLayer,
   columnId: string,
   indexPattern: IndexPattern
-): FieldBasedOperationErrorMessage[] | undefined {
+): FieldBasedOperationErrorMessage[] {
   const currentColumn = layer.columns[columnId];
   if (!currentColumn.reducedTimeRange) {
-    return;
+    return [];
   }
   const hasDateHistogram = Object.values(layer.columns).some(
     (column) => column.operationType === 'date_histogram'
   );
   const hasTimeField = Boolean(indexPattern.timeFieldName);
-  const errors: FieldBasedOperationErrorMessage[] = [
-    hasDateHistogram &&
-      i18n.translate('xpack.lens.indexPattern.reducedTimeRangeWithDateHistogram', {
+  const errors: FieldBasedOperationErrorMessage[] = [];
+  if (hasDateHistogram) {
+    errors.push({
+      message: i18n.translate('xpack.lens.indexPattern.reducedTimeRangeWithDateHistogram', {
         defaultMessage:
           'Reduced time range can only be used without a date histogram. Either remove the date histogram dimension or remove the reduced time range from {column}.',
         values: {
           column: currentColumn.label,
         },
       }),
-    !hasTimeField &&
-      i18n.translate('xpack.lens.indexPattern.reducedTimeRangeWithoutTimefield', {
+    });
+  }
+  if (!hasTimeField) {
+    errors.push({
+      message: i18n.translate('xpack.lens.indexPattern.reducedTimeRangeWithoutTimefield', {
         defaultMessage:
           'Reduced time range can only be used with a specified default time field on the data view. Either use a different data view with default time field or remove the reduced time range from {column}.',
         values: {
           column: currentColumn.label,
         },
       }),
-  ].filter(Boolean) as FieldBasedOperationErrorMessage[];
+    });
+  }
 
   return errors;
 }

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -613,9 +613,7 @@ export class Embeddable
   private fullAttributes: LensSavedObjectAttributes | undefined;
 
   public getUserMessages: UserMessagesGetter = (locationId, filters) => {
-    const externalUserMessagesHandler = this.input.handleUserMessages
-      ? this.input.handleUserMessages
-      : (d: UserMessage[]) => d;
+    const externalUserMessagesHandler = this.input.handleUserMessages ?? ((m: UserMessage[]) => m); // nop
 
     const userMessages: UserMessage[] = [];
     userMessages.push(

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -300,6 +300,8 @@ export type UserMessagesDisplayLocationId = UserMessageDisplayLocation['id'];
 
 export interface UserMessage {
   uniqueId?: string;
+  type: string;
+  name: string;
   severity: 'error' | 'warning' | 'info';
   shortMessage: string;
   longMessage: string | React.ReactNode | ((closePopover: () => void) => React.ReactNode);

--- a/x-pack/plugins/lens/public/user_messages_types.ts
+++ b/x-pack/plugins/lens/public/user_messages_types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const LENS_USER_MESSAGES_TYPES = {
+  LAYER_SETTINGS: 'LensLayerSettings',
+  LAYER_DIMENSION: 'LensLayerDimension',
+};
+
+export const LENS_USER_MESSAGES_NAMES = {
+  SAMPLING_PERCENT: 'SamplingPercent',
+  IGNORE_GLOBAL_FILTERS: 'IgnoreGlobalFilters',
+  ASC_COUNT_PRECISION_ERROR: `ascendingCountPrecisionError`,
+  UNSUPPORTED_COUNTER_OP: 'unsupportedCounterOperation',
+};

--- a/x-pack/plugins/observability_solution/infra/public/components/lens/lens_chart.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/lens/lens_chart.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import { EuiPanel, EuiToolTip, type EuiPanelProps } from '@elastic/eui';
 import { Action } from '@kbn/ui-actions-plugin/public';
 import { css } from '@emotion/react';
@@ -70,6 +71,41 @@ export const LensChart = React.memo(
         onBrushEnd={onBrushEnd}
         searchSessionId={searchSessionId}
         onFilter={onFilter}
+        handleUserMessages={(messages) => {
+          return messages.map((m) => {
+            if (
+              m.displayLocations.find((d) => d.id === 'embeddableBadge') !== undefined &&
+              m.severity === 'error'
+              // we need something else to better identify those errors
+            ) {
+              return {
+                ...m,
+                severity: 'warning' as const,
+                longMessage: (
+                  <p>
+                    <b>
+                      {i18n.translate('xpack.infra.lens.b.noResultsFoundLabel', {
+                        defaultMessage: 'No Results found',
+                      })}
+                    </b>
+                    <br />
+                    {i18n.translate('xpack.infra.lens.p.youCanShowTheLabel', {
+                      defaultMessage:
+                        'You can show the cpu by declaring metrics in your system integration',
+                    })}
+                    <br />
+                    <a>
+                      {i18n.translate('xpack.infra.lens.a.learnHowLabel', {
+                        defaultMessage: 'Learn how',
+                      })}
+                    </a>
+                  </p>
+                ),
+              };
+            }
+            return m;
+          });
+        }}
       />
     );
     const content = !toolTip ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@75lb/deep-merge@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@75lb/deep-merge/-/deep-merge-1.1.1.tgz#3b06155b90d34f5f8cc2107d796f1853ba02fd6d"
+  integrity sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==
+  dependencies:
+    lodash.assignwith "^4.2.0"
+    typical "^7.1.1"
+
 "@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
@@ -9046,6 +9054,13 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
+"@swc/helpers@^0.5.10":
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.11.tgz#5bab8c660a6e23c13b2d23fcd1ee44a2db1b0cb7"
+  integrity sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==
+  dependencies:
+    tslib "^2.4.0"
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
@@ -9539,6 +9554,16 @@
   integrity sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==
   dependencies:
     "@types/color-convert" "*"
+
+"@types/command-line-args@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/command-line-args/-/command-line-args-5.2.3.tgz#553ce2fd5acf160b448d307649b38ffc60d39639"
+  integrity sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==
+
+"@types/command-line-usage@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.4.tgz#374e4c62d78fbc5a670a0f36da10235af879a0d5"
+  integrity sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==
 
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
@@ -10268,7 +10293,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@20.10.5", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=18.0.0", "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0", "@types/node@^18.0.0", "@types/node@^18.11.18", "@types/node@^18.17.5":
+"@types/node@*", "@types/node@20.10.5", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=18.0.0", "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0", "@types/node@^18.0.0", "@types/node@^18.11.18", "@types/node@^18.17.5", "@types/node@^20.12.7":
   version "20.10.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.5.tgz#47ad460b514096b7ed63a1dae26fad0914ed3ab2"
   integrity sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==
@@ -11733,6 +11758,21 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@^3.1.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apache-arrow@16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-16.1.0.tgz#7aa8d0d436dd0995d9dc5c36febf380d5b207209"
+  integrity sha512-G6GiM6tzPDdGnKUnVkvVr1Nt5+hUaCMBISiasMSiJwI5L5GKDv5Du7Avc2kxlFfB/LEK2LTqh2GKSxutMdf8vQ==
+  dependencies:
+    "@swc/helpers" "^0.5.10"
+    "@types/command-line-args" "^5.2.3"
+    "@types/command-line-usage" "^5.0.4"
+    "@types/node" "^20.12.7"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.1"
+    flatbuffers "^24.3.25"
+    json-bignum "^0.0.3"
+    tslib "^2.6.2"
+
 apidoc-light@^0.54.0:
   version "0.54.0"
   resolved "https://registry.yarnpkg.com/apidoc-light/-/apidoc-light-0.54.0.tgz#8d819bcd893ca96a60d754c59b33dcf5f9255b59"
@@ -11892,6 +11932,16 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
 
 array-buffer-byte-length@^1.0.0:
   version "1.0.0"
@@ -13415,6 +13465,13 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
+chalk-template@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
+  integrity sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==
+  dependencies:
+    chalk "^4.1.2"
+
 chalk@2.4.2, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -13960,6 +14017,26 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+command-line-args@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^7.0.0, command-line-usage@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-7.0.1.tgz#e540afef4a4f3bc501b124ffde33956309100655"
+  integrity sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==
+  dependencies:
+    array-back "^6.2.2"
+    chalk-template "^0.4.0"
+    table-layout "^3.0.0"
+    typical "^7.1.1"
 
 commander@2, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1:
   version "2.20.3"
@@ -17486,6 +17563,13 @@ find-cypress-specs@^1.41.4:
     spec-change "^1.10.0"
     ts-node "^10.9.1"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -17546,6 +17630,11 @@ flat@5, flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+flatbuffers@^24.3.25:
+  version "24.3.25"
+  resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-24.3.25.tgz#e2f92259ba8aa53acd0af7844afb7c7eb95e7089"
+  integrity sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==
 
 flatstr@^1.0.12:
   version "1.0.12"
@@ -20977,6 +21066,11 @@ json-bigint@^1.0.0:
   dependencies:
     bignumber.js "^9.0.0"
 
+json-bignum@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/json-bignum/-/json-bignum-0.0.3.tgz#41163b50436c773d82424dbc20ed70db7604b8d7"
+  integrity sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -21610,6 +21704,11 @@ lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
+lodash.assignwith@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb"
+  integrity sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -28686,6 +28785,11 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
+stream-read-all@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stream-read-all/-/stream-read-all-3.0.1.tgz#60762ae45e61d93ba0978cda7f3913790052ad96"
+  integrity sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==
+
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -29251,6 +29355,19 @@ tabbable@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
   integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
+
+table-layout@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-3.0.2.tgz#69c2be44388a5139b48c59cf21e73b488021769a"
+  integrity sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==
+  dependencies:
+    "@75lb/deep-merge" "^1.1.1"
+    array-back "^6.2.2"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.0"
+    stream-read-all "^3.0.1"
+    typical "^7.1.1"
+    wordwrapjs "^5.1.0"
 
 table@^6.8.0, table@^6.8.1:
   version "6.8.1"
@@ -29895,7 +30012,7 @@ tslib@^1.10.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.5.2:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.5.2, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -30097,6 +30214,16 @@ typewise@^1.0.3:
   integrity sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==
   dependencies:
     typewise-core "^1.2.0"
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-7.1.1.tgz#ba177ab7ab103b78534463ffa4c0c9754523ac1f"
+  integrity sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"
@@ -31721,6 +31848,11 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wordwrapjs@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
+  integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
## Summary

This is a simple POC that provides a way to intercept, review and modify user messages coming from a Lens embeddable.

The property `handleUserMessages?: (userMessages: UserMessage[]) => UserMessage[];` can be used from the lens embeddable to remap/rewrite/filter the `UserMessages` that the embeddable is throwing to the user.
This includes both `info`, `warning` and `error` messages.

The `UserMessage` type needs to be extended a few more property to be able to correctly manipulate the user messages:
- a `messageType` property should be added to identify the message type. An enum/string can be used to represent each specific message type and have a specific semantic meaning (for example `LENS_FORMULA_MISSING_FIELD_ERROR`.
- for each `messageType` there could be some context variables that provide more information about the error itself (in the case of formula `missing field` we can provide for example the associated field names.


At the dashboard level, we can probably implement all the necessary logic to filter/review/modify the messages for `managed` dashboard at the Lens embeddable bootstrap.

<img width="860" alt="Screenshot 2024-05-15 at 15 33 47" src="https://github.com/elastic/kibana/assets/1421091/e9621350-c472-442f-9b1d-1565dd0675ff">

