### PR TITLE
[CI] Use new-infra-type agent targeting for chainguard build

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -95,7 +95,10 @@ steps:
   - command: KIBANA_DOCKER_CONTEXT=chainguard .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:
-      queue: n2-2
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-qa
+      provider: gcp
+      machineType: n2-standard-2
     timeout_in_minutes: 30
     retry:
       automatic:


### PR DESCRIPTION
## Summary
This PR ties https://github.com/elastic/kibana/pull/183200 + https://github.com/elastic/kibana/pull/182582 together

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->