### PR TITLE
[ResponseOps] Fix flaky global alerts page E2E tests

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alerts_page.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alerts_page.ts
@@ -25,9 +25,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const security = getService('security');
   const pageObjects = getPageObjects(['common', 'triggersActionsUI', 'header']);
   const log = getService('log');
+  const retry = getService('retry');
 
-  // Failing: See https://github.com/elastic/kibana/issues/181795
-  describe.skip('Stack alerts page', function () {
+  describe('Stack alerts page', function () {
     describe('Loads the page with limited privileges', () => {
       beforeEach(async () => {
         await security.testUser.restoreDefaults();
@@ -54,13 +54,20 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             shouldUseHashForSubUrl: false,
           }
         );
-        await pageObjects.triggersActionsUI.clickAlertsPageShowQueryMenuButton();
-        const quickFilters = await pageObjects.triggersActionsUI.getAlertsPageQuickFilters();
-        const solutionFilters = getSolutionNamesFromFilters(quickFilters);
-        expect(solutionFilters).to.have.length(2);
-        expect(solutionFilters[0]).to.equal('Stack management');
-        // Observability is included because of multi-consumer rules
-        expect(solutionFilters[1]).to.equal('Observability');
+
+        await pageObjects.header.waitUntilLoadingHasFinished();
+
+        await retry.try(async () => {
+          if (!(await testSubjects.exists('queryBarMenuPanel'))) {
+            await pageObjects.triggersActionsUI.clickAlertsPageShowQueryMenuButton();
+          }
+          const quickFilters = await pageObjects.triggersActionsUI.getAlertsPageQuickFilters();
+          const solutionFilters = getSolutionNamesFromFilters(quickFilters);
+          expect(solutionFilters).to.have.length(2);
+          expect(solutionFilters[0]).to.equal('Stack management');
+          // Observability is included because of multi-consumer rules
+          expect(solutionFilters[1]).to.equal('Observability');
+        });
       });
     });
 


### PR DESCRIPTION
## Summary
Resolves: https://github.com/elastic/kibana/issues/181795

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios