### PR TITLE
[ES|QL] minor typing improvement

### DIFF
--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -359,8 +359,8 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     return { cache: fn.cache, memoizedFieldsFromESQL: fn };
   }, []);
 
-  const esqlCallbacks: ESQLCallbacks = useMemo(
-    () => ({
+  const esqlCallbacks: ESQLCallbacks = useMemo(() => {
+    const callbacks: ESQLCallbacks = {
       getSources: async () => {
         const [remoteIndices, localIndices] = await Promise.all([
           getRemoteIndicesList(dataViews),
@@ -399,16 +399,16 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
         }
         return policies.map(({ type, query: policyQuery, ...rest }) => rest);
       },
-    }),
-    [
-      dataViews,
-      expressions,
-      indexManagementApiService,
-      esqlFieldsCache,
-      memoizedFieldsFromESQL,
-      abortController,
-    ]
-  );
+    };
+    return callbacks;
+  }, [
+    dataViews,
+    expressions,
+    indexManagementApiService,
+    esqlFieldsCache,
+    memoizedFieldsFromESQL,
+    abortController,
+  ]);
 
   const parseMessages = useCallback(async () => {
     if (editorModel.current) {


### PR DESCRIPTION
## Summary

I can never remember where these callbacks are and before, VSCode couldn't find them via a type search. All better now:

<img width="777" alt="Screenshot 2024-05-16 at 8 28 33 AM" src="https://github.com/elastic/kibana/assets/315764/39214f64-ee18-4d11-ac0c-b59447e1d22c">

