### PR TITLE
[SLO] Remove unnecessary appMountParameters breaking SLOs flyout

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -14,7 +14,7 @@ import { ExperimentalFeatures } from '../../common/config';
 export interface PluginContextValue {
   isDev?: boolean;
   isServerless?: boolean;
-  appMountParameters: AppMountParameters;
+  appMountParameters?: AppMountParameters;
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
   ObservabilityPageTemplate: React.ComponentType<LazyObservabilityPageTemplateProps>;
   experimentalFeatures?: ExperimentalFeatures;

--- a/x-pack/plugins/observability_solution/slo/public/pages/slo_edit/shared_flyout/get_create_slo_flyout.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slo_edit/shared_flyout/get_create_slo_flyout.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { QueryClient } from '@tanstack/react-query';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
-import { AppMountParameters, CoreStart } from '@kbn/core/public';
+import { CoreStart } from '@kbn/core/public';
 import { LazyObservabilityPageTemplateProps } from '@kbn/observability-shared-plugin/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { RecursivePartial } from '@kbn/utility-types';
@@ -23,7 +23,6 @@ import { SloAddFormFlyout } from './slo_form';
 export const getCreateSLOFlyoutLazy = ({
   core,
   plugins,
-  getAppMountParameters,
   observabilityRuleTypeRegistry,
   ObservabilityPageTemplate,
   isDev,
@@ -33,7 +32,6 @@ export const getCreateSLOFlyoutLazy = ({
 }: {
   core: CoreStart;
   plugins: SloPublicPluginsStart;
-  getAppMountParameters: () => Promise<AppMountParameters>;
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
   ObservabilityPageTemplate: React.ComponentType<LazyObservabilityPageTemplateProps>;
   isDev?: boolean;
@@ -41,7 +39,7 @@ export const getCreateSLOFlyoutLazy = ({
   isServerless?: boolean;
   experimentalFeatures: ExperimentalFeatures;
 }) => {
-  return async ({
+  return ({
     onClose,
     initialValues,
   }: {
@@ -49,7 +47,6 @@ export const getCreateSLOFlyoutLazy = ({
     initialValues?: RecursivePartial<CreateSLOForm>;
   }) => {
     const queryClient = new QueryClient();
-    const appMountParameters = await getAppMountParameters();
     return (
       <KibanaContextProvider
         services={{
@@ -67,7 +64,6 @@ export const getCreateSLOFlyoutLazy = ({
             observabilityRuleTypeRegistry,
             ObservabilityPageTemplate,
             experimentalFeatures,
-            appMountParameters,
           }}
         >
           <QueryClientProvider client={queryClient}>

--- a/x-pack/plugins/observability_solution/slo/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/slo/public/plugin.ts
@@ -14,7 +14,7 @@ import {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/public';
-import { BehaviorSubject, Subject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { SloPublicPluginsSetup, SloPublicPluginsStart } from './types';
 import { PLUGIN_NAME, sloAppId } from '../common';
 import type { SloPublicSetup, SloPublicStart } from './types';
@@ -32,7 +32,6 @@ export class SloPlugin
   implements Plugin<SloPublicSetup, SloPublicStart, SloPublicPluginsSetup, SloPublicPluginsStart>
 {
   private readonly appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
-  private readonly appMountParameters$ = new Subject<AppMountParameters<unknown>>();
   private experimentalFeatures: ExperimentalFeatures = { ruleFormV2: { enabled: false } };
 
   constructor(private readonly initContext: PluginInitializerContext<SloConfig>) {
@@ -57,7 +56,6 @@ export class SloPlugin
       const [coreStart, pluginsStart] = await coreSetup.getStartServices();
       const { ruleTypeRegistry, actionTypeRegistry } = pluginsStart.triggersActionsUi;
       const { observabilityRuleTypeRegistry } = pluginsStart.observability;
-      this.appMountParameters$.next(params);
 
       return renderApp({
         appMountParameters: params,
@@ -166,7 +164,6 @@ export class SloPlugin
         observabilityRuleTypeRegistry: pluginsStart.observability.observabilityRuleTypeRegistry,
         ObservabilityPageTemplate: pluginsStart.observabilityShared.navigation.PageTemplate,
         plugins: { ...pluginsStart, ruleTypeRegistry, actionTypeRegistry },
-        getAppMountParameters: () => firstValueFrom(this.appMountParameters$),
         isServerless: !!pluginsStart.serverless,
         experimentalFeatures: this.experimentalFeatures,
       }),


### PR DESCRIPTION
## 📓 Summary

After converting the factory function for the SLOs flyout into an async function, the experience when consuming the flyout in the Logs Explorer app was broken as React was trying to render a Promise object.

https://github.com/elastic/kibana/assets/34506779/bcb5ca86-b8a5-4b6d-b9e9-e5f8b44eb518

The bug was introduced in [this line](https://github.com/elastic/kibana/commit/90e466ac00a5d1965e6fbbd181d822ec5ca27c94#diff-a1d1227bdd927b871e65f46d0f702b2eb3a630a79e3d3e7402072d83f1249274R44), when to receive the appMountParameters and inject them into the context, the function was made async.

There is no need on this component for the `appMountParameters` to be in the context, so reverting this context value property to be optional and removing the async resolution of it fixes the issue.