### PR TITLE
[chore] bump chromedriver to 124

### DIFF
--- a/package.json
+++ b/package.json
@@ -1571,7 +1571,7 @@
     "buildkite-test-collector": "^1.7.0",
     "callsites": "^3.1.0",
     "chance": "1.0.18",
-    "chromedriver": "^123.0.3",
+    "chromedriver": "^124.0.3",
     "clean-webpack-plugin": "^3.0.0",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13568,10 +13568,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^123.0.3:
-  version "123.0.3"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-123.0.3.tgz#40f9223373cbdf8f849e118507b24b0de8ecb21a"
-  integrity sha512-35IeTqDLcVR0htF9nD/Lh+g24EG088WHVKXBXiFyWq+2lelnoM0B3tKTBiUEjLng0GnELI4QyQPFK7i97Fz1fQ==
+chromedriver@^124.0.3:
+  version "124.0.3"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-124.0.3.tgz#2818408353ee97005acb887d9f488fe34d5c6d10"
+  integrity sha512-k6Xu9fwDMgi//bGHB944QMmDHF0BBWGk4PAyVZBEuP6wnZMfQP4V6Sv+l/nuAPA006RllS6X07ZpjPwRPS4BaA==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.6.7"


### PR DESCRIPTION
## Summary

Follow up to #181002.

Updating chromedriver to support running tests on Chrome v125

<!--ONMERGE {"backportTargets":["7.17","8.13","8.14"]} ONMERGE-->