### PR TITLE
[Onboarding] Fix bash script URL in the quickstart snippet

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/server/routes/logs/route.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/routes/logs/route.ts
@@ -63,7 +63,7 @@ const installShipperSetupRoute = createObservabilityOnboardingServerRoute({
       kibanaUrl
     ).toString();
 
-    const apiEndpoint = `${kibanaUrl}/internal/observability_onboarding`;
+    const apiEndpoint = new URL(`${kibanaUrl}/internal/observability_onboarding`).toString();
 
     return {
       apiEndpoint,

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/routes/logs/route.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/routes/logs/route.ts
@@ -6,7 +6,6 @@
  */
 
 import * as t from 'io-ts';
-import { type IStaticAssets } from '@kbn/core-http-server';
 import { createObservabilityOnboardingServerRoute } from '../create_observability_onboarding_server_route';
 import { getFallbackKibanaUrl } from '../../lib/get_fallback_urls';
 import { hasLogMonitoringPrivileges } from './api_key/has_log_monitoring_privileges';
@@ -30,16 +29,6 @@ const logMonitoringPrivilegesRoute = createObservabilityOnboardingServerRoute({
     return { hasPrivileges };
   },
 });
-
-function createScriptDownloadUrl(staticAssets: IStaticAssets, kibanaHost: string) {
-  const scriptPath = staticAssets.getPluginAssetHref('standalone_agent_setup.sh');
-  const isAbsolute = scriptPath.startsWith('http');
-
-  if (isAbsolute) {
-    return scriptPath;
-  }
-  return `${kibanaHost}${scriptPath}`;
-}
 
 const installShipperSetupRoute = createObservabilityOnboardingServerRoute({
   endpoint: 'GET /internal/observability_onboarding/logs/setup/environment',
@@ -69,7 +58,10 @@ const installShipperSetupRoute = createObservabilityOnboardingServerRoute({
       core.setup.http.basePath.publicBaseUrl ?? // priority given to server.publicBaseUrl
       plugins.cloud?.setup?.kibanaUrl ?? // then cloud id
       getFallbackKibanaUrl(coreStart); // falls back to local network binding
-    const scriptDownloadUrl = createScriptDownloadUrl(coreStart.http.staticAssets, kibanaUrl);
+    const scriptDownloadUrl = new URL(
+      coreStart.http.staticAssets.getPluginAssetHref('standalone_agent_setup.sh'),
+      kibanaUrl
+    ).toString();
 
     const apiEndpoint = `${kibanaUrl}/internal/observability_onboarding`;
 

--- a/x-pack/test/observability_onboarding_api_integration/configs/index.ts
+++ b/x-pack/test/observability_onboarding_api_integration/configs/index.ts
@@ -8,7 +8,7 @@
 import { mapValues } from 'lodash';
 import { createTestConfig, CreateTestConfig } from '../common/config';
 
-export const MOCKED_PUBLIC_BASE_URL = 'http://mockedPublicBaseUrl';
+export const MOCKED_PUBLIC_BASE_URL = 'http://mockedpublicbaseurl';
 // my.mocked.domain$myMockedEsUr$myKibanaMockedUrl
 export const MOCKED_ENCODED_CLOUD_ID =
   'bXkubW9ja2VkLmRvbWFpbiRteU1vY2tlZEVzVXJsJG15TW9ja2VkS2liYW5hVXJs';

--- a/x-pack/test/observability_onboarding_api_integration/configs/index.ts
+++ b/x-pack/test/observability_onboarding_api_integration/configs/index.ts
@@ -12,7 +12,7 @@ export const MOCKED_PUBLIC_BASE_URL = 'http://mockedPublicBaseUrl';
 // my.mocked.domain$myMockedEsUr$myKibanaMockedUrl
 export const MOCKED_ENCODED_CLOUD_ID =
   'bXkubW9ja2VkLmRvbWFpbiRteU1vY2tlZEVzVXJsJG15TW9ja2VkS2liYW5hVXJs';
-export const MOCKED_KIBANA_URL = 'https://myMockedKibanaUrl.my.mocked.domain:443';
+export const MOCKED_KIBANA_URL = 'https://mymockedkibanaurl.my.mocked.domain';
 
 export const observabilityOnboardingDebugLogger = {
   name: 'plugins.observabilityOnboarding',

--- a/x-pack/test/observability_onboarding_api_integration/tests/logs/environment.spec.ts
+++ b/x-pack/test/observability_onboarding_api_integration/tests/logs/environment.spec.ts
@@ -29,7 +29,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       );
       expect(request.body.scriptDownloadUrl).to.match(
         new RegExp(
-          `${MOCKED_PUBLIC_BASE_URL}/.+?/plugins/observabilityOnboarding/assets/standalone_agent_setup.sh`
+          `${MOCKED_PUBLIC_BASE_URL}/.+?/plugins/observabilityOnboarding/assets/standalone_agent_setup.sh`,
+          'i'
         )
       );
     });

--- a/x-pack/test/observability_onboarding_api_integration/tests/logs/environment.spec.ts
+++ b/x-pack/test/observability_onboarding_api_integration/tests/logs/environment.spec.ts
@@ -46,7 +46,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       );
       expect(request.body.scriptDownloadUrl).to.match(
         new RegExp(
-          `${MOCKED_KIBANA_URL}/.+?/plugins/observabilityOnboarding/assets/standalone_agent_setup.sh`
+          `${MOCKED_KIBANA_URL}/.+?/plugins/observabilityOnboarding/assets/standalone_agent_setup.sh`,
+          'i'
         )
       );
     });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/183594

Add logic to take into account absolute CDN URLs when generating bash script download link.