### PR TITLE
[Search] [Playground] Index: Include aliases

### DIFF
--- a/x-pack/plugins/search_playground/server/lib/fetch_indices.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/fetch_indices.test.ts
@@ -19,8 +19,8 @@ describe('fetch indices', () => {
     },
     'index-2': {
       aliases: {
-        'search-alias-1': {},
-        'search-alias-2': {},
+        'search-alias-3': {},
+        'search-alias-4': {},
       },
     },
     'index-3': {
@@ -48,7 +48,15 @@ describe('fetch indices', () => {
     );
 
     expect(indexData).toEqual({
-      indexNames: ['index-1', 'index-2', 'index-3'],
+      indexNames: [
+        'index-1',
+        'index-2',
+        'index-3',
+        'search-alias-1',
+        'search-alias-2',
+        'search-alias-3',
+        'search-alias-4',
+      ],
     });
   });
 });

--- a/x-pack/plugins/search_playground/server/lib/fetch_indices.ts
+++ b/x-pack/plugins/search_playground/server/lib/fetch_indices.ts
@@ -42,9 +42,24 @@ export const fetchIndices = async (
       !isHidden(allIndexMatches[indexName]) &&
       !isClosed(allIndexMatches[indexName])
   );
+
+  const allAliases = allIndexNames.reduce<string[]>((acc, indexName) => {
+    const aliases = allIndexMatches[indexName].aliases;
+    if (aliases) {
+      Object.keys(aliases).forEach((alias) => {
+        if (!acc.includes(alias)) {
+          acc.push(alias);
+        }
+      });
+    }
+    return acc;
+  }, []);
+
+  const allOptions = [...allIndexNames, ...allAliases];
+
   const indexNames = searchQuery
-    ? allIndexNames.filter((indexName) => indexName.includes(searchQuery.toLowerCase()))
-    : allIndexNames;
+    ? allOptions.filter((indexName) => indexName.includes(searchQuery.toLowerCase()))
+    : allOptions;
 
   return {
     indexNames,


### PR DESCRIPTION
## Summary

Include aliases in the indices search


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->