### PR TITLE
chore(NA): add back 8.13 branch into versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -14,6 +14,12 @@
       "previousMinor": true
     },
     {
+      "version": "8.13.5",
+      "branch": "8.13",
+      "currentMajor": true,
+      "previousMinor": true
+    },
+    {
       "version": "7.17.22",
       "branch": "7.17",
       "previousMajor": true


### PR DESCRIPTION
This was removed too early by mistake. Re-adding it back.