### PR TITLE
[Security Solution] Remove deprecated sourcerer property

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/sourcerer/mocks.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/sourcerer/mocks.ts
@@ -61,5 +61,4 @@ export const mockSourcererScope: SelectedDataView = {
   loading: false,
   dataViewId: mockGlobalState.sourcerer.defaultDataView.id,
   runtimeMappings: mockRuntimeMappings,
-  patternList: mockPatterns,
 };

--- a/x-pack/plugins/security_solution/public/common/store/sourcerer/model.ts
+++ b/x-pack/plugins/security_solution/public/common/store/sourcerer/model.ts
@@ -108,11 +108,6 @@ export interface SelectedDataView {
   /** is an update being made to the data view */
   loading: boolean;
   /**
-   * @deprecated use sourcererDataView.title or sourcererDataView.matchedIndices
-   * all active & inactive patterns from SourcererDataView['title']
-   */
-  patternList: string[];
-  /**
    * @deprecated use sourcererDataView.runtimeMappings
    */
   runtimeMappings: SourcererDataView['runtimeMappings'];

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.test.ts
@@ -51,7 +51,6 @@ describe('useThreatIntelligenceDetails', () => {
       dataViewId: '',
       loading: false,
       indicesExist: true,
-      patternList: [],
       selectedPatterns: [],
       indexPattern: { fields: [], title: '' },
       sourcererDataView: undefined,


### PR DESCRIPTION
## Summary

This PR removes  long-deprecated `patternList` property from the sourcerer model.
