### PR TITLE
Remove GH project assignment for closed project

### DIFF
--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           issue-mappings: |
             [
-              {"label": "Feature:Lens", "projectNumber": 32, "columnName": "Long-term goals"},
               {"label": "Team:DataDiscovery", "projectNumber": 44, "columnName": "Inbox"},
               {"label": "Feature:Canvas", "projectNumber": 38, "columnName": "Inbox"},
               {"label": "Feature:Dashboard", "projectNumber": 68, "columnName": "Inbox"},


### PR DESCRIPTION
## Summary

The `Lens` [GH Project](https://github.com/elastic/kibana/projects/32) is closed and we no longer use it. 

<img width="541" alt="Screenshot 2024-05-16 at 17 19 31" src="https://github.com/elastic/kibana/assets/1421091/d648bf6d-5ea0-4606-90a2-879cba7c8963">
