### PR TITLE
[ResponseOps][Connectors] Change authentication UI for the Cases webhook connector.

### DIFF
--- a/x-pack/plugins/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/plugins/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -1113,6 +1113,45 @@ Object {
     "presence": "optional",
   },
   "keys": Object {
+    "authType": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "webhook-authentication-basic",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+        Object {
+          "schema": Object {
+            "allow": Array [
+              null,
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
     "createCommentJson": Object {
       "flags": Object {
         "default": null,

--- a/x-pack/plugins/stack_connectors/common/constants.ts
+++ b/x-pack/plugins/stack_connectors/common/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export enum SSLCertType {
-  CRT = 'ssl-crt-key',
-  PFX = 'ssl-pfx',
+export enum AuthType {
+  Basic = 'webhook-authentication-basic',
+  SSL = 'webhook-authentication-ssl',
 }

--- a/x-pack/plugins/stack_connectors/common/index.ts
+++ b/x-pack/plugins/stack_connectors/common/index.ts
@@ -15,5 +15,3 @@ export enum AdditionalEmailServices {
 export const INTERNAL_BASE_STACK_CONNECTORS_API_PATH = '/internal/stack_connectors';
 
 export { OpsgenieSubActions, OpsgenieConnectorTypeId } from './opsgenie';
-
-export { AuthType } from './constants';

--- a/x-pack/plugins/stack_connectors/common/index.ts
+++ b/x-pack/plugins/stack_connectors/common/index.ts
@@ -15,3 +15,5 @@ export enum AdditionalEmailServices {
 export const INTERNAL_BASE_STACK_CONNECTORS_API_PATH = '/internal/stack_connectors';
 
 export { OpsgenieSubActions, OpsgenieConnectorTypeId } from './opsgenie';
+
+export { AuthType } from './constants';

--- a/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/steps/auth.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/steps/auth.tsx
@@ -26,6 +26,7 @@ import {
   TextField,
   PasswordField,
   CardRadioGroupField,
+  HiddenField,
 } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import { AuthType as CasesWebhookAuthType } from '../../../../common/constants';
@@ -105,7 +106,7 @@ export const AuthStep: FunctionComponent<Props> = ({ display, readOnly }) => {
       </EuiFlexGroup>
       <EuiSpacer size="m" />
       {/* I wonder if this is necessary but I am leaving it for now because the Webhook connector does too.*/}
-      <UseField path="config.hasAuth" component={() => null} />
+      <UseField path="config.hasAuth" component={HiddenField} />
       <UseField
         path="config.authType"
         defaultValue={authTypeDefaultValue}

--- a/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/steps/auth.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/steps/auth.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -21,9 +21,16 @@ import {
   useFormContext,
   useFormData,
 } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
-import { Field, TextField, PasswordField } from '@kbn/es-ui-shared-plugin/static/forms/components';
+import {
+  Field,
+  TextField,
+  PasswordField,
+  CardRadioGroupField,
+} from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
+import { AuthType as CasesWebhookAuthType } from '../../../../common/constants';
 import * as i18n from '../translations';
+
 const { emptyField } = fieldValidators;
 
 interface Props {
@@ -31,16 +38,61 @@ interface Props {
   readOnly: boolean;
 }
 
+const basicAuthFields = (readOnly: boolean) => (
+  <EuiFlexGroup justifyContent="spaceBetween">
+    <EuiFlexItem>
+      <UseField
+        path="secrets.user"
+        config={{
+          label: i18n.USERNAME,
+          validations: [
+            {
+              validator: emptyField(i18n.USERNAME_REQUIRED),
+            },
+          ],
+        }}
+        component={Field}
+        componentProps={{
+          euiFieldProps: { readOnly, 'data-test-subj': 'webhookUserInput', fullWidth: true },
+        }}
+      />
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <UseField
+        path="secrets.password"
+        config={{
+          label: i18n.PASSWORD,
+          validations: [
+            {
+              validator: emptyField(i18n.PASSWORD_REQUIRED),
+            },
+          ],
+        }}
+        component={PasswordField}
+        componentProps={{
+          euiFieldProps: { readOnly, 'data-test-subj': 'webhookPasswordInput' },
+        }}
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+
 export const AuthStep: FunctionComponent<Props> = ({ display, readOnly }) => {
-  const { getFieldDefaultValue } = useFormContext();
+  const { setFieldValue, getFieldDefaultValue } = useFormContext();
   const [{ config, __internal__ }] = useFormData({
-    watch: ['config.hasAuth', '__internal__.hasHeaders'],
+    watch: ['config.hasAuth', 'config.authType', '__internal__.hasHeaders'],
   });
 
   const hasHeadersDefaultValue = !!getFieldDefaultValue<boolean | undefined>('config.headers');
 
-  const hasAuth = config == null ? true : config.hasAuth;
+  const authTypeDefaultValue =
+    getFieldDefaultValue('config.hasAuth') === false
+      ? null
+      : getFieldDefaultValue('config.authType') ?? CasesWebhookAuthType.Basic;
+  const authType = config == null ? CasesWebhookAuthType.Basic : config.authType;
   const hasHeaders = __internal__ != null ? __internal__.hasHeaders : false;
+
+  useEffect(() => setFieldValue('config.hasAuth', Boolean(authType)), [authType, setFieldValue]);
 
   return (
     <span data-test-subj="authStep" style={{ display: display ? 'block' : 'none' }}>
@@ -49,59 +101,31 @@ export const AuthStep: FunctionComponent<Props> = ({ display, readOnly }) => {
           <EuiTitle size="xxs">
             <h4>{i18n.AUTH_TITLE}</h4>
           </EuiTitle>
-          <EuiSpacer size="m" />
-          <UseField
-            path="config.hasAuth"
-            component={Field}
-            config={{ defaultValue: true, type: FIELD_TYPES.TOGGLE }}
-            componentProps={{
-              euiFieldProps: {
-                label: i18n.HAS_AUTH,
-                disabled: readOnly,
-                'data-test-subj': 'hasAuthToggle',
-              },
-            }}
-          />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {hasAuth ? (
-        <EuiFlexGroup justifyContent="spaceBetween">
-          <EuiFlexItem>
-            <UseField
-              path="secrets.user"
-              config={{
-                label: i18n.USERNAME,
-                validations: [
-                  {
-                    validator: emptyField(i18n.USERNAME_REQUIRED),
-                  },
-                ],
-              }}
-              component={Field}
-              componentProps={{
-                euiFieldProps: { readOnly, 'data-test-subj': 'webhookUserInput', fullWidth: true },
-              }}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <UseField
-              path="secrets.password"
-              config={{
-                label: i18n.PASSWORD,
-                validations: [
-                  {
-                    validator: emptyField(i18n.PASSWORD_REQUIRED),
-                  },
-                ],
-              }}
-              component={PasswordField}
-              componentProps={{
-                euiFieldProps: { readOnly, 'data-test-subj': 'webhookPasswordInput' },
-              }}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ) : null}
+      <EuiSpacer size="m" />
+      {/* I wonder if this is necessary but I am leaving it for now because the Webhook connector does too.*/}
+      <UseField path="config.hasAuth" component={() => null} />
+      <UseField
+        path="config.authType"
+        defaultValue={authTypeDefaultValue}
+        component={CardRadioGroupField}
+        componentProps={{
+          options: [
+            {
+              value: null,
+              label: i18n.AUTHENTICATION_NONE,
+              'data-test-subj': 'authNone',
+            },
+            {
+              value: CasesWebhookAuthType.Basic,
+              label: i18n.AUTHENTICATION_BASIC,
+              children: authType === CasesWebhookAuthType.Basic && basicAuthFields(readOnly),
+              'data-test-subj': 'authBasic',
+            },
+          ],
+        }}
+      />
       <EuiSpacer size="m" />
       <UseField
         path="__internal__.hasHeaders"

--- a/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/translations.ts
@@ -547,3 +547,24 @@ export const STATUS_IN_PROGRESS = i18n.translate(
     defaultMessage: 'In progress',
   }
 );
+
+export const AUTHENTICATION_NONE = i18n.translate(
+  'xpack.stackConnectors.components.casesWebhook.authenticationMethodNoneLabel',
+  {
+    defaultMessage: 'None',
+  }
+);
+
+export const AUTHENTICATION_BASIC = i18n.translate(
+  'xpack.stackConnectors.components.casesWebhook.authenticationMethodBasicLabel',
+  {
+    defaultMessage: 'Basic authentication',
+  }
+);
+
+export const AUTHENTICATION_SSL = i18n.translate(
+  'xpack.stackConnectors.components.casesWebhook.authenticationMethodSSLLabel',
+  {
+    defaultMessage: 'SSL authentication',
+  }
+);

--- a/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.test.tsx
@@ -94,7 +94,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
     expect(await screen.findByTestId('webhookCreateCommentJson')).toBeInTheDocument();
   });
 
-  it('Toggles work properly', async () => {
+  it('connector auth toggles work as expected', async () => {
     render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <CasesWebhookActionConnectorFields

--- a/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/webhook_connectors.test.tsx
@@ -7,8 +7,9 @@
 
 import React from 'react';
 import CasesWebhookActionConnectorFields from './webhook_connectors';
-import { ConnectorFormTestProvider, waitForComponentToUpdate } from '../lib/test_utils';
-import { act, render } from '@testing-library/react';
+import { ConnectorFormTestProvider } from '../lib/test_utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthType as CasesWebhookAuthType } from '../../../common/constants';
 import userEvent from '@testing-library/user-event';
 import * as i18n from './translations';
 
@@ -27,6 +28,7 @@ jest.mock('@kbn/triggers-actions-ui-plugin/public', () => {
 const invalidJsonTitle = `{"fields":{"summary":"wrong","description":{{{case.description}}},"project":{"key":"ROC"},"issuetype":{"id":"10024"}}}`;
 const invalidJsonBoth = `{"fields":{"summary":"wrong","description":"wrong","project":{"key":"ROC"},"issuetype":{"id":"10024"}}}`;
 const config = {
+  authType: CasesWebhookAuthType.Basic,
   createCommentJson: '{"body":{{{case.comment}}}}',
   createCommentMethod: 'post',
   createCommentUrl: 'https://coolsite.net/rest/api/2/issue/{{{external.system.id}}}/comment',
@@ -59,8 +61,8 @@ const actionConnector = {
 };
 
 describe('CasesWebhookActionConnectorFields renders', () => {
-  test('All inputs are properly rendered', async () => {
-    const { getByTestId } = render(
+  it('All inputs are properly rendered', async () => {
+    render(
       <ConnectorFormTestProvider connector={actionConnector}>
         <CasesWebhookActionConnectorFields
           readOnly={false}
@@ -69,55 +71,68 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         />
       </ConnectorFormTestProvider>
     );
-    await waitForComponentToUpdate();
-    expect(getByTestId('webhookUserInput')).toBeInTheDocument();
-    expect(getByTestId('webhookPasswordInput')).toBeInTheDocument();
-    expect(getByTestId('webhookHeadersKeyInput')).toBeInTheDocument();
-    expect(getByTestId('webhookHeadersValueInput')).toBeInTheDocument();
-    expect(getByTestId('webhookCreateMethodSelect')).toBeInTheDocument();
-    expect(getByTestId('webhookCreateUrlText')).toBeInTheDocument();
-    expect(getByTestId('webhookCreateIncidentJson')).toBeInTheDocument();
-    expect(getByTestId('createIncidentResponseKeyText')).toBeInTheDocument();
-    expect(getByTestId('getIncidentUrlInput')).toBeInTheDocument();
-    expect(getByTestId('getIncidentResponseExternalTitleKeyText')).toBeInTheDocument();
-    expect(getByTestId('viewIncidentUrlInput')).toBeInTheDocument();
-    expect(getByTestId('webhookUpdateMethodSelect')).toBeInTheDocument();
-    expect(getByTestId('updateIncidentUrlInput')).toBeInTheDocument();
-    expect(getByTestId('webhookUpdateIncidentJson')).toBeInTheDocument();
-    expect(getByTestId('webhookCreateCommentMethodSelect')).toBeInTheDocument();
-    expect(getByTestId('createCommentUrlInput')).toBeInTheDocument();
-    expect(getByTestId('webhookCreateCommentJson')).toBeInTheDocument();
+    expect(await screen.findByTestId('authNone')).toBeInTheDocument();
+    expect(await screen.findByTestId('authBasic')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookUserInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookPasswordInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookHeadersKeyInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookHeadersValueInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookCreateMethodSelect')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookCreateUrlText')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookCreateIncidentJson')).toBeInTheDocument();
+    expect(await screen.findByTestId('createIncidentResponseKeyText')).toBeInTheDocument();
+    expect(await screen.findByTestId('getIncidentUrlInput')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('getIncidentResponseExternalTitleKeyText')
+    ).toBeInTheDocument();
+    expect(await screen.findByTestId('viewIncidentUrlInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookUpdateMethodSelect')).toBeInTheDocument();
+    expect(await screen.findByTestId('updateIncidentUrlInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookUpdateIncidentJson')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookCreateCommentMethodSelect')).toBeInTheDocument();
+    expect(await screen.findByTestId('createCommentUrlInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookCreateCommentJson')).toBeInTheDocument();
   });
-  test('Toggles work properly', async () => {
-    const { getByTestId, queryByTestId } = render(
-      <ConnectorFormTestProvider connector={actionConnector}>
-        <CasesWebhookActionConnectorFields
-          readOnly={false}
-          isEdit={false}
-          registerPreSubmitValidator={() => {}}
-        />
-      </ConnectorFormTestProvider>
-    );
-    await waitForComponentToUpdate();
-    expect(getByTestId('hasAuthToggle')).toHaveAttribute('aria-checked', 'true');
-    await act(async () => {
-      userEvent.click(getByTestId('hasAuthToggle'));
-    });
-    expect(getByTestId('hasAuthToggle')).toHaveAttribute('aria-checked', 'false');
-    expect(queryByTestId('webhookUserInput')).not.toBeInTheDocument();
-    expect(queryByTestId('webhookPasswordInput')).not.toBeInTheDocument();
 
-    expect(getByTestId('webhookViewHeadersSwitch')).toHaveAttribute('aria-checked', 'true');
-    await act(async () => {
-      userEvent.click(getByTestId('webhookViewHeadersSwitch'));
-    });
-    expect(getByTestId('webhookViewHeadersSwitch')).toHaveAttribute('aria-checked', 'false');
-    expect(queryByTestId('webhookHeadersKeyInput')).not.toBeInTheDocument();
-    expect(queryByTestId('webhookHeadersValueInput')).not.toBeInTheDocument();
+  it('Toggles work properly', async () => {
+    render(
+      <ConnectorFormTestProvider connector={actionConnector}>
+        <CasesWebhookActionConnectorFields
+          readOnly={false}
+          isEdit={false}
+          registerPreSubmitValidator={() => {}}
+        />
+      </ConnectorFormTestProvider>
+    );
+
+    const authNoneToggle = await screen.findByTestId('authNone');
+
+    expect(authNoneToggle).toBeInTheDocument();
+    expect(await screen.findByTestId('authBasic')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookUserInput')).toBeInTheDocument();
+    expect(await screen.findByTestId('webhookPasswordInput')).toBeInTheDocument();
+
+    userEvent.click(authNoneToggle);
+
+    expect(screen.queryByTestId('webhookUserInput')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('webhookPasswordInput')).not.toBeInTheDocument();
+
+    expect(await screen.findByTestId('webhookViewHeadersSwitch')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    userEvent.click(await screen.findByTestId('webhookViewHeadersSwitch'));
+    expect(await screen.findByTestId('webhookViewHeadersSwitch')).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+    expect(screen.queryByTestId('webhookHeadersKeyInput')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('webhookHeadersValueInput')).not.toBeInTheDocument();
   });
+
   describe('Step Validation', () => {
-    test('Steps work correctly when all fields valid', async () => {
-      const { queryByTestId, getByTestId } = render(
+    it('Steps work correctly when all fields valid', async () => {
+      render(
         <ConnectorFormTestProvider connector={actionConnector}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -126,52 +141,52 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           />
         </ConnectorFormTestProvider>
       );
-      await waitForComponentToUpdate();
-      expect(getByTestId('horizontalStep1-current')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep2-incomplete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep3-incomplete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
-      expect(getByTestId('authStep')).toHaveAttribute('style', 'display: block;');
-      expect(getByTestId('createStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('getStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('updateStep')).toHaveAttribute('style', 'display: none;');
-      expect(queryByTestId('casesWebhookBack')).not.toBeInTheDocument();
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      expect(getByTestId('horizontalStep1-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep2-current')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep3-incomplete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
-      expect(getByTestId('authStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('createStep')).toHaveAttribute('style', 'display: block;');
-      expect(getByTestId('getStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('updateStep')).toHaveAttribute('style', 'display: none;');
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      expect(getByTestId('horizontalStep1-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep2-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep3-current')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
-      expect(getByTestId('authStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('createStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('getStep')).toHaveAttribute('style', 'display: block;');
-      expect(getByTestId('updateStep')).toHaveAttribute('style', 'display: none;');
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      expect(getByTestId('horizontalStep1-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep2-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep3-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep4-current')).toBeInTheDocument();
-      expect(getByTestId('authStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('createStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('getStep')).toHaveAttribute('style', 'display: none;');
-      expect(getByTestId('updateStep')).toHaveAttribute('style', 'display: block;');
-      expect(queryByTestId('casesWebhookNext')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep1-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('authStep')).toHaveAttribute('style', 'display: block;');
+      expect(await screen.findByTestId('createStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('getStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('updateStep')).toHaveAttribute('style', 'display: none;');
+      expect(screen.queryByTestId('casesWebhookBack')).not.toBeInTheDocument();
+
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+
+      expect(await screen.findByTestId('horizontalStep1-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('authStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('createStep')).toHaveAttribute('style', 'display: block;');
+      expect(await screen.findByTestId('getStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('updateStep')).toHaveAttribute('style', 'display: none;');
+
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+
+      expect(await screen.findByTestId('horizontalStep1-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('authStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('createStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('getStep')).toHaveAttribute('style', 'display: block;');
+      expect(await screen.findByTestId('updateStep')).toHaveAttribute('style', 'display: none;');
+
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+
+      expect(await screen.findByTestId('horizontalStep1-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep4-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('authStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('createStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('getStep')).toHaveAttribute('style', 'display: none;');
+      expect(await screen.findByTestId('updateStep')).toHaveAttribute('style', 'display: block;');
+      expect(screen.queryByTestId('casesWebhookNext')).not.toBeInTheDocument();
     });
-    test('Step 1 is properly validated', async () => {
+
+    it('Step 1 is properly validated', async () => {
       const incompleteActionConnector = {
         ...actionConnector,
         secrets: {
@@ -179,7 +194,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           password: '',
         },
       };
-      const { getByTestId } = render(
+      render(
         <ConnectorFormTestProvider connector={incompleteActionConnector}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -188,29 +203,22 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           />
         </ConnectorFormTestProvider>
       );
-      await waitForComponentToUpdate();
 
-      expect(getByTestId('horizontalStep1-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep1-current')).toBeInTheDocument();
 
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      await waitForComponentToUpdate();
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
 
-      expect(getByTestId('horizontalStep1-danger')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep1-danger')).toBeInTheDocument();
 
-      await act(async () => {
-        userEvent.click(getByTestId('hasAuthToggle'));
-        userEvent.click(getByTestId('webhookViewHeadersSwitch'));
-      });
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
+      userEvent.click(await screen.findByTestId('authNone'));
+      userEvent.click(await screen.findByTestId('webhookViewHeadersSwitch'));
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
 
-      expect(getByTestId('horizontalStep1-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep2-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep1-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-current')).toBeInTheDocument();
     });
-    test('Step 2 is properly validated', async () => {
+
+    it('Step 2 is properly validated', async () => {
       const incompleteActionConnector = {
         ...actionConnector,
         config: {
@@ -218,7 +226,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           createIncidentUrl: undefined,
         },
       };
-      const { getByText, getByTestId } = render(
+      render(
         <ConnectorFormTestProvider connector={incompleteActionConnector}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -227,37 +235,31 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           />
         </ConnectorFormTestProvider>
       );
-      await waitForComponentToUpdate();
-      expect(getByTestId('horizontalStep2-incomplete')).toBeInTheDocument();
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      getByText(i18n.CREATE_URL_REQUIRED);
-      expect(getByTestId('horizontalStep2-danger')).toBeInTheDocument();
-      await act(async () => {
-        await userEvent.type(
-          getByTestId('webhookCreateUrlText'),
-          `{selectall}{backspace}${config.createIncidentUrl}`,
-          {
-            delay: 10,
-          }
-        );
-      });
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      expect(getByTestId('horizontalStep2-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep3-current')).toBeInTheDocument();
-      await act(async () => {
-        userEvent.click(getByTestId('horizontalStep2-complete'));
-      });
-      expect(getByTestId('horizontalStep2-current')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep3-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-incomplete')).toBeInTheDocument();
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+      expect(await screen.findByText(i18n.CREATE_URL_REQUIRED)).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-danger')).toBeInTheDocument();
+      await userEvent.type(
+        await screen.findByTestId('webhookCreateUrlText'),
+        `{selectall}{backspace}${config.createIncidentUrl}`,
+        {
+          delay: 10,
+        }
+      );
+
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+
+      expect(await screen.findByTestId('horizontalStep2-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-current')).toBeInTheDocument();
+
+      userEvent.click(await screen.findByTestId('horizontalStep2-complete'));
+
+      expect(await screen.findByTestId('horizontalStep2-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-incomplete')).toBeInTheDocument();
     });
-    test('Step 3 is properly validated', async () => {
+
+    it('Step 3 is properly validated', async () => {
       const incompleteActionConnector = {
         ...actionConnector,
         config: {
@@ -265,7 +267,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           getIncidentResponseExternalTitleKey: undefined,
         },
       };
-      const { getByText, getByTestId } = render(
+      render(
         <ConnectorFormTestProvider connector={incompleteActionConnector}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -274,38 +276,34 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           />
         </ConnectorFormTestProvider>
       );
-      await waitForComponentToUpdate();
-      expect(getByTestId('horizontalStep2-incomplete')).toBeInTheDocument();
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      getByText(i18n.GET_RESPONSE_EXTERNAL_TITLE_KEY_REQUIRED);
-      expect(getByTestId('horizontalStep3-danger')).toBeInTheDocument();
-      await act(async () => {
-        await userEvent.type(
-          getByTestId('getIncidentResponseExternalTitleKeyText'),
-          `{selectall}{backspace}${config.getIncidentResponseExternalTitleKey}`,
-          {
-            delay: 10,
-          }
-        );
-      });
-      await act(async () => {
-        userEvent.click(getByTestId('casesWebhookNext'));
-      });
-      expect(getByTestId('horizontalStep3-complete')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep4-current')).toBeInTheDocument();
-      await act(async () => {
-        userEvent.click(getByTestId('horizontalStep3-complete'));
-      });
-      expect(getByTestId('horizontalStep3-current')).toBeInTheDocument();
-      expect(getByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep2-incomplete')).toBeInTheDocument();
+
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+
+      expect(
+        await screen.findByText(i18n.GET_RESPONSE_EXTERNAL_TITLE_KEY_REQUIRED)
+      ).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep3-danger')).toBeInTheDocument();
+
+      await userEvent.type(
+        await screen.findByTestId('getIncidentResponseExternalTitleKeyText'),
+        `{selectall}{backspace}${config.getIncidentResponseExternalTitleKey}`,
+        {
+          delay: 10,
+        }
+      );
+
+      userEvent.click(await screen.findByTestId('casesWebhookNext'));
+
+      expect(await screen.findByTestId('horizontalStep3-complete')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep4-current')).toBeInTheDocument();
+
+      userEvent.click(await screen.findByTestId('horizontalStep3-complete'));
+
+      expect(await screen.findByTestId('horizontalStep3-current')).toBeInTheDocument();
+      expect(await screen.findByTestId('horizontalStep4-incomplete')).toBeInTheDocument();
     });
 
     // step 4 is not validated like the others since it is the last step
@@ -346,7 +344,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
     ];
 
     it('connector validation succeeds when connector config is valid', async () => {
-      const { getByTestId } = render(
+      render(
         <ConnectorFormTestProvider connector={actionConnector} onSubmit={onSubmit}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -356,20 +354,19 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      await act(async () => {
-        userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      userEvent.click(await screen.findByTestId('form-test-provide-submit'));
       const { isPreconfigured, ...rest } = actionConnector;
-
-      expect(onSubmit).toBeCalledWith({
-        data: {
-          ...rest,
-          __internal__: {
-            hasHeaders: true,
+      await waitFor(() =>
+        expect(onSubmit).toBeCalledWith({
+          data: {
+            ...rest,
+            __internal__: {
+              hasHeaders: true,
+            },
           },
-        },
-        isValid: true,
-      });
+          isValid: true,
+        })
+      );
     });
 
     it('connector validation succeeds when auth=false', async () => {
@@ -381,7 +378,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         },
       };
 
-      const { getByTestId } = render(
+      render(
         <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -391,24 +388,25 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      await act(async () => {
-        userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      userEvent.click(await screen.findByTestId('form-test-provide-submit'));
 
       const { isPreconfigured, secrets, ...rest } = actionConnector;
-      expect(onSubmit).toBeCalledWith({
-        data: {
-          ...rest,
-          config: {
-            ...actionConnector.config,
-            hasAuth: false,
+      await waitFor(() =>
+        expect(onSubmit).toBeCalledWith({
+          data: {
+            ...rest,
+            config: {
+              ...actionConnector.config,
+              hasAuth: false,
+              authType: null,
+            },
+            __internal__: {
+              hasHeaders: true,
+            },
           },
-          __internal__: {
-            hasHeaders: true,
-          },
-        },
-        isValid: true,
-      });
+          isValid: true,
+        })
+      );
     });
 
     it('connector validation succeeds without headers', async () => {
@@ -420,7 +418,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         },
       };
 
-      const { getByTestId } = render(
+      render(
         <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -430,22 +428,22 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      await act(async () => {
-        userEvent.click(getByTestId('form-test-provide-submit'));
-      });
+      userEvent.click(await screen.findByTestId('form-test-provide-submit'));
 
       const { isPreconfigured, ...rest } = actionConnector;
       const { headers, ...rest2 } = actionConnector.config;
-      expect(onSubmit).toBeCalledWith({
-        data: {
-          ...rest,
-          config: rest2,
-          __internal__: {
-            hasHeaders: false,
+      await waitFor(() =>
+        expect(onSubmit).toBeCalledWith({
+          data: {
+            ...rest,
+            config: rest2,
+            __internal__: {
+              hasHeaders: false,
+            },
           },
-        },
-        isValid: true,
-      });
+          isValid: true,
+        })
+      );
     });
 
     it('validates correctly if the method is empty', async () => {
@@ -457,7 +455,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         },
       };
 
-      const res = render(
+      render(
         <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -467,11 +465,8 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      await act(async () => {
-        userEvent.click(res.getByTestId('form-test-provide-submit'));
-      });
-
-      expect(onSubmit).toHaveBeenCalledWith({ data: {}, isValid: false });
+      userEvent.click(await screen.findByTestId('form-test-provide-submit'));
+      await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ data: {}, isValid: false }));
     });
 
     it.each(tests)('validates correctly %p', async (field, value) => {
@@ -483,7 +478,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         },
       };
 
-      const res = render(
+      render(
         <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
           <CasesWebhookActionConnectorFields
             readOnly={false}
@@ -493,17 +488,13 @@ describe('CasesWebhookActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      await act(async () => {
-        await userEvent.type(res.getByTestId(field), `{selectall}{backspace}${value}`, {
-          delay: 10,
-        });
+      await userEvent.type(await screen.findByTestId(field), `{selectall}{backspace}${value}`, {
+        delay: 10,
       });
 
-      await act(async () => {
-        userEvent.click(res.getByTestId('form-test-provide-submit'));
-      });
+      userEvent.click(await screen.findByTestId('form-test-provide-submit'));
 
-      expect(onSubmit).toHaveBeenCalledWith({ data: {}, isValid: false });
+      await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ data: {}, isValid: false }));
     });
 
     it.each(mustacheTests)(
@@ -518,7 +509,7 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           },
         };
 
-        const res = render(
+        render(
           <ConnectorFormTestProvider connector={connector} onSubmit={onSubmit}>
             <CasesWebhookActionConnectorFields
               readOnly={false}
@@ -528,12 +519,11 @@ describe('CasesWebhookActionConnectorFields renders', () => {
           </ConnectorFormTestProvider>
         );
 
-        await act(async () => {
-          userEvent.click(res.getByTestId('form-test-provide-submit'));
-        });
-
-        expect(onSubmit).toHaveBeenCalledWith({ data: {}, isValid: false });
-        expect(res.getByText(i18n.MISSING_VARIABLES(missingVariables))).toBeInTheDocument();
+        userEvent.click(await screen.findByTestId('form-test-provide-submit'));
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ data: {}, isValid: false }));
+        expect(
+          await screen.findByText(i18n.MISSING_VARIABLES(missingVariables))
+        ).toBeInTheDocument();
       }
     );
   });

--- a/x-pack/plugins/stack_connectors/public/connector_types/webhook/webhook_connectors.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/webhook/webhook_connectors.test.tsx
@@ -11,7 +11,8 @@ import WebhookActionConnectorFields from './webhook_connectors';
 import { ConnectorFormTestProvider, waitForComponentToUpdate } from '../lib/test_utils';
 import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { WebhookAuthType, SSLCertType } from '../../../common/webhook/constants';
+import { SSLCertType } from '../../../common/webhook/constants';
+import { AuthType as WebhookAuthType } from '../../../common/constants';
 
 describe('WebhookActionConnectorFields renders', () => {
   test('all connector fields is rendered', async () => {

--- a/x-pack/plugins/stack_connectors/public/connector_types/webhook/webhook_connectors.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/webhook/webhook_connectors.tsx
@@ -37,7 +37,9 @@ import {
 } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
 import type { ActionConnectorFieldsProps } from '@kbn/triggers-actions-ui-plugin/public';
-import { WebhookAuthType, SSLCertType } from '../../../common/webhook/constants';
+import { SSLCertType } from '../../../common/webhook/constants';
+import { AuthType as WebhookAuthType } from '../../../common/constants';
+
 import * as i18n from './translations';
 
 const HTTP_VERBS = ['post', 'put'];

--- a/x-pack/plugins/stack_connectors/server/connector_types/cases_webhook/schema.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/cases_webhook/schema.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 import { CasesWebhookMethods } from './types';
 import { nullableType } from '../lib/nullable';
+import { AuthType as CasesWebhookAuthType } from '../../../common/constants';
 
 const HeadersSchema = schema.recordOf(schema.string(), schema.string());
 
@@ -52,6 +53,11 @@ export const ExternalIncidentServiceConfiguration = {
   createCommentJson: schema.nullable(schema.string()),
   headers: nullableType(HeadersSchema),
   hasAuth: schema.boolean({ defaultValue: true }),
+  authType: schema.maybe(
+    schema.oneOf([schema.literal(CasesWebhookAuthType.Basic), schema.literal(null)], {
+      defaultValue: CasesWebhookAuthType.Basic,
+    })
+  ),
 };
 
 export const ExternalIncidentServiceConfigurationSchema = schema.object(

--- a/x-pack/plugins/stack_connectors/server/connector_types/webhook/index.test.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/webhook/index.test.ts
@@ -22,7 +22,8 @@ import {
 
 import * as utils from '@kbn/actions-plugin/server/lib/axios_utils';
 import { loggerMock } from '@kbn/logging-mocks';
-import { SSLCertType, WebhookAuthType } from '../../../common/webhook/constants';
+import { SSLCertType } from '../../../common/webhook/constants';
+import { AuthType as WebhookAuthType } from '../../../common/constants';
 import { PFX_FILE, CRT_FILE, KEY_FILE } from './mocks';
 
 jest.mock('axios');

--- a/x-pack/plugins/stack_connectors/server/connector_types/webhook/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/webhook/index.ts
@@ -26,7 +26,8 @@ import {
 } from '@kbn/actions-plugin/common/types';
 import { renderMustacheString } from '@kbn/actions-plugin/server/lib/mustache_renderer';
 import { combineHeadersWithBasicAuthHeader } from '@kbn/actions-plugin/server/lib';
-import { SSLCertType, WebhookAuthType } from '../../../common/webhook/constants';
+import { SSLCertType } from '../../../common/webhook/constants';
+import { AuthType as WebhookAuthType } from '../../../common/constants';
 import { getRetryAfterIntervalFromHeaders } from '../lib/http_response_retry_header';
 import { nullableType } from '../lib/nullable';
 import { isOk, promiseResult, Result } from '../lib/result_type';

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action.ts
@@ -18,7 +18,7 @@ import {
 import { getCreateExceptionListDetectionSchemaMock } from '@kbn/lists-plugin/common/schemas/request/create_exception_list_schema.mock';
 import { EXCEPTION_LIST_ITEM_URL, EXCEPTION_LIST_URL } from '@kbn/securitysolution-list-constants';
 import { getCreateExceptionListItemMinimalSchemaMock } from '@kbn/lists-plugin/common/schemas/request/create_exception_list_item_schema.mock';
-import { WebhookAuthType } from '@kbn/stack-connectors-plugin/common/webhook/constants';
+import { AuthType as WebhookAuthType } from '@kbn/stack-connectors-plugin/common/constants';
 import { BaseDefaultableFields } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import {
   binaryToString,


### PR DESCRIPTION
Connected with #180255

## Summary

I changed the UI for the authentication step in the Cases webhook connector in preparation to support SSL auth.

I also moved around some constants that are shared by the webhook connector and the cases webhook connector. 

<details>
  <summary>Before</summary>
  <img width="978" alt="Screenshot 2024-05-17 at 12 01 47" src="https://github.com/elastic/kibana/assets/1533137/54f455fb-3362-49df-b8a0-d3dc84a3001b">
</details>

<details>
  <summary>Now</summary>
  <img width="976" alt="Screenshot 2024-05-17 at 12 02 32" src="https://github.com/elastic/kibana/assets/1533137/5688814a-3f8e-4900-8019-2714b32cdb12">
</details>

<details>
  <summary>In the future with SSL</summary>
  <img width="977" alt="Screenshot 2024-05-17 at 12 04 18" src="https://github.com/elastic/kibana/assets/1533137/db0dbc7c-f1e6-4e61-8569-04331ca6f147">
</details>

