### PR TITLE
[Connectors] Removing index name should not remove connector

### DIFF
--- a/packages/kbn-search-connectors/lib/update_connector_index_name.ts
+++ b/packages/kbn-search-connectors/lib/update_connector_index_name.ts
@@ -12,7 +12,7 @@ import { ElasticsearchClient } from '@kbn/core/server';
 export const updateConnectorIndexName = async (
   client: ElasticsearchClient,
   connectorId: string,
-  indexName: string
+  indexName: string | null
 ): Promise<Result> => {
   return await client.transport.request<Result>({
     method: 'PUT',

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -208,7 +208,7 @@ export function registerIndexRoutes({
 
         if (connector) {
           // detach the deleted index without removing the connector
-          updateConnectorIndexName(client.asCurrentUser, connector.id, null);
+          await updateConnectorIndexName(client.asCurrentUser, connector.id, null);
           if (connector.api_key_id) {
             await client.asCurrentUser.security.invalidateApiKey({ ids: [connector.api_key_id] });
           }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -14,7 +14,7 @@ import { schema } from '@kbn/config-schema';
 
 import { i18n } from '@kbn/i18n';
 
-import { deleteConnectorSecret } from '@kbn/search-connectors';
+import { deleteConnectorSecret, updateConnectorIndexName } from '@kbn/search-connectors';
 import {
   fetchConnectorByIndexName,
   fetchConnectors,
@@ -207,6 +207,8 @@ export function registerIndexRoutes({
         }
 
         if (connector) {
+          // detach the deleted index without removing the connector
+          updateConnectorIndexName(client.asCurrentUser, connector.id, null);
           if (connector.api_key_id) {
             await client.asCurrentUser.security.invalidateApiKey({ ids: [connector.api_key_id] });
           }

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -14,7 +14,7 @@ import { schema } from '@kbn/config-schema';
 
 import { i18n } from '@kbn/i18n';
 
-import { deleteConnectorById, deleteConnectorSecret } from '@kbn/search-connectors';
+import { deleteConnectorSecret } from '@kbn/search-connectors';
 import {
   fetchConnectorByIndexName,
   fetchConnectors,
@@ -207,7 +207,6 @@ export function registerIndexRoutes({
         }
 
         if (connector) {
-          await deleteConnectorById(client.asCurrentUser, connector.id);
           if (connector.api_key_id) {
             await client.asCurrentUser.security.invalidateApiKey({ ids: [connector.api_key_id] });
           }


### PR DESCRIPTION
## Summary

In `Search indices` table, if you delete an index with a connector attached to it, it deletes both of them.
This was the normally accepted behaviour but with 8.13 we decouple the connector and index. 

Ideally deleting and index should only delete index and not touch connector attached to it. Similar to the behaviour on `Connectors` table.

The connector is not deleted, instead the referenced (deleted) index is detached from connector so that user gets the warning that they need to reconfigure the index once they navigate to connectors overview. 

We are still removing api keys and connector secrets associated with the deleted index. They need to be regenerated in the connector configuration tab. 

### Screenshot


https://github.com/elastic/kibana/assets/14121688/4ed19bef-f75e-4eb9-9923-f7d77ac5239a







<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->