### PR TITLE
[Search] [Playground] Fix Selecting Index via URLParams

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
@@ -7,8 +7,6 @@
 
 import React from 'react';
 
-import { useSearchParams } from 'react-router-dom-v5-compat';
-
 import { useValues } from 'kea';
 
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
@@ -20,21 +18,13 @@ import { KibanaLogic } from '../../../shared/kibana';
 import { EnterpriseSearchApplicationsPageTemplate } from '../layout/page_template';
 
 export const Playground: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const index: string | null = searchParams.has('default-index')
-    ? searchParams.get('default-index')
-    : null;
   const { searchPlayground } = useValues(KibanaLogic);
 
   if (!searchPlayground) {
     return null;
   }
   return (
-    <searchPlayground.PlaygroundProvider
-      defaultValues={{
-        indices: index ? [index] : [],
-      }}
-    >
+    <searchPlayground.PlaygroundProvider>
       <EnterpriseSearchApplicationsPageTemplate
         pageChrome={[
           i18n.translate('xpack.enterpriseSearch.content.playground.breadcrumb', {

--- a/x-pack/plugins/search_playground/public/chat_playground_overview.tsx
+++ b/x-pack/plugins/search_playground/public/chat_playground_overview.tsx
@@ -27,11 +27,7 @@ export const ChatPlaygroundOverview: React.FC = () => {
   );
 
   return (
-    <PlaygroundProvider
-      defaultValues={{
-        indices: [],
-      }}
-    >
+    <PlaygroundProvider>
       <EuiPageTemplate
         offset={0}
         restrictWidth={false}

--- a/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.tsx
@@ -34,7 +34,7 @@ export const SourcesPanelForStartChat: React.FC = () => {
         defaultMessage:
           "Select the Elasticsearch indices you'd like to query, providing additional context for the LLM.",
       })}
-      isValid={!!selectedIndices.length}
+      isValid={!!selectedIndices?.length}
       dataTestSubj="selectIndicesChatPanel"
     >
       {!!selectedIndices?.length && (

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.test.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useSearchParams } from 'react-router-dom-v5-compat';
+import { StartNewChat } from './start_new_chat';
+import { useLoadConnectors } from '../hooks/use_load_connectors';
+import { useUsageTracker } from '../hooks/use_usage_tracker';
+import { AnalyticsEvents } from '../analytics/constants';
+import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
+import { useKibana } from '../hooks/use_kibana';
+import { PlaygroundProvider } from '../providers/playground_provider';
+
+jest.mock('../hooks/use_load_connectors');
+jest.mock('../hooks/use_usage_tracker');
+jest.mock('../hooks/use_source_indices_field', () => ({
+  useSourceIndicesFields: jest.fn(() => ({ addIndex: jest.fn() })),
+}));
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useSearchParams: jest.fn(),
+}));
+jest.mock('../hooks/use_kibana');
+
+const mockUseLoadConnectors = useLoadConnectors as jest.Mock;
+const mockUseUsageTracker = useUsageTracker as jest.Mock;
+const mockUseSearchParams = useSearchParams as jest.Mock;
+
+const renderWithForm = (ui: React.ReactElement) => {
+  const Wrapper: React.FC = ({ children }) => {
+    return (
+      <IntlProvider locale="en">
+        <PlaygroundProvider>{children}</PlaygroundProvider>
+      </IntlProvider>
+    );
+  };
+  return render(ui, { wrapper: Wrapper });
+};
+
+const mockConnectors = {
+  '1': { title: 'Connector 1' },
+  '2': { title: 'Connector 2' },
+};
+
+describe('StartNewChat', () => {
+  beforeEach(() => {
+    mockUseLoadConnectors.mockReturnValue({ data: [] });
+    mockUseUsageTracker.mockReturnValue({ load: jest.fn() });
+    mockUseSearchParams.mockReturnValue([new URLSearchParams()]);
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        triggersActionsUi: {
+          getAddConnectorFlyout: () => (
+            <div data-test-subj="addConnectorFlyout">Add Connector Flyout</div>
+          ),
+        },
+      },
+    });
+    (useLoadConnectors as jest.Mock).mockReturnValue({
+      data: mockConnectors,
+      refetch: jest.fn(),
+      isLoading: false,
+      isSuccess: true,
+    });
+  });
+
+  it('renders correctly', () => {
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('startNewChatTitle')).toBeInTheDocument();
+  });
+
+  it('disables the start button when form conditions are not met', () => {
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    const startButton = screen.getByTestId('startChatButton');
+    expect(startButton).toBeDisabled();
+  });
+
+  it('tracks the page load event', () => {
+    const usageTracker = { load: jest.fn() };
+    mockUseUsageTracker.mockReturnValue(usageTracker);
+
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(usageTracker.load).toHaveBeenCalledWith(AnalyticsEvents.startNewChatPageLoaded);
+  });
+
+  it('calls addIndex when default-index is present in searchParams', () => {
+    const addIndex = jest.fn();
+    (useSourceIndicesFields as jest.Mock).mockReturnValue({ addIndex });
+    const searchParams = new URLSearchParams({ 'default-index': 'test-index' });
+    mockUseSearchParams.mockReturnValue([searchParams]);
+
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(addIndex).toHaveBeenCalledWith('test-index');
+  });
+});

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
@@ -103,7 +103,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
             fill
             iconType="arrowRight"
             iconSide="right"
-            data-test-subj='startChatButton'
+            data-test-subj="startChatButton"
             disabled={
               !watch(ChatFormFields.indices, [])?.length ||
               !Object.keys(connectors || {}).length ||

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
@@ -15,14 +15,16 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useUsageTracker } from '../hooks/use_usage_tracker';
 import { useLoadConnectors } from '../hooks/use_load_connectors';
 import { SourcesPanelForStartChat } from './sources_panel/sources_panel_for_start_chat';
 import { SetUpConnectorPanelForStartChat } from './set_up_connector_panel_for_start_chat';
 import { ChatFormFields } from '../types';
 import { AnalyticsEvents } from '../analytics/constants';
+import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
 
 const maxWidthPage = 640;
 
@@ -35,6 +37,17 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
   const { data: connectors } = useLoadConnectors();
   const { watch } = useFormContext();
   const usageTracker = useUsageTracker();
+
+  const [searchParams] = useSearchParams();
+  const index = useMemo(() => searchParams.get('default-index'), [searchParams]);
+  const { addIndex } = useSourceIndicesFields();
+
+  useEffect(() => {
+    if (index) {
+      addIndex(index);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [index]);
 
   useEffect(() => {
     usageTracker?.load(AnalyticsEvents.startNewChatPageLoaded);
@@ -55,7 +68,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="m">
             <EuiTitle>
-              <h2>
+              <h2 data-test-subj="startNewChatTitle">
                 <FormattedMessage
                   id="xpack.searchPlayground.startNewChat.title"
                   defaultMessage="Start a new chat"
@@ -85,13 +98,14 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
           <SourcesPanelForStartChat />
         </EuiFlexItem>
 
-        <EuiFlexGroup justifyContent="flexEnd" data-test-subj="startChatButton">
+        <EuiFlexGroup justifyContent="flexEnd">
           <EuiButton
             fill
             iconType="arrowRight"
             iconSide="right"
+            data-test-subj='startChatButton'
             disabled={
-              !watch(ChatFormFields.indices, []).length ||
+              !watch(ChatFormFields.indices, [])?.length ||
               !Object.keys(connectors || {}).length ||
               !watch(ChatFormFields.elasticsearchQuery, '')
             }

--- a/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
+++ b/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
@@ -8,25 +8,23 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FormProvider, useForm } from 'react-hook-form';
-import { ChatForm, ChatFormFields } from '../types';
+import { ChatForm } from '../types';
 
 const queryClient = new QueryClient({});
 
 export interface PlaygroundProviderProps {
   children: React.ReactNode;
-  defaultValues?: Partial<Pick<ChatForm, ChatFormFields.indices>>;
 }
 
 export const PlaygroundProvider: FC<PropsWithChildren<PlaygroundProviderProps>> = ({
   children,
-  defaultValues,
 }) => {
   const form = useForm<ChatForm>({
     defaultValues: {
       prompt: 'You are an assistant for question-answering tasks.',
       doc_size: 3,
       source_fields: {},
-      indices: defaultValues?.indices || [],
+      indices: [],
     },
   });
 


### PR DESCRIPTION
## Summary

On testing BC5, we found an issue:

We have a feature where you can open playground from the index view page. The issue is that on selecting the index, the esQuery hasn't been generated which is required every time the index has been changed. 

This fix uses the hook to update the sources which in turns updates the query and default fields. 

Tested on both ESS and ES3. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->