### PR TITLE
[Reporting] Download report: add debug logging around sending of 5xx codes

### DIFF
--- a/x-pack/plugins/reporting/server/routes/common/jobs/get_document_payload.ts
+++ b/x-pack/plugins/reporting/server/routes/common/jobs/get_document_payload.ts
@@ -54,7 +54,8 @@ const getReportingHeaders = (output: TaskRunResult, exportType: ExportType) => {
 };
 
 export function getDocumentPayloadFactory(reporting: ReportingCore) {
-  const { logger } = reporting.getPluginSetupDeps();
+  const { logger: _logger } = reporting.getPluginSetupDeps();
+  const logger = _logger.get('download-report');
   const exportTypesRegistry = reporting.getExportTypesRegistry();
 
   async function getCompleted({

--- a/x-pack/plugins/reporting/server/routes/common/jobs/get_document_payload.ts
+++ b/x-pack/plugins/reporting/server/routes/common/jobs/get_document_payload.ts
@@ -54,6 +54,7 @@ const getReportingHeaders = (output: TaskRunResult, exportType: ExportType) => {
 };
 
 export function getDocumentPayloadFactory(reporting: ReportingCore) {
+  const { logger } = reporting.getPluginSetupDeps();
   const exportTypesRegistry = reporting.getExportTypesRegistry();
 
   async function getCompleted({
@@ -88,6 +89,8 @@ export function getDocumentPayloadFactory(reporting: ReportingCore) {
     const jobsQuery = jobsQueryFactory(reporting);
     const error = await jobsQuery.getError(id);
 
+    logger.debug(`Report job ${id} has failed. Sending statusCode: 500`);
+
     return {
       statusCode: 500,
       content: {
@@ -98,7 +101,9 @@ export function getDocumentPayloadFactory(reporting: ReportingCore) {
     };
   }
 
-  function getIncomplete({ status }: ReportApiJSON): Payload {
+  function getIncomplete({ id, status }: ReportApiJSON): Payload {
+    logger.debug(`Report job ${id} is processing. Sending statusCode: 503`);
+
     return {
       statusCode: 503,
       content: status,


### PR DESCRIPTION
## Summary

These logs help correlate errors one may see from investigating HTTP 5xx status codes that are sent in response to the Download Report API.

Related to: https://github.com/elastic/kibana/issues/183846