### PR TITLE
[8.14] [Search] [Playground] Fix Selecting Index via URLParams (#183843)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/playground/playground.tsx
@@ -7,8 +7,6 @@
 
 import React from 'react';
 
-import { useSearchParams } from 'react-router-dom-v5-compat';
-
 import { useValues } from 'kea';
 
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
@@ -20,21 +18,13 @@ import { KibanaLogic } from '../../../shared/kibana';
 import { EnterpriseSearchApplicationsPageTemplate } from '../layout/page_template';
 
 export const Playground: React.FC = () => {
-  const [searchParams] = useSearchParams();
-  const index: string | null = searchParams.has('default-index')
-    ? searchParams.get('default-index')
-    : null;
   const { searchPlayground } = useValues(KibanaLogic);
 
   if (!searchPlayground) {
     return null;
   }
   return (
-    <searchPlayground.PlaygroundProvider
-      defaultValues={{
-        indices: index ? [index] : [],
-      }}
-    >
+    <searchPlayground.PlaygroundProvider>
       <EnterpriseSearchApplicationsPageTemplate
         pageChrome={[
           i18n.translate('xpack.enterpriseSearch.content.playground.breadcrumb', {

--- a/x-pack/plugins/search_playground/public/chat_playground_overview.tsx
+++ b/x-pack/plugins/search_playground/public/chat_playground_overview.tsx
@@ -17,11 +17,7 @@ import { PlaygroundHeaderDocs } from './components/playground_header_docs';
 
 export const ChatPlaygroundOverview: React.FC = () => {
   return (
-    <PlaygroundProvider
-      defaultValues={{
-        indices: [],
-      }}
-    >
+    <PlaygroundProvider>
       <EuiPageTemplate
         offset={0}
         restrictWidth={false}

--- a/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/sources_panel/sources_panel_for_start_chat.tsx
@@ -34,7 +34,7 @@ export const SourcesPanelForStartChat: React.FC = () => {
         defaultMessage:
           "Select the Elasticsearch indices you'd like to query, providing additional context for the LLM.",
       })}
-      isValid={!!selectedIndices.length}
+      isValid={!!selectedIndices?.length}
       dataTestSubj="selectIndicesChatPanel"
     >
       {!!selectedIndices?.length && (

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.test.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useSearchParams } from 'react-router-dom-v5-compat';
+import { StartNewChat } from './start_new_chat';
+import { useLoadConnectors } from '../hooks/use_load_connectors';
+import { useUsageTracker } from '../hooks/use_usage_tracker';
+import { AnalyticsEvents } from '../analytics/constants';
+import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
+import { useKibana } from '../hooks/use_kibana';
+import { PlaygroundProvider } from '../providers/playground_provider';
+
+jest.mock('../hooks/use_load_connectors');
+jest.mock('../hooks/use_usage_tracker');
+jest.mock('../hooks/use_source_indices_field', () => ({
+  useSourceIndicesFields: jest.fn(() => ({ addIndex: jest.fn() })),
+}));
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useSearchParams: jest.fn(),
+}));
+jest.mock('../hooks/use_kibana');
+
+const mockUseLoadConnectors = useLoadConnectors as jest.Mock;
+const mockUseUsageTracker = useUsageTracker as jest.Mock;
+const mockUseSearchParams = useSearchParams as jest.Mock;
+
+const renderWithForm = (ui: React.ReactElement) => {
+  const Wrapper: React.FC = ({ children }) => {
+    return (
+      <IntlProvider locale="en">
+        <PlaygroundProvider>{children}</PlaygroundProvider>
+      </IntlProvider>
+    );
+  };
+  return render(ui, { wrapper: Wrapper });
+};
+
+const mockConnectors = {
+  '1': { title: 'Connector 1' },
+  '2': { title: 'Connector 2' },
+};
+
+describe('StartNewChat', () => {
+  beforeEach(() => {
+    mockUseLoadConnectors.mockReturnValue({ data: [] });
+    mockUseUsageTracker.mockReturnValue({ load: jest.fn() });
+    mockUseSearchParams.mockReturnValue([new URLSearchParams()]);
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        triggersActionsUi: {
+          getAddConnectorFlyout: () => (
+            <div data-test-subj="addConnectorFlyout">Add Connector Flyout</div>
+          ),
+        },
+      },
+    });
+    (useLoadConnectors as jest.Mock).mockReturnValue({
+      data: mockConnectors,
+      refetch: jest.fn(),
+      isLoading: false,
+      isSuccess: true,
+    });
+  });
+
+  it('renders correctly', () => {
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('startNewChatTitle')).toBeInTheDocument();
+  });
+
+  it('disables the start button when form conditions are not met', () => {
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    const startButton = screen.getByTestId('startChatButton');
+    expect(startButton).toBeDisabled();
+  });
+
+  it('tracks the page load event', () => {
+    const usageTracker = { load: jest.fn() };
+    mockUseUsageTracker.mockReturnValue(usageTracker);
+
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(usageTracker.load).toHaveBeenCalledWith(AnalyticsEvents.startNewChatPageLoaded);
+  });
+
+  it('calls addIndex when default-index is present in searchParams', () => {
+    const addIndex = jest.fn();
+    (useSourceIndicesFields as jest.Mock).mockReturnValue({ addIndex });
+    const searchParams = new URLSearchParams({ 'default-index': 'test-index' });
+    mockUseSearchParams.mockReturnValue([searchParams]);
+
+    renderWithForm(
+      <MemoryRouter>
+        <StartNewChat onStartClick={jest.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(addIndex).toHaveBeenCalledWith('test-index');
+  });
+});

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
@@ -54,7 +54,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
   }, [usageTracker]);
 
   return (
-    <EuiFlexGroup justifyContent="center" className="eui-yScroll">
+    <EuiFlexGroup justifyContent="center" className="eui-yScroll" data-test-subj="startChatPage">
       <EuiFlexGroup
         css={{
           height: 'fit-content',
@@ -98,7 +98,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
           <SourcesPanelForStartChat />
         </EuiFlexItem>
 
-        <EuiFlexGroup justifyContent="flexEnd" data-test-subj="startChatButton">
+        <EuiFlexGroup justifyContent="flexEnd">
           <EuiButton
             fill
             iconType="arrowRight"

--- a/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
+++ b/x-pack/plugins/search_playground/public/components/start_new_chat.tsx
@@ -15,14 +15,16 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useUsageTracker } from '../hooks/use_usage_tracker';
 import { useLoadConnectors } from '../hooks/use_load_connectors';
 import { SourcesPanelForStartChat } from './sources_panel/sources_panel_for_start_chat';
 import { SetUpConnectorPanelForStartChat } from './set_up_connector_panel_for_start_chat';
 import { ChatFormFields } from '../types';
 import { AnalyticsEvents } from '../analytics/constants';
+import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
 
 const maxWidthPage = 640;
 
@@ -35,6 +37,17 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
   const { data: connectors } = useLoadConnectors();
   const { watch } = useFormContext();
   const usageTracker = useUsageTracker();
+
+  const [searchParams] = useSearchParams();
+  const index = useMemo(() => searchParams.get('default-index'), [searchParams]);
+  const { addIndex } = useSourceIndicesFields();
+
+  useEffect(() => {
+    if (index) {
+      addIndex(index);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [index]);
 
   useEffect(() => {
     usageTracker?.load(AnalyticsEvents.startNewChatPageLoaded);
@@ -55,7 +68,7 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
         <EuiFlexItem grow={false}>
           <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="m">
             <EuiTitle>
-              <h2>
+              <h2 data-test-subj="startNewChatTitle">
                 <FormattedMessage
                   id="xpack.searchPlayground.startNewChat.title"
                   defaultMessage="Start a new chat"
@@ -90,8 +103,9 @@ export const StartNewChat: React.FC<StartNewChatProps> = ({ onStartClick }) => {
             fill
             iconType="arrowRight"
             iconSide="right"
+            data-test-subj="startChatButton"
             disabled={
-              !watch(ChatFormFields.indices, []).length ||
+              !watch(ChatFormFields.indices, [])?.length ||
               !Object.keys(connectors || {}).length ||
               !watch(ChatFormFields.elasticsearchQuery, '')
             }

--- a/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
+++ b/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
@@ -16,9 +16,7 @@ export interface PlaygroundProviderProps {
   children: React.ReactNode;
 }
 
-export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
-  children,
-}) => {
+export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({ children }) => {
   const form = useForm<ChatForm>({
     defaultValues: {
       prompt: 'You are an assistant for question-answering tasks.',

--- a/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
+++ b/x-pack/plugins/search_playground/public/providers/playground_provider.tsx
@@ -8,24 +8,23 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FormProvider, useForm } from 'react-hook-form';
-import { ChatForm, ChatFormFields } from '../types';
+import { ChatForm } from '../types';
 
 const queryClient = new QueryClient({});
 
 export interface PlaygroundProviderProps {
-  defaultValues?: Partial<Pick<ChatForm, ChatFormFields.indices>>;
+  children: React.ReactNode;
 }
 
 export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
   children,
-  defaultValues,
 }) => {
   const form = useForm<ChatForm>({
     defaultValues: {
       prompt: 'You are an assistant for question-answering tasks.',
       doc_size: 3,
       source_fields: {},
-      indices: defaultValues?.indices || [],
+      indices: [],
     },
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Search] [Playground] Fix Selecting Index via URLParams (#183843)](https://github.com/elastic/kibana/pull/183843)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Joe McElroy","email":"joseph.mcelroy@elastic.co"},"sourceCommit":{"committedDate":"2024-05-20T18:42:10Z","message":"[Search] [Playground] Fix Selecting Index via URLParams (#183843)\n\n## Summary\r\n\r\nOn testing BC5, we found an issue:\r\n\r\nWe have a feature where you can open playground from the index view\r\npage. The issue is that on selecting the index, the esQuery hasn't been\r\ngenerated which is required every time the index has been changed.\r\n\r\nThis fix uses the hook to update the sources which in turns updates the\r\nquery and default fields.\r\n\r\nTested on both ESS and ES3. \r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"07feb6e35dc4354a7ac1b657860a005dd252f8cd","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.14.0","v8.15.0"],"number":183843,"url":"https://github.com/elastic/kibana/pull/183843","mergeCommit":{"message":"[Search] [Playground] Fix Selecting Index via URLParams (#183843)\n\n## Summary\r\n\r\nOn testing BC5, we found an issue:\r\n\r\nWe have a feature where you can open playground from the index view\r\npage. The issue is that on selecting the index, the esQuery hasn't been\r\ngenerated which is required every time the index has been changed.\r\n\r\nThis fix uses the hook to update the sources which in turns updates the\r\nquery and default fields.\r\n\r\nTested on both ESS and ES3. \r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"07feb6e35dc4354a7ac1b657860a005dd252f8cd"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183843","number":183843,"mergeCommit":{"message":"[Search] [Playground] Fix Selecting Index via URLParams (#183843)\n\n## Summary\r\n\r\nOn testing BC5, we found an issue:\r\n\r\nWe have a feature where you can open playground from the index view\r\npage. The issue is that on selecting the index, the esQuery hasn't been\r\ngenerated which is required every time the index has been changed.\r\n\r\nThis fix uses the hook to update the sources which in turns updates the\r\nquery and default fields.\r\n\r\nTested on both ESS and ES3. \r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"07feb6e35dc4354a7ac1b657860a005dd252f8cd"}}]}] BACKPORT-->