### PR TITLE
[Console]  Maintain state of persistent console

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -122,21 +122,6 @@ export const ConsoleWrapper = (props: ConsoleWrapperProps) => {
     }
   }, [dependencies, setDependencies, core, usageCollection, isOpen]);
 
-  useEffect(() => {
-    const stopAutoCompletePolling = () => {
-      if (dependencies) {
-        dependencies.autocompleteInfo.clearSubscriptions();
-      }
-    };
-
-    if (!isOpen) {
-      stopAutoCompletePolling();
-    }
-    return () => {
-      stopAutoCompletePolling();
-    };
-  }, [dependencies, isOpen]);
-
   if (!dependencies && !isOpen) {
     // Console has not been opened
     return null;

--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -107,29 +107,43 @@ interface ConsoleWrapperProps
     'setDispatch' | 'alternateView' | 'setConsoleHeight' | 'getConsoleHeight'
   > {
   onKeyDown: (this: Window, ev: WindowEventMap['keydown']) => any;
+  isOpen: boolean;
 }
 
 export const ConsoleWrapper = (props: ConsoleWrapperProps) => {
   const [dependencies, setDependencies] = useState<ConsoleDependencies | null>(null);
-  const { core, usageCollection, onKeyDown, isMonacoEnabled } = props;
+  const { core, usageCollection, onKeyDown, isMonacoEnabled, isOpen } = props;
   const { analytics, i18n, theme } = core;
   const startServices = { analytics, i18n, theme };
 
   useEffect(() => {
-    if (dependencies === null) {
+    if (dependencies === null && isOpen) {
       loadDependencies(core, usageCollection).then(setDependencies);
     }
-  }, [dependencies, setDependencies, core, usageCollection]);
+  }, [dependencies, setDependencies, core, usageCollection, isOpen]);
 
   useEffect(() => {
-    return () => {
+    const stopAutoCompletePolling = () => {
       if (dependencies) {
         dependencies.autocompleteInfo.clearSubscriptions();
       }
     };
-  }, [dependencies]);
+
+    if (!isOpen) {
+      stopAutoCompletePolling();
+    }
+    return () => {
+      stopAutoCompletePolling();
+    };
+  }, [dependencies, isOpen]);
+
+  if (!dependencies && !isOpen) {
+    // Console has not been opened
+    return null;
+  }
 
   if (!dependencies) {
+    // Console open for the first time, wait for dependencies to load.
     return <EditorContentSpinner />;
   }
 
@@ -171,10 +185,14 @@ export const ConsoleWrapper = (props: ConsoleWrapperProps) => {
       >
         <RequestContextProvider>
           <EditorContextProvider settings={settings.toJSON()}>
-            <div className="embeddableConsole__content" data-test-subj="consoleEmbeddedBody">
-              <EuiWindowEvent event="keydown" handler={onKeyDown} />
-              <Main hideWelcome />
-            </div>
+            {isOpen ? (
+              <div className="embeddableConsole__content" data-test-subj="consoleEmbeddedBody">
+                <EuiWindowEvent event="keydown" handler={onKeyDown} />
+                <Main hideWelcome />
+              </div>
+            ) : (
+              <span />
+            )}
           </EditorContextProvider>
         </RequestContextProvider>
       </ServicesContextProvider>

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -190,8 +190,14 @@ export const EmbeddableConsole = ({
               </div>
             </div>
           </EuiThemeProvider>
-          {showConsole ? (
-            <ConsoleWrapper {...{ core, usageCollection, onKeyDown, isMonacoEnabled }} />
+          {consoleState.consoleHasBeenOpened ? (
+            <ConsoleWrapper
+              isOpen={showConsole}
+              core={core}
+              usageCollection={usageCollection}
+              onKeyDown={onKeyDown}
+              isMonacoEnabled={isMonacoEnabled}
+            />
           ) : null}
           {showAlternateView ? (
             <div className="embeddableConsole__content" data-test-subj="consoleEmbeddedBody">

--- a/src/plugins/console/public/application/stores/embeddable_console.ts
+++ b/src/plugins/console/public/application/stores/embeddable_console.ts
@@ -18,6 +18,7 @@ import {
 
 export const initialValue: EmbeddedConsoleStore = produce<EmbeddedConsoleStore>(
   {
+    consoleHasBeenOpened: false,
     view: EmbeddableConsoleView.Closed,
   },
   identity
@@ -31,6 +32,7 @@ export const reducer: Reducer<EmbeddedConsoleStore, EmbeddedConsoleAction> = (st
           ? EmbeddableConsoleView.Alternate
           : EmbeddableConsoleView.Console;
         if (state.view !== newView) {
+          draft.consoleHasBeenOpened = true;
           draft.view = newView;
           draft.loadFromContent = action.payload?.content;
           return draft;

--- a/src/plugins/console/public/types/embeddable_console.ts
+++ b/src/plugins/console/public/types/embeddable_console.ts
@@ -31,6 +31,7 @@ export enum EmbeddableConsoleView {
 }
 
 export interface EmbeddedConsoleStore {
+  consoleHasBeenOpened: boolean;
   view: EmbeddableConsoleView;
   loadFromContent?: string;
 }


### PR DESCRIPTION
## Summary

Updating how the console wrapper is rendered to keep the request context provider rendered once the console has been opened. This will allow maintaining the output between sessions or switching between notebooks and the console. But still allow unmounting the editor so that resources are cleaned up when it's not in use.


https://github.com/elastic/kibana/assets/1972968/ae6b8ead-36f2-45c4-8571-f897fce94791