### PR TITLE
[UII] Make request diagnostics expiration test more tolerant

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
@@ -41,8 +41,9 @@ export default function (providerContext: FtrProviderContext) {
 
       expect(actionStatus.nbAgentsActionCreated).to.eql(agentCount);
       expect(
-        moment(actionStatus.expiration).diff(moment(actionStatus.creationTime), 'hours')
-      ).to.eql(3);
+        moment(actionStatus.expiration).diff(moment(actionStatus.creationTime), 'minutes') > 170 &&
+          moment(actionStatus.expiration).diff(moment(actionStatus.creationTime), 'minutes') < 190
+      ).to.eql(true);
     }
 
     it('should respond 403 if user lacks fleet read permissions', async () => {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/183865. The test here using `moment.diff` fails if the expiration and creation time are off even by even a fraction of a second. This PR makes the test more tolerant by seeing if the difference is minutes is 3 hours-ish.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->