### PR TITLE
[EuiProvider] Fix Data-Discover code

### DIFF
--- a/examples/discover_customization_examples/public/plugin.tsx
+++ b/examples/discover_customization_examples/public/plugin.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import { CoreSetup, CoreStart, Plugin, SimpleSavedObject } from '@kbn/core/public';
 import type { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import type {
   CustomizationCallback,
   DiscoverSetup,
@@ -140,41 +141,43 @@ export class DiscoverCustomizationExamplesPlugin implements Plugin {
                 document.body.appendChild(optionsContainer);
 
                 const element = (
-                  <EuiWrappingPopover
-                    ownFocus
-                    button={anchorElement}
-                    isOpen={true}
-                    panelPaddingSize="s"
-                    closePopover={closeOptionsPopover}
-                  >
-                    <EuiContextMenu
-                      size="s"
-                      initialPanelId={0}
-                      panels={[
-                        {
-                          id: 0,
-                          items: [
-                            {
-                              name: 'Create new',
-                              icon: 'plusInCircle',
-                              onClick: () => alert('Create new clicked'),
-                            },
-                            {
-                              name: 'Make a copy',
-                              icon: 'copy',
-                              onClick: () => alert('Make a copy clicked'),
-                            },
-                            {
-                              name: 'Manage saved searches',
-                              icon: 'gear',
-                              onClick: () => alert('Manage saved searches clicked'),
-                            },
-                          ],
-                        },
-                      ]}
-                      data-test-subj="customOptionsPopover"
-                    />
-                  </EuiWrappingPopover>
+                  <KibanaRenderContextProvider {...core}>
+                    <EuiWrappingPopover
+                      ownFocus
+                      button={anchorElement}
+                      isOpen={true}
+                      panelPaddingSize="s"
+                      closePopover={closeOptionsPopover}
+                    >
+                      <EuiContextMenu
+                        size="s"
+                        initialPanelId={0}
+                        panels={[
+                          {
+                            id: 0,
+                            items: [
+                              {
+                                name: 'Create new',
+                                icon: 'plusInCircle',
+                                onClick: () => alert('Create new clicked'),
+                              },
+                              {
+                                name: 'Make a copy',
+                                icon: 'copy',
+                                onClick: () => alert('Make a copy clicked'),
+                              },
+                              {
+                                name: 'Manage saved searches',
+                                icon: 'gear',
+                                onClick: () => alert('Manage saved searches clicked'),
+                              },
+                            ],
+                          },
+                        ]}
+                        data-test-subj="customOptionsPopover"
+                      />
+                    </EuiWrappingPopover>
+                  </KibanaRenderContextProvider>
                 );
 
                 ReactDOM.render(element, optionsContainer);

--- a/examples/discover_customization_examples/tsconfig.json
+++ b/examples/discover_customization_examples/tsconfig.json
@@ -14,6 +14,7 @@
     "@kbn/i18n-react",
     "@kbn/react-kibana-context-theme",
     "@kbn/data-plugin",
+    "@kbn/react-kibana-context-render",
   ],
   "exclude": ["target/**/*"]
 }

--- a/examples/search_examples/public/application.tsx
+++ b/examples/search_examples/public/application.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Redirect } from 'react-router-dom';
 import { Router, Routes, Route } from '@kbn/shared-ux-router';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { I18nProvider } from '@kbn/i18n-react';
 import { AppMountParameters, CoreStart } from '@kbn/core/public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
@@ -44,45 +45,48 @@ export const renderApp = (
   { element, history }: AppMountParameters
 ) => {
   ReactDOM.render(
-    <I18nProvider>
-      <RedirectAppLinks
-        coreStart={{
-          application,
-        }}
-      >
-        <SearchExamplePage exampleLinks={LINKS} basePath={http.basePath}>
-          <Router history={history}>
-            <Routes>
-              <Route path={LINKS[0].path}>
-                <SearchExamplesApp
-                  notifications={notifications}
-                  navigation={navigation}
-                  data={data}
-                  http={http}
-                  unifiedSearch={unifiedSearch}
-                  {...startServices}
-                />
-              </Route>
-              <Route path={LINKS[1].path}>
-                <SqlSearchExampleApp notifications={notifications} data={data} />
-              </Route>
-              <Route path={LINKS[2].path}>
-                <SearchSessionsExampleApp
-                  navigation={navigation}
-                  notifications={notifications}
-                  data={data}
-                  unifiedSearch={unifiedSearch}
-                />
-              </Route>
+    <KibanaRenderContextProvider {...startServices}>
+      <I18nProvider>
+        <RedirectAppLinks
+          coreStart={{
+            application,
+          }}
+        >
+          <SearchExamplePage exampleLinks={LINKS} basePath={http.basePath}>
+            <Router history={history}>
+              <Routes>
+                <Route path={LINKS[0].path}>
+                  <SearchExamplesApp
+                    notifications={notifications}
+                    navigation={navigation}
+                    data={data}
+                    http={http}
+                    unifiedSearch={unifiedSearch}
+                    {...startServices}
+                  />
+                </Route>
+                <Route path={LINKS[1].path}>
+                  <SqlSearchExampleApp notifications={notifications} data={data} />
+                </Route>
+                <Route path={LINKS[2].path}>
+                  <SearchSessionsExampleApp
+                    navigation={navigation}
+                    notifications={notifications}
+                    data={data}
+                    unifiedSearch={unifiedSearch}
+                    {...startServices}
+                  />
+                </Route>
 
-              <Route path="/" exact={true}>
-                <Redirect to={LINKS[0].path} />
-              </Route>
-            </Routes>
-          </Router>
-        </SearchExamplePage>
-      </RedirectAppLinks>
-    </I18nProvider>,
+                <Route path="/" exact={true}>
+                  <Redirect to={LINKS[0].path} />
+                </Route>
+              </Routes>
+            </Router>
+          </SearchExamplePage>
+        </RedirectAppLinks>
+      </I18nProvider>
+    </KibanaRenderContextProvider>,
     element
   );
 

--- a/examples/search_examples/tsconfig.json
+++ b/examples/search_examples/tsconfig.json
@@ -35,5 +35,6 @@
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/react-kibana-mount",
     "@kbn/search-response-warnings",
+    "@kbn/react-kibana-context-render",
   ]
 }


### PR DESCRIPTION
## Summary

Fixes needed for getting CI to pass when EUI throws an error if attempting to render a component without the EuiProvider in the render tree.

## Detailed description
In https://github.com/elastic/kibana/pull/180819, I will deliver a change that will cause EUI components to throw an error if the EuiProvider context is missing. This PR comes in as part of the final work to get all functional tests passing in an environment where EUI will throw the error. The tied to the ["Fix 'dark mode' inconsistencies in Kibana" Epic](https://github.com/elastic/kibana-team/issues/805) has so far been in preparation for this. 

**Reviewers: Please interact with critical paths through the UI components touched in this PR, ESPECIALLY in terms of testing dark mode and i18n.**

<img width="1107" alt="image" src="https://github.com/elastic/kibana/assets/908371/c0d2ce08-ac35-45a7-8192-0b2256fceb0e">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)