### PR TITLE
[EuiProvider] Fix Response-Ops code

### DIFF
--- a/x-pack/examples/triggers_actions_ui_example/public/application.tsx
+++ b/x-pack/examples/triggers_actions_ui_example/public/application.tsx
@@ -12,6 +12,7 @@ import { Route } from '@kbn/shared-ux-router';
 import { EuiPage, EuiTitle, EuiText, EuiSpacer } from '@elastic/eui';
 import { AppMountParameters, CoreStart } from '@kbn/core/public';
 import { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
@@ -157,23 +158,25 @@ export const renderApp = (
   const { triggersActionsUi } = deps;
   const { ruleTypeRegistry, actionTypeRegistry } = triggersActionsUi;
   ReactDOM.render(
-    <KibanaContextProvider
-      services={{
-        ...core,
-        ...deps,
-        ruleTypeRegistry,
-        actionTypeRegistry,
-      }}
-    >
-      <IntlProvider locale="en">
-        <TriggersActionsUiExampleApp
-          basename={appBasePath}
-          http={http}
-          triggersActionsUi={deps.triggersActionsUi}
-          data={deps.data}
-        />
-      </IntlProvider>
-    </KibanaContextProvider>,
+    <KibanaRenderContextProvider {...core}>
+      <KibanaContextProvider
+        services={{
+          ...core,
+          ...deps,
+          ruleTypeRegistry,
+          actionTypeRegistry,
+        }}
+      >
+        <IntlProvider locale="en">
+          <TriggersActionsUiExampleApp
+            basename={appBasePath}
+            http={http}
+            triggersActionsUi={deps.triggersActionsUi}
+            data={deps.data}
+          />
+        </IntlProvider>
+      </KibanaContextProvider>
+    </KibanaRenderContextProvider>,
     element
   );
 

--- a/x-pack/examples/triggers_actions_ui_example/tsconfig.json
+++ b/x-pack/examples/triggers_actions_ui_example/tsconfig.json
@@ -26,5 +26,6 @@
     "@kbn/i18n",
     "@kbn/actions-plugin",
     "@kbn/config-schema",
+    "@kbn/react-kibana-context-render",
   ]
 }

--- a/x-pack/test/functional_with_es_ssl/plugins/alerts/public/application.tsx
+++ b/x-pack/test/functional_with_es_ssl/plugins/alerts/public/application.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { Route } from '@kbn/shared-ux-router';
 
 import { EuiPage, EuiText } from '@elastic/eui';
@@ -42,7 +43,12 @@ export const renderApp = (
   deps: any,
   { appBasePath, element }: AppMountParameters
 ) => {
-  ReactDOM.render(<AlertingExampleApp basename={appBasePath} {...deps} />, element);
+  ReactDOM.render(
+    <KibanaRenderContextProvider {...core}>
+      <AlertingExampleApp basename={appBasePath} {...deps} />
+    </KibanaRenderContextProvider>,
+    element
+  );
 
   return () => ReactDOM.unmountComponentAtNode(element);
 };

--- a/x-pack/test/functional_with_es_ssl/plugins/alerts/tsconfig.json
+++ b/x-pack/test/functional_with_es_ssl/plugins/alerts/tsconfig.json
@@ -16,5 +16,6 @@
     "@kbn/alerting-plugin",
     "@kbn/triggers-actions-ui-plugin",
     "@kbn/shared-ux-router",
+    "@kbn/react-kibana-context-render",
   ]
 }


### PR DESCRIPTION
## Summary

Fixes needed for getting CI to pass when EUI throws an error if attempting to render a component without the EuiProvider in the render tree.

## Detailed description
In https://github.com/elastic/kibana/pull/180819, I will deliver a change that will cause EUI components to throw an error if the EuiProvider context is missing. This PR comes in as part of the final work to get all functional tests passing in an environment where EUI will throw the error. The tied to the ["Fix 'dark mode' inconsistencies in Kibana" Epic](https://github.com/elastic/kibana-team/issues/805) has so far been in preparation for this. 

**Reviewers: Please interact with critical paths through the UI components touched in this PR, ESPECIALLY in terms of testing dark mode and i18n.**

<img width="1107" alt="image" src="https://github.com/elastic/kibana/assets/908371/c0d2ce08-ac35-45a7-8192-0b2256fceb0e">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)