### PR TITLE
[EuiProvider] Fix Security Plugin code

### DIFF
--- a/x-pack/plugins/security/public/plugin.tsx
+++ b/x-pack/plugins/security/public/plugin.tsx
@@ -191,7 +191,7 @@ export class SecurityPlugin
     core: CoreStart,
     { management, share }: PluginStartDependencies
   ): SecurityPluginStart {
-    const { application, http, notifications, docLinks } = core;
+    const { application, http, notifications } = core;
     const { anonymousPaths } = http;
 
     const logoutUrl = getLogoutUrl(http);
@@ -202,7 +202,7 @@ export class SecurityPlugin
     this.sessionTimeout = new SessionTimeout(core, notifications, sessionExpired, http, tenant);
 
     this.sessionTimeout.start();
-    this.securityCheckupService.start({ http, notifications, docLinks });
+    this.securityCheckupService.start(core);
     this.securityApiClients.userProfiles.start();
 
     if (management) {

--- a/x-pack/plugins/security/public/security_checkup/components/insecure_cluster_alert.tsx
+++ b/x-pack/plugins/security/public/security_checkup/components/insecure_cluster_alert.tsx
@@ -16,26 +16,38 @@ import {
 import React, { useState } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
-import type { DocLinksStart, MountPoint } from '@kbn/core/public';
+import type {
+  AnalyticsServiceStart,
+  DocLinksStart,
+  I18nStart,
+  MountPoint,
+  ThemeServiceStart,
+} from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage, I18nProvider } from '@kbn/i18n-react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 
 export const insecureClusterAlertTitle = i18n.translate(
   'xpack.security.checkup.insecureClusterTitle',
   { defaultMessage: 'Your data is not secure' }
 );
 
-export const insecureClusterAlertText = (
-  docLinks: DocLinksStart,
-  onDismiss: (persist: boolean) => void
-) =>
+interface Deps {
+  docLinks: DocLinksStart;
+  analytics: Pick<AnalyticsServiceStart, 'reportEvent'>;
+  i18n: I18nStart;
+  theme: Pick<ThemeServiceStart, 'theme$'>;
+}
+
+export const insecureClusterAlertText = (deps: Deps, onDismiss: (persist: boolean) => void) =>
   ((e) => {
+    const { docLinks, ...startServices } = deps;
     const AlertText = () => {
       const [persist, setPersist] = useState(false);
       const enableSecurityDocLink = `${docLinks.links.security.elasticsearchEnableSecurity}?blade=kibanasecuritymessage`;
 
       return (
-        <I18nProvider>
+        <KibanaRenderContextProvider {...startServices}>
           <div data-test-subj="insecureClusterAlertText">
             <EuiText size="s">
               <FormattedMessage
@@ -81,7 +93,7 @@ export const insecureClusterAlertText = (
               </EuiFlexItem>
             </EuiFlexGroup>
           </div>
-        </I18nProvider>
+        </KibanaRenderContextProvider>
       );
     };
 


### PR DESCRIPTION
## Summary

Fixes needed for getting CI to pass when EUI throws an error if attempting to render a component without the EuiProvider in the render tree.

## Detailed description
In https://github.com/elastic/kibana/pull/180819, I will deliver a change that will cause EUI components to throw an error if the EuiProvider context is missing. This PR comes in as part of the final work to get all functional tests passing in an environment where EUI will throw the error. The tied to the ["Fix 'dark mode' inconsistencies in Kibana" Epic](https://github.com/elastic/kibana-team/issues/805) has so far been in preparation for this. 

**Reviewers: Please interact with critical paths through the UI components touched in this PR, ESPECIALLY in terms of testing dark mode and i18n.**

<img width="1107" alt="image" src="https://github.com/elastic/kibana/assets/908371/c0d2ce08-ac35-45a7-8192-0b2256fceb0e">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)