### PR TITLE
[EuiProvider] Fix ML Plugin code

### DIFF
--- a/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/jobs_list_page.tsx
+++ b/x-pack/plugins/ml/public/application/management/jobs_list/components/jobs_list_page/jobs_list_page.tsx
@@ -113,11 +113,19 @@ export const JobsListPage: FC<Props> = ({
   }
 
   if (accessDenied) {
-    return <AccessDeniedPage />;
+    return (
+      <KibanaRenderContextProvider {...coreStart}>
+        <AccessDeniedPage />
+      </KibanaRenderContextProvider>
+    );
   }
 
   if (isPlatinumOrTrialLicense === false) {
-    return <InsufficientLicensePage basePath={coreStart.http.basePath} />;
+    return (
+      <KibanaRenderContextProvider {...coreStart}>
+        <InsufficientLicensePage basePath={coreStart.http.basePath} />
+      </KibanaRenderContextProvider>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Fixes needed for getting CI to pass when EUI throws an error if attempting to render a component without the EuiProvider in the render tree.

## Detailed description
In https://github.com/elastic/kibana/pull/180819, I will deliver a change that will cause EUI components to throw an error if the EuiProvider context is missing. This PR comes in as part of the final work to get all functional tests passing in an environment where EUI will throw the error. The tied to the ["Fix 'dark mode' inconsistencies in Kibana" Epic](https://github.com/elastic/kibana-team/issues/805) has so far been in preparation for this. 

**Reviewers: Please interact with critical paths through the UI components touched in this PR, ESPECIALLY in terms of testing dark mode and i18n.**

<img width="1107" alt="image" src="https://github.com/elastic/kibana/assets/908371/c0d2ce08-ac35-45a7-8192-0b2256fceb0e">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)