### PR TITLE
[ES|QL] Improve editor's performance by caching the data sources

### DIFF
--- a/packages/kbn-text-based-editor/src/helpers.ts
+++ b/packages/kbn-text-based-editor/src/helpers.ts
@@ -228,3 +228,11 @@ export const clearCacheWhenOld = (cache: MapCache, esqlQuery: string) => {
     }
   }
 };
+
+export const getESQLSources = async (dataViews: DataViewsPublicPluginStart) => {
+  const [remoteIndices, localIndices] = await Promise.all([
+    getRemoteIndicesList(dataViews),
+    getIndicesList(dataViews),
+  ]);
+  return [...localIndices, ...remoteIndices];
+};

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -50,9 +50,8 @@ import {
   type MonacoMessage,
   getWrappedInPipesCode,
   parseErrors,
-  getIndicesList,
-  getRemoteIndicesList,
   clearCacheWhenOld,
+  getESQLSources,
 } from './helpers';
 import { EditorFooter } from './editor_footer';
 import { ResizableButton } from './resizable_button';
@@ -359,14 +358,24 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     return { cache: fn.cache, memoizedFieldsFromESQL: fn };
   }, []);
 
+  const { cache: dataSourcesCache, memoizedSources } = useMemo(() => {
+    const fn = memoize(
+      (...args: [DataViewsPublicPluginStart]) => ({
+        timestamp: Date.now(),
+        result: getESQLSources(...args),
+      }),
+      ({ esql }) => esql
+    );
+
+    return { cache: fn.cache, memoizedSources: fn };
+  }, []);
+
   const esqlCallbacks: ESQLCallbacks = useMemo(() => {
     const callbacks: ESQLCallbacks = {
       getSources: async () => {
-        const [remoteIndices, localIndices] = await Promise.all([
-          getRemoteIndicesList(dataViews),
-          getIndicesList(dataViews),
-        ]);
-        return [...localIndices, ...remoteIndices];
+        clearCacheWhenOld(dataSourcesCache, queryString);
+        const sources = await memoizedSources(dataViews).result;
+        return sources;
       },
       getFieldsFor: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
         if (queryToExecute) {
@@ -402,12 +411,15 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     };
     return callbacks;
   }, [
+    queryString,
+    memoizedSources,
+    dataSourcesCache,
     dataViews,
-    expressions,
-    indexManagementApiService,
     esqlFieldsCache,
     memoizedFieldsFromESQL,
+    expressions,
     abortController,
+    indexManagementApiService,
   ]);
 
   const parseMessages = useCallback(async () => {


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/180588

Caching the sources in the editor in order to not retrieve them every time a user is typing something. This is an important performance boost for the editor. 

There are more things wrong, for example we are always fetching the metadata. I think this is wrong, the metadata is and will always be a static list. This should be cleaned up in a follow up PR