### PR TITLE
[Search] [Playground] Resolve NPE when parent elements in the path are not defined

### DIFF
--- a/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.test.ts
+++ b/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.test.ts
@@ -44,7 +44,7 @@ describe('getValueForSelectedField', () => {
     );
   });
 
-  test('should return undefined for missing key', () => {
+  test('should return empty string for missing key', () => {
     const hit = {
       _index: 'sample-index',
       _id: '8jSNY48B6iHEi98DL1C-',
@@ -58,6 +58,23 @@ describe('getValueForSelectedField', () => {
       },
     };
 
-    expect(getValueForSelectedField(hit._source, 'metadata.sources')).toBeUndefined();
+    expect(getValueForSelectedField(hit._source, 'metadata.sources')).toBe('');
+  });
+
+  test('should return empty string for nested key', () => {
+    const hit = {
+      _index: 'sample-index',
+      _id: '8jSNY48B6iHEi98DL1C-',
+      _score: 0.7789394,
+      _source: {
+        test: 'The Shawshank Redemption',
+        metadata: {
+          source:
+            'Over the course of several years, two convicts form a friendship, seeking consolation and, eventually, redemption through basic compassion',
+        },
+      },
+    };
+
+    expect(getValueForSelectedField(hit._source, 'bla.sources')).toBe('');
   });
 });

--- a/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.ts
+++ b/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-// @ts-ignore
-export const getValueForSelectedField = (source, path: string): string => {
-  return path.split('.').reduce((acc, key) => acc[key], source);
+import { get } from 'lodash';
+
+export const getValueForSelectedField = (source: unknown, path: string): string => {
+  return get(source, path, '');
 };


### PR DESCRIPTION
## Summary

Issue occurs when the field path used is undefined in any of the parents. Switching to get which handles these cases gracefully. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)