### PR TITLE
[PoC] adding basic apache arrow support to expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -955,6 +955,7 @@
     "ajv": "^8.12.0",
     "ansi-regex": "^6.0.1",
     "antlr4": "^4.13.1-patch-1",
+    "apache-arrow": "^16.1.0",
     "archiver": "^5.3.1",
     "async": "^3.2.3",
     "aws4": "^1.12.0",

--- a/src/plugins/chart_expressions/expression_legacy_metric/common/types/expression_functions.ts
+++ b/src/plugins/chart_expressions/expression_legacy_metric/common/types/expression_functions.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
+import { Table } from 'apache-arrow';
 import type { PaletteOutput } from '@kbn/coloring';
 import {
-  Datatable,
   ExpressionFunctionDefinition,
   ExpressionValueRender,
   Style,
@@ -33,11 +33,14 @@ export interface MetricArguments {
   autoScale?: boolean;
 }
 
-export type MetricInput = Datatable;
+export interface MetricInput {
+  type: 'arrow';
+  table: Table;
+}
 
 export interface MetricVisRenderConfig {
   visType: typeof visType;
-  visData: Datatable;
+  visData: Table;
   visConfig: Pick<VisParams, 'metric' | 'dimensions'>;
   canNavigateToLens: boolean;
 }

--- a/src/plugins/chart_expressions/expression_legacy_metric/public/expression_renderers/metric_vis_renderer.tsx
+++ b/src/plugins/chart_expressions/expression_legacy_metric/public/expression_renderers/metric_vis_renderer.tsx
@@ -8,6 +8,7 @@
 
 import React, { lazy } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
+import { Table } from 'apache-arrow/Arrow.node';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import {
@@ -19,7 +20,7 @@ import {
   IInterpreterRenderHandlers,
 } from '@kbn/expressions-plugin/common/expression_renderers';
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
-import { Datatable } from '@kbn/expressions-plugin/common';
+import { DatatableColumn } from '@kbn/expressions-plugin/common';
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import {
   ChartSizeEvent,
@@ -34,13 +35,15 @@ const MetricVisComponent = lazy(() => import('../components/metric_component'));
 
 async function metricFilterable(
   dimensions: VisParams['dimensions'],
-  table: Datatable,
+  table: Table,
   handlers: IInterpreterRenderHandlers
 ) {
+  const columns = table.schema.fields as unknown as DatatableColumn[];
+
   return Promise.all(
     dimensions.metrics.map(async (metric: string | ExpressionValueVisDimension) => {
-      const column = getColumnByAccessor(metric, table.columns);
-      const colIndex = table.columns.indexOf(column!);
+      const column = getColumnByAccessor(metric, columns);
+      const colIndex = columns.indexOf(column!);
       return Boolean(
         await handlers.hasCompatibleActions?.({
           name: 'filter',
@@ -113,7 +116,7 @@ export const getMetricVisRenderer: (
         <VisualizationContainer
           data-test-subj="legacyMtrVis"
           className="legacyMtrVis"
-          showNoResult={!visData.rows?.length}
+          showNoResult={!visData.numRows}
           renderComplete={renderComplete}
           handlers={handlers}
         >

--- a/src/plugins/expressions/common/expression_functions/specs/arrowlog.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/arrowlog.ts
@@ -22,8 +22,19 @@ export const arrowlog: ExpressionFunctionArrowlog = {
   inputTypes: ['arrow'],
   help: 'Outputs the first row of arrow table to the console. This function is for debug purposes',
   fn: (input: { type: 'arrow'; table: Table }) => {
-    // eslint-disable-next-line no-console
-    console.log(input.table.get(0)!.toJSON());
+    let x = 0;
+    console.time('pass over');
+    for (let i = 0; i < input.table.numRows; i++) {
+      x += input.table.get(i)!.time;
+    }
+    console.timeEnd('pass over');
+
+    console.time('pass over2');
+    for (let i = 0; i < input.table.numRows; i++) {
+      x += input.table.getChild('time')!.get(i);
+    }
+    console.timeEnd('pass over2');
+    console.log(input.table.get(0)!.toJSON(), x);
     return input;
   },
 };

--- a/src/plugins/expressions/common/expression_functions/specs/arrowlog.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/arrowlog.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Table } from 'apache-arrow';
+import { ExpressionFunctionDefinition } from '../types';
+
+export type ExpressionFunctionArrowlog = ExpressionFunctionDefinition<
+  'arrowlog',
+  { type: 'arrow'; table: Table },
+  {},
+  unknown
+>;
+
+export const arrowlog: ExpressionFunctionArrowlog = {
+  name: 'arrowlog',
+  args: {},
+  inputTypes: ['arrow'],
+  help: 'Outputs the first row of arrow table to the console. This function is for debug purposes',
+  fn: (input: { type: 'arrow'; table: Table }) => {
+    // eslint-disable-next-line no-console
+    console.log(input.table.get(0)!.toJSON());
+    return input;
+  },
+};

--- a/src/plugins/expressions/common/expression_functions/specs/demoarrow.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/demoarrow.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Table, tableFromArrays } from 'apache-arrow';
+import { ExpressionFunctionDefinition } from '../types';
+
+export type ExpressionFunctionArrowlog = ExpressionFunctionDefinition<
+  'demoarrow',
+  unknown,
+  {},
+  { type: 'arrow'; table: Table }
+>;
+
+export const demoarrow: ExpressionFunctionArrowlog = {
+  name: 'demoarrow',
+  args: {},
+  type: 'arrow',
+  help: 'generates sample arrow table',
+  fn: () => {
+    // const table = tableFromJSON([{ test: 'hello', test2: 'world', test3: 4 }]);
+    const table = tableFromArrays({ test: ['hello'], test2: ['world'], test3: [4] });
+    return { type: 'arrow', table };
+  },
+};

--- a/src/plugins/expressions/common/expression_functions/specs/demoarrow.ts
+++ b/src/plugins/expressions/common/expression_functions/specs/demoarrow.ts
@@ -6,24 +6,85 @@
  * Side Public License, v 1.
  */
 
-import { Table, tableFromArrays } from 'apache-arrow';
+import { Table, tableFromJSON } from 'apache-arrow';
+import { i18n } from '@kbn/i18n';
 import { ExpressionFunctionDefinition } from '../types';
 
-export type ExpressionFunctionArrowlog = ExpressionFunctionDefinition<
+export type ExpressionFunctionDemoArrow = ExpressionFunctionDefinition<
   'demoarrow',
   unknown,
-  {},
+  {
+    rows: number;
+    type: 'ci' | 'shirts';
+  },
   { type: 'arrow'; table: Table }
 >;
 
-export const demoarrow: ExpressionFunctionArrowlog = {
+const countries = ['CN', 'US', 'UK', 'DE', 'US', 'US'];
+const projects = ['elasticsearch', 'kibana', 'beats'];
+const states = ['start', 'in_progress', 'complete'];
+const users = ['user1', 'user2', 'user3', 'user4', 'user5'];
+
+function generateCIRow(time: number) {
+  return {
+    age: Math.round(Math.random() * 70),
+    cost: 20 + Math.random() * 100,
+    country: countries[Math.floor(Math.random() * countries.length)],
+    price: 63,
+    project: projects[Math.floor(Math.random() * projects.length)],
+    state: states[Math.floor(Math.random() * states.length)],
+    time,
+    '@timestamp': time,
+    username: users[Math.floor(Math.random() * users.length)],
+    percent_uptime: Math.random(),
+  };
+}
+
+const sizes = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
+const colors = ['Red', 'Yellow', 'Blue'];
+const cut = ['fitted', 'slim'];
+
+function generateShirtsRow() {
+  return {
+    size: users[Math.floor(Math.random() * users.length)],
+    color: users[Math.floor(Math.random() * users.length)],
+    price: 10 + Math.random() * 100,
+    cut: users[Math.floor(Math.random() * users.length)],
+  };
+}
+
+export const demoarrow: ExpressionFunctionDemoArrow = {
   name: 'demoarrow',
-  args: {},
+  args: {
+    type: {
+      types: ['string'],
+      aliases: ['_'],
+      help: i18n.translate('expressions.functions.demoarrow.args.typeHelpText', {
+        defaultMessage: 'The name of the demo data set to use.',
+      }),
+      default: 'ci',
+      options: ['ci', 'shirts'],
+    },
+    rows: {
+      types: ['number'],
+      help: i18n.translate('expressions.functions.demoarrow.args.rowsHelpText', {
+        defaultMessage: 'Number of rows to return.',
+      }),
+      default: 100,
+    },
+  },
   type: 'arrow',
   help: 'generates sample arrow table',
-  fn: () => {
-    // const table = tableFromJSON([{ test: 'hello', test2: 'world', test3: 4 }]);
-    const table = tableFromArrays({ test: ['hello'], test2: ['world'], test3: [4] });
+  fn: (input, args) => {
+    const data = [];
+
+    const endDate = Date.now();
+    const startDate = endDate - 7 * 24 * 3600 * 1000;
+    const interval = (endDate - startDate) / args.rows;
+    for (let i = 0; i < args.rows; i++) {
+      data.push(args.type === 'ci' ? generateCIRow(startDate + i * interval) : generateShirtsRow());
+    }
+    const table = tableFromJSON(data);
     return { type: 'arrow', table };
   },
 };

--- a/src/plugins/expressions/common/expression_types/specs/arrow.ts
+++ b/src/plugins/expressions/common/expression_types/specs/arrow.ts
@@ -18,16 +18,7 @@ export const arrow: ExpressionTypeDefinition<
   { type: 'arrow'; table: Table }
 > = {
   name,
-  validate: (table: Record<string, unknown>) => {
-    // TODO: Check columns types. Only string, boolean, number, date, allowed for now.
-    if (!table.columns) {
-      throw new Error('datatable must have a columns array, even if it is empty');
-    }
-
-    if (!table.rows) {
-      throw new Error('datatable must have a rows array, even if it is empty');
-    }
-  },
+  validate: (table: Record<string, unknown>) => {},
   serialize: (table) => {
     return table;
   },

--- a/src/plugins/expressions/common/expression_types/specs/arrow.ts
+++ b/src/plugins/expressions/common/expression_types/specs/arrow.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Table } from 'apache-arrow';
+
+import { ExpressionTypeDefinition } from '../types';
+
+const name = 'arrow';
+
+export const arrow: ExpressionTypeDefinition<
+  typeof name,
+  { type: 'arrow'; table: Table },
+  { type: 'arrow'; table: Table }
+> = {
+  name,
+  validate: (table: Record<string, unknown>) => {
+    // TODO: Check columns types. Only string, boolean, number, date, allowed for now.
+    if (!table.columns) {
+      throw new Error('datatable must have a columns array, even if it is empty');
+    }
+
+    if (!table.rows) {
+      throw new Error('datatable must have a rows array, even if it is empty');
+    }
+  },
+  serialize: (table) => {
+    return table;
+  },
+  deserialize: (table) => {
+    return table;
+  },
+  from: {},
+  to: {},
+};

--- a/src/plugins/expressions/common/expression_types/specs/index.ts
+++ b/src/plugins/expressions/common/expression_types/specs/index.ts
@@ -22,6 +22,7 @@ import { string } from './string';
 import { style } from './style';
 import { AnyExpressionTypeDefinition } from '../types';
 import { uiSetting } from './ui_setting';
+import { arrow } from './arrow';
 
 export const typeSpecs: AnyExpressionTypeDefinition[] = [
   boolean,
@@ -39,6 +40,7 @@ export const typeSpecs: AnyExpressionTypeDefinition[] = [
   string,
   style,
   uiSetting,
+  arrow,
 ];
 
 export * from './boolean';

--- a/src/plugins/expressions/common/service/expressions_services.ts
+++ b/src/plugins/expressions/common/service/expressions_services.ts
@@ -19,6 +19,8 @@ import {
 } from '@kbn/kibana-utils-plugin/common';
 import { Adapters } from '@kbn/inspector-plugin/common/adapters';
 import { ExecutionContextSearch } from '@kbn/es-query';
+import { arrowlog } from '../expression_functions/specs/arrowlog';
+import { demoarrow } from '../expression_functions/specs/demoarrow';
 import { Executor } from '../executor';
 import { AnyExpressionRenderDefinition, ExpressionRendererRegistry } from '../expression_renderers';
 import { ExpressionAstExpression } from '../ast';
@@ -467,6 +469,8 @@ export class ExpressionsService
       mapColumn,
       math,
       mathColumn,
+      arrowlog,
+      demoarrow,
     ]) {
       this.registerFunction(fn);
     }

--- a/src/plugins/visualizations/common/utils/accessors.ts
+++ b/src/plugins/visualizations/common/utils/accessors.ts
@@ -14,7 +14,7 @@ const getAccessorByIndex = (accessor: number, columns: Datatable['columns']) =>
   columns.length > accessor ? accessor : undefined;
 
 const getAccessorById = (accessor: DatatableColumn['id'], columns: Datatable['columns']) =>
-  columns.find((c) => c.id === accessor);
+  columns.find((c) => (c.id ? c.id === accessor : c.name === 'accessor'));
 
 export function findAccessor(
   accessor: string,
@@ -112,7 +112,7 @@ export const getColumnByAccessor = (
   columns: Datatable['columns'] = []
 ) => {
   if (typeof accessor === 'string') {
-    return columns.find(({ id }) => accessor === id);
+    return columns.find(({ id, name }) => (id ? accessor === id : accessor === name));
   }
 
   const visDimensionAccessor = accessor.accessor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@75lb/deep-merge@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@75lb/deep-merge/-/deep-merge-1.1.1.tgz#3b06155b90d34f5f8cc2107d796f1853ba02fd6d"
+  integrity sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==
+  dependencies:
+    lodash.assignwith "^4.2.0"
+    typical "^7.1.1"
+
 "@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
@@ -9050,6 +9058,13 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
+"@swc/helpers@^0.5.10":
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.11.tgz#5bab8c660a6e23c13b2d23fcd1ee44a2db1b0cb7"
+  integrity sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==
+  dependencies:
+    tslib "^2.4.0"
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
@@ -9543,6 +9558,16 @@
   integrity sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==
   dependencies:
     "@types/color-convert" "*"
+
+"@types/command-line-args@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/command-line-args/-/command-line-args-5.2.3.tgz#553ce2fd5acf160b448d307649b38ffc60d39639"
+  integrity sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==
+
+"@types/command-line-usage@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.4.tgz#374e4c62d78fbc5a670a0f36da10235af879a0d5"
+  integrity sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==
 
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
@@ -10277,7 +10302,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@20.10.5", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=18.0.0", "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0", "@types/node@^18.0.0", "@types/node@^18.11.18":
+"@types/node@*", "@types/node@20.10.5", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=18.0.0", "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0", "@types/node@^18.0.0", "@types/node@^18.11.18", "@types/node@^20.12.7":
   version "20.10.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.5.tgz#47ad460b514096b7ed63a1dae26fad0914ed3ab2"
   integrity sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==
@@ -11749,6 +11774,21 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@^3.1.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apache-arrow@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-16.1.0.tgz#7aa8d0d436dd0995d9dc5c36febf380d5b207209"
+  integrity sha512-G6GiM6tzPDdGnKUnVkvVr1Nt5+hUaCMBISiasMSiJwI5L5GKDv5Du7Avc2kxlFfB/LEK2LTqh2GKSxutMdf8vQ==
+  dependencies:
+    "@swc/helpers" "^0.5.10"
+    "@types/command-line-args" "^5.2.3"
+    "@types/command-line-usage" "^5.0.4"
+    "@types/node" "^20.12.7"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.1"
+    flatbuffers "^24.3.25"
+    json-bignum "^0.0.3"
+    tslib "^2.6.2"
+
 apidoc-light@^0.54.0:
   version "0.54.0"
   resolved "https://registry.yarnpkg.com/apidoc-light/-/apidoc-light-0.54.0.tgz#8d819bcd893ca96a60d754c59b33dcf5f9255b59"
@@ -11908,6 +11948,16 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
 
 array-buffer-byte-length@^1.0.0:
   version "1.0.0"
@@ -13438,6 +13488,13 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
+chalk-template@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
+  integrity sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==
+  dependencies:
+    chalk "^4.1.2"
+
 chalk@2.4.2, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -13983,6 +14040,26 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+command-line-args@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^7.0.0, command-line-usage@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-7.0.1.tgz#e540afef4a4f3bc501b124ffde33956309100655"
+  integrity sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==
+  dependencies:
+    array-back "^6.2.2"
+    chalk-template "^0.4.0"
+    table-layout "^3.0.0"
+    typical "^7.1.1"
 
 commander@2, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1:
   version "2.20.3"
@@ -17508,6 +17585,13 @@ find-cypress-specs@^1.41.4:
     spec-change "^1.10.0"
     ts-node "^10.9.1"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -17568,6 +17652,11 @@ flat@5, flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+flatbuffers@^24.3.25:
+  version "24.3.25"
+  resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-24.3.25.tgz#e2f92259ba8aa53acd0af7844afb7c7eb95e7089"
+  integrity sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==
 
 flatstr@^1.0.12:
   version "1.0.12"
@@ -20998,6 +21087,11 @@ json-bigint@^1.0.0:
   dependencies:
     bignumber.js "^9.0.0"
 
+json-bignum@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/json-bignum/-/json-bignum-0.0.3.tgz#41163b50436c773d82424dbc20ed70db7604b8d7"
+  integrity sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -21631,6 +21725,11 @@ lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
+lodash.assignwith@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz#127a97f02adc41751a954d24b0de17e100e038eb"
+  integrity sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -28718,6 +28817,11 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
+stream-read-all@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stream-read-all/-/stream-read-all-3.0.1.tgz#60762ae45e61d93ba0978cda7f3913790052ad96"
+  integrity sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==
+
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -28759,7 +28863,7 @@ string-replace-loader@^2.2.0:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -28776,6 +28880,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -28886,7 +28999,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -28899,6 +29012,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -29282,6 +29402,19 @@ tabbable@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
   integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
+
+table-layout@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-3.0.2.tgz#69c2be44388a5139b48c59cf21e73b488021769a"
+  integrity sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==
+  dependencies:
+    "@75lb/deep-merge" "^1.1.1"
+    array-back "^6.2.2"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.0"
+    stream-read-all "^3.0.1"
+    typical "^7.1.1"
+    wordwrapjs "^5.1.0"
 
 table@^6.8.0, table@^6.8.1:
   version "6.8.1"
@@ -29926,7 +30059,7 @@ tslib@^1.10.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.5.2:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.5.2, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -30128,6 +30261,16 @@ typewise@^1.0.3:
   integrity sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==
   dependencies:
     typewise-core "^1.2.0"
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-7.1.1.tgz#ba177ab7ab103b78534463ffa4c0c9754523ac1f"
+  integrity sha512-T+tKVNs6Wu7IWiAce5BgMd7OZfNYUndHwc5MknN+UHOudi7sGZzuHdCadllRuqJ3fPtgFtIH9+lt9qRv6lmpfA==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"
@@ -31753,6 +31896,11 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
+wordwrapjs@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
+  integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
+
 worker-farm@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
@@ -31772,7 +31920,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -31793,6 +31941,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary

The goal of this PR is to test out how feasible it is to convert from kibana datatable to arrow table and vice versa. This will allow us to further test converting various parts of kibana to this new data format.

This adds basic support for apache arrow to expressions:
- new 'arrow' datatype and conversion from/to datatable were added
- sample arrowlog function which logs first row of the table to the console
- sample demoarrow function which generates a simple arrow dataset
- legacy metric visualization was converted to use new arrow format

with this we can test converting from/to and allows us to:
- add data fetching functions with support for arrow format. Any legacy data fetching methods can coexist with the old ones.
- add support for arrow format to charts. we can update charts one by one and leave legacy ones as they are.
- test performance of converting from/to kibana datatable/arrow

## How to test
to test this you will need to add the following to your kibana.yaml, as arrow library is using unsafe eval under the hood:

```csp.script_src: ['unsafe-eval']```

then go to canvas and try with theese expressions:

`demoarrow rows=1000 | table` generates arrow table and converts it to datatable so it can be rendered by table
`demoarrow | arrowlog` generates arrow table and logs first row to the console
`demodata | arrowlog | table` generates datatable, converts to arrow table, logs first row, converts to datatable and renders the table
`demoarrow rows=1 | arrowlog | legacyMetricVis percentageMode=false colorMode="None" showLabels=true metric={visdimension accessor=0 format="number"}` to test with legacy metric vis

## Issues discovered
- current implementation of arrow for js requires `unsafe-eval` enabled.
- there is very little documentation available
- apis seems to be changing rapidly so most information online is outdated

## relevant content online
https://arrow.apache.org/docs/js/
https://observablehq.com/@theneuralbit/using-apache-arrow-js-with-large-datasets
https://arrow.apache.org/docs/js/classes/Arrow_dom.Table.html
https://github.com/apache/arrow/blob/main/js/src/table.ts

## outcome
- converting from kibana datatable to apache arrow and vice versa is straight forward
- adapting existing visualizations is not hard, but might involve significant amount of work depending on the implementation of visualization. legacy metric vis was converted in matter of hours.
- its hard to measure performance improvement without full stack support for arrow format. Assuming its a tabular format, which is similar to js array of objects, we can assume that we will not see any relevant speedups just for the reason we are reading arrow format rather than array of js objects. Performance benefits might become before being consumed by visualisations or if in the future we start working with bigger datasets and/or processing data in web assembly using gpu.
- performance:
  - it takes around 700ms to convert 1 million rows to arrow and around 5s to convert from arrow to datatable.
  - it takes around 10ms to convert 10.000 rows to arrow and around 50ms to convert from arrow to datatable.
  - a single pass over the table with 1 million rows (just calculating sum of a value of a single column) takes 500ms on datatable and 5000ms on arrow table
  - accessing data in columnar way (column per column rather than row per row) is faster, but still slow (takes around 3s to convert the same table, single pass on a single column is fast (300ms))

## whats required to actually move forward:
- arrow implementation up to the expression level (search service, kibana core, elasticsearch client, elasticsearch)
- solution for unsafe-eval issue
- estimated cost of implementation in lens/elasticcharts
