### PR TITLE
[Search] [Chat Playground] handle when the ActionLLM is not a ChatModel

### DIFF
--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.ts
@@ -150,6 +150,7 @@ class ConversationalChainFn {
       {
         callbacks: [
           {
+            // callback for chat based models (OpenAI)
             handleChatModelStart(
               llm,
               msg: BaseMessage[][],
@@ -163,6 +164,15 @@ class ConversationalChainFn {
                 data.appendMessageAnnotation({
                   type: 'prompt_token_count',
                   count: getTokenEstimateFromMessages(msg),
+                });
+              }
+            },
+            // callback for prompt based models (Bedrock uses ActionsClientLlm)
+            handleLLMStart(llm, input, runId, parentRunId, extraParams, tags, metadata) {
+              if (metadata?.type === 'question_answer_qa') {
+                data.appendMessageAnnotation({
+                  type: 'prompt_token_count',
+                  count: getTokenEstimate(input[0]),
                 });
               }
             },


### PR DESCRIPTION
## Summary

Two action based LLMs: `ActionsClientChatOpenAI` and `ActionsClientLlm`. `ActionsClientChatOpenAI` is based on the ChatModel LLM, `ActionsClientLlm` is a prompt based model. The callbacks are different when using a ChatModel vs LLMModel. Token count is done on the ChatModelStart callback. This meant the token count didn't happen for LLMModel based actions (Bedrock).

To fix i listen on both callbacks.    

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
