### PR TITLE
chore(FullStory): report `buildSha` instead of `buildNum`

### DIFF
--- a/packages/analytics/shippers/fullstory/src/fullstory_shipper.ts
+++ b/packages/analytics/shippers/fullstory/src/fullstory_shipper.ts
@@ -30,7 +30,7 @@ const PAGE_VARS_KEYS = [
 
   // Deployment-specific keys
   'version', // x4, split to version_major, version_minor, version_patch for easier filtering
-  'buildNum', // May be useful for Serverless, TODO: replace with buildHash
+  'buildSha', // Useful for Serverless
   'cloudId',
   'deploymentId',
   'projectId', // projectId and deploymentId are mutually exclusive. They shouldn't be sent in the same offering.


### PR DESCRIPTION
## Summary

Just ticking off the `TODO` we had there 😇 


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->