### PR TITLE
fix(slo): hide pagination when not enough result and fix state

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
@@ -231,7 +231,10 @@ export function GroupListView({
                     activePage={page}
                     onChangePage={handlePageClick}
                     itemsPerPage={itemsPerPage}
-                    onChangeItemsPerPage={(perPage) => setItemsPerPage(perPage)}
+                    onChangeItemsPerPage={(perPage) => {
+                      setPage(0);
+                      setItemsPerPage(perPage);
+                    }}
                   />
                 ) : null}
               </>

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_list_view.tsx
@@ -225,13 +225,15 @@ export function GroupListView({
                   sloView={sloView}
                 />
                 <EuiSpacer size="m" />
-                <EuiTablePagination
-                  pageCount={Math.ceil(total / itemsPerPage)}
-                  activePage={page}
-                  onChangePage={handlePageClick}
-                  itemsPerPage={itemsPerPage}
-                  onChangeItemsPerPage={(perPage) => setItemsPerPage(perPage)}
-                />
+                {total > 0 && total > itemsPerPage ? (
+                  <EuiTablePagination
+                    pageCount={Math.ceil(total / itemsPerPage)}
+                    activePage={page}
+                    onChangePage={handlePageClick}
+                    itemsPerPage={itemsPerPage}
+                    onChangeItemsPerPage={(perPage) => setItemsPerPage(perPage)}
+                  />
+                ) : null}
               </>
             )}
           </MemoEuiAccordion>

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_view.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_view.tsx
@@ -93,7 +93,7 @@ export function GroupView({
           />
         ))}
 
-      {total > 0 ? (
+      {total > 0 && total > perPage ? (
         <EuiFlexItem>
           <EuiTablePagination
             data-test-subj="sloGroupListPagination"

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_view.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/grouped_slos/group_view.tsx
@@ -103,7 +103,7 @@ export function GroupView({
             itemsPerPage={perPage}
             itemsPerPageOptions={[10, 25, 50, 100]}
             onChangeItemsPerPage={(newPerPage) => {
-              onStateChange({ perPage: newPerPage });
+              onStateChange({ perPage: newPerPage, page: 0 });
             }}
           />
         </EuiFlexItem>

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/slo_list.tsx
@@ -109,7 +109,7 @@ export function SloList() {
                 itemsPerPage={perPage}
                 itemsPerPageOptions={[10, 25, 50, 100]}
                 onChangeItemsPerPage={(newPerPage) => {
-                  onStateChange({ perPage: newPerPage });
+                  onStateChange({ perPage: newPerPage, page: 0 });
                 }}
               />
             </EuiFlexItem>

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/components/slo_list.tsx
@@ -98,7 +98,7 @@ export function SloList() {
             error={isError}
             sloView={view}
           />
-          {total > 0 ? (
+          {total > 0 && total > perPage ? (
             <EuiFlexItem>
               <EuiTablePagination
                 pageCount={Math.ceil(total / perPage)}


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/180642

## 🧷 Summary

This PR hides the pagination for the ungroup and group views when the number of items is less than the perPage option.

It also fixes the pagination behaviour when changing the perPage option on a non-first page, which can result in attempting to display out of bound SLOs, displaying a "no results found" warning card. The correct behaviour when changing the perPage option is to go back to the first page.

Description | Screenshots 
-- | --
Ungrouped, total > perPage | ![image](https://github.com/elastic/kibana/assets/1376800/ac747aba-b01c-4fdf-be83-61a4d525ea66)
Ungrouped, total <= perPage |  ![image](https://github.com/elastic/kibana/assets/1376800/e161088c-bdb2-4c85-b973-2c7400929874)
Grouped, group: total > perPage | ![image](https://github.com/elastic/kibana/assets/1376800/e849c38a-5688-4527-a657-2db0dc38d11e)
Grouped, group: total <= perPage | ![image](https://github.com/elastic/kibana/assets/1376800/3590dbc1-58a6-44b3-ad1f-2fe311d01581)
Grouped, global total <= perPage | ![image](https://github.com/elastic/kibana/assets/1376800/a2dda50f-d93d-4287-a6a7-99b23fa0ad83)


### Pagination out of bound issue

https://github.com/elastic/kibana/assets/1376800/43aa9ae0-b7c9-4082-a270-1b552c466944




