### PR TITLE
[8.14] [Security Solution][Endpoint] Enable `responseActionsSentinelOneV2Enabled` feature flag in `main` (#183664)

### DIFF
--- a/x-pack/plugins/security_solution/server/config.ts
+++ b/x-pack/plugins/security_solution/server/config.ts
@@ -128,7 +128,7 @@ export const configSchema = schema.object({
    * Complete External Response Actions task: Timeout value for how long the task should run
    */
   completeExternalResponseActionsTaskTimeout: schema.string({
-    defaultValue: '20m',
+    defaultValue: '5m',
     validate: isValidTaskManagerDuration,
   }),
 

--- a/x-pack/plugins/security_solution/server/endpoint/lib/response_actions/complete_external_actions_task.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/response_actions/complete_external_actions_task.ts
@@ -41,7 +41,7 @@ export class CompleteExternalResponseActionsTask {
   private log: Logger;
   private esClient: ElasticsearchClient | undefined = undefined;
   private cleanup: (() => void | Promise<void>) | undefined;
-  private taskTimeout = '20m'; // Default. Real value comes from server config
+  private taskTimeout = '5m'; // Default. Real value comes from server config
   private taskInterval = '60s'; // Default. Real value comes from server config
 
   constructor(protected readonly options: CompleteExternalResponseActionsTaskConstructorOptions) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Security Solution][Endpoint] Enable `responseActionsSentinelOneV2Enabled` feature flag in `main` (#183664)](https://github.com/elastic/kibana/pull/183664)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-05-21T19:59:51Z","message":"[Security Solution][Endpoint] Enable `responseActionsSentinelOneV2Enabled` feature flag in `main` (#183664)\n\n## Summary\r\n\r\n- Enables the `responseActionsSentinelOneV2Enabled` feature flag for\r\n`main`\r\n- This same FF was enabled already in 8.14 via:\r\nhttps://github.com/elastic/kibana/pull/182384\r\n- Changes the background task for completing response actions to have an\r\ninitial timeout of `5m` (instead of `20m`)","sha":"4b2afc8461ae2d1804b1daef8b79eca39c3b3905","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","v8.14.0","v8.15.0"],"number":183664,"url":"https://github.com/elastic/kibana/pull/183664","mergeCommit":{"message":"[Security Solution][Endpoint] Enable `responseActionsSentinelOneV2Enabled` feature flag in `main` (#183664)\n\n## Summary\r\n\r\n- Enables the `responseActionsSentinelOneV2Enabled` feature flag for\r\n`main`\r\n- This same FF was enabled already in 8.14 via:\r\nhttps://github.com/elastic/kibana/pull/182384\r\n- Changes the background task for completing response actions to have an\r\ninitial timeout of `5m` (instead of `20m`)","sha":"4b2afc8461ae2d1804b1daef8b79eca39c3b3905"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183664","number":183664,"mergeCommit":{"message":"[Security Solution][Endpoint] Enable `responseActionsSentinelOneV2Enabled` feature flag in `main` (#183664)\n\n## Summary\r\n\r\n- Enables the `responseActionsSentinelOneV2Enabled` feature flag for\r\n`main`\r\n- This same FF was enabled already in 8.14 via:\r\nhttps://github.com/elastic/kibana/pull/182384\r\n- Changes the background task for completing response actions to have an\r\ninitial timeout of `5m` (instead of `20m`)","sha":"4b2afc8461ae2d1804b1daef8b79eca39c3b3905"}}]}] BACKPORT-->