### PR TITLE
[SLO] Fix SLO plugin context

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -20,10 +20,4 @@ export interface PluginContextValue {
   experimentalFeatures?: ExperimentalFeatures;
 }
 
-export interface OverviewEmbeddableContextValue {
-  observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
-}
-
-export const OverviewEmbeddableContext = createContext<OverviewEmbeddableContextValue | null>(null);
-
 export const PluginContext = createContext<PluginContextValue | null>(null);

--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -24,6 +24,6 @@ export interface OverviewEmbeddableContextValue {
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
 }
 
-export const OverviewEmbeddableContext = createContext<OverviewEmbeddableContextValue | null>(null);
-
-export const PluginContext = createContext<PluginContextValue | null>(null);
+export const PluginContext = createContext(
+  {} as PluginContextValue | OverviewEmbeddableContextValue
+);

--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -16,7 +16,7 @@ export interface PluginContextValue {
   isServerless?: boolean;
   appMountParameters?: AppMountParameters;
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
-  ObservabilityPageTemplate: React.ComponentType<LazyObservabilityPageTemplateProps>;
+  ObservabilityPageTemplate?: React.ComponentType<LazyObservabilityPageTemplateProps>;
   experimentalFeatures?: ExperimentalFeatures;
 }
 

--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -16,7 +16,7 @@ export interface PluginContextValue {
   isServerless?: boolean;
   appMountParameters?: AppMountParameters;
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
-  ObservabilityPageTemplate?: React.ComponentType<LazyObservabilityPageTemplateProps>;
+  ObservabilityPageTemplate: React.ComponentType<LazyObservabilityPageTemplateProps>;
   experimentalFeatures?: ExperimentalFeatures;
 }
 

--- a/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/context/plugin_context.tsx
@@ -24,6 +24,6 @@ export interface OverviewEmbeddableContextValue {
   observabilityRuleTypeRegistry: ObservabilityRuleTypeRegistry;
 }
 
-export const PluginContext = createContext(
-  {} as PluginContextValue | OverviewEmbeddableContextValue
-);
+export const OverviewEmbeddableContext = createContext<OverviewEmbeddableContextValue | null>(null);
+
+export const PluginContext = createContext<PluginContextValue | null>(null);

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/overview_embeddable_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/overview_embeddable_context.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { Router } from '@kbn/shared-ux-router';
+import { createBrowserHistory } from 'history';
+import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PluginContext } from '../../../context/plugin_context';
+import { SloEmbeddableDeps } from '../overview/types';
+
+const queryClient = new QueryClient();
+
+export interface OverviewEmbeddableContextProps {
+  deps: SloEmbeddableDeps;
+  children: React.ReactNode;
+}
+
+export function SloOverviewEmbeddableContext({ deps, children }: OverviewEmbeddableContextProps) {
+  const { observabilityRuleTypeRegistry } = deps.observability;
+
+  return (
+    <Router history={createBrowserHistory()}>
+      <EuiThemeProvider darkMode={true}>
+        <KibanaContextProvider services={deps}>
+          <PluginContext.Provider value={{ observabilityRuleTypeRegistry }}>
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+          </PluginContext.Provider>
+        </KibanaContextProvider>
+      </EuiThemeProvider>
+    </Router>
+  );
+}

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_embeddable_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_embeddable_context.tsx
@@ -22,12 +22,18 @@ export interface SloEmbeddableContextProps {
 
 export function SloEmbeddableContext({ deps, children }: SloEmbeddableContextProps) {
   const { observabilityRuleTypeRegistry } = deps.observability;
+  const { navigation } = deps.observabilityShared;
 
   return (
     <Router history={createBrowserHistory()}>
       <EuiThemeProvider darkMode={true}>
         <KibanaContextProvider services={deps}>
-          <PluginContext.Provider value={{ observabilityRuleTypeRegistry }}>
+          <PluginContext.Provider
+            value={{
+              observabilityRuleTypeRegistry,
+              ObservabilityPageTemplate: navigation.PageTemplate,
+            }}
+          >
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
           </PluginContext.Provider>
         </KibanaContextProvider>

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_embeddable_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/common/slo_embeddable_context.tsx
@@ -15,12 +15,12 @@ import { SloEmbeddableDeps } from '../overview/types';
 
 const queryClient = new QueryClient();
 
-export interface OverviewEmbeddableContextProps {
+export interface SloEmbeddableContextProps {
   deps: SloEmbeddableDeps;
   children: React.ReactNode;
 }
 
-export function SloOverviewEmbeddableContext({ deps, children }: OverviewEmbeddableContextProps) {
+export function SloEmbeddableContext({ deps, children }: SloEmbeddableContextProps) {
   const { observabilityRuleTypeRegistry } = deps.observability;
 
   return (

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
@@ -117,7 +117,6 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
             groupFilters$,
             remoteName$
           );
-          const { observabilityRuleTypeRegistry } = deps.observability;
 
           useEffect(() => {
             return () => {

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
@@ -29,7 +29,7 @@ import {
   GroupSloCustomInput,
 } from './types';
 import { EDIT_SLO_OVERVIEW_ACTION } from '../../../ui_actions/edit_slo_overview_panel';
-import { SloOverviewEmbeddableContext } from '../common/overview_embeddable_context';
+import { SloEmbeddableContext } from '../common/slo_embeddable_context';
 
 export const getOverviewPanelTitle = () =>
   i18n.translate('xpack.slo.sloEmbeddable.displayName', {
@@ -182,9 +182,9 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
             }
           };
           return (
-            <SloOverviewEmbeddableContext deps={deps}>
+            <SloEmbeddableContext deps={deps}>
               {showAllGroupByInstances ? <SloCardChartList sloId={sloId!} /> : renderOverview()}
-            </SloOverviewEmbeddableContext>
+            </SloEmbeddableContext>
           );
         },
       };

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
@@ -9,7 +9,6 @@ import { i18n } from '@kbn/i18n';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { EuiFlexItem, EuiLink, EuiFlexGroup } from '@elastic/eui';
-import { Router } from '@kbn/shared-ux-router';
 import { ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import {
   initializeTitles,
@@ -17,10 +16,6 @@ import {
   fetch$,
 } from '@kbn/presentation-publishing';
 import { BehaviorSubject, Subject } from 'rxjs';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
-import { createBrowserHistory } from 'history';
 import { CONTEXT_MENU_TRIGGER } from '@kbn/embeddable-plugin/public';
 import { ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import { SLO_OVERVIEW_EMBEDDABLE_ID } from './constants';
@@ -34,9 +29,8 @@ import {
   GroupSloCustomInput,
 } from './types';
 import { EDIT_SLO_OVERVIEW_ACTION } from '../../../ui_actions/edit_slo_overview_panel';
-import { OverviewEmbeddableContext } from '../../../context/plugin_context';
+import { SloOverviewEmbeddableContext } from '../common/overview_embeddable_context';
 
-const queryClient = new QueryClient();
 export const getOverviewPanelTitle = () =>
   i18n.translate('xpack.slo.sloEmbeddable.displayName', {
     defaultMessage: 'SLO Overview',
@@ -188,21 +182,9 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
             }
           };
           return (
-            <Router history={createBrowserHistory()}>
-              <EuiThemeProvider darkMode={true}>
-                <KibanaContextProvider services={deps}>
-                  <OverviewEmbeddableContext.Provider value={{ observabilityRuleTypeRegistry }}>
-                    <QueryClientProvider client={queryClient}>
-                      {showAllGroupByInstances ? (
-                        <SloCardChartList sloId={sloId!} />
-                      ) : (
-                        renderOverview()
-                      )}
-                    </QueryClientProvider>
-                  </OverviewEmbeddableContext.Provider>
-                </KibanaContextProvider>
-              </EuiThemeProvider>
-            </Router>
+            <SloOverviewEmbeddableContext deps={deps}>
+              {showAllGroupByInstances ? <SloCardChartList sloId={sloId!} /> : renderOverview()}
+            </SloOverviewEmbeddableContext>
           );
         },
       };

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
@@ -34,7 +34,7 @@ import {
   GroupSloCustomInput,
 } from './types';
 import { EDIT_SLO_OVERVIEW_ACTION } from '../../../ui_actions/edit_slo_overview_panel';
-import { PluginContext } from '../../../context/plugin_context';
+import { OverviewEmbeddableContext } from '../../../context/plugin_context';
 
 const queryClient = new QueryClient();
 export const getOverviewPanelTitle = () =>
@@ -191,7 +191,7 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
             <Router history={createBrowserHistory()}>
               <EuiThemeProvider darkMode={true}>
                 <KibanaContextProvider services={deps}>
-                  <PluginContext.Provider value={{ observabilityRuleTypeRegistry }}>
+                  <OverviewEmbeddableContext.Provider value={{ observabilityRuleTypeRegistry }}>
                     <QueryClientProvider client={queryClient}>
                       {showAllGroupByInstances ? (
                         <SloCardChartList sloId={sloId!} />
@@ -199,7 +199,7 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
                         renderOverview()
                       )}
                     </QueryClientProvider>
-                  </PluginContext.Provider>
+                  </OverviewEmbeddableContext.Provider>
                 </KibanaContextProvider>
               </EuiThemeProvider>
             </Router>

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
@@ -34,7 +34,7 @@ import {
   GroupSloCustomInput,
 } from './types';
 import { EDIT_SLO_OVERVIEW_ACTION } from '../../../ui_actions/edit_slo_overview_panel';
-import { OverviewEmbeddableContext } from '../../../context/plugin_context';
+import { PluginContext } from '../../../context/plugin_context';
 
 const queryClient = new QueryClient();
 export const getOverviewPanelTitle = () =>
@@ -191,7 +191,7 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
             <Router history={createBrowserHistory()}>
               <EuiThemeProvider darkMode={true}>
                 <KibanaContextProvider services={deps}>
-                  <OverviewEmbeddableContext.Provider value={{ observabilityRuleTypeRegistry }}>
+                  <PluginContext.Provider value={{ observabilityRuleTypeRegistry }}>
                     <QueryClientProvider client={queryClient}>
                       {showAllGroupByInstances ? (
                         <SloCardChartList sloId={sloId!} />
@@ -199,7 +199,7 @@ export const getOverviewEmbeddableFactory = (deps: SloEmbeddableDeps) => {
                         renderOverview()
                       )}
                     </QueryClientProvider>
-                  </OverviewEmbeddableContext.Provider>
+                  </PluginContext.Provider>
                 </KibanaContextProvider>
               </EuiThemeProvider>
             </Router>

--- a/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/types.ts
+++ b/x-pack/plugins/observability_solution/slo/public/embeddable/slo/overview/types.ts
@@ -20,6 +20,7 @@ import {
 } from '@kbn/core/public';
 import { ObservabilityPublicStart } from '@kbn/observability-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import { ObservabilitySharedPluginStart } from '@kbn/observability-shared-plugin/public';
 
 export type OverviewMode = 'single' | 'groups';
 export type GroupBy = 'slo.tags' | 'status' | 'slo.indicator.type';
@@ -77,6 +78,7 @@ export interface SloEmbeddableDeps {
   application: ApplicationStart;
   notifications: NotificationsStart;
   observability: ObservabilityPublicStart;
+  observabilityShared: ObservabilitySharedPluginStart;
   uiActions: UiActionsStart;
 }
 

--- a/x-pack/plugins/observability_solution/slo/public/hooks/use_get_filtered_rule_types.ts
+++ b/x-pack/plugins/observability_solution/slo/public/hooks/use_get_filtered_rule_types.ts
@@ -7,16 +7,10 @@
 
 import { useMemo } from 'react';
 import { ES_QUERY_ID, ML_ANOMALY_DETECTION_RULE_TYPE_ID } from '@kbn/rule-data-utils';
-import { useKibana } from '../utils/kibana_react';
-import { useOverviewEmbeddableContext, usePluginContext } from './use_plugin_context';
+import { usePluginContext } from './use_plugin_context';
 
 export function useGetFilteredRuleTypes() {
-  const { executionContext } = useKibana().services;
-  const executionContextName = executionContext.get().name;
-
-  const { observabilityRuleTypeRegistry } =
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    executionContextName === 'dashboards' ? useOverviewEmbeddableContext() : usePluginContext();
+  const { observabilityRuleTypeRegistry } = usePluginContext();
 
   return useMemo(() => {
     return [

--- a/x-pack/plugins/observability_solution/slo/public/hooks/use_get_filtered_rule_types.ts
+++ b/x-pack/plugins/observability_solution/slo/public/hooks/use_get_filtered_rule_types.ts
@@ -7,10 +7,16 @@
 
 import { useMemo } from 'react';
 import { ES_QUERY_ID, ML_ANOMALY_DETECTION_RULE_TYPE_ID } from '@kbn/rule-data-utils';
-import { usePluginContext } from './use_plugin_context';
+import { useKibana } from '../utils/kibana_react';
+import { useOverviewEmbeddableContext, usePluginContext } from './use_plugin_context';
 
 export function useGetFilteredRuleTypes() {
-  const { observabilityRuleTypeRegistry } = usePluginContext();
+  const { executionContext } = useKibana().services;
+  const executionContextName = executionContext.get().name;
+
+  const { observabilityRuleTypeRegistry } =
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    executionContextName === 'dashboards' ? useOverviewEmbeddableContext() : usePluginContext();
 
   return useMemo(() => {
     return [

--- a/x-pack/plugins/observability_solution/slo/public/hooks/use_plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/hooks/use_plugin_context.tsx
@@ -6,22 +6,13 @@
  */
 
 import { useContext } from 'react';
-import { PluginContext, OverviewEmbeddableContext } from '../context/plugin_context';
-import type { PluginContextValue, OverviewEmbeddableContextValue } from '../context/plugin_context';
+import { PluginContext } from '../context/plugin_context';
+import type { PluginContextValue } from '../context/plugin_context';
 
 export function usePluginContext(): PluginContextValue {
   const context = useContext(PluginContext);
   if (!context) {
     throw new Error('Plugin context value is missing!');
-  }
-
-  return context;
-}
-
-export function useOverviewEmbeddableContext(): OverviewEmbeddableContextValue {
-  const context = useContext(OverviewEmbeddableContext);
-  if (!context) {
-    throw new Error('Overview Embeddable context value is missing!');
   }
 
   return context;

--- a/x-pack/plugins/observability_solution/slo/public/hooks/use_plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/hooks/use_plugin_context.tsx
@@ -6,9 +6,23 @@
  */
 
 import { useContext } from 'react';
-import { PluginContext } from '../context/plugin_context';
-import type { PluginContextValue } from '../context/plugin_context';
+import { PluginContext, OverviewEmbeddableContext } from '../context/plugin_context';
+import type { PluginContextValue, OverviewEmbeddableContextValue } from '../context/plugin_context';
 
-export function usePluginContext() {
-  return useContext(PluginContext) as PluginContextValue;
+export function usePluginContext(): PluginContextValue {
+  const context = useContext(PluginContext);
+  if (!context) {
+    throw new Error('Plugin context value is missing!');
+  }
+
+  return context;
+}
+
+export function useOverviewEmbeddableContext(): OverviewEmbeddableContextValue {
+  const context = useContext(OverviewEmbeddableContext);
+  if (!context) {
+    throw new Error('Overview Embeddable context value is missing!');
+  }
+
+  return context;
 }

--- a/x-pack/plugins/observability_solution/slo/public/hooks/use_plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/hooks/use_plugin_context.tsx
@@ -9,11 +9,6 @@ import { useContext } from 'react';
 import { PluginContext } from '../context/plugin_context';
 import type { PluginContextValue } from '../context/plugin_context';
 
-export function usePluginContext(): PluginContextValue {
-  const context = useContext(PluginContext);
-  if (!context) {
-    throw new Error('Plugin context value is missing!');
-  }
-
-  return context;
+export function usePluginContext() {
+  return useContext(PluginContext) as PluginContextValue;
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/183967

This PR reverts the changes introduced in this [PR](https://github.com/elastic/kibana/pull/182195) regarding SLO Plugin context.

## Before

Notice how the embeddable breaks when user clicks on the group accordion in order to expand it.

https://github.com/elastic/kibana/assets/2852703/0a688af9-10a6-4656-87c1-2d9e189b7a5a

## After
This is the fixed version, where clicking on the group shows the respective SLOs

https://github.com/elastic/kibana/assets/2852703/132fbcea-e058-4730-ad2f-8e618a71f36c

