### PR TITLE
[Search] Remove connector label from delete modal

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/connectors/connectors_table.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors/connectors_table.tsx
@@ -38,7 +38,6 @@ import React, { useEffect, useState } from 'react';
 import { generatePath } from 'react-router-dom';
 import {
   CONNECTORS_LABEL,
-  CONNECTOR_LABEL,
   COPY_CONNECTOR_ID_LABEL,
   DELETE_CONNECTOR_LABEL,
 } from '../../../../common/i18n_string';
@@ -297,7 +296,7 @@ const DeleteConnectorModalAction: React.FC<{ connector: Connector }> = ({ connec
         <DeleteConnectorModal
           closeDeleteModal={() => setModalIsOpen(false)}
           connectorId={connector.id}
-          connectorName={connector.name || CONNECTOR_LABEL}
+          connectorName={connector.name}
         />
       )}
       <EuiToolTip content={DELETE_CONNECTOR_LABEL}>

--- a/x-pack/plugins/serverless_search/public/application/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors/delete_connector_modal.tsx
@@ -19,6 +19,10 @@ interface DeleteConnectorModalProps {
   onSuccess?: () => void;
 }
 
+const DELETE_LABEL = i18n.translate('xpack.serverlessSearch.connectors.deleteModal.deleteLabel', {
+  defaultMessage: 'DELETE',
+});
+
 export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({
   connectorId,
   connectorName,
@@ -50,7 +54,7 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({
     <EuiConfirmModal
       title={i18n.translate('xpack.serverlessSearch.connectors.deleteModal.title', {
         defaultMessage: 'Are you sure you want to delete connector {connectorName}',
-        values: { connectorName },
+        values: { connectorName: connectorName || connectorId },
       })}
       onCancel={() => {
         closeDeleteModal();
@@ -70,12 +74,12 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({
       confirmButtonText={i18n.translate(
         'xpack.serverlessSearch.connectors.deleteModal.confirmButton.title',
         {
-          defaultMessage: 'Delete index',
+          defaultMessage: 'Delete connector',
         }
       )}
       defaultFocusedButton="confirm"
       buttonColor="danger"
-      confirmButtonDisabled={inputConnectorName.trim() !== connectorName}
+      confirmButtonDisabled={inputConnectorName.trim() !== (connectorName || DELETE_LABEL)}
       isLoading={isLoading}
     >
       <p>
@@ -83,7 +87,7 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({
           'xpack.serverlessSearch.connectors.deleteModal.syncsWarning.connectorNameDescription',
           {
             defaultMessage: 'This action cannot be undone. Please type {connectorName} to confirm.',
-            values: { connectorName },
+            values: { connectorName: connectorName || DELETE_LABEL },
           }
         )}
       </p>

--- a/x-pack/plugins/serverless_search/public/application/components/connectors/edit_connector.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors/edit_connector.tsx
@@ -103,7 +103,7 @@ export const EditConnector: React.FC = () => {
               <DeleteConnectorModal
                 closeDeleteModal={() => setDeleteModalIsOpen(false)}
                 connectorId={connector.id}
-                connectorName={connector.name || CONNECTOR_LABEL}
+                connectorName={connector.name}
                 onSuccess={() => navigateToUrl('./')}
               />
             )}

--- a/x-pack/plugins/serverless_search/public/application/components/connectors_overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors_overview.tsx
@@ -44,7 +44,7 @@ export const ConnectorsOverview = () => {
         data-test-subj="serverlessSearchConnectorsTitle"
         restrictWidth
         rightSideItems={[
-          <EuiFlexGroup direction="row" alignItems="flexStart">
+          <EuiFlexGroup direction="row" alignItems="flexStart" justifyContent="center">
             <EuiFlexItem>
               <EuiFlexGroup
                 alignItems="center"


### PR DESCRIPTION
## Summary

Fixes an issue with the delete connector modal that was asking for the text Connector, which doesn't make a lot of sense.