### PR TITLE
fix: explicitly enable native role mappings for Mock IDP

### DIFF
--- a/packages/kbn-es/src/utils/docker.test.ts
+++ b/packages/kbn-es/src/utils/docker.test.ts
@@ -438,7 +438,6 @@ describe('resolveEsArgs()', () => {
       kibanaUrl: 'https://localhost:5601/',
     });
 
-    expect(esArgs).toHaveLength(26);
     expect(esArgs).toMatchInlineSnapshot(`
       Array [
         "--env",
@@ -447,6 +446,8 @@ describe('resolveEsArgs()', () => {
         "xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/certs/elasticsearch.p12",
         "--env",
         "xpack.security.http.ssl.verification_mode=certificate",
+        "--env",
+        "xpack.security.authc.native_role_mappings.enabled=true",
         "--env",
         "xpack.security.authc.realms.saml.cloud-saml-kibana.order=0",
         "--env",
@@ -477,7 +478,6 @@ describe('resolveEsArgs()', () => {
       kibanaUrl: 'https://localhost:5601/',
     });
 
-    expect(esArgs).toHaveLength(8);
     expect(esArgs).toMatchInlineSnapshot(`
       Array [
         "--env",

--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -486,6 +486,10 @@ export function resolveEsArgs(
   ) {
     const trimTrailingSlash = (url: string) => (url.endsWith('/') ? url.slice(0, -1) : url);
 
+    // The mock IDP setup requires a custom role mapping, but since native role mappings are disabled by default in
+    // Serverless, we have to re-enable them explicitly here.
+    esArgs.set('xpack.security.authc.native_role_mappings.enabled', 'true');
+
     esArgs.set(`xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.order`, '0');
     esArgs.set(
       `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.idp.metadata.path`,


### PR DESCRIPTION
## Summary

The most recent versions of the Serverless Elasticsearch disable native role mappings by default and this conflicts with the Mock IDP package/plugin that we use for local development and tests. To unblock ES snapshot promotion I explicitly enable native role mappings for Mock IDP only, but eventually we should consider switching to a file-based role mapping (`config/operator/settings.json`, I didn't manage to make it work in a reasonable amount of time).

```bash
$ cat config/operator/settings.json
{
  "metadata": {
    "version": "%s",
    "compatibility": "8.4.0"
  },
  "state": {
    "role_mappings": {
      "mock-idp-mapping": {
        "enabled": true,
        "role_templates": [
          {
            "format": "json",
            "template": "{\"source\":\"{{#tojson}}groups{{/tojson}}\"}"
          }
        ],
        "rules": {
          "all": [
            {
              "field": {
                "realm.name": "cloud-saml-kibana"
              }
            }
          ]
        }
      }
    }
  }
}
```

/cc @albertzaharovits 