### PR TITLE
[Cloud Security][Quick Wins] Fixing Overflow on CIS widget

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -160,7 +160,7 @@ export const SummarySection = ({
       gutterSize="l"
       css={css`
         // height for compliance by cis section with max rows
-        height: 310px;
+        height: 350px;
       `}
       data-test-subj={DASHBOARD_SUMMARY_CONTAINER}
     >


### PR DESCRIPTION
## Summary
Part of Quick Wins, fix for issue where CIS widget collides/overflow with next widget's outline stroke
<img width="1443" alt="Screenshot 2024-05-22 at 9 30 45 AM" src="https://github.com/elastic/kibana/assets/8703149/06a54012-6f49-4383-b360-8f00ce79e8ba">



