### PR TITLE
[CI] Add missing slack notification channels

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -20,6 +20,7 @@ spec:
     spec:
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
       allow_rebuilds: true
       branch_configuration: main 8.14 7.17
       default_branch: main

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -21,6 +21,7 @@ spec:
       env:
         RELEASE_BUILD: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
       allow_rebuilds: true
       branch_configuration: 7.17 8.14
       repository: elastic/kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
@@ -21,6 +21,7 @@ spec:
       env:
         RELEASE_BUILD: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
       allow_rebuilds: true
       branch_configuration: '8.14'
       default_branch: main

--- a/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
@@ -20,6 +20,7 @@ spec:
     spec:
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'false'
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
       allow_rebuilds: false
       branch_configuration: main
       default_branch: main


### PR DESCRIPTION
## Summary
Some jobs were missing the notification channel, despite having originally had notifications turned on.
This PR adds  `SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'` here.