### PR TITLE
[Semantic Text UI] Banner dismissal is not persisted after a page reload

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/semantic_text_bannner.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/semantic_text_bannner.test.tsx
@@ -10,13 +10,31 @@ import { act } from 'react-dom/test-utils';
 import { SemanticTextBanner } from '../../../public/application/sections/home/index_list/details_page/semantic_text_banner';
 
 describe('When semantic_text is enabled', () => {
-  const setup = registerTestBed(SemanticTextBanner, {
-    defaultProps: { isSemanticTextEnabled: true },
-    memoryRouter: { wrapComponent: false },
+  let exists: any;
+  let find: any;
+  let wrapper: any;
+  let getItemSpy: jest.SpyInstance;
+  let setItemSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+    setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+    const setup = registerTestBed(SemanticTextBanner, {
+      defaultProps: { isSemanticTextEnabled: true },
+      memoryRouter: { wrapComponent: false },
+    });
+    const testBed = setup();
+    ({ exists, find } = testBed);
+    wrapper = testBed.component;
   });
-  const { exists, find } = setup();
+
+  afterEach(() => {
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
+  });
 
   it('should display the banner', () => {
+    expect(getItemSpy).toHaveBeenCalledWith('semantic-text-banner-display');
     expect(exists('indexDetailsMappingsSemanticTextBanner')).toBe(true);
   });
 
@@ -30,7 +48,11 @@ describe('When semantic_text is enabled', () => {
     await act(async () => {
       find('SemanticTextBannerDismissButton').simulate('click');
     });
-    expect(exists('indexDetailsMappingsSemanticTextBanner')).toBe(true);
+
+    wrapper.update();
+
+    expect(setItemSpy).toHaveBeenCalledWith('semantic-text-banner-display', 'false');
+    expect(exists('indexDetailsMappingsSemanticTextBanner')).toBe(false);
   });
 });
 

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/semantic_text_banner.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/semantic_text_banner.tsx
@@ -6,7 +6,8 @@
  */
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useState } from 'react';
+import React from 'react';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 interface SemanticTextBannerProps {
   isSemanticTextEnabled: boolean;
@@ -14,7 +15,8 @@ interface SemanticTextBannerProps {
 
 export function SemanticTextBanner({ isSemanticTextEnabled }: SemanticTextBannerProps) {
   const [isSemanticTextBannerDisplayable, setIsSemanticTextBannerDisplayable] =
-    useState<boolean>(true);
+    useLocalStorage<boolean>('semantic-text-banner-display', true);
+
   return isSemanticTextBannerDisplayable && isSemanticTextEnabled ? (
     <>
       <EuiPanel color="success" data-test-subj="indexDetailsMappingsSemanticTextBanner">


### PR DESCRIPTION
The banner is displayed even after a semantic field is added and the dismissal is not persisted after a page reload.

### After Change

https://github.com/elastic/kibana/assets/132922331/41c3b755-aeaa-45b5-88f0-c8286756d990

### How to enable semantic text locally for testing these changes
Set isSemanticTextEnabled = true in this [location](https://github.com/elastic/kibana/blob/3890189eee10555e67514ea8a3e9ca03b07eb887/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx#L72)

