### PR TITLE
[Onboarding] Change navigation behavior for the o11y guide cards to pre-select the correct solution

### DIFF
--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_cards.constants.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_cards.constants.tsx
@@ -117,6 +117,7 @@ export const guideCards: GuideCardConstants[] = [
     }),
     navigateTo: {
       appId: 'observabilityOnboarding',
+      path: '/?category=logs',
     },
     telemetryId: 'onboarding--observability--logs',
     order: 2,
@@ -147,8 +148,8 @@ export const guideCards: GuideCardConstants[] = [
       defaultMessage: 'Monitor my host metrics',
     }),
     navigateTo: {
-      appId: 'integrations',
-      path: '/browse/os_system',
+      appId: 'observabilityOnboarding',
+      path: '/?category=infra',
     },
     telemetryId: 'onboarding--observability--hosts',
     order: 8,


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/observability-dev/issues/3342.

This patch will change the link behavior to pre-select the correct solution for logs and metrics from the onboarding cards.

## Testing note

To reveal this view locally, you need to specify a cloud ID in kibana's config file, example:

```
xpack.cloud.id: 'testID'
```