### PR TITLE
[8.14] [HTTP] Make `alerting` APIs public (#183945)

### DIFF
--- a/x-pack/plugins/alerting/server/routes/delete_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/delete_rule.ts
@@ -22,6 +22,10 @@ export const deleteRuleRoute = (
   router.delete(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}`,
+      options: {
+        access: 'public',
+        description: `Delete a rule`,
+      },
       validate: {
         params: paramSchema,
       },

--- a/x-pack/plugins/alerting/server/routes/disable_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/disable_rule.ts
@@ -30,6 +30,10 @@ export const disableRuleRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}/_disable`,
+      options: {
+        access: 'public',
+        description: `Disable a rule`,
+      },
       validate: {
         params: paramSchema,
         body: bodySchema,

--- a/x-pack/plugins/alerting/server/routes/enable_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/enable_rule.ts
@@ -22,6 +22,10 @@ export const enableRuleRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}/_enable`,
+      options: {
+        access: 'public',
+        description: `Enable a rule`,
+      },
       validate: {
         params: paramSchema,
       },

--- a/x-pack/plugins/alerting/server/routes/find_rules.ts
+++ b/x-pack/plugins/alerting/server/routes/find_rules.ts
@@ -90,6 +90,10 @@ const buildFindRulesRoute = ({
   router.get(
     {
       path,
+      options: {
+        access: 'public',
+        description: `Get rules`,
+      },
       validate: {
         query: querySchema,
       },

--- a/x-pack/plugins/alerting/server/routes/get_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/get_rule.ts
@@ -7,7 +7,7 @@
 
 import { omit } from 'lodash';
 import { schema } from '@kbn/config-schema';
-import { IRouter } from '@kbn/core/server';
+import { IRouter, RouteConfigOptions, RouteMethod } from '@kbn/core/server';
 import { ILicenseState } from '../lib';
 import { verifyAccessAndContext, rewriteRuleLastRun } from './lib';
 import {
@@ -75,16 +75,19 @@ interface BuildGetRulesRouteParams {
   path: string;
   router: IRouter<AlertingRequestHandlerContext>;
   excludeFromPublicApi?: boolean;
+  options?: RouteConfigOptions<RouteMethod>;
 }
 const buildGetRuleRoute = ({
   licenseState,
   path,
   router,
   excludeFromPublicApi = false,
+  options,
 }: BuildGetRulesRouteParams) => {
   router.get(
     {
       path,
+      options,
       validate: {
         params: paramSchema,
       },
@@ -115,6 +118,10 @@ export const getRuleRoute = (
     licenseState,
     path: `${BASE_ALERTING_API_PATH}/rule/{id}`,
     router,
+    options: {
+      access: 'public',
+      description: `Get rule details`,
+    },
   });
 
 export const getInternalRuleRoute = (

--- a/x-pack/plugins/alerting/server/routes/health.ts
+++ b/x-pack/plugins/alerting/server/routes/health.ts
@@ -40,6 +40,10 @@ export const healthRoute = (
   router.get(
     {
       path: `${BASE_ALERTING_API_PATH}/_health`,
+      options: {
+        access: 'public',
+        description: `Get the health of the alerting framework`,
+      },
       validate: false,
     },
     router.handleLegacyErrors(

--- a/x-pack/plugins/alerting/server/routes/mute_all_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/mute_all_rule.ts
@@ -25,6 +25,10 @@ export const muteAllRuleRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}/_mute_all`,
+      options: {
+        access: 'public',
+        description: `Mute all alerts`,
+      },
       validate: {
         params: paramSchema,
       },

--- a/x-pack/plugins/alerting/server/routes/rule/apis/create/create_rule_route.ts
+++ b/x-pack/plugins/alerting/server/routes/rule/apis/create/create_rule_route.ts
@@ -32,6 +32,10 @@ export const createRuleRoute = ({ router, licenseState, usageCounter }: RouteOpt
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id?}`,
+      options: {
+        access: 'public',
+        description: `Create a rule`,
+      },
       validate: {
         body: createBodySchemaV1,
         params: createParamsSchemaV1,

--- a/x-pack/plugins/alerting/server/routes/rule/apis/mute_alert/mute_alert.ts
+++ b/x-pack/plugins/alerting/server/routes/rule/apis/mute_alert/mute_alert.ts
@@ -21,6 +21,10 @@ export const muteAlertRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{rule_id}/alert/{alert_id}/_mute`,
+      options: {
+        access: 'public',
+        description: `Mute an alert`,
+      },
       validate: {
         params: muteAlertParamsSchemaV1,
       },

--- a/x-pack/plugins/alerting/server/routes/rule/apis/update/update_rule_route.ts
+++ b/x-pack/plugins/alerting/server/routes/rule/apis/update/update_rule_route.ts
@@ -31,6 +31,10 @@ export const updateRuleRoute = (
   router.put(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}`,
+      options: {
+        access: 'public',
+        description: `Update a rule`,
+      },
       validate: {
         body: updateBodySchemaV1,
         params: updateParamsSchemaV1,

--- a/x-pack/plugins/alerting/server/routes/rule_types.ts
+++ b/x-pack/plugins/alerting/server/routes/rule_types.ts
@@ -55,6 +55,10 @@ export const ruleTypesRoute = (
   router.get(
     {
       path: `${BASE_ALERTING_API_PATH}/rule_types`,
+      options: {
+        access: 'public',
+        description: `Get rule types`,
+      },
       validate: {},
     },
     router.handleLegacyErrors(

--- a/x-pack/plugins/alerting/server/routes/unmute_alert.ts
+++ b/x-pack/plugins/alerting/server/routes/unmute_alert.ts
@@ -32,6 +32,10 @@ export const unmuteAlertRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{rule_id}/alert/{alert_id}/_unmute`,
+      options: {
+        access: 'public',
+        description: `Unmute an alert`,
+      },
       validate: {
         params: paramSchema,
       },

--- a/x-pack/plugins/alerting/server/routes/unmute_all_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/unmute_all_rule.ts
@@ -22,6 +22,10 @@ export const unmuteAllRuleRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}/_unmute_all`,
+      options: {
+        access: 'public',
+        description: `Unmute all alerts`,
+      },
       validate: {
         params: paramSchema,
       },

--- a/x-pack/plugins/alerting/server/routes/update_rule_api_key.ts
+++ b/x-pack/plugins/alerting/server/routes/update_rule_api_key.ts
@@ -22,6 +22,10 @@ export const updateRuleApiKeyRoute = (
   router.post(
     {
       path: `${BASE_ALERTING_API_PATH}/rule/{id}/_update_api_key`,
+      options: {
+        access: 'public',
+        description: `Update the API key for a rule`,
+      },
       validate: {
         params: paramSchema,
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[HTTP] Make `alerting` APIs public (#183945)](https://github.com/elastic/kibana/pull/183945)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2024-05-22T14:30:51Z","message":"[HTTP] Make `alerting` APIs public (#183945)","sha":"f0aef3d3aeec655a4bd4c00cb1ca70c767e9129e","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","docs","v8.14.0","v8.15.0"],"number":183945,"url":"https://github.com/elastic/kibana/pull/183945","mergeCommit":{"message":"[HTTP] Make `alerting` APIs public (#183945)","sha":"f0aef3d3aeec655a4bd4c00cb1ca70c767e9129e"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183945","number":183945,"mergeCommit":{"message":"[HTTP] Make `alerting` APIs public (#183945)","sha":"f0aef3d3aeec655a4bd4c00cb1ca70c767e9129e"}}]}] BACKPORT-->