### PR TITLE
[Discover] Fix the pinned state when the field has a custom label

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -174,7 +174,7 @@ export const DocViewerTable = ({
   );
 
   const fieldToItem = useCallback(
-    (field: string) => {
+    (field: string, isPinned: boolean) => {
       const fieldMapping = mapping(field);
       const displayName = fieldMapping?.displayName ?? field;
       const columnMeta = columnsMeta?.[field];
@@ -202,7 +202,7 @@ export const DocViewerTable = ({
           fieldMapping,
           fieldType,
           scripted: Boolean(fieldMapping?.scripted),
-          pinned: pinnedFields.includes(displayName),
+          pinned: isPinned,
           onTogglePinned,
         },
         value: {
@@ -226,7 +226,6 @@ export const DocViewerTable = ({
       columns,
       columnsMeta,
       flattened,
-      pinnedFields,
       onTogglePinned,
       fieldFormats,
     ]
@@ -256,7 +255,7 @@ export const DocViewerTable = ({
         }
 
         if (pinnedFields.includes(curFieldName)) {
-          acc.pinnedItems.push(fieldToItem(curFieldName));
+          acc.pinnedItems.push(fieldToItem(curFieldName, true));
         } else {
           const fieldMapping = mapping(curFieldName);
           if (
@@ -267,7 +266,7 @@ export const DocViewerTable = ({
             )
           ) {
             // filter only unpinned fields
-            acc.restItems.push(fieldToItem(curFieldName));
+            acc.restItems.push(fieldToItem(curFieldName, false));
           }
         }
 


### PR DESCRIPTION
- As reported in https://github.com/elastic/kibana/pull/175787#pullrequestreview-2073603505

## Summary

This PR fixes how the pinned state is rendered in DocViewer for fields with custom labels.

Before:
<img width="872" alt="Screenshot 2024-05-23 at 13 49 00" src="https://github.com/elastic/kibana/assets/1415710/54216c1c-8ac0-4cc8-8d2c-7ac55a763ef4">


After:
<img width="915" alt="Screenshot 2024-05-23 at 13 47 46" src="https://github.com/elastic/kibana/assets/1415710/76aa4265-a738-466d-945a-37d17281935d">





<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->