### PR TITLE
[Fleet] Show in UI warning which data streams require root

### DIFF
--- a/x-pack/plugins/fleet/common/services/package_helpers.test.ts
+++ b/x-pack/plugins/fleet/common/services/package_helpers.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { getRootIntegrations, isRootPrivilegesRequired } from './package_helpers';
+import {
+  getRootIntegrations,
+  getRootPrivilegedDataStreams,
+  isRootPrivilegesRequired,
+} from './package_helpers';
 
 describe('isRootPrivilegesRequired', () => {
   it('should return true if root privileges is required at root level', () => {
@@ -36,6 +40,42 @@ describe('isRootPrivilegesRequired', () => {
       data_streams: [],
     } as any);
     expect(res).toBe(false);
+  });
+});
+
+describe('getRootPrivilegedDataStreams', () => {
+  it('should return empty datastreams if root privileges is required at root level', () => {
+    const res = getRootPrivilegedDataStreams({
+      agent: {
+        privileges: {
+          root: true,
+        },
+      },
+    } as any);
+    expect(res).toEqual([]);
+  });
+  it('should return datastreams if root privileges is required at datastreams', () => {
+    const res = getRootPrivilegedDataStreams({
+      data_streams: [
+        {
+          name: 'syslog',
+          title: 'System syslog logs',
+          agent: {
+            privileges: { root: true },
+          },
+        },
+        {
+          name: 'sysauth',
+          title: 'System auth logs',
+        },
+      ],
+    } as any);
+    expect(res).toEqual([
+      {
+        name: 'syslog',
+        title: 'System syslog logs',
+      },
+    ]);
   });
 });
 

--- a/x-pack/plugins/fleet/common/services/package_helpers.ts
+++ b/x-pack/plugins/fleet/common/services/package_helpers.ts
@@ -19,6 +19,19 @@ export function isRootPrivilegesRequired(packageInfo: PackageInfo) {
   );
 }
 
+export function getRootPrivilegedDataStreams(
+  packageInfo: PackageInfo
+): Array<{ name: string; title: string }> {
+  if (packageInfo.agent?.privileges?.root) {
+    return [];
+  }
+  return (
+    packageInfo.data_streams
+      ?.filter((d) => d.agent?.privileges?.root)
+      .map((ds) => ({ name: ds.name, title: ds.title })) ?? []
+  );
+}
+
 export function getRootIntegrations(
   packagePolicies: PackagePolicy[]
 ): Array<{ name: string; title: string }> {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/confirm_deploy_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/confirm_deploy_modal.tsx
@@ -20,6 +20,7 @@ export const ConfirmDeployAgentPolicyModal: React.FunctionComponent<{
   agentPolicy: AgentPolicy;
   showUnprivilegedAgentsCallout?: boolean;
   unprivilegedAgentsCount?: number;
+  dataStreams?: Array<{ name: string; title: string }>;
 }> = ({
   onConfirm,
   onCancel,
@@ -27,6 +28,7 @@ export const ConfirmDeployAgentPolicyModal: React.FunctionComponent<{
   agentPolicy,
   showUnprivilegedAgentsCallout = false,
   unprivilegedAgentsCount = 0,
+  dataStreams,
 }) => {
   return (
     <EuiConfirmModal
@@ -80,6 +82,7 @@ export const ConfirmDeployAgentPolicyModal: React.FunctionComponent<{
           <UnprivilegedAgentsCallout
             agentPolicyName={agentPolicy.name}
             unprivilegedAgentsCount={unprivilegedAgentsCount}
+            dataStreams={dataStreams ?? []}
           />
         </>
       )}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/confirm_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/confirm_modal.tsx
@@ -15,6 +15,7 @@ export interface UnprivilegedConfirmModalProps {
   onCancel: () => void;
   agentPolicyName: string;
   unprivilegedAgentsCount: number;
+  dataStreams: Array<{ name: string; title: string }>;
 }
 
 export const UnprivilegedConfirmModal: React.FC<UnprivilegedConfirmModalProps> = ({
@@ -22,6 +23,7 @@ export const UnprivilegedConfirmModal: React.FC<UnprivilegedConfirmModalProps> =
   onCancel,
   agentPolicyName,
   unprivilegedAgentsCount,
+  dataStreams,
 }: UnprivilegedConfirmModalProps) => {
   return (
     <EuiConfirmModal
@@ -50,6 +52,7 @@ export const UnprivilegedConfirmModal: React.FC<UnprivilegedConfirmModalProps> =
       <UnprivilegedAgentsCallout
         unprivilegedAgentsCount={unprivilegedAgentsCount}
         agentPolicyName={agentPolicyName}
+        dataStreams={dataStreams}
       />
     </EuiConfirmModal>
   );
@@ -58,7 +61,8 @@ export const UnprivilegedConfirmModal: React.FC<UnprivilegedConfirmModalProps> =
 export const UnprivilegedAgentsCallout: React.FC<{
   agentPolicyName: string;
   unprivilegedAgentsCount: number;
-}> = ({ agentPolicyName, unprivilegedAgentsCount }) => {
+  dataStreams: Array<{ name: string; title: string }>;
+}> = ({ agentPolicyName, unprivilegedAgentsCount, dataStreams }) => {
   return (
     <EuiCallOut
       color="warning"
@@ -68,14 +72,32 @@ export const UnprivilegedAgentsCallout: React.FC<{
       })}
       data-test-subj="unprivilegedAgentsCallout"
     >
-      <FormattedMessage
-        id="xpack.fleet.addIntegration.confirmModal.unprivilegedAgentsMessage"
-        defaultMessage="This integration requires Elastic Agents to have root privileges. There {unprivilegedAgentsCount, plural, one {is # agent} other {are # agents}} running in an unprivileged mode using {agentPolicyName}. To ensure that all data required by the integration can be collected, re-enroll the {unprivilegedAgentsCount, plural, one {agent} other {agents}} using an account with root privileges."
-        values={{
-          unprivilegedAgentsCount,
-          agentPolicyName,
-        }}
-      />
+      {dataStreams.length === 0 ? (
+        <FormattedMessage
+          id="xpack.fleet.addIntegration.confirmModal.unprivilegedAgentsMessage"
+          defaultMessage="This integration requires Elastic Agents to have root privileges. There {unprivilegedAgentsCount, plural, one {is # agent} other {are # agents}} running in an unprivileged mode using {agentPolicyName}. To ensure that all data required by the integration can be collected, re-enroll the {unprivilegedAgentsCount, plural, one {agent} other {agents}} using an account with root privileges."
+          values={{
+            unprivilegedAgentsCount,
+            agentPolicyName,
+          }}
+        />
+      ) : (
+        <>
+          <FormattedMessage
+            id="xpack.fleet.addIntegration.confirmModal.unprivilegedAgentsDataStreamsMessage"
+            defaultMessage="This integration has the following data streams that require Elastic Agents to have root privileges. There {unprivilegedAgentsCount, plural, one {is # agent} other {are # agents}} running in an unprivileged mode using {agentPolicyName}. To ensure that all data required by the integration can be collected, re-enroll the {unprivilegedAgentsCount, plural, one {agent} other {agents}} using an account with root privileges."
+            values={{
+              unprivilegedAgentsCount,
+              agentPolicyName,
+            }}
+          />
+          <ul>
+            {dataStreams.map((item) => (
+              <li key={item.name}>{item.title}</li>
+            ))}
+          </ul>
+        </>
+      )}
     </EuiCallOut>
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -34,7 +34,11 @@ import {
 
 import { useCancelAddPackagePolicy } from '../hooks';
 
-import { isRootPrivilegesRequired, splitPkgKey } from '../../../../../../../common/services';
+import {
+  getRootPrivilegedDataStreams,
+  isRootPrivilegesRequired,
+  splitPkgKey,
+} from '../../../../../../../common/services';
 import type { NewAgentPolicy, PackagePolicyEditExtensionComponentProps } from '../../../../types';
 import { SetupTechnology } from '../../../../types';
 import {
@@ -438,6 +442,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     );
   }
 
+  const rootPrivilegedDataStreams = packageInfo ? getRootPrivilegedDataStreams(packageInfo) : [];
+
   return (
     <CreatePackagePolicySinglePageLayout {...layoutProps} data-test-subj="createPackagePolicy">
       <EuiErrorBoundary>
@@ -453,6 +459,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
                 (agentPolicy?.unprivileged_agents ?? 0) > 0
             )}
             unprivilegedAgentsCount={agentPolicy?.unprivileged_agents ?? 0}
+            dataStreams={rootPrivilegedDataStreams}
           />
         )}
         {formState === 'CONFIRM_UNPRIVILEGED' && agentPolicy ? (
@@ -461,6 +468,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
             onConfirm={onSubmit}
             unprivilegedAgentsCount={agentPolicy?.unprivileged_agents ?? 0}
             agentPolicyName={agentPolicy?.name ?? ''}
+            dataStreams={rootPrivilegedDataStreams}
           />
         ) : null}
         {formState === 'SUBMITTED_NO_AGENTS' &&

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -43,6 +43,7 @@ import {
   isInputOnlyPolicyTemplate,
   getNormalizedDataStreams,
   getNormalizedInputs,
+  isRootPrivilegesRequired,
 } from '../../common/services';
 import {
   SO_SEARCH_LIMIT,
@@ -329,10 +330,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
         });
       }
 
-      if (enrichedPackagePolicy.package && pkgInfo?.agent?.privileges?.root) {
+      const requiresRoot = isRootPrivilegesRequired(pkgInfo);
+      if (enrichedPackagePolicy.package && requiresRoot) {
         enrichedPackagePolicy.package = {
           ...enrichedPackagePolicy.package,
-          requires_root: pkgInfo?.agent?.privileges?.root ?? false,
+          requires_root: requiresRoot,
         };
       }
     }
@@ -465,10 +467,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
 
           elasticsearch = pkgInfo?.elasticsearch;
 
-          if (packagePolicy.package && pkgInfo?.agent?.privileges?.root) {
+          const requiresRoot = isRootPrivilegesRequired(pkgInfo);
+          if (packagePolicy.package && requiresRoot) {
             packagePolicy.package = {
               ...packagePolicy.package,
-              requires_root: pkgInfo?.agent?.privileges?.root ?? false,
+              requires_root: requiresRoot,
             };
           }
         }
@@ -877,10 +880,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       );
       elasticsearchPrivileges = pkgInfo.elasticsearch?.privileges;
 
-      if (restOfPackagePolicy.package && pkgInfo?.agent?.privileges?.root) {
+      const requiresRoot = isRootPrivilegesRequired(pkgInfo);
+      if (restOfPackagePolicy.package && requiresRoot) {
         restOfPackagePolicy.package = {
           ...restOfPackagePolicy.package,
-          requires_root: pkgInfo?.agent?.privileges?.root ?? false,
+          requires_root: requiresRoot,
         };
       }
     }
@@ -1064,10 +1068,11 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
             );
             elasticsearchPrivileges = pkgInfo.elasticsearch?.privileges;
 
-            if (restOfPackagePolicy.package && pkgInfo?.agent?.privileges?.root) {
+            const requiresRoot = isRootPrivilegesRequired(pkgInfo);
+            if (restOfPackagePolicy.package && requiresRoot) {
               restOfPackagePolicy.package = {
                 ...restOfPackagePolicy.package,
-                requires_root: pkgInfo?.agent?.privileges?.root ?? false,
+                requires_root: requiresRoot,
               };
             }
           }

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
@@ -32,6 +32,7 @@ Object {
       "namespace": "default",
       "package": Object {
         "name": "system",
+        "requires_root": true,
         "title": "System",
       },
       "revision": 1,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/3357

Updated UI warning to show which data streams require root, if not all.

To verify:
- enroll an unprivileged agent to an agent policy (e.g. using docker)
- add system integration to the agent policy
- when clicking `Save and continue`, verify that the modal shows a callout saying which data streams require root

<img width="853" alt="image" src="https://github.com/elastic/kibana/assets/90178898/db8bf26e-de46-4eeb-a471-002021fff3bc">

Updated the Add agent flyout condition as well to show those packages that has data streams that require root:

To verify:
- create an agent policy with system integration
- open `Add agent` flyout
- verify that the warning callout mentions `System` integration requiring root

<img width="819" alt="image" src="https://github.com/elastic/kibana/assets/90178898/abb7e620-f9e4-4662-b0e8-9a16448e52bb">

Open question:
- Do we want to show data stream names that require root on Add agent flyout too? It is possible but increases the complexity to store data stream names in package policy SO and populate in API. At this point I think it's enough to show the list of integrations there.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
