### PR TITLE
[CI] Skip build step, if `KIBANA_BUILD_ID` is given

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -48,6 +48,7 @@ steps:
           provider: gcp
           machineType: n2-standard-16
         key: build
+        if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
         depends_on: pre-build
         timeout_in_minutes: 60
         retry:


### PR DESCRIPTION
## Summary
Similar to other cases in our CI, if `KIBANA_BUILD_ID` is present, we can skip the build step, and the test steps would download artifacts from the referenced build.

If the elasticsearch side invocations to this pipeline provide `KIBANA_BUILD_ID`, then we can save ~15-20m on these runs.

see: https://elastic.slack.com/archives/C5UDAFZQU/p1716450726916959

closes: https://github.com/elastic/kibana-operations/issues/116