### PR TITLE
[Security Solution][PoC] Lazy load all sub-plugin routes

### DIFF
--- a/x-pack/plugins/security_solution/public/assets/index.ts
+++ b/x-pack/plugins/security_solution/public/assets/index.ts
@@ -5,15 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { ASSETS_PATH } from '../../common/constants';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const AssetsPageLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-assets" */
+    './routes'
+  ).then(({ AssetsPage }) => ({ default: AssetsPage }))
+);
 
 export class Assets {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: ASSETS_PATH,
+          component: withSubPluginRouteSuspense(AssetsPageLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/assets/routes.tsx
+++ b/x-pack/plugins/security_solution/public/assets/routes.tsx
@@ -6,25 +6,15 @@
  */
 import React from 'react';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import { ASSETS_PATH } from '../../common/constants';
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { Assets } from './assets';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 
-const AssetsPage = React.memo(function AssetsPage() {
-  return (
-    <PluginTemplateWrapper>
-      <SecurityRoutePageWrapper pageName={SecurityPageName.assets} redirectOnMissing>
-        <Assets />
-      </SecurityRoutePageWrapper>
-    </PluginTemplateWrapper>
-  );
-});
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: ASSETS_PATH,
-    component: AssetsPage,
-  },
-];
+export const AssetsPage = React.memo(() => (
+  <PluginTemplateWrapper>
+    <SecurityRoutePageWrapper pageName={SecurityPageName.assets} redirectOnMissing>
+      <Assets />
+    </SecurityRoutePageWrapper>
+  </PluginTemplateWrapper>
+));
+AssetsPage.displayName = 'AssetsPage';

--- a/x-pack/plugins/security_solution/public/attack_discovery/index.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/index.ts
@@ -5,15 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { ATTACK_DISCOVERY_PATH } from '../../common/constants';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const AttackDiscoveryRoutesLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-attack_discovery" */
+    './routes'
+  ).then(({ AttackDiscoveryRoutes }) => ({ default: AttackDiscoveryRoutes }))
+);
 
 export class AttackDiscovery {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: ATTACK_DISCOVERY_PATH,
+          component: withSubPluginRouteSuspense(AttackDiscoveryRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/attack_discovery/routes.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/routes.tsx
@@ -9,9 +9,7 @@ import React from 'react';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { AttackDiscoveryPage } from './pages';
 
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
-import { ATTACK_DISCOVERY_PATH } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 
@@ -24,10 +22,3 @@ export const AttackDiscoveryRoutes = () => (
     </TrackApplicationView>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: ATTACK_DISCOVERY_PATH,
-    component: AttackDiscoveryRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/cases/index.ts
+++ b/x-pack/plugins/security_solution/public/cases/index.ts
@@ -5,15 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { CASES_PATH } from '../../common/constants';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const CasesRoutesLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-cases" */
+    './routes'
+  ).then(({ CasesRoutes }) => ({ default: CasesRoutes }))
+);
 
 export class Cases {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: CASES_PATH,
+          component: withSubPluginRouteSuspense(CasesRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/cases/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cases/routes.tsx
@@ -8,8 +8,6 @@
 import React from 'react';
 
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
-import type { SecuritySubPluginRoutes } from '../app/types';
-import { CASES_PATH } from '../../common/constants';
 import { Cases } from './pages';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
@@ -22,10 +20,3 @@ export const CasesRoutes = () => {
     </PluginTemplateWrapper>
   );
 };
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: CASES_PATH,
-    component: CasesRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/cloud_defend/index.ts
+++ b/x-pack/plugins/security_solution/public/cloud_defend/index.ts
@@ -5,13 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
+import { CLOUD_DEFEND_BASE_PATH } from '@kbn/cloud-defend-plugin/public';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const CloudDefendLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-cloud_defend" */
+    './routes'
+  ).then(({ CloudDefend }) => ({ default: CloudDefend }))
+);
 
 export class CloudDefend {
   public setup() {}
 
   public start(): SecuritySubPlugin {
-    return { routes };
+    return {
+      routes: [
+        {
+          path: CLOUD_DEFEND_BASE_PATH,
+          component: withSubPluginRouteSuspense(CloudDefendLazy),
+        },
+      ],
+    };
   }
 }

--- a/x-pack/plugins/security_solution/public/cloud_defend/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_defend/routes.tsx
@@ -10,8 +10,7 @@ import type {
   CloudDefendPageId,
   CloudDefendSecuritySolutionContext,
 } from '@kbn/cloud-defend-plugin/public';
-import { CLOUD_DEFEND_BASE_PATH } from '@kbn/cloud-defend-plugin/public';
-import type { SecurityPageName, SecuritySubPluginRoutes } from '../app/types';
+import type { SecurityPageName } from '../app/types';
 import { useKibana } from '../common/lib/kibana';
 import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
 import { SpyRoute } from '../common/utils/route/spy_routes';
@@ -28,7 +27,7 @@ const cloudDefendSecuritySolutionContext: CloudDefendSecuritySolutionContext = {
   getSpyRouteComponent: () => CloudDefendSpyRoute,
 };
 
-const CloudDefend = () => {
+export const CloudDefend = () => {
   const { cloudDefend } = useKibana().services;
   const CloudDefendRouter = cloudDefend.getCloudDefendRouter();
 
@@ -40,12 +39,4 @@ const CloudDefend = () => {
     </PluginTemplateWrapper>
   );
 };
-
 CloudDefend.displayName = 'CloudDefend';
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: CLOUD_DEFEND_BASE_PATH,
-    component: CloudDefend,
-  },
-];

--- a/x-pack/plugins/security_solution/public/cloud_security_posture/index.ts
+++ b/x-pack/plugins/security_solution/public/cloud_security_posture/index.ts
@@ -5,13 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
+import { CLOUD_SECURITY_POSTURE_BASE_PATH } from '@kbn/cloud-security-posture-plugin/public';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const CloudSecurityPostureLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-cloud_security_posture" */
+    './routes'
+  ).then(({ CloudSecurityPosture }) => ({ default: CloudSecurityPosture }))
+);
 
 export class CloudSecurityPosture {
   public setup() {}
 
   public start(): SecuritySubPlugin {
-    return { routes };
+    return {
+      routes: [
+        {
+          path: CLOUD_SECURITY_POSTURE_BASE_PATH,
+          component: withSubPluginRouteSuspense(CloudSecurityPostureLazy),
+        },
+      ],
+    };
   }
 }

--- a/x-pack/plugins/security_solution/public/cloud_security_posture/routes.tsx
+++ b/x-pack/plugins/security_solution/public/cloud_security_posture/routes.tsx
@@ -7,12 +7,9 @@
 
 import React from 'react';
 import type { CloudSecurityPosturePageId } from '@kbn/cloud-security-posture-plugin/public';
-import {
-  CLOUD_SECURITY_POSTURE_BASE_PATH,
-  type CspSecuritySolutionContext,
-} from '@kbn/cloud-security-posture-plugin/public';
+import { type CspSecuritySolutionContext } from '@kbn/cloud-security-posture-plugin/public';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
-import type { SecurityPageName, SecuritySubPluginRoutes } from '../app/types';
+import type { SecurityPageName } from '../app/types';
 import { useKibana } from '../common/lib/kibana';
 import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
 import { SpyRoute } from '../common/utils/route/spy_routes';
@@ -29,7 +26,7 @@ const cspSecuritySolutionContext: CspSecuritySolutionContext = {
   getSpyRouteComponent: () => CloudPostureSpyRoute,
 };
 
-const CloudSecurityPosture = () => {
+export const CloudSecurityPosture = () => {
   const { cloudSecurityPosture } = useKibana().services;
   const CloudSecurityPostureRouter = cloudSecurityPosture.getCloudSecurityPostureRouter();
 
@@ -43,12 +40,4 @@ const CloudSecurityPosture = () => {
     </PluginTemplateWrapper>
   );
 };
-
 CloudSecurityPosture.displayName = 'CloudSecurityPosture';
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: CLOUD_SECURITY_POSTURE_BASE_PATH,
-    component: CloudSecurityPosture,
-  },
-];

--- a/x-pack/plugins/security_solution/public/common/components/with_sub_plugin_route_suspense/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/with_sub_plugin_route_suspense/index.ts
@@ -5,15 +5,4 @@
  * 2.0.
  */
 
-import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
-
-export class ThreatIntelligence {
-  public setup() {}
-
-  public start(): SecuritySubPlugin {
-    return {
-      routes,
-    };
-  }
-}
+export { withSubPluginRouteSuspense } from './with_sub_plugin_route_suspense';

--- a/x-pack/plugins/security_solution/public/common/components/with_sub_plugin_route_suspense/with_sub_plugin_route_suspense.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/with_sub_plugin_route_suspense/with_sub_plugin_route_suspense.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLoadingLogo } from '@elastic/eui';
+import type { ComponentType } from 'react';
+import React, { Suspense } from 'react';
+
+const centerLogoStyle = { display: 'flex', margin: 'auto' };
+
+const defaultFallback = <EuiLoadingLogo logo="logoSecurity" size="xl" style={centerLogoStyle} />;
+
+export const withSubPluginRouteSuspense = <T extends {} = {}>(
+  WrappedComponent: ComponentType<T>,
+  fallback: React.ReactNode = defaultFallback
+) =>
+  function WithSubPluginRouteSuspense(props: T) {
+    return (
+      <Suspense fallback={fallback}>
+        <WrappedComponent {...props} />
+      </Suspense>
+    );
+  };

--- a/x-pack/plugins/security_solution/public/dashboards/index.ts
+++ b/x-pack/plugins/security_solution/public/dashboards/index.ts
@@ -4,15 +4,29 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import React from 'react';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { DASHBOARDS_PATH } from '../../common/constants';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const DashboardsRoutesLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-dashboards" */
+    './routes'
+  ).then(({ DashboardsRoutes }) => ({ default: DashboardsRoutes }))
+);
 
 export class Dashboards {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: DASHBOARDS_PATH,
+          component: withSubPluginRouteSuspense(DashboardsRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/dashboards/routes.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/routes.tsx
@@ -7,22 +7,14 @@
 import React from 'react';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 
-import { DASHBOARDS_PATH, SecurityPageName } from '../../common/constants';
-import type { SecuritySubPluginRoutes } from '../app/types';
+import { SecurityPageName } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { DashboardsContainer } from './pages';
 
-export const DashboardRoutes = () => (
+export const DashboardsRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.dashboards}>
       <DashboardsContainer />
     </TrackApplicationView>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: DASHBOARDS_PATH,
-    component: DashboardRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/detections/index.ts
+++ b/x-pack/plugins/security_solution/public/detections/index.ts
@@ -5,17 +5,32 @@
  * 2.0.
  */
 
+import React from 'react';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { TableIdLiteral } from '@kbn/securitysolution-data-table';
+import { ALERTS_PATH, DETECTIONS_PATH } from '../../common/constants';
 import { getDataTablesInStorageByIds } from '../timelines/containers/local_storage';
-import { routes } from './routes';
 import type { SecuritySubPlugin } from '../app/types';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
 
 export const DETECTIONS_TABLE_IDS: TableIdLiteral[] = [
   TableId.alertsOnRuleDetailsPage,
   TableId.alertsOnAlertsPage,
 ];
+
+const loadRoutes = () =>
+  import(
+    /* webpackChunkName: "sub_plugin-detections" */
+    './routes'
+  );
+
+const AlertsRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ AlertsRoutes }) => ({ default: AlertsRoutes }))
+);
+const LegacyDetectionsRouteLazy = React.lazy(() =>
+  loadRoutes().then(({ LegacyDetectionsRoute }) => ({ default: LegacyDetectionsRoute }))
+);
 
 export class Detections {
   public setup() {}
@@ -25,7 +40,16 @@ export class Detections {
       storageDataTables: {
         tableById: getDataTablesInStorageByIds(storage, DETECTIONS_TABLE_IDS),
       },
-      routes,
+      routes: [
+        {
+          path: DETECTIONS_PATH,
+          component: withSubPluginRouteSuspense(LegacyDetectionsRouteLazy),
+        },
+        {
+          path: ALERTS_PATH,
+          component: withSubPluginRouteSuspense(AlertsRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/detections/routes.tsx
+++ b/x-pack/plugins/security_solution/public/detections/routes.tsx
@@ -6,32 +6,21 @@
  */
 
 import React from 'react';
-import type { RouteProps, RouteComponentProps } from 'react-router-dom';
+import type { RouteComponentProps } from 'react-router-dom';
 import { Redirect } from 'react-router-dom';
 import { ALERTS_PATH, DETECTIONS_PATH } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { Alerts } from './pages/alerts';
 
-const AlertsRoutes = () => (
+export const AlertsRoutes = () => (
   <PluginTemplateWrapper>
     <Alerts />
   </PluginTemplateWrapper>
 );
 
-const DetectionsRedirects = ({ location }: RouteComponentProps) =>
+export const LegacyDetectionsRoute = ({ location }: RouteComponentProps) =>
   location.pathname === DETECTIONS_PATH ? (
     <Redirect to={{ ...location, pathname: ALERTS_PATH }} />
   ) : (
     <Redirect to={{ ...location, pathname: location.pathname.replace(DETECTIONS_PATH, '') }} />
   );
-
-export const routes: RouteProps[] = [
-  {
-    path: DETECTIONS_PATH,
-    render: DetectionsRedirects,
-  },
-  {
-    path: ALERTS_PATH,
-    component: AlertsRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/entity_analytics/index.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/index.ts
@@ -5,15 +5,46 @@
  * 2.0.
  */
 
+import React from 'react';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import {
+  ENTITY_ANALYTICS_ASSET_CRITICALITY_PATH,
+  ENTITY_ANALYTICS_MANAGEMENT_PATH,
+} from '../../common/constants';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const loadRoutes = () =>
+  import(
+    /* webpackChunkName: "sub_plugin-entity_analytics" */
+    './routes'
+  );
+
+const EntityAnalyticsManagementLazy = React.lazy(() =>
+  loadRoutes().then(({ EntityAnalyticsManagement }) => ({ default: EntityAnalyticsManagement }))
+);
+const EntityAnalyticsAssetClassificationLazy = React.lazy(() =>
+  loadRoutes().then(({ EntityAnalyticsAssetClassification }) => ({
+    default: EntityAnalyticsAssetClassification,
+  }))
+);
 
 export class EntityAnalytics {
   public setup() {}
 
   public start(isEnabled = false): SecuritySubPlugin {
     return {
-      routes: isEnabled ? routes : [],
+      routes: isEnabled
+        ? [
+            {
+              path: ENTITY_ANALYTICS_MANAGEMENT_PATH,
+              component: withSubPluginRouteSuspense(EntityAnalyticsManagementLazy),
+            },
+            {
+              path: ENTITY_ANALYTICS_ASSET_CRITICALITY_PATH,
+              component: withSubPluginRouteSuspense(EntityAnalyticsAssetClassificationLazy),
+            },
+          ]
+        : [],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/entity_analytics/routes.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/routes.tsx
@@ -69,14 +69,3 @@ const EntityAnalyticsAssetClassificationContainer: React.FC = React.memo(() => {
 
 EntityAnalyticsAssetClassificationContainer.displayName =
   'EntityAnalyticsAssetClassificationContainer';
-
-export const routes = [
-  {
-    path: ENTITY_ANALYTICS_MANAGEMENT_PATH,
-    component: EntityAnalyticsManagementContainer,
-  },
-  {
-    path: ENTITY_ANALYTICS_ASSET_CRITICALITY_PATH,
-    component: EntityAnalyticsAssetClassificationContainer,
-  },
-];

--- a/x-pack/plugins/security_solution/public/entity_analytics/routes.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/routes.tsx
@@ -31,7 +31,7 @@ const EntityAnalyticsManagementTelemetry = () => (
   </PluginTemplateWrapper>
 );
 
-const EntityAnalyticsManagementContainer: React.FC = React.memo(() => {
+export const EntityAnalyticsManagement: React.FC = React.memo(() => {
   return (
     <Switch>
       <Route
@@ -43,7 +43,7 @@ const EntityAnalyticsManagementContainer: React.FC = React.memo(() => {
     </Switch>
   );
 });
-EntityAnalyticsManagementContainer.displayName = 'EntityAnalyticsManagementContainer';
+EntityAnalyticsManagement.displayName = 'EntityAnalyticsManagement';
 
 const EntityAnalyticsAssetClassificationTelemetry = () => (
   <PluginTemplateWrapper>
@@ -54,7 +54,7 @@ const EntityAnalyticsAssetClassificationTelemetry = () => (
   </PluginTemplateWrapper>
 );
 
-const EntityAnalyticsAssetClassificationContainer: React.FC = React.memo(() => {
+export const EntityAnalyticsAssetClassification: React.FC = React.memo(() => {
   return (
     <Switch>
       <Route
@@ -67,5 +67,4 @@ const EntityAnalyticsAssetClassificationContainer: React.FC = React.memo(() => {
   );
 });
 
-EntityAnalyticsAssetClassificationContainer.displayName =
-  'EntityAnalyticsAssetClassificationContainer';
+EntityAnalyticsAssetClassification.displayName = 'EntityAnalyticsAssetClassification';

--- a/x-pack/plugins/security_solution/public/exceptions/index.ts
+++ b/x-pack/plugins/security_solution/public/exceptions/index.ts
@@ -4,12 +4,21 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import React from 'react';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 
+import { EXCEPTIONS_PATH } from '../../common/constants';
 import type { SecuritySubPlugin } from '../app/types';
 import { DETECTIONS_TABLE_IDS } from '../detections';
 import { getDataTablesInStorageByIds } from '../timelines/containers/local_storage';
-import { routes } from './routes';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const ExceptionsLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-exceptions" */
+    './routes'
+  ).then(({ Exceptions }) => ({ default: Exceptions }))
+);
 
 export class Exceptions {
   public setup() {}
@@ -19,7 +28,12 @@ export class Exceptions {
       storageDataTables: {
         tableById: getDataTablesInStorageByIds(storage, DETECTIONS_TABLE_IDS),
       },
-      routes,
+      routes: [
+        {
+          path: EXCEPTIONS_PATH,
+          component: withSubPluginRouteSuspense(ExceptionsLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/exceptions/routes.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/routes.tsx
@@ -51,13 +51,4 @@ const ExceptionsContainerComponent: React.FC = () => {
   );
 };
 
-const Exceptions = React.memo(ExceptionsContainerComponent);
-
-const renderExceptionsRoutes = () => <Exceptions />;
-
-export const routes = [
-  {
-    path: EXCEPTIONS_PATH,
-    render: renderExceptionsRoutes,
-  },
-];
+export const Exceptions = React.memo(ExceptionsContainerComponent);

--- a/x-pack/plugins/security_solution/public/explore/routes.tsx
+++ b/x-pack/plugins/security_solution/public/explore/routes.tsx
@@ -11,13 +11,11 @@ import { UsersContainer } from './users/pages';
 import { HostsContainer } from './hosts/pages';
 import { NetworkContainer } from './network/pages';
 
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
-import { EXPLORE_PATH, HOSTS_PATH, NETWORK_PATH, USERS_PATH } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { ExploreLandingPage } from './landing';
 
-const ExploreLanding = () => (
+export const ExploreLanding = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.exploreLanding}>
       <ExploreLandingPage />
@@ -25,7 +23,7 @@ const ExploreLanding = () => (
   </PluginTemplateWrapper>
 );
 
-const NetworkRoutes = () => (
+export const NetworkRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.network}>
       <NetworkContainer />
@@ -33,7 +31,7 @@ const NetworkRoutes = () => (
   </PluginTemplateWrapper>
 );
 
-const UsersRoutes = () => (
+export const UsersRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.users}>
       <UsersContainer />
@@ -41,30 +39,10 @@ const UsersRoutes = () => (
   </PluginTemplateWrapper>
 );
 
-const HostsRoutes = () => (
+export const HostsRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.hosts}>
       <HostsContainer />
     </TrackApplicationView>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: EXPLORE_PATH,
-    exact: true,
-    component: ExploreLanding,
-  },
-  {
-    path: NETWORK_PATH,
-    component: NetworkRoutes,
-  },
-  {
-    path: USERS_PATH,
-    component: UsersRoutes,
-  },
-  {
-    path: HOSTS_PATH,
-    component: HostsRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/investigations/index.ts
+++ b/x-pack/plugins/security_solution/public/investigations/index.ts
@@ -5,15 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { INVESTIGATIONS_PATH } from '../../common/constants';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const InvestigationsPageLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-investigations" */
+    './routes'
+  ).then(({ InvestigationsPage }) => ({ default: InvestigationsPage }))
+);
 
 export class Investigations {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: INVESTIGATIONS_PATH,
+          component: withSubPluginRouteSuspense(InvestigationsPageLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/investigations/routes.tsx
+++ b/x-pack/plugins/security_solution/public/investigations/routes.tsx
@@ -6,25 +6,15 @@
  */
 import React from 'react';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import { INVESTIGATIONS_PATH } from '../../common/constants';
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { Investigations } from './investigations';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 
-const InvestigationsPage = React.memo(function InvestigationsPage() {
-  return (
-    <PluginTemplateWrapper>
-      <SecurityRoutePageWrapper pageName={SecurityPageName.investigations} redirectOnMissing>
-        <Investigations />
-      </SecurityRoutePageWrapper>
-    </PluginTemplateWrapper>
-  );
-});
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: INVESTIGATIONS_PATH,
-    component: InvestigationsPage,
-  },
-];
+export const InvestigationsPage = React.memo(() => (
+  <PluginTemplateWrapper>
+    <SecurityRoutePageWrapper pageName={SecurityPageName.investigations} redirectOnMissing>
+      <Investigations />
+    </SecurityRoutePageWrapper>
+  </PluginTemplateWrapper>
+));
+InvestigationsPage.displayName = 'InvestigationsPage';

--- a/x-pack/plugins/security_solution/public/kubernetes/index.ts
+++ b/x-pack/plugins/security_solution/public/kubernetes/index.ts
@@ -5,15 +5,29 @@
  * 2.0.
  */
 
+import React from 'react';
+import { KUBERNETES_PATH } from '@kbn/kubernetes-security-plugin/public';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const KubernetesRoutesLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-kubernetes" */
+    './routes'
+  ).then(({ KubernetesRoutes }) => ({ default: KubernetesRoutes }))
+);
 
 export class Kubernetes {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: KUBERNETES_PATH,
+          component: withSubPluginRouteSuspense(KubernetesRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/kubernetes/routes.tsx
+++ b/x-pack/plugins/security_solution/public/kubernetes/routes.tsx
@@ -9,9 +9,7 @@ import React from 'react';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { KubernetesContainer } from './pages';
 
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
-import { KUBERNETES_PATH } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
 export const KubernetesRoutes = () => (
@@ -21,10 +19,3 @@ export const KubernetesRoutes = () => (
     </TrackApplicationView>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: KUBERNETES_PATH,
-    component: KubernetesRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/machine_learning/routes.tsx
+++ b/x-pack/plugins/security_solution/public/machine_learning/routes.tsx
@@ -6,13 +6,11 @@
  */
 import React from 'react';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import { MACHINE_LEARNING_PATH } from '../../common/constants';
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { MachineLearning } from './machine_learning';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 
-const MachineLearningPage = React.memo(function MachineLearningPage() {
+export const MachineLearningPage = React.memo(function MachineLearningPage() {
   return (
     <PluginTemplateWrapper>
       <SecurityRoutePageWrapper pageName={SecurityPageName.mlLanding} redirectOnMissing>
@@ -21,10 +19,3 @@ const MachineLearningPage = React.memo(function MachineLearningPage() {
     </PluginTemplateWrapper>
   );
 });
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: MACHINE_LEARNING_PATH,
-    component: MachineLearningPage,
-  },
-];

--- a/x-pack/plugins/security_solution/public/management/routes.tsx
+++ b/x-pack/plugins/security_solution/public/management/routes.tsx
@@ -7,40 +7,29 @@
 
 import React from 'react';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
-import { MANAGEMENT_PATH, MANAGE_PATH } from '../../common/constants';
 import { SecurityPageName } from '../app/types';
 import { ManagementContainer } from './pages';
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { CurrentLicense } from '../common/components/current_license';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { ManageLandingPage } from './pages/landing';
 
-const ManagementLanding = () => (
+export const ManagementLanding = React.memo(() => (
   <PluginTemplateWrapper>
     <SecurityRoutePageWrapper pageName={SecurityPageName.administration} redirectOnMissing>
       <ManageLandingPage />
     </SecurityRoutePageWrapper>
   </PluginTemplateWrapper>
-);
+));
+ManagementLanding.displayName = 'ManagementLanding';
 
 /**
  * Returns the React Router Routes for the management area
  */
-const ManagementRoutes = () => (
+export const ManagementRoutes = React.memo(() => (
   <PluginTemplateWrapper>
     <CurrentLicense>
       <ManagementContainer />
     </CurrentLicense>
   </PluginTemplateWrapper>
-);
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: MANAGE_PATH,
-    component: React.memo(ManagementLanding),
-  },
-  {
-    path: MANAGEMENT_PATH,
-    component: React.memo(ManagementRoutes),
-  },
-];
+));
+ManagementRoutes.displayName = 'ManagementRoutes';

--- a/x-pack/plugins/security_solution/public/overview/index.ts
+++ b/x-pack/plugins/security_solution/public/overview/index.ts
@@ -5,15 +5,66 @@
  * 2.0.
  */
 
+import React from 'react';
+import {
+  DATA_QUALITY_PATH,
+  DETECTION_RESPONSE_PATH,
+  ENTITY_ANALYTICS_PATH,
+  LANDING_PATH,
+  OVERVIEW_PATH,
+} from '../../common/constants';
 import type { SecuritySubPlugin } from '../app/types';
-import { routes } from './routes';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
+
+const loadRoutes = () =>
+  import(
+    /* webpackChunkName: "sub_plugin_routes-overview" */
+    './routes'
+  );
+
+const OverviewRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ OverviewRoutes }) => ({ default: OverviewRoutes }))
+);
+const DetectionResponseRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ DetectionResponseRoutes }) => ({ default: DetectionResponseRoutes }))
+);
+const LandingRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ LandingRoutes }) => ({ default: LandingRoutes }))
+);
+const EntityAnalyticsRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ EntityAnalyticsRoutes }) => ({ default: EntityAnalyticsRoutes }))
+);
+const DataQualityRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ DataQualityRoutes }) => ({ default: DataQualityRoutes }))
+);
 
 export class Overview {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
-      routes,
+      routes: [
+        {
+          path: OVERVIEW_PATH,
+          component: withSubPluginRouteSuspense(OverviewRoutesLazy),
+        },
+        {
+          path: DETECTION_RESPONSE_PATH,
+          component: withSubPluginRouteSuspense(DetectionResponseRoutesLazy),
+        },
+        {
+          path: LANDING_PATH,
+          component: withSubPluginRouteSuspense(LandingRoutesLazy),
+        },
+        {
+          path: ENTITY_ANALYTICS_PATH,
+          component: withSubPluginRouteSuspense(EntityAnalyticsRoutesLazy),
+        },
+        {
+          path: DATA_QUALITY_PATH,
+          component: withSubPluginRouteSuspense(DataQualityRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/overview/routes.tsx
+++ b/x-pack/plugins/security_solution/public/overview/routes.tsx
@@ -7,15 +7,7 @@
 
 import React from 'react';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
-import {
-  LANDING_PATH,
-  OVERVIEW_PATH,
-  DATA_QUALITY_PATH,
-  DETECTION_RESPONSE_PATH,
-  SecurityPageName,
-  ENTITY_ANALYTICS_PATH,
-} from '../../common/constants';
-import type { SecuritySubPluginRoutes } from '../app/types';
+import { SecurityPageName } from '../../common/constants';
 
 import { StatefulOverview } from './pages/overview';
 import { DataQuality } from './pages/data_quality';
@@ -25,7 +17,7 @@ import { EntityAnalyticsPage } from '../entity_analytics/pages/entity_analytics_
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 import { LandingPage } from './pages/landing';
 
-const OverviewRoutes = () => (
+export const OverviewRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.overview}>
       <StatefulOverview />
@@ -33,7 +25,7 @@ const OverviewRoutes = () => (
   </PluginTemplateWrapper>
 );
 
-const DetectionResponseRoutes = () => (
+export const DetectionResponseRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.detectionAndResponse}>
       <DetectionResponse />
@@ -41,7 +33,7 @@ const DetectionResponseRoutes = () => (
   </PluginTemplateWrapper>
 );
 
-const LandingRoutes = () => (
+export const LandingRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.landing}>
       <LandingPage />
@@ -49,7 +41,7 @@ const LandingRoutes = () => (
   </PluginTemplateWrapper>
 );
 
-const EntityAnalyticsRoutes = () => (
+export const EntityAnalyticsRoutes = () => (
   <PluginTemplateWrapper>
     <SecurityRoutePageWrapper pageName={SecurityPageName.entityAnalytics}>
       <EntityAnalyticsPage />
@@ -57,33 +49,10 @@ const EntityAnalyticsRoutes = () => (
   </PluginTemplateWrapper>
 );
 
-const DataQualityRoutes = () => (
+export const DataQualityRoutes = () => (
   <PluginTemplateWrapper>
     <SecurityRoutePageWrapper pageName={SecurityPageName.dataQuality}>
       <DataQuality />
     </SecurityRoutePageWrapper>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: OVERVIEW_PATH,
-    component: OverviewRoutes,
-  },
-  {
-    path: DETECTION_RESPONSE_PATH,
-    component: DetectionResponseRoutes,
-  },
-  {
-    path: LANDING_PATH,
-    render: LandingRoutes,
-  },
-  {
-    path: ENTITY_ANALYTICS_PATH,
-    render: EntityAnalyticsRoutes,
-  },
-  {
-    path: DATA_QUALITY_PATH,
-    component: DataQualityRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/rules/index.ts
+++ b/x-pack/plugins/security_solution/public/rules/index.ts
@@ -5,11 +5,27 @@
  * 2.0.
  */
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import React from 'react';
 
+import { COVERAGE_OVERVIEW_PATH, RULES_LANDING_PATH, RULES_PATH } from '../../common/constants';
 import type { SecuritySubPlugin } from '../app/types';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
 import { DETECTIONS_TABLE_IDS } from '../detections';
 import { getDataTablesInStorageByIds } from '../timelines/containers/local_storage';
-import { routes } from './routes';
+
+const loadRoutes = () =>
+  import(
+    /* webpackChunkName: "sub_plugin-rules" */
+    './routes'
+  );
+
+const RulesLandingPageLazy = React.lazy(() =>
+  loadRoutes().then(({ RulesLandingPage }) => ({ default: RulesLandingPage }))
+);
+const RulesLazy = React.lazy(() => loadRoutes().then(({ Rules }) => ({ default: Rules })));
+const CoverageOverviewRoutesLazy = React.lazy(() =>
+  loadRoutes().then(({ CoverageOverviewRoutes }) => ({ default: CoverageOverviewRoutes }))
+);
 
 export class Rules {
   public setup() {}
@@ -19,7 +35,20 @@ export class Rules {
       storageDataTables: {
         tableById: getDataTablesInStorageByIds(storage, DETECTIONS_TABLE_IDS),
       },
-      routes,
+      routes: [
+        {
+          path: RULES_LANDING_PATH,
+          component: withSubPluginRouteSuspense(RulesLandingPageLazy),
+        },
+        {
+          path: RULES_PATH,
+          component: withSubPluginRouteSuspense(RulesLazy),
+        },
+        {
+          path: COVERAGE_OVERVIEW_PATH,
+          component: withSubPluginRouteSuspense(CoverageOverviewRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/rules/routes.tsx
+++ b/x-pack/plugins/security_solution/public/rules/routes.tsx
@@ -10,12 +10,7 @@ import { Routes, Route } from '@kbn/shared-ux-router';
 
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import * as i18n from './translations';
-import {
-  COVERAGE_OVERVIEW_PATH,
-  RULES_LANDING_PATH,
-  RULES_PATH,
-  SecurityPageName,
-} from '../../common/constants';
+import { SecurityPageName } from '../../common/constants';
 import { NotFoundPage } from '../app/404';
 import { RulesPage } from '../detection_engine/rule_management_ui/pages/rule_management';
 import { CreateRulePage } from '../detection_engine/rule_creation_ui/pages/rule_creation';
@@ -26,10 +21,9 @@ import { PluginTemplateWrapper } from '../common/components/plugin_template_wrap
 import { SpyRoute } from '../common/utils/route/spy_routes';
 import { AllRulesTabs } from '../detection_engine/rule_management_ui/components/rules_table/rules_table_toolbar';
 import { AddRulesPage } from '../detection_engine/rule_management_ui/pages/add_rules';
-import type { SecuritySubPluginRoutes } from '../app/types';
-import { RulesLandingPage } from './landing';
 import { CoverageOverviewPage } from '../detection_engine/rule_management_ui/pages/coverage_overview';
 import { RuleDetailTabs } from '../detection_engine/rule_details_ui/pages/rule_details/use_rule_details_tabs';
+export { RulesLandingPage } from './landing';
 
 const RulesSubRoutes = [
   {
@@ -104,27 +98,12 @@ const RulesContainerComponent: React.FC = () => {
   );
 };
 
-const Rules = React.memo(RulesContainerComponent);
+export const Rules = React.memo(RulesContainerComponent);
 
-const CoverageOverviewRoutes = () => (
+export const CoverageOverviewRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.coverageOverview}>
       <CoverageOverviewPage />
     </TrackApplicationView>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: RULES_LANDING_PATH,
-    component: RulesLandingPage,
-  },
-  {
-    path: RULES_PATH,
-    component: Rules,
-  },
-  {
-    path: COVERAGE_OVERVIEW_PATH,
-    component: CoverageOverviewRoutes,
-  },
-];

--- a/x-pack/plugins/security_solution/public/threat_intelligence/index.ts
+++ b/x-pack/plugins/security_solution/public/threat_intelligence/index.ts
@@ -6,26 +6,26 @@
  */
 
 import React from 'react';
-import { MACHINE_LEARNING_PATH } from '../../common/constants';
+import { THREAT_INTELLIGENCE_BASE_PATH } from '@kbn/threat-intelligence-plugin/public';
 import type { SecuritySubPlugin } from '../app/types';
 import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
 
-const MachineLearningPageLazy = React.lazy(() =>
+const ThreatIntelligenceLazy = React.lazy(() =>
   import(
-    /* webpackChunkName: "sub_plugin-machine_learning" */
+    /* webpackChunkName: "sub_plugin-threat_intelligence" */
     './routes'
-  ).then(({ MachineLearningPage }) => ({ default: MachineLearningPage }))
+  ).then(({ ThreatIntelligence }) => ({ default: ThreatIntelligence }))
 );
 
-export class MachineLearning {
+export class ThreatIntelligence {
   public setup() {}
 
   public start(): SecuritySubPlugin {
     return {
       routes: [
         {
-          path: MACHINE_LEARNING_PATH,
-          component: withSubPluginRouteSuspense(MachineLearningPageLazy),
+          path: THREAT_INTELLIGENCE_BASE_PATH,
+          component: withSubPluginRouteSuspense(ThreatIntelligenceLazy),
         },
       ],
     };

--- a/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
+++ b/x-pack/plugins/security_solution/public/threat_intelligence/routes.tsx
@@ -7,7 +7,6 @@
 
 import React, { memo, useMemo } from 'react';
 import type { SecuritySolutionPluginContext } from '@kbn/threat-intelligence-plugin/public';
-import { THREAT_INTELLIGENCE_BASE_PATH } from '@kbn/threat-intelligence-plugin/public';
 import type { Store } from 'redux';
 import { useSelector } from 'react-redux';
 import type { SelectedDataView } from '@kbn/threat-intelligence-plugin/public/types';
@@ -22,7 +21,6 @@ import { FiltersGlobal } from '../common/components/filters_global';
 import { SpyRoute } from '../common/utils/route/spy_routes';
 import { licenseService } from '../common/hooks/use_license';
 import { SecurityPageName } from '../app/types';
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { useSourcererDataView } from '../common/containers/sourcerer';
 import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
 import { SiemSearchBar } from '../common/components/search_bar';
@@ -32,7 +30,7 @@ import { InputsModelId } from '../common/store/inputs/constants';
 import { ArtifactFlyout } from '../management/components/artifact_list_page/components/artifact_flyout';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
 
-const ThreatIntelligence = memo(() => {
+export const ThreatIntelligence = memo(() => {
   const { threatIntelligence, http } = useKibana().services;
   const ThreatIntelligencePlugin = threatIntelligence.getComponent();
 
@@ -97,10 +95,3 @@ const ThreatIntelligence = memo(() => {
 });
 
 ThreatIntelligence.displayName = 'ThreatIntelligence';
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: THREAT_INTELLIGENCE_BASE_PATH,
-    render: () => <ThreatIntelligence />,
-  },
-];

--- a/x-pack/plugins/security_solution/public/timelines/index.ts
+++ b/x-pack/plugins/security_solution/public/timelines/index.ts
@@ -5,21 +5,35 @@
  * 2.0.
  */
 
+import React from 'react';
+import { TIMELINES_PATH } from '../../common/constants';
 import type { SecuritySubPluginWithStore } from '../app/types';
-import { routes } from './routes';
+import { withSubPluginRouteSuspense } from '../common/components/with_sub_plugin_route_suspense';
 import { initialTimelineState, timelineReducer } from './store/reducer';
 import type { TimelineState } from './store/types';
+
+const TimelinesRoutesLazy = React.lazy(() =>
+  import(
+    /* webpackChunkName: "sub_plugin-timeline" */
+    './routes'
+  ).then(({ TimelinesRoutes }) => ({ default: TimelinesRoutes }))
+);
 
 export class Timelines {
   public setup() {}
 
   public start(): SecuritySubPluginWithStore<'timeline', TimelineState> {
     return {
-      routes,
       store: {
         initialState: { timeline: initialTimelineState },
         reducer: { timeline: timelineReducer },
       },
+      routes: [
+        {
+          path: TIMELINES_PATH,
+          component: withSubPluginRouteSuspense(TimelinesRoutesLazy),
+        },
+      ],
     };
   }
 }

--- a/x-pack/plugins/security_solution/public/timelines/routes.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/routes.tsx
@@ -8,23 +8,14 @@
 import React from 'react';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
 import { Timelines } from './pages';
-import { TIMELINES_PATH } from '../../common/constants';
 
-import type { SecuritySubPluginRoutes } from '../app/types';
 import { SecurityPageName } from '../app/types';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 
-const TimelinesRoutes = () => (
+export const TimelinesRoutes = () => (
   <PluginTemplateWrapper>
     <TrackApplicationView viewId={SecurityPageName.timelines}>
       <Timelines />
     </TrackApplicationView>
   </PluginTemplateWrapper>
 );
-
-export const routes: SecuritySubPluginRoutes = [
-  {
-    path: TIMELINES_PATH,
-    component: TimelinesRoutes,
-  },
-];


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/181138

Checking if splitting the bundle in sub-plugin lazy chunks will be beneficial

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
