### PR TITLE
UI Counters report API: use `refresh: false`

### DIFF
--- a/src/plugins/usage_collection/server/report/store_application_usage.test.ts
+++ b/src/plugins/usage_collection/server/report/store_application_usage.test.ts
@@ -110,6 +110,7 @@ const expectedIncrementParams = (
         viewId,
         timestamp: moment(`${moment(dayId).format('YYYY-MM-DD')}T00:00:00Z`).toISOString(),
       },
+      refresh: false,
     },
   ];
 };

--- a/src/plugins/usage_collection/server/report/store_application_usage.ts
+++ b/src/plugins/usage_collection/server/report/store_application_usage.ts
@@ -73,6 +73,7 @@ const incrementUsageCounters = (
         viewId,
         timestamp: getTimestamp(dayId),
       },
+      refresh: false,
     }
   );
 };

--- a/src/plugins/usage_collection/server/report/store_report.test.ts
+++ b/src/plugins/usage_collection/server/report/store_report.test.ts
@@ -76,6 +76,7 @@ describe('store_report', () => {
           Object {
             "id": "key-user-agent:test-user-agent",
             "overwrite": true,
+            "refresh": false,
           },
         ],
       ]

--- a/src/plugins/usage_collection/server/report/store_report.ts
+++ b/src/plugins/usage_collection/server/report/store_report.ts
@@ -37,6 +37,7 @@ export async function storeReport(
         {
           id: savedObjectId,
           overwrite: true,
+          refresh: false,
         }
       );
     }),


### PR DESCRIPTION
## Summary

Our APM data shows that the API that handles the storage of UI Counters has a high latency (for the actual work it does):
<img width="1012" alt="image" src="https://github.com/elastic/kibana/assets/5469006/7dd03741-0d9a-427e-a826-4fd3df6700e7">

This is likely caused because the persistence of the documents uses the default `refresh: 'wait_for'`. Bearing in mind the default refresh interval is 1s, it could take up to that much to confirm the successful storage. 
In this case, we want to have confirmation that the document was stored, but we don't need to wait until it's searchable. Using `refresh: false` will only wait for the write to occur, which should happen much faster.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
