### PR TITLE
[Response Ops][Task Manager] Adding debug logs for metrics collection

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/create_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/create_aggregator.test.ts
@@ -8,6 +8,7 @@
 import sinon from 'sinon';
 import { Subject } from 'rxjs';
 import { take, bufferCount, skip } from 'rxjs';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
 import {
   isTaskManagerMetricEvent,
   isTaskManagerStatEvent,
@@ -31,6 +32,7 @@ import { metricsAggregatorMock } from './metrics_aggregator.mock';
 import { getTaskManagerMetricEvent } from './task_overdue_metrics_aggregator.test';
 import { TaskOverdueMetric, TaskOverdueMetricsAggregator } from './task_overdue_metrics_aggregator';
 
+const logger = loggingSystemMock.createLogger();
 const mockMetricsAggregator = metricsAggregatorMock.create();
 const config: TaskManagerConfig = {
   allow_reading_invalid_state: false,
@@ -788,7 +790,7 @@ describe('createAggregator', () => {
         reset$: new Subject<boolean>(),
         eventFilter: (event: TaskLifecycleEvent) =>
           isTaskRunEvent(event) || isTaskManagerStatEvent(event),
-        metricsAggregator: new TaskRunMetricsAggregator(),
+        metricsAggregator: new TaskRunMetricsAggregator(logger),
       });
 
       return new Promise<void>((resolve) => {
@@ -1816,7 +1818,7 @@ describe('createAggregator', () => {
         reset$,
         eventFilter: (event: TaskLifecycleEvent) =>
           isTaskRunEvent(event) || isTaskManagerStatEvent(event),
-        metricsAggregator: new TaskRunMetricsAggregator(),
+        metricsAggregator: new TaskRunMetricsAggregator(logger),
       });
 
       return new Promise<void>((resolve) => {
@@ -2781,7 +2783,7 @@ describe('createAggregator', () => {
         reset$: new Subject<boolean>(),
         eventFilter: (event: TaskLifecycleEvent) =>
           isTaskRunEvent(event) || isTaskManagerStatEvent(event),
-        metricsAggregator: new TaskRunMetricsAggregator(),
+        metricsAggregator: new TaskRunMetricsAggregator(logger),
       });
 
       return new Promise<void>((resolve) => {

--- a/x-pack/plugins/task_manager/server/metrics/index.ts
+++ b/x-pack/plugins/task_manager/server/metrics/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { Observable } from 'rxjs';
+import { Logger } from '@kbn/core/server';
 import { TaskManagerConfig } from '../config';
 import { Metrics, createMetricsAggregators, createMetricsStream } from './metrics_stream';
 import { TaskPollingLifecycle } from '../polling_lifecycle';
@@ -14,6 +15,7 @@ export type { Metrics } from './metrics_stream';
 
 interface MetricsStreamOpts {
   config: TaskManagerConfig;
+  logger: Logger;
   reset$: Observable<boolean>; // emits when counter metrics should be reset
   taskPollingLifecycle?: TaskPollingLifecycle; // subscribe to task lifecycle events
   taskManagerMetricsCollector?: TaskManagerMetricsCollector; // subscribe to collected task manager metrics
@@ -22,12 +24,14 @@ interface MetricsStreamOpts {
 export function metricsStream({
   config,
   reset$,
+  logger,
   taskPollingLifecycle,
   taskManagerMetricsCollector,
 }: MetricsStreamOpts): Observable<Metrics> {
   return createMetricsStream(
     createMetricsAggregators({
       config,
+      logger,
       reset$,
       taskPollingLifecycle,
       taskManagerMetricsCollector,

--- a/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as uuid from 'uuid';
+import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { asOk, asErr } from '../lib/result_type';
 import { TaskStatus } from '../task';
 import {
@@ -16,6 +17,8 @@ import {
 } from '../task_events';
 import { TaskRunResult } from '../task_running';
 import { TaskRunMetricsAggregator } from './task_run_metrics_aggregator';
+
+const logger = loggingSystemMock.createLogger();
 
 export const getTaskRunSuccessEvent = (type: string, isExpired: boolean = false) => {
   const id = uuid.v4();
@@ -81,7 +84,7 @@ export const getTaskManagerStatEvent = (value: number, id: TaskManagerStats = 'r
 describe('TaskRunMetricsAggregator', () => {
   let taskRunMetricsAggregator: TaskRunMetricsAggregator;
   beforeEach(() => {
-    taskRunMetricsAggregator = new TaskRunMetricsAggregator();
+    taskRunMetricsAggregator = new TaskRunMetricsAggregator(logger);
   });
 
   test('should correctly initialize', () => {

--- a/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
@@ -7,6 +7,7 @@
 
 import { JsonObject } from '@kbn/utility-types';
 import { merge } from 'lodash';
+import { Logger } from '@kbn/core/server';
 import { isUserError } from '../task_running';
 import { isOk, Ok, unwrap } from '../lib/result_type';
 import { TaskLifecycleEvent } from '../polling_lifecycle';
@@ -63,12 +64,16 @@ export interface TaskRunMetric extends JsonObject {
 }
 
 export class TaskRunMetricsAggregator implements ITaskMetricsAggregator<TaskRunMetric> {
+  private logger: Logger;
   private counter: MetricCounterService<TaskRunMetric> = new MetricCounterService(
     Object.values(TaskRunKeys),
     TaskRunMetricKeys.OVERALL
   );
   private delayHistogram = new SimpleHistogram(HDR_HISTOGRAM_MAX, HDR_HISTOGRAM_BUCKET_SIZE);
 
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
   public initialMetric(): TaskRunMetric {
     return merge(this.counter.initialMetrics(), {
       by_type: {},
@@ -96,6 +101,9 @@ export class TaskRunMetricsAggregator implements ITaskMetricsAggregator<TaskRunM
   public processTaskLifecycleEvent(taskEvent: TaskLifecycleEvent) {
     if (isTaskRunEvent(taskEvent)) {
       this.processTaskRunEvent(taskEvent);
+      this.logger.debug(
+        `Collected metrics after processing lifecycle event - ${JSON.stringify(this.collect())}`
+      );
     } else if (isTaskManagerStatEvent(taskEvent)) {
       this.processTaskManagerStatEvent(taskEvent);
     }
@@ -115,6 +123,7 @@ export class TaskRunMetricsAggregator implements ITaskMetricsAggregator<TaskRunM
     if (success) {
       this.incrementCounters(TaskRunKeys.SUCCESS, taskType, taskTypeGroup);
     } else {
+      this.logger.debug(`Incrementing error counter for task ${task.taskType}`);
       // increment total error counts
       this.incrementCounters(TaskRunKeys.TOTAL_ERRORS, taskType, taskTypeGroup);
 

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -163,6 +163,7 @@ export class TaskManagerPlugin
     });
     metricsRoute({
       router,
+      logger: this.logger,
       metrics$: this.metrics$,
       resetMetrics$: this.resetMetrics$,
       taskManagerId: this.taskManagerId,
@@ -295,6 +296,7 @@ export class TaskManagerPlugin
 
     metricsStream({
       config: this.config!,
+      logger: this.logger,
       reset$: this.resetMetrics$,
       taskPollingLifecycle: this.taskPollingLifecycle,
       taskManagerMetricsCollector: this.taskManagerMetricsCollector,

--- a/x-pack/plugins/task_manager/server/routes/metrics.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/metrics.test.ts
@@ -5,21 +5,25 @@
  * 2.0.
  */
 
+import { Logger } from '@kbn/core/server';
 import { of, Subject } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
-import { httpServiceMock } from '@kbn/core/server/mocks';
+import { httpServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { metricsRoute } from './metrics';
 import { mockHandlerArguments } from './_mock_handler_arguments';
 
 describe('metricsRoute', () => {
+  let logger: Logger;
   beforeEach(() => {
     jest.resetAllMocks();
+    logger = loggingSystemMock.createLogger();
   });
 
   it('registers route', async () => {
     const router = httpServiceMock.createRouter();
     metricsRoute({
       router,
+      logger,
       metrics$: of(),
       resetMetrics$: new Subject<boolean>(),
       taskManagerId: uuidv4(),
@@ -41,6 +45,7 @@ describe('metricsRoute', () => {
     const router = httpServiceMock.createRouter();
     metricsRoute({
       router,
+      logger,
       metrics$: of(),
       resetMetrics$,
       taskManagerId: uuidv4(),
@@ -66,6 +71,7 @@ describe('metricsRoute', () => {
     const router = httpServiceMock.createRouter();
     metricsRoute({
       router,
+      logger,
       metrics$: of(),
       resetMetrics$,
       taskManagerId: uuidv4(),

--- a/x-pack/plugins/task_manager/server/routes/metrics.ts
+++ b/x-pack/plugins/task_manager/server/routes/metrics.ts
@@ -7,6 +7,7 @@
 
 import {
   IRouter,
+  Logger,
   RequestHandlerContext,
   KibanaRequest,
   IKibanaResponse,
@@ -25,6 +26,7 @@ export interface NodeMetrics {
 
 export interface MetricsRouteParams {
   router: IRouter;
+  logger: Logger;
   metrics$: Observable<Metrics>;
   resetMetrics$: Subject<boolean>;
   taskManagerId: string;
@@ -35,8 +37,9 @@ const QuerySchema = schema.object({
 });
 
 export function metricsRoute(params: MetricsRouteParams) {
-  const { router, metrics$, resetMetrics$, taskManagerId } = params;
+  const { router, logger, metrics$, resetMetrics$, taskManagerId } = params;
 
+  const debugLogger = logger.get(`metrics-debugger`);
   let lastMetrics: NodeMetrics | null = null;
 
   metrics$.subscribe((metrics) => {
@@ -63,6 +66,11 @@ export function metricsRoute(params: MetricsRouteParams) {
       req: KibanaRequest<unknown, TypeOf<typeof QuerySchema>, unknown>,
       res: KibanaResponseFactory
     ): Promise<IKibanaResponse> {
+      debugLogger.debug(
+        `/api/task_manager/metrics route accessed with reset=${req.query.reset} - metrics ${
+          lastMetrics ? JSON.stringify(lastMetrics) : 'not available'
+        }`
+      );
       if (req.query.reset) {
         resetMetrics$.next(true);
       }

--- a/x-pack/plugins/task_manager/server/routes/metrics.ts
+++ b/x-pack/plugins/task_manager/server/routes/metrics.ts
@@ -40,10 +40,12 @@ export function metricsRoute(params: MetricsRouteParams) {
   const { router, logger, metrics$, resetMetrics$, taskManagerId } = params;
 
   const debugLogger = logger.get(`metrics-debugger`);
+  const additionalDebugLogger = logger.get(`metrics-subscribe-debugger`);
   let lastMetrics: NodeMetrics | null = null;
 
   metrics$.subscribe((metrics) => {
     lastMetrics = { process_uuid: taskManagerId, timestamp: new Date().toISOString(), ...metrics };
+    additionalDebugLogger.debug(`subscribed metrics ${JSON.stringify(metrics)}`);
   });
 
   router.get(

--- a/x-pack/plugins/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/plugins/task_manager/server/task_running/task_runner.test.ts
@@ -2086,11 +2086,11 @@ describe('TaskManagerRunner', () => {
       });
       await runner.run();
 
-      expect(logger.debug).toHaveBeenCalledTimes(2);
+      expect(logger.debug).toHaveBeenCalledTimes(3);
       expect(logger.debug).toHaveBeenNthCalledWith(1, 'Running task bar "foo"', {
         tags: ['task:start', 'foo', 'bar'],
       });
-      expect(logger.debug).toHaveBeenNthCalledWith(2, 'Task bar "foo" ended', {
+      expect(logger.debug).toHaveBeenNthCalledWith(3, 'Task bar "foo" ended', {
         tags: ['task:end', 'foo', 'bar'],
       });
     });

--- a/x-pack/plugins/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/plugins/task_manager/server/task_running/task_runner.ts
@@ -693,6 +693,8 @@ export class TaskManagerRunner implements TaskRunner {
   ): Promise<Result<SuccessfulRunResult, FailedRunResult>> {
     const { task } = this.instance;
 
+    const debugLogger = this.logger.get(`metrics-debugger`);
+
     const taskHasExpired = this.isExpired;
 
     await eitherAsync(
@@ -711,8 +713,10 @@ export class TaskManagerRunner implements TaskRunner {
         // when the alerting task fails, so we check for this condition in order
         // to emit the correct task run event for metrics collection
         // taskRunError contains the "source" (TaskErrorSource) data
-        const taskRunEvent = !!taskRunError
-          ? asTaskRunEvent(
+        if (!!taskRunError) {
+          debugLogger.debug(`Emitting task run failed event for task ${this.taskType}`);
+          this.onTaskEvent(
+            asTaskRunEvent(
               this.id,
               asErr({
                 ...processedResult,
@@ -721,14 +725,19 @@ export class TaskManagerRunner implements TaskRunner {
               }),
               taskTiming
             )
-          : asTaskRunEvent(
+          );
+        } else {
+          this.onTaskEvent(
+            asTaskRunEvent(
               this.id,
               asOk({ ...processedResult, isExpired: taskHasExpired }),
               taskTiming
-            );
-        this.onTaskEvent(taskRunEvent);
+            )
+          );
+        }
       },
       async ({ error }: FailedRunResult) => {
+        debugLogger.debug(`Emitting task run failed event for task ${this.taskType}`);
         this.onTaskEvent(
           asTaskRunEvent(
             this.id,


### PR DESCRIPTION
## Summary

Adding debug log under `plugins.taskManager.metrics-debugger` context for debugging error count discrepancies.
