### PR TITLE
[Cloud Security] [Quick Wins] Allow Findings page tables to consume all the available space

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -77,6 +77,10 @@ export interface CloudSecurityDataTableProps {
    * Height override for the data grid.
    */
   height?: number | string;
+  /**
+   * Specify if distribution bar is shown on data table, used to calculate height of data table in virtualized mode
+   */
+  hasDistributionBar?: boolean;
 }
 
 export const CloudSecurityDataTable = ({
@@ -91,6 +95,7 @@ export const CloudSecurityDataTable = ({
   customCellRenderer,
   groupSelectorComponent,
   height,
+  hasDistributionBar = true,
   ...rest
 }: CloudSecurityDataTableProps) => {
   const {
@@ -171,6 +176,31 @@ export const CloudSecurityDataTable = ({
     sort,
   });
 
+  /**
+   * This object is used to determine if the table rendering will be virtualized and the virtualization wrapper height.
+   * mode should be passed as a key to the UnifiedDataTable component to force a re-render when the mode changes.
+   */
+  const computeDataTableRendering = useMemo(() => {
+    // Enable virtualization mode when the table is set to a large page size.
+    const isVirtualizationEnabled = pageSize >= 100;
+
+    const getWrapperHeight = () => {
+      if (height) return height;
+
+      if (isVirtualizationEnabled) return 'auto';
+
+      const baseHeight = 362; // height of Kibana Header + Findings page header and search bar
+      const filterBarHeight = filters?.length > 0 ? 40 : 0;
+      const distributionBarHeight = hasDistributionBar ? 52 : 0;
+      return `calc(100vh - ${baseHeight}px - ${filterBarHeight}px - ${distributionBarHeight}px)`;
+    };
+
+    return {
+      wrapperHeight: getWrapperHeight(),
+      mode: isVirtualizationEnabled ? 'virtualized' : 'standard',
+    };
+  }, [pageSize, height, filters?.length, hasDistributionBar]);
+
   const onAddFilter: AddFieldFilterHandler | undefined = useMemo(
     () =>
       filterManager && dataView
@@ -229,13 +259,6 @@ export const CloudSecurityDataTable = ({
     />
   );
 
-  const dataTableStyle = {
-    // Change the height of the grid to fit the page
-    // If there are filters, leave space for the filter bar
-    // Todo: Replace this component with EuiAutoSizer
-    height: height ?? `calc(100vh - ${filters?.length > 0 ? 454 : 414}px)`,
-  };
-
   const rowHeightState = 0;
 
   const loadingStyle = {
@@ -250,10 +273,13 @@ export const CloudSecurityDataTable = ({
       <div
         data-test-subj={rest['data-test-subj']}
         className={styles.gridContainer}
-        style={dataTableStyle}
+        style={{
+          height: computeDataTableRendering.wrapperHeight,
+        }}
       >
         <EuiProgress size="xs" color="accent" style={loadingStyle} />
         <UnifiedDataTable
+          key={computeDataTableRendering.mode}
           className={styles.gridStyle}
           ariaLabelledBy={title}
           columns={currentColumns}

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -187,7 +187,8 @@ export const CloudSecurityDataTable = ({
     const getWrapperHeight = () => {
       if (height) return height;
 
-      if (isVirtualizationEnabled) return 'auto';
+      // If virtualization is not needed the table will render unconstrained.
+      if (!isVirtualizationEnabled) return 'auto';
 
       const baseHeight = 362; // height of Kibana Header + Findings page header and search bar
       const filterBarHeight = filters?.length > 0 ? 40 : 0;

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_container.tsx
@@ -98,7 +98,6 @@ export const LatestFindingsContainer = () => {
         <LatestFindingsTable
           groupSelectorComponent={groupSelectorComponent}
           nonPersistedFilters={[...(parentGroupFilters ? JSON.parse(parentGroupFilters) : [])]}
-          height={DEFAULT_GROUPING_TABLE_HEIGHT}
           showDistributionBar={selectedGroupOptions.includes('none')}
         />
       );

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_table.tsx
@@ -90,6 +90,7 @@ export const LatestFindingsTable = ({
     rows,
     error,
     isFetching,
+    isLoading,
     fetchNextPage,
     passed,
     failed,
@@ -124,7 +125,7 @@ export const LatestFindingsTable = ({
           )}
           <CloudSecurityDataTable
             data-test-subj={TEST_SUBJECTS.LATEST_FINDINGS_TABLE}
-            isLoading={isFetching}
+            isLoading={isFetching || isLoading}
             defaultColumns={defaultColumns}
             rows={rows}
             total={total}

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_table.tsx
@@ -43,6 +43,7 @@ export const useLatestFindingsTable = ({
     error: fetchError,
     isFetching,
     fetchNextPage,
+    isLoading,
   } = useLatestFindings({
     query,
     sort,
@@ -77,6 +78,7 @@ export const useLatestFindingsTable = ({
     rows,
     error,
     isFetching,
+    isLoading,
     fetchNextPage,
     passed,
     failed,

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/latest_vulnerabilities_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/latest_vulnerabilities_container.tsx
@@ -95,7 +95,6 @@ export const LatestVulnerabilitiesContainer = () => {
         <LatestVulnerabilitiesTable
           groupSelectorComponent={groupSelectorComponent}
           nonPersistedFilters={[...(parentGroupFilters ? JSON.parse(parentGroupFilters) : [])]}
-          height={DEFAULT_GROUPING_TABLE_HEIGHT}
         />
       );
     }

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/latest_vulnerabilities_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/latest_vulnerabilities_table.tsx
@@ -93,8 +93,6 @@ export const LatestVulnerabilitiesTable = ({
       nonPersistedFilters,
     });
 
-  const { filters } = cloudPostureDataTable;
-
   return (
     <>
       {error ? (
@@ -115,7 +113,8 @@ export const LatestVulnerabilitiesTable = ({
           title={title}
           customCellRenderer={customCellRenderer}
           groupSelectorComponent={groupSelectorComponent}
-          height={height ?? `calc(100vh - ${filters?.length > 0 ? 404 : 364}px)`}
+          height={height}
+          hasDistributionBar={false}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

Part of a quick wins [PR](https://github.com/elastic/security-team/issues/9520)

This PR adds the following changes to the Findings pages:

- Fixed flickering Empty State component on the initial load of the Misconfigurations table.
- Updated CloudSecurityDatatable height logic to use virtualization only when pagination starts to affect performance (PageSize > 100). 
- Updated CloudSecurityDatatable height logic to consume all the page available space when virtualization is enabled.



## Recording

https://github.com/elastic/kibana/assets/19270322/fe63545c-7957-4067-b455-5b259df8e751



