### PR TITLE
[CI] Fix agent targeting for pipelines added since the PR-build migration

### DIFF
--- a/.buildkite/pipelines/pull_request/build_project.yml
+++ b/.buildkite/pipelines/pull_request/build_project.yml
@@ -2,7 +2,11 @@ steps:
   - command: .buildkite/scripts/steps/artifacts/docker_image.sh
     label: 'Build Project Image'
     agents:
-      queue: n2-16-spot
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-16
+      preemptible: true
     timeout_in_minutes: 60
     soft_fail: true
     retry:

--- a/.buildkite/pipelines/pull_request/slo_plugin_e2e.yml
+++ b/.buildkite/pipelines/pull_request/slo_plugin_e2e.yml
@@ -2,7 +2,11 @@ steps:
   - command: .buildkite/scripts/steps/functional/slo_plugin_e2e.sh
     label: 'SLO Plugin @elastic/synthetics Tests'
     agents:
-      queue: n2-4-spot
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-prod
+      provider: gcp
+      machineType: n2-standard-4
+      preemptible: true
     depends_on:
       - build
       - quick_checks


### PR DESCRIPTION
## Summary
Some pipelines were added/changed since the PR build pipeline was open, this retroactively fixes those agent targeting rules.