### PR TITLE
Revert "[ES|QL] Remove version from _query requests (#184053)"

### DIFF
--- a/packages/kbn-es-types/src/search.ts
+++ b/packages/kbn-es-types/src/search.ts
@@ -688,6 +688,7 @@ export interface ESQLSearchParams {
   // https://github.com/elastic/elasticsearch/pull/102767
   // time_zone?: string;
   query: string;
+  version: string;
   filter?: unknown;
   locale?: string;
   dropNullColumns?: boolean;

--- a/packages/kbn-esql-utils/constants.ts
+++ b/packages/kbn-esql-utils/constants.ts
@@ -5,6 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-// only used for security solution
+
+// we are expecting to retrieve this from an API instead
+// https://github.com/elastic/elasticsearch/issues/107069
 export const ESQL_LATEST_VERSION = '2024.04.01';
 export const ENABLE_ESQL = 'enableESQL';

--- a/packages/kbn-esql-utils/index.ts
+++ b/packages/kbn-esql-utils/index.ts
@@ -22,4 +22,4 @@ export {
   TextBasedLanguages,
 } from './src';
 
-export { ENABLE_ESQL, ESQL_LATEST_VERSION } from './constants';
+export { ESQL_LATEST_VERSION, ENABLE_ESQL } from './constants';

--- a/packages/kbn-esql-utils/src/utils/run_query.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.ts
@@ -11,6 +11,7 @@ import type { ISearchGeneric } from '@kbn/search-types';
 import { esFieldTypeToKibanaFieldType } from '@kbn/field-types';
 import type { ESQLColumn, ESQLSearchReponse, ESQLSearchParams } from '@kbn/es-types';
 import { lastValueFrom } from 'rxjs';
+import { ESQL_LATEST_VERSION } from '../../constants';
 
 export function formatESQLColumns(columns: ESQLColumn[]): DatatableColumn[] {
   return columns.map(({ name, type }) => {
@@ -40,6 +41,7 @@ export async function getESQLQueryColumnsRaw({
         {
           params: {
             query: `${esqlQuery} | limit 0`,
+            version: ESQL_LATEST_VERSION,
           },
         },
         {
@@ -74,6 +76,7 @@ export async function getESQLQueryColumns({
   try {
     const rawColumns = await getESQLQueryColumnsRaw({ esqlQuery, search, signal });
     const columns = formatESQLColumns(rawColumns) ?? [];
+
     return columns;
   } catch (error) {
     throw new Error(
@@ -109,6 +112,7 @@ export async function getESQLResults({
         params: {
           ...(filter ? { filter } : {}),
           query: esqlQuery,
+          version: ESQL_LATEST_VERSION,
           ...(dropNullColumns ? { dropNullColumns: true } : {}),
         },
       },

--- a/packages/kbn-generate-csv/src/generate_csv_esql.test.ts
+++ b/packages/kbn-generate-csv/src/generate_csv_esql.test.ts
@@ -22,6 +22,7 @@ import type { IKibanaSearchResponse } from '@kbn/search-types';
 import { IScopedSearchClient } from '@kbn/data-plugin/server';
 import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
 import { CancellationToken } from '@kbn/reporting-common';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import type { ReportingConfigType } from '@kbn/reporting-server';
 import type { ESQLSearchReponse as ESQLSearchResponse } from '@kbn/es-types';
 import {
@@ -311,7 +312,7 @@ describe('CsvESQLGenerator', () => {
       );
 
       expect(mockDataClientSearchFn).toBeCalledWith(
-        { params: { filter: undefined, locale: 'en', query: '' } },
+        { params: { filter: undefined, locale: 'en', query: '', version: ESQL_LATEST_VERSION } },
         {
           strategy: 'esql',
           transport: {
@@ -389,7 +390,7 @@ describe('CsvESQLGenerator', () => {
       );
 
       expect(mockDataClientSearchFn).toBeCalledWith(
-        { params: { filter: undefined, locale: 'en', query: '' } },
+        { params: { filter: undefined, locale: 'en', query: '', version: ESQL_LATEST_VERSION } },
         {
           strategy: 'esql',
           transport: {
@@ -485,6 +486,7 @@ describe('CsvESQLGenerator', () => {
             },
             locale: 'en',
             query: '',
+            version: ESQL_LATEST_VERSION,
           },
         },
         {

--- a/packages/kbn-generate-csv/src/generate_csv_esql.ts
+++ b/packages/kbn-generate-csv/src/generate_csv_esql.ts
@@ -8,6 +8,7 @@
 
 import { lastValueFrom } from 'rxjs';
 import type { Writable } from 'stream';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { errors as esErrors } from '@elastic/elasticsearch';
 import type { IScopedClusterClient, IUiSettingsClient, Logger } from '@kbn/core/server';
 import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
@@ -94,6 +95,7 @@ export class CsvESQLGenerator {
         // we will need to add it back in once it is supported again.
         // https://github.com/elastic/elasticsearch/pull/102767
         // timezone
+        version: ESQL_LATEST_VERSION,
       },
     };
 

--- a/packages/kbn-generate-csv/tsconfig.json
+++ b/packages/kbn-generate-csv/tsconfig.json
@@ -28,6 +28,7 @@
     "@kbn/reporting-export-types-csv-common",
     "@kbn/es-query",
     "@kbn/es-types",
+    "@kbn/esql-utils",
     "@kbn/data-views-plugin",
     "@kbn/search-types",
   ]

--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -19,6 +19,7 @@ import { catchError, map, switchMap, tap } from 'rxjs';
 import { buildEsQuery } from '@kbn/es-query';
 import type { ISearchGeneric } from '@kbn/search-types';
 import type { ESQLSearchReponse, ESQLSearchParams } from '@kbn/es-types';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { getEsQueryConfig } from '../../es_query';
 import { getTime } from '../../query';
 import { ESQL_ASYNC_SEARCH_STRATEGY, KibanaContext } from '..';
@@ -147,6 +148,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             query,
             // time_zone: timezone,
             locale,
+            version: ESQL_LATEST_VERSION,
           };
           if (input) {
             const esQueryConfigs = getEsQueryConfig(

--- a/src/plugins/data/server/search/strategies/esql_async_search/esql_async_search_strategy.test.ts
+++ b/src/plugins/data/server/search/strategies/esql_async_search/esql_async_search_strategy.test.ts
@@ -8,6 +8,7 @@
 
 import { firstValueFrom } from 'rxjs';
 import { KbnServerError } from '@kbn/kibana-utils-plugin/server';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { KbnSearchError } from '../../report_search_error';
 import { errors } from '@elastic/elasticsearch';
 import indexNotFoundException from '../../../../common/search/test_data/index_not_found_exception.json';
@@ -66,6 +67,7 @@ describe('ES|QL async search strategy', () => {
         const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
         const params = {
           query: 'from logs* | limit 10',
+          version: ESQL_LATEST_VERSION,
         };
         await esSearch
           .search(
@@ -89,6 +91,7 @@ describe('ES|QL async search strategy', () => {
 
         const params = {
           query: 'from logs* | limit 10',
+          version: ESQL_LATEST_VERSION,
         };
         const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
@@ -108,6 +111,7 @@ describe('ES|QL async search strategy', () => {
           query: 'from logs* | limit 10',
           wait_for_completion_timeout: '10s',
           keep_alive: '5m',
+          version: ESQL_LATEST_VERSION,
         };
         const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
@@ -123,7 +127,7 @@ describe('ES|QL async search strategy', () => {
       it('sets transport options on POST requests', async () => {
         const transportOptions = { maxRetries: 1 };
         mockApiCaller.mockResolvedValueOnce(mockAsyncResponse);
-        const params = { query: 'from logs' };
+        const params = { query: 'from logs', version: ESQL_LATEST_VERSION };
         const esSearch = esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
         await firstValueFrom(
@@ -140,6 +144,7 @@ describe('ES|QL async search strategy', () => {
               wait_for_completion_timeout: '100ms',
               keep_on_completion: false,
               query: 'from logs',
+              version: ESQL_LATEST_VERSION,
             },
           }),
           expect.objectContaining({ maxRetries: 1, meta: true, signal: undefined })
@@ -150,6 +155,7 @@ describe('ES|QL async search strategy', () => {
         mockApiCaller.mockResolvedValueOnce(mockAsyncResponse);
         const params = {
           query: 'from logs* | limit 10',
+          version: ESQL_LATEST_VERSION,
         };
         const esSearch = esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
@@ -175,6 +181,7 @@ describe('ES|QL async search strategy', () => {
 
         const params = {
           query: 'from logs* | limit 10',
+          version: ESQL_LATEST_VERSION,
         };
         const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
@@ -197,6 +204,7 @@ describe('ES|QL async search strategy', () => {
 
         const params = {
           query: 'from logs* | limit 10',
+          version: ESQL_LATEST_VERSION,
         };
         const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
         const abortController = new AbortController();
@@ -230,6 +238,7 @@ describe('ES|QL async search strategy', () => {
 
       const params = {
         query: 'from logs* | limit 10',
+        version: ESQL_LATEST_VERSION,
       };
       const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 
@@ -253,6 +262,7 @@ describe('ES|QL async search strategy', () => {
 
       const params = {
         query: 'from logs* | limit 10',
+        version: ESQL_LATEST_VERSION,
       };
       const esSearch = await esqlAsyncSearchStrategyProvider(mockSearchConfig, mockLogger);
 

--- a/src/plugins/data/tsconfig.json
+++ b/src/plugins/data/tsconfig.json
@@ -54,6 +54,7 @@
     "@kbn/es-types",
     "@kbn/code-editor",
     "@kbn/core-test-helpers-model-versions",
+    "@kbn/esql-utils",
     "@kbn/react-kibana-mount",
     "@kbn/search-types"
   ],

--- a/test/api_integration/apis/esql/errors.ts
+++ b/test/api_integration/apis/esql/errors.ts
@@ -11,6 +11,7 @@ import Path from 'path';
 import expect from '@kbn/expect';
 import { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 import { REPO_ROOT } from '@kbn/repo-info';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import uniqBy from 'lodash/uniqBy';
 import { groupBy, mapValues } from 'lodash';
 import { FtrProviderContext } from '../../ftr_provider_context';
@@ -126,6 +127,7 @@ export default function ({ getService }: FtrProviderContext) {
         path: '/_query',
         body: {
           query,
+          version: ESQL_LATEST_VERSION,
         },
       });
       return { resp, error: undefined };

--- a/test/api_integration/apis/search/bsearch.ts
+++ b/test/api_integration/apis/search/bsearch.ts
@@ -8,6 +8,7 @@
 
 import expect from '@kbn/expect';
 import request from 'superagent';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { inflateResponse } from '@kbn/bfetch-plugin/public/streaming';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { BFETCH_ROUTE_VERSION_LATEST } from '@kbn/bfetch-plugin/common';
@@ -413,6 +414,7 @@ export default function ({ getService }: FtrProviderContext) {
                     request: {
                       params: {
                         query: 'from .kibana | limit 1',
+                        version: ESQL_LATEST_VERSION,
                       },
                     },
                     options: {
@@ -441,6 +443,7 @@ export default function ({ getService }: FtrProviderContext) {
                     request: {
                       params: {
                         query: 'fro .kibana | limit 1',
+                        version: ESQL_LATEST_VERSION,
                       },
                     },
                     options: {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -72,6 +72,7 @@
     "@kbn/links-plugin",
     "@kbn/ftr-common-functional-ui-services",
     "@kbn/monaco",
+    "@kbn/esql-utils",
     "@kbn/search-types",
   ]
 }

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_esql_overall_stats_data.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_esql_overall_stats_data.ts
@@ -14,7 +14,7 @@ import { type UseCancellableSearch, useCancellableSearch } from '@kbn/ml-cancell
 import type { estypes } from '@elastic/elasticsearch';
 import type { ISearchOptions } from '@kbn/search-types';
 import type { TimeBucketsInterval } from '@kbn/ml-time-buckets';
-import { getESQLWithSafeLimit, appendToESQLQuery } from '@kbn/esql-utils';
+import { getESQLWithSafeLimit, ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import { isDefined } from '@kbn/ml-is-defined';
 import { OMIT_FIELDS } from '../../../../../common/constants';
 import type {
@@ -94,6 +94,7 @@ const getESQLDocumentCountStats = async (
       params: {
         query: aggQuery,
         ...(filter ? { filter } : {}),
+        version: ESQL_LATEST_VERSION,
       },
     };
     try {
@@ -139,6 +140,7 @@ const getESQLDocumentCountStats = async (
       params: {
         query: appendToESQLQuery(esqlBaseQuery, ' | STATS _count_ = COUNT(*)  | LIMIT 1'),
         ...(filter ? { filter } : {}),
+        version: ESQL_LATEST_VERSION,
       },
     };
     try {
@@ -268,6 +270,7 @@ export const useESQLOverallStatsData = (
               // Doing this to match with the default limit
               query: esqlBaseQuery,
               ...(filter ? { filter } : {}),
+              version: ESQL_LATEST_VERSION,
               dropNullColumns: true,
             },
           },

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_boolean_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_boolean_field_stats.ts
@@ -9,7 +9,7 @@ import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import pLimit from 'p-limit';
-import { appendToESQLQuery } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import { isFulfilled, isRejected } from '../../../common/util/promise_all_settled_utils';
@@ -49,6 +49,7 @@ export const getESQLBooleanFieldStats = async ({
           params: {
             query,
             ...(filter ? { filter } : {}),
+            version: ESQL_LATEST_VERSION,
           },
         },
       };

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_count_and_cardinality.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_count_and_cardinality.ts
@@ -9,7 +9,7 @@ import pLimit from 'p-limit';
 import { chunk } from 'lodash';
 import { isDefined } from '@kbn/ml-is-defined';
 import type { ESQLSearchReponse } from '@kbn/es-types';
-import { appendToESQLQuery } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { i18n } from '@kbn/i18n';
@@ -109,6 +109,7 @@ const getESQLOverallStatsInChunk = async ({
       params: {
         query,
         ...(filter ? { filter } : {}),
+        version: ESQL_LATEST_VERSION,
       },
     };
 

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_date_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_date_field_stats.ts
@@ -8,7 +8,7 @@
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
-import { appendToESQLQuery } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import type { DateFieldStats, FieldStatsError } from '../../../../../common/types/field_stats';
@@ -42,6 +42,7 @@ export const getESQLDateFieldStats = async ({
       params: {
         query,
         ...(filter ? { filter } : {}),
+        version: ESQL_LATEST_VERSION,
       },
     };
     try {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_keyword_fields.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_keyword_fields.ts
@@ -9,7 +9,7 @@ import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import pLimit from 'p-limit';
-import { appendToESQLQuery } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import { isFulfilled, isRejected } from '../../../common/util/promise_all_settled_utils';
@@ -47,6 +47,7 @@ export const getESQLKeywordFieldStats = async ({
         params: {
           query,
           ...(filter ? { filter } : {}),
+          version: ESQL_LATEST_VERSION,
         },
       },
     };

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_numeric_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_numeric_field_stats.ts
@@ -8,7 +8,7 @@
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
-import { appendToESQLQuery } from '@kbn/esql-utils';
+import { ESQL_LATEST_VERSION, appendToESQLQuery } from '@kbn/esql-utils';
 import { chunk } from 'lodash';
 import pLimit from 'p-limit';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
@@ -71,6 +71,7 @@ const getESQLNumericFieldStatsInChunk = async ({
       params: {
         query,
         ...(filter ? { filter } : {}),
+        version: ESQL_LATEST_VERSION,
       },
     };
     try {

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -11,7 +11,11 @@ import { lastValueFrom } from 'rxjs';
 import { tap } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 import { Adapters } from '@kbn/inspector-plugin/common/adapters';
-import { getIndexPatternFromESQLQuery, getLimitFromESQLQuery } from '@kbn/esql-utils';
+import {
+  getIndexPatternFromESQLQuery,
+  getLimitFromESQLQuery,
+  ESQL_LATEST_VERSION,
+} from '@kbn/esql-utils';
 import { buildEsQuery } from '@kbn/es-query';
 import type { Filter, Query } from '@kbn/es-query';
 import type { ESQLSearchParams, ESQLSearchReponse } from '@kbn/es-types';
@@ -153,6 +157,7 @@ export class ESQLSource
     const params: ESQLSearchParams = {
       query: this._descriptor.esql,
       dropNullColumns: true,
+      version: ESQL_LATEST_VERSION,
     };
 
     const query: Query[] = [];

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/server/functions/query/esql_docs/esql-api.txt
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/server/functions/query/esql_docs/esql-api.txt
@@ -11,6 +11,7 @@ FROM library
     | SORT year
     | LIMIT 5
   """,
+  "version": "2024.04.01"
 ```
 
 }
@@ -48,6 +49,9 @@ For syntax, refer to Returning localized results.
 Passing parameters to a query.
 `query`
 (Required, string) ES|QL query to run. For syntax, refer to Syntax reference.
+`version`
+(Required, string) ES|QL language version. Can be sent in short or long form, e.g.
+`2024.04.01` or `2024.04.01.🚀`. See Language versions for details.
 Response bodyedit
 `columns`
 (array of objects)

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/server/functions/query/index.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/server/functions/query/index.ts
@@ -11,6 +11,7 @@ import pLimit from 'p-limit';
 import Path from 'path';
 import { lastValueFrom, startWith } from 'rxjs';
 import { promisify } from 'util';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { FunctionVisibility, MessageRole } from '@kbn/observability-ai-assistant-plugin/common';
 import {
   VisualizeESQLUserIntention,
@@ -126,6 +127,7 @@ export function registerQueryFunction({ functions, resources }: FunctionRegistra
         path: '_query',
         body: {
           query,
+          version: ESQL_LATEST_VERSION,
         },
       })) as ESQLSearchReponse;
 

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/server/functions/query/validate_esql_query.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/server/functions/query/validate_esql_query.ts
@@ -8,6 +8,7 @@
 import { validateQuery } from '@kbn/esql-validation-autocomplete';
 import { getAstAndSyntaxErrors } from '@kbn/esql-ast';
 import type { ElasticsearchClient } from '@kbn/core/server';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { ESQLSearchReponse } from '@kbn/es-types';
 import { esFieldTypeToKibanaFieldType, type KBN_FIELD_TYPES } from '@kbn/field-types';
 import { splitIntoCommands } from './correct_common_esql_mistakes';
@@ -56,6 +57,7 @@ export async function validateEsqlQuery({
       path: '_query',
       body: {
         query: performantQuery,
+        version: ESQL_LATEST_VERSION,
       },
     })
     .then((res) => {

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.test.ts
@@ -67,6 +67,7 @@ describe('fetchEsqlQuery', () => {
             },
           },
           "query": "from test",
+          "version": "2024.04.01",
         }
       `);
     });
@@ -94,6 +95,7 @@ describe('fetchEsqlQuery', () => {
             },
           },
           "query": "from test | limit 100",
+          "version": "2024.04.01",
         }
       `);
     });

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
@@ -6,6 +6,7 @@
  */
 
 import { parseAggregationResults } from '@kbn/triggers-actions-ui-plugin/common';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { SharePluginStart } from '@kbn/share-plugin/server';
 import { IScopedClusterClient, Logger } from '@kbn/core/server';
 import { OnlyEsqlQueryRuleParams } from '../types';
@@ -90,6 +91,7 @@ export const getEsqlQuery = (
 
   const query = {
     query: alertLimit ? `${params.esqlQuery.esql} | limit ${alertLimit}` : params.esqlQuery.esql,
+    version: ESQL_LATEST_VERSION,
     filter: {
       bool: {
         filter: rangeFilter,

--- a/x-pack/test/api_integration/apis/maps/bsearch.ts
+++ b/x-pack/test/api_integration/apis/maps/bsearch.ts
@@ -8,6 +8,7 @@
 import request from 'superagent';
 import { inflateResponse } from '@kbn/bfetch-plugin/public/streaming';
 import expect from '@kbn/expect';
+import { ESQL_LATEST_VERSION } from '@kbn/esql-utils';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { BFETCH_ROUTE_VERSION_LATEST } from '@kbn/bfetch-plugin/common';
 import type { FtrProviderContext } from '../../ftr_provider_context';
@@ -37,6 +38,7 @@ export default function ({ getService }: FtrProviderContext) {
                 request: {
                   params: {
                     query: 'from logstash-* | keep geo.coordinates | limit 0',
+                    version: ESQL_LATEST_VERSION,
                   },
                 },
                 options: {
@@ -72,6 +74,7 @@ export default function ({ getService }: FtrProviderContext) {
                     dropNullColumns: true,
                     query:
                       'from logstash-* | keep geo.coordinates, @timestamp | sort @timestamp | limit 1',
+                    version: ESQL_LATEST_VERSION,
                   },
                 },
                 options: {

--- a/x-pack/test/tsconfig.json
+++ b/x-pack/test/tsconfig.json
@@ -172,6 +172,7 @@
     "@kbn/aiops-log-rate-analysis",
     "@kbn/apm-data-view",
     "@kbn/core-saved-objects-api-server",
+    "@kbn/esql-utils",
     "@kbn/search-types",
     "@kbn/analytics-ftr-helpers-plugin",
     "@kbn/reporting-server",


### PR DESCRIPTION
This reverts commit 5c78c0132163b10917ea68407d66bc4d70d09025.

## Summary

Reverts the https://github.com/elastic/kibana/pull/184053 as we don't want to land in serverless before ES PR does.
