### PR TITLE
[EuiProvider] Fix Response-Stream example

### DIFF
--- a/examples/response_stream/public/mount.tsx
+++ b/examples/response_stream/public/mount.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { CoreSetup, CoreStart, AppMountParameters } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { PLUGIN_NAME } from '../common/constants';
 import { ResponseStreamStartPlugins } from './plugin';
 import { App } from './containers/app';
@@ -41,9 +42,11 @@ export const mount =
     ]);
 
     const reactElement = (
-      <KibanaContextProvider services={deps}>
-        <App />
-      </KibanaContextProvider>
+      <KibanaRenderContextProvider {...core}>
+        <KibanaContextProvider services={deps}>
+          <App />
+        </KibanaContextProvider>
+      </KibanaRenderContextProvider>
     );
     render(reactElement, element);
     return () => unmountComponentAtNode(element);

--- a/examples/response_stream/tsconfig.json
+++ b/examples/response_stream/tsconfig.json
@@ -22,5 +22,6 @@
     "@kbn/config-schema",
     "@kbn/shared-ux-router",
     "@kbn/ml-response-stream",
+    "@kbn/react-kibana-context-render",
   ]
 }


### PR DESCRIPTION
## Summary

Fixes needed for getting CI to pass when EUI throws an error if attempting to render a component without the EuiProvider in the render tree:

## Detailed description
In https://github.com/elastic/kibana/pull/180819, I will deliver a change that will cause EUI components to throw an error if the EuiProvider context is missing. This PR comes in as part of the final work to get all functional tests passing in an environment where EUI will throw the error. The tied to the ["Fix 'dark mode' inconsistencies in Kibana" Epic](https://github.com/elastic/kibana-team/issues/805) has so far been in preparation for this. 

> [[job]](https://buildkite.com/elastic/kibana-pull-request/builds/211859#018fa751-0f89-4253-bab7-b941897a15e1) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/211859/jobs/018fa751-0f89-4253-bab7-b941897a15e1/artifacts/018fa779-eab5-4d08-a948-17a1cd95826e) FTR Configs 33 / response-stream string stream example navigates to the example
[[job]](https://buildkite.com/elastic/kibana-pull-request/builds/211859#018fa77a-4796-429d-8165-9c8227307a0e) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/211859/jobs/018fa77a-4796-429d-8165-9c8227307a0e/artifacts/018fa788-2ed8-43ab-83c1-b781ae09b1cd) FTR Configs 33 / response-stream string stream example navigates to the example

**Reviewers: Please interact with critical paths through the UI components touched in this PR, ESPECIALLY in terms of testing dark mode and i18n.**

<img width="1107" alt="image" src="https://github.com/elastic/kibana/assets/908371/c0d2ce08-ac35-45a7-8192-0b2256fceb0e">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)