### PR TITLE
Skip serverless synthetics enablement API tests for MKI runs

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/observability/synthetics/synthetics_enablement.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/synthetics/synthetics_enablement.ts
@@ -43,6 +43,8 @@ export default function ({ getService }: FtrProviderContext) {
   };
 
   describe('SyntheticsEnablement', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/184273
+    this.tags(['failsOnMKI']);
     const svlUserManager = getService('svlUserManager');
     const svlCommonApi = getService('svlCommonApi');
     const supertestWithoutAuth = getService('supertestWithoutAuth');


### PR DESCRIPTION
## Summary

This PR skips the serverless synthetics enablement API tests for MKI runs.
Details about the failure in #184273.
