### PR TITLE
avoid calculating hash of all index pattern properties

### DIFF
--- a/src/plugins/kibana_utils/common/calculate_object_hash.test.ts
+++ b/src/plugins/kibana_utils/common/calculate_object_hash.test.ts
@@ -15,7 +15,7 @@ describe('calculateObjectHash', () => {
     expect(calculateObjectHash(object)).toEqual('5094c3dc');
   });
 
-  test('ignores inner properties of index object', () => {
+  test('ignore inner props of index object expect for the value.id', () => {
     const object1 = { test: 123, index: { value: { id: 'test', otherprop: 1 } } };
     const object2 = { test: 123, index: { value: { id: 'test', otherprop: 2 } } };
 

--- a/src/plugins/kibana_utils/common/calculate_object_hash.test.ts
+++ b/src/plugins/kibana_utils/common/calculate_object_hash.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { calculateObjectHash } from './calculate_object_hash';
+
+describe('calculateObjectHash', () => {
+  test('calculates hash of the object', () => {
+    const object = { test: 123 };
+
+    expect(calculateObjectHash(object)).toEqual('5094c3dc');
+  });
+
+  test('ignores inner properties of index object', () => {
+    const object1 = { test: 123, index: { value: { id: 'test', otherprop: 1 } } };
+    const object2 = { test: 123, index: { value: { id: 'test', otherprop: 2 } } };
+
+    expect(calculateObjectHash(object1)).toEqual(calculateObjectHash(object2));
+  });
+});

--- a/src/plugins/kibana_utils/common/calculate_object_hash.ts
+++ b/src/plugins/kibana_utils/common/calculate_object_hash.ts
@@ -53,7 +53,7 @@ function foldValue(input: number, value: any, key: string, seen: any[]) {
     if (key === 'vis' && value.constructor.name === 'Vis') {
       return hash;
     }
-    if (key === 'index' && value?.value?.id) {
+    if (key === 'index' && value.value?.id) {
       return fold(hash, value.value.id);
     }
     if (seen.indexOf(value) !== -1) {

--- a/src/plugins/kibana_utils/common/calculate_object_hash.ts
+++ b/src/plugins/kibana_utils/common/calculate_object_hash.ts
@@ -54,7 +54,7 @@ function foldValue(input: number, value: any, key: string, seen: any[]) {
       return hash;
     }
     if (key === 'index' && value.value.id) {
-      return fold(hash, value.value.id);
+      return fold(hash, value.value?.id);
     }
     if (seen.indexOf(value) !== -1) {
       return fold(hash, '[Circular]' + key);

--- a/src/plugins/kibana_utils/common/calculate_object_hash.ts
+++ b/src/plugins/kibana_utils/common/calculate_object_hash.ts
@@ -53,8 +53,8 @@ function foldValue(input: number, value: any, key: string, seen: any[]) {
     if (key === 'vis' && value.constructor.name === 'Vis') {
       return hash;
     }
-    if (key === 'index' && value.value.id) {
-      return fold(hash, value.value?.id);
+    if (key === 'index' && value?.value?.id) {
+      return fold(hash, value.value.id);
     }
     if (seen.indexOf(value) !== -1) {
       return fold(hash, '[Circular]' + key);

--- a/src/plugins/kibana_utils/common/calculate_object_hash.ts
+++ b/src/plugins/kibana_utils/common/calculate_object_hash.ts
@@ -53,6 +53,9 @@ function foldValue(input: number, value: any, key: string, seen: any[]) {
     if (key === 'vis' && value.constructor.name === 'Vis') {
       return hash;
     }
+    if (key === 'index' && value.value.id) {
+      return fold(hash, value.value.id);
+    }
     if (seen.indexOf(value) !== -1) {
       return fold(hash, '[Circular]' + key);
     }


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/kibana/issues/184130

calculateObjectHash function time could explode with very large index patterns. this fix avoids calculating hash for properties on the index pattern and just takes index id into account.

