### PR TITLE
[KQL] Remove unnecessary contrived wildcard match_all handling

### DIFF
--- a/packages/kbn-es-query/src/kuery/functions/is.test.ts
+++ b/packages/kbn-es-query/src/kuery/functions/is.test.ts
@@ -74,19 +74,6 @@ describe('kuery functions', () => {
         expect(result).toEqual(expected);
       });
 
-      test('should return an ES match_all query for queries that match all fields and values', () => {
-        const expected = {
-          match_all: {},
-        };
-        const node = nodeTypes.function.buildNode('is', 'n*', '*') as KqlIsFunctionNode;
-        const result = is.toElasticsearchQuery(node, {
-          ...indexPattern,
-          fields: indexPattern.fields.filter((field) => field.name.startsWith('n')),
-        });
-
-        expect(result).toEqual(expected);
-      });
-
       test('should return an ES match_all query for * queries without an index pattern', () => {
         const expected = {
           match_all: {},

--- a/packages/kbn-es-query/src/kuery/functions/is.ts
+++ b/packages/kbn-es-query/src/kuery/functions/is.ts
@@ -106,11 +106,6 @@ export function toElasticsearchQuery(
     });
   }
 
-  // Special case for wildcards where there are no fields or all fields share the same prefix
-  if (isExistsQuery && (!fields?.length || fields?.length === indexPattern?.fields.length)) {
-    return { match_all: {} };
-  }
-
   const queries = fields!.reduce((accumulator: any, field: DataViewFieldBase) => {
     const isKeywordField = field.esTypes?.length === 1 && field.esTypes.includes('keyword');
     const wrapWithNestedQuery = (query: any) => {


### PR DESCRIPTION
## Summary

The following code was was introduced in https://github.com/elastic/kibana/pull/96902:

https://github.com/elastic/kibana/blob/69b28f317b07af12fa346571b04b411a6130b25f/packages/kbn-es-query/src/kuery/functions/is.ts#L109-L112

 As far as I can tell it was really just added to ensure that a contrived behavior stayed exactly the same after the optimization that PR made. I thought it was related to the case where we have a query like `*` or `*:*` (in other words, a query that matches all documents) but we are already handling that in this code:

https://github.com/elastic/kibana/blob/69b28f317b07af12fa346571b04b411a6130b25f/packages/kbn-es-query/src/kuery/functions/is.ts#L62-L68

As we are moving to a scenario where we expect the field list passed to this code to be a subset of the entire list of fields (see https://github.com/elastic/kibana/pull/183694), this condition and the corresponding contrived test are removed in this PR.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
