### PR TITLE
[Search] Fix integration id overlap for connectors

### DIFF
--- a/test/api_integration/apis/custom_integration/integrations.ts
+++ b/test/api_integration/apis/custom_integration/integrations.ts
@@ -22,7 +22,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(resp.body).to.be.an('array');
 
-        expect(resp.body.length).to.be(51);
+        expect(resp.body.length).to.be(55);
 
         // Test for sample data card
         expect(resp.body.findIndex((c: { id: string }) => c.id === 'sample_data_all')).to.be.above(

--- a/x-pack/plugins/enterprise_search/server/integrations.ts
+++ b/x-pack/plugins/enterprise_search/server/integrations.ts
@@ -97,7 +97,7 @@ export const registerEnterpriseSearchIntegrations = (
             type: 'svg',
           },
         ],
-        id: connector.serviceType,
+        id: `${connector.serviceType}-${connector.name}`,
         isBeta: connector.isBeta,
         shipper: 'enterprise_search',
         title: connector.name,


### PR DESCRIPTION
## Summary

Connectors registered as custom integrations use the value in `connector.serviceType` as an id. However, there are some connectors that share a service type. This causes an error when running Kibana due to the id clash.

This PR changes the id into a concatenation of `serviceType` and `name` to ensure all ids are unique.

Errors before change (these no longer recur after the changes):

```log
[2024-05-28T12:06:10.514+00:00][ERROR][plugins.customIntegrations] Integration with id=confluence already exists.
[2024-05-28T12:06:10.516+00:00][ERROR][plugins.customIntegrations] Integration with id=jira already exists.
[2024-05-28T12:06:10.517+00:00][ERROR][plugins.customIntegrations] Integration with id=jira already exists.
[2024-05-28T12:06:10.518+00:00][ERROR][plugins.customIntegrations] Integration with id=salesforce already exists
``` 



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->