### PR TITLE
[Banner] Fix can't update the banner text from advanced settings 

### DIFF
--- a/packages/kbn-management/settings/components/field_input/input/code_editor_input.tsx
+++ b/packages/kbn-management/settings/components/field_input/input/code_editor_input.tsx
@@ -54,12 +54,13 @@ export const CodeEditorInput = ({
 
   const updateValue = useCallback(
     async (newValue: string, onUpdateFn) => {
-      const isJsonArray = Array.isArray(JSON.parse(defaultValue || '{}'));
-      const parsedValue = newValue || (isJsonArray ? '[]' : '{}');
+      let parsedValue;
 
       // Validate JSON syntax
       if (field.type === 'json') {
         try {
+          const isJsonArray = Array.isArray(JSON.parse(defaultValue || 'null'));
+          parsedValue = newValue || (isJsonArray ? '[]' : '{}');
           JSON.parse(parsedValue);
         } catch (e) {
           onUpdateFn({

--- a/packages/kbn-management/settings/components/field_input/input/markdown_editor_input.test.tsx
+++ b/packages/kbn-management/settings/components/field_input/input/markdown_editor_input.test.tsx
@@ -71,11 +71,15 @@ describe('MarkdownEditorInput', () => {
     const input = getByTestId(`${TEST_SUBJ_PREFIX_FIELD}-${id}`);
     fireEvent.change(input, { target: { value: '# New Markdown Title' } });
 
-    await waitFor(() =>
+    await waitFor(() => {
+      expect(defaultProps.onInputChange).not.toHaveBeenCalledWith({
+        error: expect.any(String),
+      });
+
       expect(defaultProps.onInputChange).toHaveBeenCalledWith({
         type: 'markdown',
         unsavedValue: '# New Markdown Title',
-      })
-    );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/184199 , by restricting the attempt to check that valid JSON was provided so it only happens when the expectation of the current field type is JSON.

## How to test

- Set a banner using advanced settings. Save it. Reload the page. Confirm the banner is displayed
- Try to edit or remove the banner message in the editor.
- The save button should appear with no errors in the console

<!-- 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

-->