### PR TITLE
(+Doc) Make "expired hot timestamps" searchable to resolve

### DIFF
--- a/docs/user/production-considerations/task-manager-troubleshooting.asciidoc
+++ b/docs/user/production-considerations/task-manager-troubleshooting.asciidoc
@@ -997,6 +997,7 @@ Task Manager has run out of Available Workers:
 [source, txt]
 --------------------------------------------------
 server log [12:41:33.672] [info][plugins][taskManager][taskManager] [Task Ownership]: Task Manager has skipped Claiming Ownership of available tasks at it has ran out Available Workers.
+server log [12:41:33.672] [warn][plugins][taskManager][taskManager] taskManager plugin is now degraded: Task Manager is unhealthy - Reason: setting HealthStatus.Error because of expired hot timestamps
 --------------------------------------------------
 
 This log message tells us that Task Manager is not managing to keep up with the sheer amount of work it has been tasked with completing. This might mean that rules are not running at the frequency that was expected (instead of running every 5 minutes, it runs every 7-8 minutes, just as an example).


### PR DESCRIPTION

## Summary

Adds `Task Manager is unhealthy - Reason: setting HealthStatus.Error because of expired hot timestamps` to docs for resolution discussion searchability. 


### Checklist


### For maintainers

👋🏽 howdy, team! AFAICT `Task Manager is unhealthy - Reason: setting HealthStatus.Error because of expired hot timestamps` is a newer Kibana (Task Manager) error which generally correlates not necessarily to sheer resource usage (cpu/heap) but workers/intervals vs load/drift. So adding to [docs where we're already discussing that](https://www.elastic.co/guide/en/kibana/master/task-manager-troubleshooting.html#task-manager-kibana-log) so users+Support can search-find the appropriate conversation. Recent high severity examples : 01607184 , 01607982 .