### PR TITLE
[CI] Make cypress reporting more resilient

### DIFF
--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -493,10 +493,14 @@ ${JSON.stringify(cyCustomEnv, null, 2)}
               (runResult) => !failedSpecFilePaths.includes(runResult.spec.absolute)
             )
         ),
-        ...retryResults,
+        ..._.filter(retryResults, (retryResult) => !!retryResult),
       ] as CypressCommandLine.CypressRunResult[];
 
-      renderSummaryTable(finalResults);
+      try {
+        renderSummaryTable(finalResults);
+      } catch (e) {
+        log.error('Failed to render summary table', e);
+      }
 
       const hasFailedTests = (
         runResults: Array<

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -499,7 +499,8 @@ ${JSON.stringify(cyCustomEnv, null, 2)}
       try {
         renderSummaryTable(finalResults);
       } catch (e) {
-        log.error('Failed to render summary table', e);
+        log.error('Failed to render summary table');
+        log.error(e);
       }
 
       const hasFailedTests = (

--- a/x-pack/plugins/security_solution/scripts/run_cypress/print_run.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/print_run.ts
@@ -277,7 +277,11 @@ function formatFooterSummary(results: CypressCommandLine.CypressRunResult) {
 export function renderSummaryTable(results: CypressCommandLine.CypressRunResult[]) {
   const parsedResults = _.reduce(
     results,
-    (acc: CypressCommandLine.CypressRunResult, result) => {
+    (acc: CypressCommandLine.CypressRunResult, result, index) => {
+      if (!result) {
+        console.warn(`Result for index: ${index} is empty (${result}). Skipping...`);
+      }
+
       acc.startedTestsAt =
         acc.startedTestsAt && new Date(result.startedTestsAt) > new Date(acc.startedTestsAt)
           ? acc.startedTestsAt

--- a/x-pack/plugins/security_solution/scripts/run_cypress/print_run.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/print_run.ts
@@ -277,12 +277,7 @@ function formatFooterSummary(results: CypressCommandLine.CypressRunResult) {
 export function renderSummaryTable(results: CypressCommandLine.CypressRunResult[]) {
   const parsedResults = _.reduce(
     results,
-    (acc: CypressCommandLine.CypressRunResult, result, index) => {
-      if (!result) {
-        console.warn(`Result for index: ${index} is empty (${result}). Skipping...`);
-        return acc;
-      }
-
+    (acc: CypressCommandLine.CypressRunResult, result) => {
       acc.startedTestsAt =
         acc.startedTestsAt && new Date(result.startedTestsAt) > new Date(acc.startedTestsAt)
           ? acc.startedTestsAt

--- a/x-pack/plugins/security_solution/scripts/run_cypress/print_run.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/print_run.ts
@@ -280,6 +280,7 @@ export function renderSummaryTable(results: CypressCommandLine.CypressRunResult[
     (acc: CypressCommandLine.CypressRunResult, result, index) => {
       if (!result) {
         console.warn(`Result for index: ${index} is empty (${result}). Skipping...`);
+        return acc;
       }
 
       acc.startedTestsAt =


### PR DESCRIPTION
## Summary
cypress reporter will occasionally get an empty result object - it draws attention from other error messages in the stream, and allows misleading conclusions

let's not fail reporting because of that, and hope that the real error will also surface.


See: https://buildkite.com/elastic/kibana-pull-request/builds/212655#018fc04b-e385-4760-87db-41b65f86fb40

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->