### PR TITLE
[8.14] [ResponseOps][Rules] Fix KQL wildcards in alerts filtering in actions and MW (#183901)

### DIFF
--- a/x-pack/plugins/alerting/common/maintenance_window.ts
+++ b/x-pack/plugins/alerting/common/maintenance_window.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import type { IUiSettingsClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import { FilterStateStore } from '@kbn/es-query';
 import { RRuleParams } from './rrule_type';
 
@@ -76,6 +76,7 @@ export type MaintenanceWindowCreateBody = Omit<
 >;
 
 export interface MaintenanceWindowClientContext {
+  readonly uiSettings: IUiSettingsClient;
   getModificationMetadata: () => Promise<MaintenanceWindowModificationMetadata>;
   savedObjectsClient: SavedObjectsClientContract;
   logger: Logger;

--- a/x-pack/plugins/alerting/public/hooks/use_create_maintenance_window.test.tsx
+++ b/x-pack/plugins/alerting/public/hooks/use_create_maintenance_window.test.tsx
@@ -79,7 +79,25 @@ describe('useCreateMaintenanceWindow', () => {
     });
 
     await waitFor(() =>
-      expect(mockAddDanger).toBeCalledWith('Failed to create maintenance window.')
+      expect(mockAddDanger).toBeCalledWith('Failed to create maintenance window')
+    );
+  });
+
+  it('should show 400 error messages', async () => {
+    createMaintenanceWindow.mockRejectedValue({
+      body: { statusCode: 400, message: 'Bad request' },
+    });
+
+    const { result } = renderHook(() => useCreateMaintenanceWindow(), {
+      wrapper: appMockRenderer.AppWrapper,
+    });
+
+    act(() => {
+      result.current.mutate(maintenanceWindow);
+    });
+
+    await waitFor(() =>
+      expect(mockAddDanger).toBeCalledWith('Failed to create maintenance window: Bad request')
     );
   });
 });

--- a/x-pack/plugins/alerting/public/hooks/use_create_maintenance_window.ts
+++ b/x-pack/plugins/alerting/public/hooks/use_create_maintenance_window.ts
@@ -13,6 +13,19 @@ import type { KibanaServerError } from '@kbn/kibana-utils-plugin/public';
 import { useKibana } from '../utils/kibana_react';
 import { createMaintenanceWindow, CreateParams } from '../services/maintenance_windows_api/create';
 
+const onErrorWithMessage = (message: string) =>
+  i18n.translate('xpack.alerting.maintenanceWindowsCreateFailureWithMessage', {
+    defaultMessage: 'Failed to create maintenance window: {message}',
+    values: { message },
+  });
+
+const onErrorWithoutMessage = i18n.translate(
+  'xpack.alerting.maintenanceWindowsCreateFailureWithoutMessage',
+  {
+    defaultMessage: 'Failed to create maintenance window',
+  }
+);
+
 interface UseCreateMaintenanceWindowProps {
   onError?: (error: IHttpFetchError<KibanaServerError>) => void;
 }
@@ -41,10 +54,11 @@ export function useCreateMaintenanceWindow(props?: UseCreateMaintenanceWindowPro
       );
     },
     onError: (error: IHttpFetchError<KibanaServerError>) => {
+      const getDefaultErrorMessage = (message?: string): string =>
+        !message ? onErrorWithoutMessage : onErrorWithMessage(message);
+
       toasts.addDanger(
-        i18n.translate('xpack.alerting.maintenanceWindowsCreateFailure', {
-          defaultMessage: 'Failed to create maintenance window.',
-        })
+        getDefaultErrorMessage(error.body?.statusCode === 400 ? error.body?.message : '')
       );
       onError?.(error);
     },

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/archive/archive_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/archive/archive_maintenance_window.test.ts
@@ -8,7 +8,11 @@
 import moment from 'moment-timezone';
 import { Frequency } from '@kbn/rrule';
 import { archiveMaintenanceWindow } from './archive_maintenance_window';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObjectsUpdateResponse, SavedObject } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -18,6 +22,7 @@ import { getMockMaintenanceWindow } from '../../../../data/maintenance_window/te
 import type { MaintenanceWindow } from '../../types';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const firstTimestamp = '2023-02-26T00:00:00.000Z';
 const secondTimestamp = '2023-03-26T00:00:00.000Z';
@@ -33,6 +38,7 @@ const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - archive', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/bulk_get/bulk_get_maintenance_windows.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/bulk_get/bulk_get_maintenance_windows.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { bulkGetMaintenanceWindows } from './bulk_get_maintenance_windows';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObject } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -15,11 +19,13 @@ import {
 import { getMockMaintenanceWindow } from '../../../../data/maintenance_window/test_helpers';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - get', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/delete/delete_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/delete/delete_maintenance_window.test.ts
@@ -6,18 +6,24 @@
  */
 
 import { deleteMaintenanceWindow } from './delete_maintenance_window';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import {
   MaintenanceWindowClientContext,
   MAINTENANCE_WINDOW_SAVED_OBJECT_TYPE,
 } from '../../../../../common';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - delete', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/find/find_maintenance_windows.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/find/find_maintenance_windows.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { findMaintenanceWindows } from './find_maintenance_windows';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObjectsFindResponse } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -15,11 +19,13 @@ import {
 import { getMockMaintenanceWindow } from '../../../../data/maintenance_window/test_helpers';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - find', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/finish/finish_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/finish/finish_maintenance_window.test.ts
@@ -8,7 +8,11 @@
 import moment from 'moment-timezone';
 import { Frequency } from '@kbn/rrule';
 import { finishMaintenanceWindow } from './finish_maintenance_window';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObjectsUpdateResponse, SavedObject } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -18,6 +22,7 @@ import { getMockMaintenanceWindow } from '../../../../data/maintenance_window/te
 import type { MaintenanceWindow } from '../../types';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const firstTimestamp = '2023-02-26T00:00:00.000Z';
 
@@ -32,6 +37,7 @@ const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - finish', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/get/get_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/get/get_maintenance_window.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { getMaintenanceWindow } from './get_maintenance_window';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObject } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -15,11 +19,13 @@ import {
 import { getMockMaintenanceWindow } from '../../../../data/maintenance_window/test_helpers';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - get', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/get_active/get_active_maintenance_windows.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/get_active/get_active_maintenance_windows.test.ts
@@ -7,7 +7,11 @@
 
 import { getActiveMaintenanceWindows } from './get_active_maintenance_windows';
 import { toElasticsearchQuery } from '@kbn/es-query';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObjectsFindResponse } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -16,11 +20,13 @@ import {
 import { getMockMaintenanceWindow } from '../../../../data/maintenance_window/test_helpers';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - getActiveMaintenanceWindows', () => {

--- a/x-pack/plugins/alerting/server/application/maintenance_window/methods/update/update_maintenance_window.test.ts
+++ b/x-pack/plugins/alerting/server/application/maintenance_window/methods/update/update_maintenance_window.test.ts
@@ -9,7 +9,11 @@ import moment from 'moment-timezone';
 import { Frequency } from '@kbn/rrule';
 import { updateMaintenanceWindow } from './update_maintenance_window';
 import { UpdateMaintenanceWindowParams } from './types';
-import { savedObjectsClientMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  savedObjectsClientMock,
+  loggingSystemMock,
+  uiSettingsServiceMock,
+} from '@kbn/core/server/mocks';
 import { SavedObject } from '@kbn/core/server';
 import {
   MaintenanceWindowClientContext,
@@ -20,6 +24,7 @@ import type { MaintenanceWindow } from '../../types';
 import { FilterStateStore } from '@kbn/es-query';
 
 const savedObjectsClient = savedObjectsClientMock.create();
+const uiSettings = uiSettingsServiceMock.createClient();
 
 const firstTimestamp = '2023-02-26T00:00:00.000Z';
 const secondTimestamp = '2023-03-26T00:00:00.000Z';
@@ -47,6 +52,7 @@ const mockContext: jest.Mocked<MaintenanceWindowClientContext> = {
   logger: loggingSystemMock.create().get(),
   getModificationMetadata: jest.fn(),
   savedObjectsClient,
+  uiSettings,
 };
 
 describe('MaintenanceWindowClient - update', () => {

--- a/x-pack/plugins/alerting/server/lib/get_es_query_config.test.ts
+++ b/x-pack/plugins/alerting/server/lib/get_es_query_config.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
+import { getEsQueryConfig } from './get_es_query_config';
+
+describe('getEsQueryConfig', () => {
+  const uiSettingsClient = uiSettingsServiceMock.createClient();
+
+  it('should get the es query config correctly', async () => {
+    const settings = await getEsQueryConfig(uiSettingsClient);
+
+    expect(settings).toEqual({
+      allowLeadingWildcards: false,
+      ignoreFilterIfFieldNotInIndex: false,
+      queryStringOptions: false,
+    });
+  });
+});

--- a/x-pack/plugins/alerting/server/lib/get_es_query_config.ts
+++ b/x-pack/plugins/alerting/server/lib/get_es_query_config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IUiSettingsClient } from '@kbn/core/server';
+import { UI_SETTINGS } from '@kbn/data-plugin/server';
+
+export async function getEsQueryConfig(uiSettings: IUiSettingsClient) {
+  const allowLeadingWildcards = await uiSettings.get(UI_SETTINGS.QUERY_ALLOW_LEADING_WILDCARDS);
+  const queryStringOptions = await uiSettings.get(UI_SETTINGS.QUERY_STRING_OPTIONS);
+  const ignoreFilterIfFieldNotInIndex = await uiSettings.get(
+    UI_SETTINGS.COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX
+  );
+
+  return {
+    allowLeadingWildcards,
+    queryStringOptions,
+    ignoreFilterIfFieldNotInIndex,
+  };
+}

--- a/x-pack/plugins/alerting/server/maintenance_window_client/maintenance_window_client.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client/maintenance_window_client.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import { IUiSettingsClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
 
 import { createMaintenanceWindow } from '../application/maintenance_window/methods/create/create_maintenance_window';
 import type { CreateMaintenanceWindowParams } from '../application/maintenance_window/methods/create/types';
@@ -33,6 +33,7 @@ import {
 import type { MaintenanceWindow } from '../application/maintenance_window/types';
 
 export interface MaintenanceWindowClientConstructorOptions {
+  readonly uiSettings: IUiSettingsClient;
   readonly logger: Logger;
   readonly savedObjectsClient: SavedObjectsClientContract;
   readonly getUserName: () => Promise<string | null>;
@@ -52,6 +53,7 @@ export class MaintenanceWindowClient {
       logger: this.logger,
       savedObjectsClient: this.savedObjectsClient,
       getModificationMetadata: this.getModificationMetadata.bind(this),
+      uiSettings: options.uiSettings,
     };
   }
 

--- a/x-pack/plugins/alerting/server/maintenance_window_client_factory.test.ts
+++ b/x-pack/plugins/alerting/server/maintenance_window_client_factory.test.ts
@@ -13,6 +13,7 @@ import {
   savedObjectsClientMock,
   savedObjectsServiceMock,
   loggingSystemMock,
+  uiSettingsServiceMock,
 } from '@kbn/core/server/mocks';
 import { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { securityMock } from '@kbn/security-plugin/server/mocks';
@@ -23,12 +24,13 @@ jest.mock('./maintenance_window_client');
 
 const savedObjectsClient = savedObjectsClientMock.create();
 const savedObjectsService = savedObjectsServiceMock.createInternalStartContract();
-
 const securityPluginStart = securityMock.createStart();
+const uiSettings = uiSettingsServiceMock.createStartContract();
 
 const maintenanceWindowClientFactoryParams: jest.Mocked<MaintenanceWindowClientFactoryOpts> = {
   logger: loggingSystemMock.create().get(),
   savedObjectsService,
+  uiSettings,
 };
 
 beforeEach(() => {

--- a/x-pack/plugins/alerting/server/plugin.ts
+++ b/x-pack/plugins/alerting/server/plugin.ts
@@ -539,6 +539,7 @@ export class AlertingPlugin {
       logger: this.logger,
       savedObjectsService: core.savedObjects,
       securityPluginStart: plugins.security,
+      uiSettings: core.uiSettings,
     });
 
     const getRulesClientWithRequest = (request: KibanaRequest) => {

--- a/x-pack/plugins/alerting/server/rules_client/lib/__snapshots__/add_generated_action_values.test.ts.snap
+++ b/x-pack/plugins/alerting/server/rules_client/lib/__snapshots__/add_generated_action_values.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`addGeneratedActionValues() throws error if KQL is not valid: "Error creating DSL query: invalid KQL" 1`] = `"Error creating DSL query: invalid KQL"`;

--- a/x-pack/plugins/alerting/server/rules_client/lib/add_generated_action_values.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/lib/add_generated_action_values.test.ts
@@ -183,12 +183,10 @@ describe('addGeneratedActionValues()', () => {
           minimumScheduleIntervalInMs: 0,
         }
       )
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `
-      "Invalid KQL: Expected AND, OR, end of input but \\":\\" found.
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Invalid KQL: Expected AND, OR, end of input, whitespace but \\":\\" found.
       foo:bar:1
       -------^"
-    `
-    );
+    `);
   });
 });

--- a/x-pack/plugins/alerting/server/rules_client/lib/add_generated_action_values.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/lib/add_generated_action_values.test.ts
@@ -31,14 +31,16 @@ describe('addGeneratedActionValues()', () => {
   const taskManager = taskManagerMock.createStart();
   const ruleTypeRegistry = ruleTypeRegistryMock.create();
   const unsecuredSavedObjectsClient = savedObjectsClientMock.create();
-
   const encryptedSavedObjects = encryptedSavedObjectsMock.createClient();
   const authorization = alertingAuthorizationMock.create();
   const actionsAuthorization = actionsAuthorizationMock.create();
   const internalSavedObjectsRepository = savedObjectsRepositoryMock.create();
-
   const kibanaVersion = 'v7.10.0';
   const logger = loggingSystemMock.create().get();
+  const uiSettings = uiSettingsServiceMock.createStartContract();
+  const uiSettingsClient = uiSettingsServiceMock.createClient();
+
+  uiSettings.asScopedToClient.mockReturnValue(uiSettingsClient);
 
   const rulesClientParams: jest.Mocked<ConstructorOptions> = {
     taskManager,
@@ -62,7 +64,7 @@ describe('addGeneratedActionValues()', () => {
     getAuthenticationAPIKey: jest.fn(),
     getAlertIndicesAlias: jest.fn(),
     alertsService: null,
-    uiSettings: uiSettingsServiceMock.createStartContract(),
+    uiSettings,
     connectorAdapterRegistry: new ConnectorAdapterRegistry(),
     isSystemAction: jest.fn(),
   };
@@ -100,6 +102,10 @@ describe('addGeneratedActionValues()', () => {
     actionTypeId: 'slack',
     params: {},
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   test('adds uuid', async () => {
     const actionWithGeneratedValues = await addGeneratedActionValues(
@@ -143,6 +149,21 @@ describe('addGeneratedActionValues()', () => {
       params: {},
       uuid: '111-222',
     });
+
+    expect(uiSettingsClient.get).toHaveBeenCalledTimes(3);
+    expect(uiSettingsClient.get.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "query:allowLeadingWildcards",
+        ],
+        Array [
+          "query:queryString:options",
+        ],
+        Array [
+          "courier:ignoreFilterIfFieldNotInIndex",
+        ],
+      ]
+    `);
   });
 
   test('throws error if KQL is not valid', async () => {
@@ -154,6 +175,7 @@ describe('addGeneratedActionValues()', () => {
             alertsFilter: { query: { kql: 'foo:bar:1', filters: [] } },
           },
         ],
+
         [mockSystemAction],
         {
           ...rulesClientParams,
@@ -161,6 +183,12 @@ describe('addGeneratedActionValues()', () => {
           minimumScheduleIntervalInMs: 0,
         }
       )
-    ).rejects.toThrowErrorMatchingSnapshot('"Error creating DSL query: invalid KQL"');
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `
+      "Invalid KQL: Expected AND, OR, end of input but \\":\\" found.
+      foo:bar:1
+      -------^"
+    `
+    );
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ResponseOps][Rules] Fix KQL wildcards in alerts filtering in actions and MW (#183901)](https://github.com/elastic/kibana/pull/183901)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2024-05-29T10:32:12Z","message":"[ResponseOps][Rules] Fix KQL wildcards in alerts filtering in actions and MW (#183901)\n\n## Summary\r\n\r\nThis PR \r\n\r\n1. Show KQL error messages to the UI\r\n2. Respect the `query:allowLeadingWildcards` advance setting in the MW\r\n\r\n## Testing\r\n\r\nVerify that the bug except the one about DSL filtering described in\r\nhttps://github.com/elastic/kibana/issues/168600 is fixed. Also, test the\r\nfollowing scenarios.\r\n\r\n### Actions\r\n\r\n**Error**:\r\n1. Go to Stack -> Advanced setting and disable\r\n`query:allowLeadingWildcards`\r\n2. Create a rule with an action and make the action conditional by\r\ntoggling the \"If alert matches query\"\r\n3. Add a KQL like `kibana.alert.instance.id : *development`. The leading\r\n`*` is important\r\n4. Save the rule. You should see a toaster error with a message about\r\n`query:allowLeadingWildcards`\r\n\r\n**Happy path**:\r\n1. Go to Stack -> Advanced setting and make sure\r\n`query:allowLeadingWildcards` is enabled\r\n2. Create a rule with an action and make the action conditional by\r\ntoggling the \"If alert matches query\"\r\n3. Add a KQL like `kibana.alert.instance.id : *development`. The leading\r\n`*` is important\r\n4. Save the rule. You should not see any errors.\r\n\r\n### Maintenance Windows\r\n\r\n**Error**:\r\n1. Go to Stack -> Advanced setting and disable\r\n`query:allowLeadingWildcards`\r\n2. Go to Stack -> Maintenance Windows -> Create window\r\n3. Toggle \"Filter alerts\" and add a KQL like `kibana.alert.instance.id :\r\n*development`. The leading `*` is important\r\n4. Create the MW. You should see a toaster error with a message about\r\n`query:allowLeadingWildcards`\r\n\r\n**Happy path**:\r\n1. Go to Stack -> Advanced setting and make sure\r\n`query:allowLeadingWildcards` is enabled\r\n2. Go to Stack -> Maintenance Windows -> Create window\r\n3. Toggle \"Filter alerts\" and add a KQL like `kibana.alert.instance.id :\r\n*development`. The leading `*` is important\r\n4. Create the MW. You should not see any errors.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/168600\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n## Release notes\r\nShow errors about invalid KQL in conditional actions and respect the\r\n`query:allowLeadingWildcards` advanced setting in maintenance windows","sha":"b9e47025fa2723cdc83eb38df2ffdfe33ceb6896","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:ResponseOps","v8.14.0","v8.15.0"],"number":183901,"url":"https://github.com/elastic/kibana/pull/183901","mergeCommit":{"message":"[ResponseOps][Rules] Fix KQL wildcards in alerts filtering in actions and MW (#183901)\n\n## Summary\r\n\r\nThis PR \r\n\r\n1. Show KQL error messages to the UI\r\n2. Respect the `query:allowLeadingWildcards` advance setting in the MW\r\n\r\n## Testing\r\n\r\nVerify that the bug except the one about DSL filtering described in\r\nhttps://github.com/elastic/kibana/issues/168600 is fixed. Also, test the\r\nfollowing scenarios.\r\n\r\n### Actions\r\n\r\n**Error**:\r\n1. Go to Stack -> Advanced setting and disable\r\n`query:allowLeadingWildcards`\r\n2. Create a rule with an action and make the action conditional by\r\ntoggling the \"If alert matches query\"\r\n3. Add a KQL like `kibana.alert.instance.id : *development`. The leading\r\n`*` is important\r\n4. Save the rule. You should see a toaster error with a message about\r\n`query:allowLeadingWildcards`\r\n\r\n**Happy path**:\r\n1. Go to Stack -> Advanced setting and make sure\r\n`query:allowLeadingWildcards` is enabled\r\n2. Create a rule with an action and make the action conditional by\r\ntoggling the \"If alert matches query\"\r\n3. Add a KQL like `kibana.alert.instance.id : *development`. The leading\r\n`*` is important\r\n4. Save the rule. You should not see any errors.\r\n\r\n### Maintenance Windows\r\n\r\n**Error**:\r\n1. Go to Stack -> Advanced setting and disable\r\n`query:allowLeadingWildcards`\r\n2. Go to Stack -> Maintenance Windows -> Create window\r\n3. Toggle \"Filter alerts\" and add a KQL like `kibana.alert.instance.id :\r\n*development`. The leading `*` is important\r\n4. Create the MW. You should see a toaster error with a message about\r\n`query:allowLeadingWildcards`\r\n\r\n**Happy path**:\r\n1. Go to Stack -> Advanced setting and make sure\r\n`query:allowLeadingWildcards` is enabled\r\n2. Go to Stack -> Maintenance Windows -> Create window\r\n3. Toggle \"Filter alerts\" and add a KQL like `kibana.alert.instance.id :\r\n*development`. The leading `*` is important\r\n4. Create the MW. You should not see any errors.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/168600\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n## Release notes\r\nShow errors about invalid KQL in conditional actions and respect the\r\n`query:allowLeadingWildcards` advanced setting in maintenance windows","sha":"b9e47025fa2723cdc83eb38df2ffdfe33ceb6896"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183901","number":183901,"mergeCommit":{"message":"[ResponseOps][Rules] Fix KQL wildcards in alerts filtering in actions and MW (#183901)\n\n## Summary\r\n\r\nThis PR \r\n\r\n1. Show KQL error messages to the UI\r\n2. Respect the `query:allowLeadingWildcards` advance setting in the MW\r\n\r\n## Testing\r\n\r\nVerify that the bug except the one about DSL filtering described in\r\nhttps://github.com/elastic/kibana/issues/168600 is fixed. Also, test the\r\nfollowing scenarios.\r\n\r\n### Actions\r\n\r\n**Error**:\r\n1. Go to Stack -> Advanced setting and disable\r\n`query:allowLeadingWildcards`\r\n2. Create a rule with an action and make the action conditional by\r\ntoggling the \"If alert matches query\"\r\n3. Add a KQL like `kibana.alert.instance.id : *development`. The leading\r\n`*` is important\r\n4. Save the rule. You should see a toaster error with a message about\r\n`query:allowLeadingWildcards`\r\n\r\n**Happy path**:\r\n1. Go to Stack -> Advanced setting and make sure\r\n`query:allowLeadingWildcards` is enabled\r\n2. Create a rule with an action and make the action conditional by\r\ntoggling the \"If alert matches query\"\r\n3. Add a KQL like `kibana.alert.instance.id : *development`. The leading\r\n`*` is important\r\n4. Save the rule. You should not see any errors.\r\n\r\n### Maintenance Windows\r\n\r\n**Error**:\r\n1. Go to Stack -> Advanced setting and disable\r\n`query:allowLeadingWildcards`\r\n2. Go to Stack -> Maintenance Windows -> Create window\r\n3. Toggle \"Filter alerts\" and add a KQL like `kibana.alert.instance.id :\r\n*development`. The leading `*` is important\r\n4. Create the MW. You should see a toaster error with a message about\r\n`query:allowLeadingWildcards`\r\n\r\n**Happy path**:\r\n1. Go to Stack -> Advanced setting and make sure\r\n`query:allowLeadingWildcards` is enabled\r\n2. Go to Stack -> Maintenance Windows -> Create window\r\n3. Toggle \"Filter alerts\" and add a KQL like `kibana.alert.instance.id :\r\n*development`. The leading `*` is important\r\n4. Create the MW. You should not see any errors.\r\n\r\nFixes: https://github.com/elastic/kibana/issues/168600\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n## Release notes\r\nShow errors about invalid KQL in conditional actions and respect the\r\n`query:allowLeadingWildcards` advanced setting in maintenance windows","sha":"b9e47025fa2723cdc83eb38df2ffdfe33ceb6896"}}]}] BACKPORT-->