### PR TITLE
[Fleet] added force flag to delete agent_policies API

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3814,6 +3814,10 @@
                 "properties": {
                   "agentPolicyId": {
                     "type": "string"
+                  },
+                  "force": {
+                    "type": "boolean",
+                    "description": "bypass validation checks that can prevent agent policy deletion"
                   }
                 },
                 "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2387,6 +2387,11 @@ paths:
               properties:
                 agentPolicyId:
                   type: string
+                force:
+                  type: boolean
+                  description: >-
+                    bypass validation checks that can prevent agent policy
+                    deletion
               required:
                 - agentPolicyId
       parameters:

--- a/x-pack/plugins/fleet/common/openapi/paths/agent_policies@delete.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agent_policies@delete.yaml
@@ -28,6 +28,9 @@ post:
           properties:
             agentPolicyId:
               type: string
+            force:
+              type: boolean
+              description: bypass validation checks that can prevent agent policy deletion
           required:
             - agentPolicyId
   parameters:

--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -335,6 +335,7 @@ export const deleteAgentPoliciesHandler: RequestHandler<
       request.body.agentPolicyId,
       {
         user: user || undefined,
+        force: request.body.force,
       }
     );
     return response.ok({

--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -467,6 +467,19 @@ describe('Agent policy', () => {
       }
     });
 
+    it('should allow delete with force for agent policy which has managed package policy', async () => {
+      mockedPackagePolicyService.findAllForAgentPolicy.mockReturnValue([
+        {
+          id: 'package-1',
+          is_managed: true,
+        },
+      ] as any);
+      const response = await agentPolicyService.delete(soClient, esClient, 'mocked', {
+        force: true,
+      });
+      expect(response.id).toEqual('mocked');
+    });
+
     it('should call audit logger', async () => {
       await agentPolicyService.delete(soClient, esClient, 'mocked');
 

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent_policy.ts
@@ -79,6 +79,7 @@ export const CopyAgentPolicyRequestSchema = {
 export const DeleteAgentPolicyRequestSchema = {
   body: schema.object({
     agentPolicyId: schema.string(),
+    force: schema.maybe(schema.boolean()),
   }),
 };
 

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -1216,6 +1216,28 @@ export default function (providerContext: FtrProviderContext) {
         });
       });
 
+      it('should allow hosted policy delete with force flag', async () => {
+        const {
+          body: { item: createdPolicy },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Hosted policy',
+            namespace: 'default',
+            is_managed: true,
+          })
+          .expect(200);
+        hostedPolicy = createdPolicy;
+        await supertest
+          .post('/api/fleet/agent_policies/delete')
+          .set('kbn-xsrf', 'xxx')
+          .send({ agentPolicyId: hostedPolicy.id, force: true })
+          .expect(200);
+
+        await supertest.get(`/api/fleet/agent_policies/${hostedPolicy.id}`).expect(404);
+      });
+
       describe('Errors when trying to delete', () => {
         it('should prevent policies having agents from being deleted', async () => {
           const {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/182913

Added `force` flag to delete managed agent policy / agent policy with managed package policies. 
It is still not possible to force delete an agent policy which has agents enrolled.

To verify:
- create managed agent policy / policy with managed package policies
- use the force flag to delete the agent policy

```
POST kbn:/api/fleet/agent_policies/delete
{
  "agentPolicyId": "POLICY_ID",
  "force": true
}
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
