### PR TITLE
Mark missing encryption key errors as Framework error

### DIFF
--- a/x-pack/plugins/actions/server/lib/action_executor.test.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.test.ts
@@ -936,7 +936,7 @@ describe('Action Executor', () => {
         expect(e.message).toBe(
           'Unable to execute action because the Encrypted Saved Objects plugin is missing encryption key. Please set xpack.encryptedSavedObjects.encryptionKey in the kibana.yml or use the bin/kibana-encryption-keys command.'
         );
-        expect(getErrorSource(e)).toBe(TaskErrorSource.USER);
+        expect(getErrorSource(e)).toBe(TaskErrorSource.FRAMEWORK);
       }
     });
 

--- a/x-pack/plugins/actions/server/lib/action_executor.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.ts
@@ -317,7 +317,7 @@ export class ActionExecutor {
         new Error(
           `Unable to execute action because the Encrypted Saved Objects plugin is missing encryption key. Please set xpack.encryptedSavedObjects.encryptionKey in the kibana.yml or use the bin/kibana-encryption-keys command.`
         ),
-        TaskErrorSource.USER
+        TaskErrorSource.FRAMEWORK
       );
     }
 


### PR DESCRIPTION
Resolves: #180418

This PR marks `Encrypted Saved Objects plugin is missing encryption key` errors as framework error.