### PR TITLE
[Fleet] Add API integration to inputs endpoint

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1,5 +1,6 @@
 {
   "openapi": "3.0.0",
+  "tags": [],
   "info": {
     "title": "Fleet",
     "description": "OpenAPI schema for Fleet API endpoints",
@@ -18,12 +19,6 @@
       "description": "Public and supported Fleet API"
     }
   ],
-  "security": [
-    {
-      "basicAuth": []
-    }
-  ],
-  "tags": [],
   "paths": {
     "/health_check": {
       "post": {
@@ -9404,5 +9399,10 @@
         }
       }
     }
-  }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ]
 }

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1,6 +1,5 @@
 {
   "openapi": "3.0.0",
-  "tags": [],
   "info": {
     "title": "Fleet",
     "description": "OpenAPI schema for Fleet API endpoints",
@@ -19,6 +18,12 @@
       "description": "Public and supported Fleet API"
     }
   ],
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "tags": [],
   "paths": {
     "/health_check": {
       "post": {
@@ -1621,6 +1626,14 @@
           },
           "name": "prerelease",
           "description": "Specify if version is prerelease",
+          "in": "query"
+        },
+        {
+          "schema": {
+            "type": "boolean"
+          },
+          "name": "ignoreUnverified",
+          "description": "Ignore if the package is fails signature verification",
           "in": "query"
         }
       ]
@@ -9391,10 +9404,5 @@
         }
       }
     }
-  },
-  "security": [
-    {
-      "basicAuth": []
-    }
-  ]
+  }
 }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -207,7 +207,7 @@ paths:
                       id:
                         type: string
                         nullable: true
-                        description: the key ID of the GPG key used to verify package signatures
+                        description: The key ID of the GPG key used to verify package signatures
                   statusCode:
                     type: number
                   headers:

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1,4 +1,5 @@
 openapi: 3.0.0
+tags: []
 info:
   title: Fleet
   description: OpenAPI schema for Fleet API endpoints
@@ -11,9 +12,6 @@ info:
 servers:
   - url: http://KIBANA_HOST:5601/api/fleet
     description: Public and supported Fleet API
-security:
-  - basicAuth: []
-tags: []
 paths:
   /health_check:
     post:
@@ -132,7 +130,10 @@ paths:
           required: false
           schema:
             type: string
-          description: An agent policy ID to scope the enrollment settings to. For example, that policy's Fleet Server host, its proxy, download location, etc. If not provided, the default Fleet Server policy is used (if any).
+          description: >-
+            An agent policy ID to scope the enrollment settings to. For example,
+            that policy's Fleet Server host, its proxy, download location, etc.
+            If not provided, the default Fleet Server policy is used (if any).
       responses:
         '200':
           description: OK
@@ -207,7 +208,9 @@ paths:
                       id:
                         type: string
                         nullable: true
-                        description: The key ID of the GPG key used to verify package signatures
+                        description: >-
+                          the key ID of the GPG key used to verify package
+                          signatures
                   statusCode:
                     type: number
                   headers:
@@ -270,7 +273,9 @@ paths:
         schema:
           type: boolean
           default: false
-        description: Whether to include prerelease packages in categories count (e.g. beta, rc, preview)
+        description: >-
+          Whether to include prerelease packages in categories count (e.g. beta,
+          rc, preview)
       - in: query
         name: experimental
         deprecated: true
@@ -324,13 +329,20 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Whether to exclude the install status of each package. Enabling this option will opt in to caching for the response via `cache-control` headers. If you don't need up-to-date installation info for a package, and are querying for a list of available packages, providing this flag can improve performance substantially.
+          description: >-
+            Whether to exclude the install status of each package. Enabling this
+            option will opt in to caching for the response via `cache-control`
+            headers. If you don't need up-to-date installation info for a
+            package, and are querying for a list of available packages,
+            providing this flag can improve performance substantially.
         - in: query
           name: prerelease
           schema:
             type: boolean
             default: false
-          description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
+          description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
         - in: query
           name: experimental
           deprecated: true
@@ -395,7 +407,9 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Skip data stream rollover during index template mapping or settings update
+          description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
       requestBody:
         content:
           application/zip:
@@ -427,7 +441,9 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
+          description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
       requestBody:
         content:
           application/json:
@@ -499,7 +515,9 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
+          description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
       deprecated: true
     post:
       summary: Install package
@@ -551,7 +569,9 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Skip data stream rollover during index template mapping or settings update
+          description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
       requestBody:
         content:
           application/json:
@@ -670,14 +690,18 @@ paths:
       - schema:
           type: boolean
         name: full
-        description: Return all fields from the package manifest, not just those supported by the Elastic Package Registry
+        description: >-
+          Return all fields from the package manifest, not just those supported
+          by the Elastic Package Registry
         in: query
       - in: query
         name: prerelease
         schema:
           type: boolean
           default: false
-        description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
+        description: >-
+          Whether to return prerelease versions of packages (e.g. beta, rc,
+          preview)
     post:
       summary: Install package
       tags:
@@ -732,7 +756,9 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Skip data stream rollover during index template mapping or settings update
+          description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
       requestBody:
         content:
           application/json:
@@ -880,7 +906,9 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Whether to include prerelease packages in categories count (e.g. beta, rc, preview)
+          description: >-
+            Whether to include prerelease packages in categories count (e.g.
+            beta, rc, preview)
       requestBody:
         content:
           application/json:
@@ -1374,7 +1402,9 @@ paths:
                           description: creation time of action
                         latestErrors:
                           type: array
-                          description: latest errors that happened when the agents executed the action
+                          description: >-
+                            latest errors that happened when the agents executed
+                            the action
                           items:
                             type: object
                             properties:
@@ -1871,7 +1901,9 @@ paths:
                   description: Unenrolls hosted agents too
                 includeInactive:
                   type: boolean
-                  description: When passing agents by KQL query, unenrolls inactive agents too
+                  description: >-
+                    When passing agents by KQL query, unenrolls inactive agents
+                    too
               required:
                 - agents
             example:
@@ -2074,12 +2106,18 @@ paths:
             type: boolean
           in: query
           name: full
-          description: When set to true, retrieve the related package policies for each agent policy.
+          description: >-
+            When set to true, retrieve the related package policies for each
+            agent policy.
         - schema:
             type: boolean
           in: query
           name: noAgentCount
-          description: When set to true, do not count how many agents are in the agent policy, this can improve performance if you are searching over a large number of agent policies. The "agents" property will always be 0 if set to true.
+          description: >-
+            When set to true, do not count how many agents are in the agent
+            policy, this can improve performance if you are searching over a
+            large number of agent policies. The "agents" property will always be
+            0 if set to true.
       description: ''
     post:
       summary: Create agent policy
@@ -2659,7 +2697,9 @@ paths:
         '409':
           $ref: '#/components/responses/error'
       requestBody:
-        description: You should use inputs as an object and not use the deprecated inputs array.
+        description: >-
+          You should use inputs as an object and not use the deprecated inputs
+          array.
         content:
           application/json:
             schema:
@@ -3284,7 +3324,9 @@ paths:
                 is_internal:
                   type: boolean
                 proxy_id:
-                  description: The ID of the proxy to use for this fleet server host. See the proxies API for more information.
+                  description: >-
+                    The ID of the proxy to use for this fleet server host. See
+                    the proxies API for more information.
                   type: string
                 host_urls:
                   type: array
@@ -3359,7 +3401,9 @@ paths:
                 is_internal:
                   type: boolean
                 proxy_id:
-                  description: The ID of the proxy to use for this fleet server host. See the proxies API for more information.
+                  description: >-
+                    The ID of the proxy to use for this fleet server host. See
+                    the proxies API for more information.
                   type: string
                   nullable: true
                 host_urls:
@@ -3877,7 +3921,9 @@ components:
         host:
           type: string
         proxy_id:
-          description: The ID of the proxy to use for this download source. See the proxies API for more information.
+          description: >-
+            The ID of the proxy to use for this download source. See the proxies
+            API for more information.
           type: string
           nullable: true
       required:
@@ -4262,7 +4308,9 @@ components:
         release:
           type: string
           deprecated: true
-          description: release label is deprecated, derive from the version instead (packages follow semver)
+          description: >-
+            release label is deprecated, derive from the version instead
+            (packages follow semver)
           enum:
             - experimental
             - beta
@@ -4541,7 +4589,9 @@ components:
           properties:
             cpu_avg:
               type: number
-              description: Average agent CPU usage during the last 5 minutes, number between 0-1
+              description: >-
+                Average agent CPU usage during the last 5 minutes, number
+                between 0-1
             memory_size_byte_avg:
               type: number
               description: Average agent memory consumption during the last 5 minutes
@@ -4813,7 +4863,9 @@ components:
               - metrics
               - logs
         keep_monitoring_alive:
-          description: When set to true, monitoring will be enabled but logs/metrics collection will be disabled
+          description: >-
+            When set to true, monitoring will be enabled but logs/metrics
+            collection will be disabled
           type: boolean
           nullable: true
         data_output_id:
@@ -4833,7 +4885,10 @@ components:
         inactivity_timeout:
           type: integer
         package_policies:
-          description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
+          description: >-
+            This field is present only when retrieving a single agent policy, or
+            when retrieving a list of agent policies with the ?full=true
+            parameter
           type: array
           items:
             $ref: '#/components/schemas/package_policy'
@@ -4861,19 +4916,28 @@ components:
               - name
               - enabled
         is_protected:
-          description: Indicates whether the agent policy has tamper protection enabled. Default false.
+          description: >-
+            Indicates whether the agent policy has tamper protection enabled.
+            Default false.
           type: boolean
         overrides:
           type: object
-          description: Override settings that are defined in the agent policy. Input settings cannot be overridden. The override option should be used only in unusual circumstances and not as a routine procedure.
+          description: >-
+            Override settings that are defined in the agent policy. Input
+            settings cannot be overridden. The override option should be used
+            only in unusual circumstances and not as a routine procedure.
           nullable: true
         advanced_settings:
           type: object
-          description: Advanced settings stored in the agent policy, e.g. agent_limits_go_max_procs
+          description: >-
+            Advanced settings stored in the agent policy, e.g.
+            agent_limits_go_max_procs
           nullable: true
         supports_agentless:
           type: boolean
-          description: Indicates whether the agent policy supports agentless integrations. Only allowed in a serverless environment.
+          description: >-
+            Indicates whether the agent policy supports agentless integrations.
+            Only allowed in a serverless environment.
         global_data_tags:
           type: array
           items:
@@ -4882,7 +4946,9 @@ components:
               oneOf:
                 - type: string
                 - type: number
-            description: User defined data tags that are added to all of the inputs. The values can be strings or numbers.
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
       required:
         - id
         - status
@@ -4948,7 +5014,9 @@ components:
               oneOf:
                 - type: string
                 - type: number
-            description: User defined data tags that are added to all of the inputs. The values can be strings or numbers.
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
       required:
         - name
         - namespace
@@ -5215,7 +5283,9 @@ components:
           example: my description
         namespace:
           type: string
-          description: The package policy namespace. Leave blank to inherit the agent policy's namespace.
+          description: >-
+            The package policy namespace. Leave blank to inherit the agent
+            policy's namespace.
           example: customnamespace
         policy_id:
           type: string
@@ -5237,10 +5307,14 @@ components:
             - version
         vars:
           type: object
-          description: Package root level variable (see integration documentation for more information)
+          description: >-
+            Package root level variable (see integration documentation for more
+            information)
         inputs:
           type: object
-          description: Package policy inputs (see integration documentation to know what inputs are available)
+          description: >-
+            Package policy inputs (see integration documentation to know what
+            inputs are available)
           example:
             nginx-logfile:
               enabled: true
@@ -5262,10 +5336,14 @@ components:
                 description: enable or disable that input, (default to true)
               vars:
                 type: object
-                description: Input level variable (see integration documentation for more information)
+                description: >-
+                  Input level variable (see integration documentation for more
+                  information)
               streams:
                 type: object
-                description: Input streams (see integration documentation to know what streams are available)
+                description: >-
+                  Input streams (see integration documentation to know what
+                  streams are available)
                 additionalProperties:
                   type: object
                   properties:
@@ -5274,17 +5352,24 @@ components:
                       description: enable or disable that stream, (default to true)
                     vars:
                       type: object
-                      description: Stream level variable (see integration documentation for more information)
+                      description: >-
+                        Stream level variable (see integration documentation for
+                        more information)
         overrides:
           type: object
           properties:
             inputs:
               type: object
-          description: Override settings that are defined in the package policy. The override option should be used only in unusual circumstances and not as a routine procedure.
+          description: >-
+            Override settings that are defined in the package policy. The
+            override option should be used only in unusual circumstances and not
+            as a routine procedure.
           nullable: true
         force:
           type: boolean
-          description: Force package policy creation even if package is not verified, or if the agent policy is managed.
+          description: >-
+            Force package policy creation even if package is not verified, or if
+            the agent policy is managed.
       required:
         - name
         - policy_id
@@ -5575,7 +5660,9 @@ components:
                 type: string
               when:
                 deprecated: true
-                description: Deprecated, kafka output do not support conditionnal topics anymore.
+                description: >-
+                  Deprecated, kafka output do not support conditionnal topics
+                  anymore.
                 type: object
                 properties:
                   type:
@@ -5920,7 +6007,9 @@ components:
                 type: string
               when:
                 deprecated: true
-                description: Deprecated, kafka output do not support conditionnal topics anymore.
+                description: >-
+                  Deprecated, kafka output do not support conditionnal topics
+                  anymore.
                 type: object
                 properties:
                   type:
@@ -6018,3 +6107,5 @@ components:
           elasticsearch: '#/components/schemas/output_update_request_elasticsearch'
           kafka: '#/components/schemas/output_update_request_kafka'
           logstash: '#/components/schemas/output_update_request_logstash'
+security:
+  - basicAuth: []

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -1,5 +1,4 @@
 openapi: 3.0.0
-tags: []
 info:
   title: Fleet
   description: OpenAPI schema for Fleet API endpoints
@@ -12,6 +11,9 @@ info:
 servers:
   - url: http://KIBANA_HOST:5601/api/fleet
     description: Public and supported Fleet API
+security:
+  - basicAuth: []
+tags: []
 paths:
   /health_check:
     post:
@@ -130,10 +132,7 @@ paths:
           required: false
           schema:
             type: string
-          description: >-
-            An agent policy ID to scope the enrollment settings to. For example,
-            that policy's Fleet Server host, its proxy, download location, etc.
-            If not provided, the default Fleet Server policy is used (if any).
+          description: An agent policy ID to scope the enrollment settings to. For example, that policy's Fleet Server host, its proxy, download location, etc. If not provided, the default Fleet Server policy is used (if any).
       responses:
         '200':
           description: OK
@@ -208,9 +207,7 @@ paths:
                       id:
                         type: string
                         nullable: true
-                        description: >-
-                          the key ID of the GPG key used to verify package
-                          signatures
+                        description: the key ID of the GPG key used to verify package signatures
                   statusCode:
                     type: number
                   headers:
@@ -273,9 +270,7 @@ paths:
         schema:
           type: boolean
           default: false
-        description: >-
-          Whether to include prerelease packages in categories count (e.g. beta,
-          rc, preview)
+        description: Whether to include prerelease packages in categories count (e.g. beta, rc, preview)
       - in: query
         name: experimental
         deprecated: true
@@ -329,20 +324,13 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Whether to exclude the install status of each package. Enabling this
-            option will opt in to caching for the response via `cache-control`
-            headers. If you don't need up-to-date installation info for a
-            package, and are querying for a list of available packages,
-            providing this flag can improve performance substantially.
+          description: Whether to exclude the install status of each package. Enabling this option will opt in to caching for the response via `cache-control` headers. If you don't need up-to-date installation info for a package, and are querying for a list of available packages, providing this flag can improve performance substantially.
         - in: query
           name: prerelease
           schema:
             type: boolean
             default: false
-          description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
+          description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
         - in: query
           name: experimental
           deprecated: true
@@ -407,9 +395,7 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
+          description: Skip data stream rollover during index template mapping or settings update
       requestBody:
         content:
           application/zip:
@@ -441,9 +427,7 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
+          description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
       requestBody:
         content:
           application/json:
@@ -515,9 +499,7 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
+          description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
       deprecated: true
     post:
       summary: Install package
@@ -569,9 +551,7 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
+          description: Skip data stream rollover during index template mapping or settings update
       requestBody:
         content:
           application/json:
@@ -690,18 +670,14 @@ paths:
       - schema:
           type: boolean
         name: full
-        description: >-
-          Return all fields from the package manifest, not just those supported
-          by the Elastic Package Registry
+        description: Return all fields from the package manifest, not just those supported by the Elastic Package Registry
         in: query
       - in: query
         name: prerelease
         schema:
           type: boolean
           default: false
-        description: >-
-          Whether to return prerelease versions of packages (e.g. beta, rc,
-          preview)
+        description: Whether to return prerelease versions of packages (e.g. beta, rc, preview)
     post:
       summary: Install package
       tags:
@@ -756,9 +732,7 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
+          description: Skip data stream rollover during index template mapping or settings update
       requestBody:
         content:
           application/json:
@@ -906,9 +880,7 @@ paths:
           schema:
             type: boolean
             default: false
-          description: >-
-            Whether to include prerelease packages in categories count (e.g.
-            beta, rc, preview)
+          description: Whether to include prerelease packages in categories count (e.g. beta, rc, preview)
       requestBody:
         content:
           application/json:
@@ -1025,6 +997,11 @@ paths:
           type: boolean
         name: prerelease
         description: Specify if version is prerelease
+        in: query
+      - schema:
+          type: boolean
+        name: ignoreUnverified
+        description: Ignore if the package is fails signature verification
         in: query
   /agents/setup:
     get:
@@ -1397,9 +1374,7 @@ paths:
                           description: creation time of action
                         latestErrors:
                           type: array
-                          description: >-
-                            latest errors that happened when the agents executed
-                            the action
+                          description: latest errors that happened when the agents executed the action
                           items:
                             type: object
                             properties:
@@ -1896,9 +1871,7 @@ paths:
                   description: Unenrolls hosted agents too
                 includeInactive:
                   type: boolean
-                  description: >-
-                    When passing agents by KQL query, unenrolls inactive agents
-                    too
+                  description: When passing agents by KQL query, unenrolls inactive agents too
               required:
                 - agents
             example:
@@ -2101,18 +2074,12 @@ paths:
             type: boolean
           in: query
           name: full
-          description: >-
-            When set to true, retrieve the related package policies for each
-            agent policy.
+          description: When set to true, retrieve the related package policies for each agent policy.
         - schema:
             type: boolean
           in: query
           name: noAgentCount
-          description: >-
-            When set to true, do not count how many agents are in the agent
-            policy, this can improve performance if you are searching over a
-            large number of agent policies. The "agents" property will always be
-            0 if set to true.
+          description: When set to true, do not count how many agents are in the agent policy, this can improve performance if you are searching over a large number of agent policies. The "agents" property will always be 0 if set to true.
       description: ''
     post:
       summary: Create agent policy
@@ -2692,9 +2659,7 @@ paths:
         '409':
           $ref: '#/components/responses/error'
       requestBody:
-        description: >-
-          You should use inputs as an object and not use the deprecated inputs
-          array.
+        description: You should use inputs as an object and not use the deprecated inputs array.
         content:
           application/json:
             schema:
@@ -3319,9 +3284,7 @@ paths:
                 is_internal:
                   type: boolean
                 proxy_id:
-                  description: >-
-                    The ID of the proxy to use for this fleet server host. See
-                    the proxies API for more information.
+                  description: The ID of the proxy to use for this fleet server host. See the proxies API for more information.
                   type: string
                 host_urls:
                   type: array
@@ -3396,9 +3359,7 @@ paths:
                 is_internal:
                   type: boolean
                 proxy_id:
-                  description: >-
-                    The ID of the proxy to use for this fleet server host. See
-                    the proxies API for more information.
+                  description: The ID of the proxy to use for this fleet server host. See the proxies API for more information.
                   type: string
                   nullable: true
                 host_urls:
@@ -3916,9 +3877,7 @@ components:
         host:
           type: string
         proxy_id:
-          description: >-
-            The ID of the proxy to use for this download source. See the proxies
-            API for more information.
+          description: The ID of the proxy to use for this download source. See the proxies API for more information.
           type: string
           nullable: true
       required:
@@ -4303,9 +4262,7 @@ components:
         release:
           type: string
           deprecated: true
-          description: >-
-            release label is deprecated, derive from the version instead
-            (packages follow semver)
+          description: release label is deprecated, derive from the version instead (packages follow semver)
           enum:
             - experimental
             - beta
@@ -4584,9 +4541,7 @@ components:
           properties:
             cpu_avg:
               type: number
-              description: >-
-                Average agent CPU usage during the last 5 minutes, number
-                between 0-1
+              description: Average agent CPU usage during the last 5 minutes, number between 0-1
             memory_size_byte_avg:
               type: number
               description: Average agent memory consumption during the last 5 minutes
@@ -4858,9 +4813,7 @@ components:
               - metrics
               - logs
         keep_monitoring_alive:
-          description: >-
-            When set to true, monitoring will be enabled but logs/metrics
-            collection will be disabled
+          description: When set to true, monitoring will be enabled but logs/metrics collection will be disabled
           type: boolean
           nullable: true
         data_output_id:
@@ -4880,10 +4833,7 @@ components:
         inactivity_timeout:
           type: integer
         package_policies:
-          description: >-
-            This field is present only when retrieving a single agent policy, or
-            when retrieving a list of agent policies with the ?full=true
-            parameter
+          description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
           type: array
           items:
             $ref: '#/components/schemas/package_policy'
@@ -4911,28 +4861,19 @@ components:
               - name
               - enabled
         is_protected:
-          description: >-
-            Indicates whether the agent policy has tamper protection enabled.
-            Default false.
+          description: Indicates whether the agent policy has tamper protection enabled. Default false.
           type: boolean
         overrides:
           type: object
-          description: >-
-            Override settings that are defined in the agent policy. Input
-            settings cannot be overridden. The override option should be used
-            only in unusual circumstances and not as a routine procedure.
+          description: Override settings that are defined in the agent policy. Input settings cannot be overridden. The override option should be used only in unusual circumstances and not as a routine procedure.
           nullable: true
         advanced_settings:
           type: object
-          description: >-
-            Advanced settings stored in the agent policy, e.g.
-            agent_limits_go_max_procs
+          description: Advanced settings stored in the agent policy, e.g. agent_limits_go_max_procs
           nullable: true
         supports_agentless:
           type: boolean
-          description: >-
-            Indicates whether the agent policy supports agentless integrations.
-            Only allowed in a serverless environment.
+          description: Indicates whether the agent policy supports agentless integrations. Only allowed in a serverless environment.
         global_data_tags:
           type: array
           items:
@@ -4941,9 +4882,7 @@ components:
               oneOf:
                 - type: string
                 - type: number
-            description: >-
-              User defined data tags that are added to all of the inputs. The
-              values can be strings or numbers.
+            description: User defined data tags that are added to all of the inputs. The values can be strings or numbers.
       required:
         - id
         - status
@@ -5009,9 +4948,7 @@ components:
               oneOf:
                 - type: string
                 - type: number
-            description: >-
-              User defined data tags that are added to all of the inputs. The
-              values can be strings or numbers.
+            description: User defined data tags that are added to all of the inputs. The values can be strings or numbers.
       required:
         - name
         - namespace
@@ -5278,9 +5215,7 @@ components:
           example: my description
         namespace:
           type: string
-          description: >-
-            The package policy namespace. Leave blank to inherit the agent
-            policy's namespace.
+          description: The package policy namespace. Leave blank to inherit the agent policy's namespace.
           example: customnamespace
         policy_id:
           type: string
@@ -5302,14 +5237,10 @@ components:
             - version
         vars:
           type: object
-          description: >-
-            Package root level variable (see integration documentation for more
-            information)
+          description: Package root level variable (see integration documentation for more information)
         inputs:
           type: object
-          description: >-
-            Package policy inputs (see integration documentation to know what
-            inputs are available)
+          description: Package policy inputs (see integration documentation to know what inputs are available)
           example:
             nginx-logfile:
               enabled: true
@@ -5331,14 +5262,10 @@ components:
                 description: enable or disable that input, (default to true)
               vars:
                 type: object
-                description: >-
-                  Input level variable (see integration documentation for more
-                  information)
+                description: Input level variable (see integration documentation for more information)
               streams:
                 type: object
-                description: >-
-                  Input streams (see integration documentation to know what
-                  streams are available)
+                description: Input streams (see integration documentation to know what streams are available)
                 additionalProperties:
                   type: object
                   properties:
@@ -5347,24 +5274,17 @@ components:
                       description: enable or disable that stream, (default to true)
                     vars:
                       type: object
-                      description: >-
-                        Stream level variable (see integration documentation for
-                        more information)
+                      description: Stream level variable (see integration documentation for more information)
         overrides:
           type: object
           properties:
             inputs:
               type: object
-          description: >-
-            Override settings that are defined in the package policy. The
-            override option should be used only in unusual circumstances and not
-            as a routine procedure.
+          description: Override settings that are defined in the package policy. The override option should be used only in unusual circumstances and not as a routine procedure.
           nullable: true
         force:
           type: boolean
-          description: >-
-            Force package policy creation even if package is not verified, or if
-            the agent policy is managed.
+          description: Force package policy creation even if package is not verified, or if the agent policy is managed.
       required:
         - name
         - policy_id
@@ -5655,9 +5575,7 @@ components:
                 type: string
               when:
                 deprecated: true
-                description: >-
-                  Deprecated, kafka output do not support conditionnal topics
-                  anymore.
+                description: Deprecated, kafka output do not support conditionnal topics anymore.
                 type: object
                 properties:
                   type:
@@ -6002,9 +5920,7 @@ components:
                 type: string
               when:
                 deprecated: true
-                description: >-
-                  Deprecated, kafka output do not support conditionnal topics
-                  anymore.
+                description: Deprecated, kafka output do not support conditionnal topics anymore.
                 type: object
                 properties:
                   type:
@@ -6102,5 +6018,3 @@ components:
           elasticsearch: '#/components/schemas/output_update_request_elasticsearch'
           kafka: '#/components/schemas/output_update_request_kafka'
           logstash: '#/components/schemas/output_update_request_logstash'
-security:
-  - basicAuth: []

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@templates@{pkg_name}@{pkg_version}@inputs.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@templates@{pkg_name}@{pkg_version}@inputs.yaml
@@ -35,3 +35,8 @@ parameters:
     name: prerelease
     description: 'Specify if version is prerelease'
     in: query
+  - schema:
+      type: boolean
+    name: ignoreUnverified
+    description: 'Ignore if the package is fails signature verification'
+    in: query

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -588,12 +588,26 @@ export const getInputsHandler: FleetRequestHandler<
 
   try {
     const { pkgName, pkgVersion } = request.params;
-    const { format, prerelease } = request.query;
+    const { format, prerelease, ignoreUnverified } = request.query;
     let body;
     if (format === 'json') {
-      body = await getTemplateInputs(soClient, pkgName, pkgVersion, 'json', prerelease);
+      body = await getTemplateInputs(
+        soClient,
+        pkgName,
+        pkgVersion,
+        'json',
+        prerelease,
+        ignoreUnverified
+      );
     } else if (format === 'yml' || format === 'yaml') {
-      body = await getTemplateInputs(soClient, pkgName, pkgVersion, 'yml', prerelease);
+      body = await getTemplateInputs(
+        soClient,
+        pkgName,
+        pkgVersion,
+        'yml',
+        prerelease,
+        ignoreUnverified
+      );
     }
     return response.ok({ body });
   } catch (error) {

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -660,6 +660,7 @@ export async function getInstalledPackageWithAssets(options: {
   savedObjectsClient: SavedObjectsClientContract;
   pkgName: string;
   logger?: Logger;
+  ignoreUnverified?: boolean;
 }) {
   const installation = await getInstallation(options);
   if (!installation) {
@@ -709,10 +710,12 @@ export async function getPackageAssetsMap({
   savedObjectsClient,
   packageInfo,
   logger,
+  ignoreUnverified,
 }: {
   savedObjectsClient: SavedObjectsClientContract;
   packageInfo: PackageInfo;
   logger: Logger;
+  ignoreUnverified?: boolean;
 }) {
   const installedPackageWithAssets = await getInstalledPackageWithAssets({
     savedObjectsClient,
@@ -723,7 +726,9 @@ export async function getPackageAssetsMap({
   let assetsMap: AssetsMap | undefined;
   if (installedPackageWithAssets?.installation.version !== packageInfo.version) {
     // Try to get from registry
-    const pkg = await Registry.getPackage(packageInfo.name, packageInfo.version);
+    const pkg = await Registry.getPackage(packageInfo.name, packageInfo.version, {
+      ignoreUnverified,
+    });
     assetsMap = pkg.assetsMap;
   } else {
     assetsMap = installedPackageWithAssets.assetsMap;

--- a/x-pack/plugins/fleet/server/services/epm/packages/get_template_inputs.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get_template_inputs.ts
@@ -62,7 +62,8 @@ export async function getTemplateInputs(
   pkgName: string,
   pkgVersion: string,
   format: Format,
-  prerelease?: boolean
+  prerelease?: boolean,
+  ignoreUnverified?: boolean
 ) {
   const packageInfoMap = new Map<string, PackageInfo>();
   let packageInfo: PackageInfo;
@@ -75,6 +76,7 @@ export async function getTemplateInputs(
       pkgName,
       pkgVersion,
       prerelease,
+      ignoreUnverified,
     });
   }
   const emptyPackagePolicy = packageToPackagePolicy(packageInfo, '');
@@ -83,6 +85,7 @@ export async function getTemplateInputs(
     logger: appContextService.getLogger(),
     packageInfo,
     savedObjectsClient: soClient,
+    ignoreUnverified,
   });
 
   const compiledInputs = await _compilePackagePolicyInputs(

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -262,5 +262,6 @@ export const GetInputsRequestSchema = {
       defaultValue: 'json',
     }),
     prerelease: schema.maybe(schema.boolean()),
+    ignoreUnverified: schema.maybe(schema.boolean()),
   }),
 };

--- a/x-pack/test/fleet_api_integration/apis/integrations/index.js
+++ b/x-pack/test/fleet_api_integration/apis/integrations/index.js
@@ -8,5 +8,6 @@
 export default function loadTests({ loadTestFile }) {
   describe('Integrations', () => {
     loadTestFile(require.resolve('./elastic_agent'));
+    loadTestFile(require.resolve('./inputs_with_standalone_docker_agent'));
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -88,7 +88,7 @@ ${inputsYaml}
           foundMetrics = true;
           break;
         }
-
+        await agent.log();
         await new Promise((resolve) => setTimeout(resolve, 5 * 1000));
       }
 
@@ -100,6 +100,7 @@ ${inputsYaml}
 interface AgentProcess {
   name: string;
   stop: () => void;
+  log: () => void;
 }
 
 async function startAgent({
@@ -146,6 +147,9 @@ async function startAgent({
 
   return {
     name: hostName,
+    log: () => {
+      console.log(execa.sync('docker', ['logs', agentContainerId]));
+    },
     stop: () => {
       try {
         execa.sync('docker', ['kill', agentContainerId]);

--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -148,6 +148,7 @@ async function startAgent({
   return {
     name: hostName,
     log: () => {
+      // eslint-disable-next-line no-console
       console.log(execa.sync('docker', ['logs', agentContainerId]));
     },
     stop: () => {

--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -73,6 +73,7 @@ ${inputsYaml}
         const searchRes = await es.search({
           index: 'metrics-system.cpu-default',
           q: `agent.name:${agent.name}`,
+          ignore_unavailable: true,
         });
 
         // @ts-expect-error TotalHit

--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -88,7 +88,7 @@ ${inputsYaml}
           foundMetrics = true;
           break;
         }
-        await agent.log();
+        // await agent.log(); uncomment if you need to debug agent logs
         await new Promise((resolve) => setTimeout(resolve, 5 * 1000));
       }
 

--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolingLog } from '@kbn/tooling-log';
+import { tmpdir } from 'os';
+import { writeFile } from 'fs/promises';
+import { v4 as uuid } from 'uuid';
+import execa from 'execa';
+import path from 'path';
+import expect from '@kbn/expect';
+
+import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { getLatestVersion } from '../../../fleet_cypress/artifact_manager';
+import { skipIfNoDockerRegistry } from '../../helpers';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const config = getService('config');
+  const log = getService('log');
+
+  describe('inputs_with_standalone_docker_agent', () => {
+    skipIfNoDockerRegistry(providerContext);
+    let apiKey: string;
+    let agent: AgentProcess;
+
+    const esHost = `http://host.docker.internal:${config.get('servers.elasticsearch.port')}`;
+
+    before(async () => {
+      const res = await es.security.createApiKey({
+        name: 'test standalone agent',
+      });
+      apiKey = `${res.id}:${res.api_key}`;
+    });
+    afterEach(async () => {
+      agent?.stop();
+    });
+    it('generate a valid config for standalone agents', async () => {
+      const pkgName = 'system';
+      const { body: pkgRes } = await supertest.get(
+        `/api/fleet/epm/packages/${pkgName}?ignoreUnverified=true`
+      );
+      const { version } = pkgRes.item;
+
+      const res = await supertest.get(
+        `/api/fleet/epm/templates/${pkgName}/${version}/inputs?format=yaml&prerelease=false&ignoreUnverified=true`
+      );
+
+      const inputsYaml = res.text;
+
+      const policyYaml = `
+outputs:
+  default:
+    type: elasticsearch
+    hosts:
+      - ${esHost}
+    api_key: ${apiKey}
+${inputsYaml}
+`;
+
+      agent = await startAgent({ log, elasticAgentYaml: policyYaml });
+
+      // Poll for metrics
+      const MAX_ITERATIONS = 20;
+      let foundMetrics = false;
+      for (let i = 0; i < MAX_ITERATIONS; i++) {
+        const searchRes = await es.search({
+          index: 'metrics-system.cpu-default',
+          q: `agent.name:${agent.name}`,
+        });
+
+        // @ts-expect-error TotalHit
+        if (searchRes.hits.total.value > 0) {
+          foundMetrics = true;
+          break;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 2 * 1000));
+      }
+
+      expect(foundMetrics).to.be(true);
+    });
+  });
+}
+
+interface AgentProcess {
+  name: string;
+  stop: () => void;
+}
+
+async function startAgent({
+  log,
+  elasticAgentYaml,
+}: {
+  log: ToolingLog;
+  elasticAgentYaml: string;
+}): Promise<AgentProcess> {
+  log.info('Running the agent');
+
+  const artifact = `docker.elastic.co/beats/elastic-agent:${await getLatestVersion()}`;
+  log.info(artifact);
+
+  const fileName = `${uuid()}-elastic-agent.yml`;
+
+  const filePath = path.join(tmpdir(), fileName);
+  await writeFile(filePath, elasticAgentYaml);
+  log.info(filePath);
+  const hostName = `test-agent-${Date.now()}`;
+  const args = [
+    'run',
+    '--detach',
+    '--name',
+    hostName,
+    '--net',
+    'elastic',
+    '--hostname',
+    hostName,
+    '--add-host',
+    'host.docker.internal:host-gateway',
+    '--mount',
+    `type=bind,source=${filePath},target=/etc/elastic-agent/agent.yml`,
+    '--rm',
+    artifact,
+    '/usr/local/bin/docker-entrypoint',
+    '-c',
+    '/etc/elastic-agent/agent.yml',
+    '-e',
+  ];
+
+  const startedContainer = await execa('docker', args);
+
+  log.info(`agent docker container started:\n${JSON.stringify(startedContainer, null, 2)}`);
+
+  const agentContainerId = startedContainer.stdout;
+
+  return {
+    name: hostName,
+    stop: () => {
+      try {
+        execa.sync('docker', ['kill', agentContainerId]);
+      } catch (err) {
+        log.info(`error killing agent docker container ${err.message}`);
+      }
+    },
+  };
+}

--- a/x-pack/test/fleet_api_integration/config.base.ts
+++ b/x-pack/test/fleet_api_integration/config.base.ts
@@ -54,7 +54,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       },
     }),
     services: xPackAPITestsConfig.get('services'),
-    esTestCluster: xPackAPITestsConfig.get('esTestCluster'),
+    esTestCluster: {
+      ...xPackAPITestsConfig.get('esTestCluster'),
+      serverArgs: [...xPackAPITestsConfig.get('esTestCluster.serverArgs'), 'http.host=0.0.0.0'],
+    },
     kbnTestServer: {
       ...xPackAPITestsConfig.get('kbnTestServer'),
       serverArgs: [


### PR DESCRIPTION
## Summary

Resolve #182507

Add tests to inputs endpoints.
Launch a real standalone agent to verify the generated config is a valid config.
I choose to use the `system` package, as it's easy to test and get data for.
I also add to add the `ignoreUnverified` flag to the inputs endpoint, to be able to test it.

## What test does?

Retrieve the inputs for the `/api/**/inputs` endpoint and add this to an agent policy.
Run a docker standalone agent with that policy.
Verify we collect system cpu metrics for that agent.






