### PR TITLE
fix(tests): update built-in ES privileges to expect `remote_cluster` only starting from 8.15.0+.

### DIFF
--- a/x-pack/plugins/security/server/routes/authorization/privileges/get_builtin.ts
+++ b/x-pack/plugins/security/server/routes/authorization/privileges/get_builtin.ts
@@ -16,15 +16,12 @@ export function defineGetBuiltinPrivilegesRoutes({ router }: RouteDefinitionPara
 
       // Exclude the `none` privilege, as it doesn't make sense as an option within the Kibana UI
       privileges.cluster = privileges.cluster.filter((privilege) => privilege !== 'none');
-      const indexPriviledges = Array.isArray(privileges.index)
+      const indexPrivileges = Array.isArray(privileges.index)
         ? privileges.index
         : [privileges.index];
-      privileges.index = indexPriviledges.filter((privilege) => privilege !== 'none');
+      privileges.index = indexPrivileges.filter((privilege) => privilege !== 'none');
 
-      // TODO: remove hardcoded value once ES returns built-in privileges for remote_cluster
-      const remoteClusterPrivileges = ['monitor_enrich'];
-
-      return response.ok({ body: { ...privileges, remote_cluster: remoteClusterPrivileges } });
+      return response.ok({ body: privileges });
     }
   );
 }


### PR DESCRIPTION
## Summary

Update built-in ES privileges to expect `remote_cluster` only starting from 8.15.0+.

```http
GET /_security/privilege/_builtin HTTP/1.1
x-elastic-product-origin: kibana
user-agent: Kibana/8.15.0
x-elastic-client-meta: es=8.13.0,js=20.13.1,t=8.4.1,hc=20.13.1
accept: application/vnd.elasticsearch+json; compatible-with=8,text/plain
Host: localhost:9220

HTTP/1.1 200 OK
X-elastic-product: Elasticsearch
content-type: application/json
content-length: 1562

{
  "cluster": [
    "all",
    ...
  ],
  "index": [
    "all",
    ...
  ],
  "remote_cluster": [
    "monitor_enrich"
  ]
}
```

__Fixes: https://github.com/elastic/kibana/issues/184431__
__Fixes: https://github.com/elastic/kibana/issues/184432__

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->