### PR TITLE
[Fleet] Allow to run docker registry for tests externally

### DIFF
--- a/x-pack/plugins/fleet/README.md
+++ b/x-pack/plugins/fleet/README.md
@@ -74,8 +74,8 @@ To avoid the enforcing of version headers when running in dev mode, add the foll
 ```
 server.versioned.versionResolution: oldest
 ```
-This will provide a default version for the public apis.
 
+This will provide a default version for the public apis.
 
 If Kibana fails to start, it is possible that your local setup got corrupted. An easy fix is to run:
 
@@ -185,7 +185,9 @@ Note: Docker needs to be running to run these tests.
    ```
    FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:server --config x-pack/test/fleet_api_integration/<configFile>
    ```
+
    where `configFile` is the relevant config file relevant from the following:
+
    - config.agent.ts
    - config.agent_policy.ts
    - config.epm.ts
@@ -210,17 +212,25 @@ Note: you can also supply which Docker image to use for the Package Registry via
 FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE='docker.elastic.co/package-registry/distribution:production' FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:runner
 ```
 
+To speed up test you can also use the `FLEET_SKIP_RUNNING_PACKAGE_REGISTRY=true` flag to not re-run the package registry each time. When launching the test for the first time you will get the docker command to run the package registry.
+
+```bash
+FLEET_SKIP_RUNNING_PACKAGE_REGISTRY=true FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:runner
+```
+
 #### API integration tests (serverless)
 
 The process for running serverless API integration tests is similar as above. Security and observability project types have Fleet enabled. At the time of writing, the same tests exist for Fleet under these two project types.
 
 Security:
+
 ```bash
 FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:server --config x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts
 FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:runner --config  x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts
 ```
 
 Observability:
+
 ```bash
 FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:server --config x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
 FLEET_PACKAGE_REGISTRY_PORT=12345 yarn test:ftr:runner --config  x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts

--- a/x-pack/test/fleet_api_integration/apis/epm/bulk_get_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/bulk_get_assets.ts
@@ -7,14 +7,12 @@
 
 import { GetBulkAssetsResponse } from '@kbn/fleet-plugin/common';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
   const pkgName = 'all_assets';
   const pkgVersion = '0.1.0';
 
@@ -34,11 +32,11 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('installs all assets when installing a package for the first time', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await installPackage(pkgName, pkgVersion);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage(pkgName, pkgVersion);
       });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/file.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/file.ts
@@ -9,83 +9,62 @@ import fs from 'fs';
 import path from 'path';
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { warnAndSkipTest } from '../../helpers';
+import { skipIfNoDockerRegistry } from '../../helpers';
 import { testUsers } from '../test_users';
 
-export default function ({ getService }: FtrProviderContext) {
-  const log = getService('log');
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  const server = dockerServers.get('registry');
   describe('EPM - package file', () => {
+    skipIfNoDockerRegistry(providerContext);
     describe('it gets files from registry', () => {
       it('fetches a .png screenshot image', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/filetest/0.1.0/img/screenshots/metricbeat_dashboard.png')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'image/png')
-            .expect(200);
-          expect(Buffer.isBuffer(res.body)).to.equal(true);
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/filetest/0.1.0/img/screenshots/metricbeat_dashboard.png')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'image/png')
+          .expect(200);
+        expect(Buffer.isBuffer(res.body)).to.equal(true);
       });
 
       it('fetches an .svg icon image', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/filetest/0.1.0/img/logo.svg')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'image/svg+xml')
-            .expect(200);
-          expect(Buffer.isBuffer(res.body)).to.equal(true);
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/filetest/0.1.0/img/logo.svg')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'image/svg+xml')
+          .expect(200);
+        expect(Buffer.isBuffer(res.body)).to.equal(true);
       });
 
       it('fetches a .json kibana visualization file', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get(
-              '/api/fleet/epm/packages/filetest/0.1.0/kibana/visualization/sample_visualization.json'
-            )
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'application/json; charset=utf-8')
-            .expect(200);
-          expect(typeof res.body).to.equal('object');
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get(
+            '/api/fleet/epm/packages/filetest/0.1.0/kibana/visualization/sample_visualization.json'
+          )
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'application/json; charset=utf-8')
+          .expect(200);
+        expect(typeof res.body).to.equal('object');
       });
 
       it('fetches a .json kibana dashboard file', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/filetest/0.1.0/kibana/dashboard/sample_dashboard.json')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'application/json; charset=utf-8')
-            .expect(200);
-          expect(typeof res.body).to.equal('object');
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/filetest/0.1.0/kibana/dashboard/sample_dashboard.json')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'application/json; charset=utf-8')
+          .expect(200);
+        expect(typeof res.body).to.equal('object');
       });
 
       it('fetches a .json search file', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/filetest/0.1.0/kibana/search/sample_search.json')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'application/json; charset=utf-8')
-            .expect(200);
-          expect(typeof res.body).to.equal('object');
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/filetest/0.1.0/kibana/search/sample_search.json')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'application/json; charset=utf-8')
+          .expect(200);
+        expect(typeof res.body).to.equal('object');
       });
 
       it('should return 200 if the user has only integrations access', async function () {
@@ -116,7 +95,6 @@ export default function ({ getService }: FtrProviderContext) {
     });
     describe('it gets files from an uploaded package', () => {
       before(async () => {
-        if (!server.enabled) return;
         const testPkgArchiveTgz = path.join(
           path.dirname(__filename),
           '../fixtures/direct_upload_packages/apache_0.1.4.tar.gz'
@@ -130,77 +108,56 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
       });
       after(async () => {
-        if (!server.enabled) return;
         await supertest.delete(`/api/fleet/epm/packages/apache/0.1.4`).set('kbn-xsrf', 'xxxx');
       });
       it('fetches a .png screenshot image', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/apache/0.1.4/img/kibana-apache-test.png')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'image/png')
-            .expect(200);
-          expect(Buffer.isBuffer(res.body)).to.equal(true);
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/apache/0.1.4/img/kibana-apache-test.png')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'image/png')
+          .expect(200);
+        expect(Buffer.isBuffer(res.body)).to.equal(true);
       });
       it('fetches the logo', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/apache/0.1.4/img/logo_apache_test.svg')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'image/svg+xml')
-            .expect(200);
-          await supertest
-            .get('/api/fleet/epm/packages/apache/0.1.4/img/logo_apache.svg')
-            .set('kbn-xsrf', 'xxx')
-            .expect(404);
-          expect(Buffer.isBuffer(res.body)).to.equal(true);
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/apache/0.1.4/img/logo_apache_test.svg')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'image/svg+xml')
+          .expect(200);
+        await supertest
+          .get('/api/fleet/epm/packages/apache/0.1.4/img/logo_apache.svg')
+          .set('kbn-xsrf', 'xxx')
+          .expect(404);
+        expect(Buffer.isBuffer(res.body)).to.equal(true);
       });
 
       it('fetches a .json kibana dashboard file', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get(
-              '/api/fleet/epm/packages/apache/0.1.4/kibana/dashboard/apache-Logs-Apache-Dashboard-ecs-new.json'
-            )
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'application/json; charset=utf-8')
-            .expect(200);
-          expect(typeof res.body).to.equal('object');
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get(
+            '/api/fleet/epm/packages/apache/0.1.4/kibana/dashboard/apache-Logs-Apache-Dashboard-ecs-new.json'
+          )
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'application/json; charset=utf-8')
+          .expect(200);
+        expect(typeof res.body).to.equal('object');
       });
 
       it('fetches a README file', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/apache/0.1.4/docs/README.md')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'text/markdown; charset=utf-8')
-            .expect(200);
-          expect(res.text).to.equal('# Apache Uploaded Test Integration');
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/apache/0.1.4/docs/README.md')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'text/markdown; charset=utf-8')
+          .expect(200);
+        expect(res.text).to.equal('# Apache Uploaded Test Integration');
       });
 
       it('fetches the logo of a not uploaded (and installed) version from the registry when another version is uploaded (and installed)', async function () {
-        if (server.enabled) {
-          const res = await supertest
-            .get('/api/fleet/epm/packages/apache/0.1.3/img/logo_apache.svg')
-            .set('kbn-xsrf', 'xxx')
-            .expect('Content-Type', 'image/svg+xml')
-            .expect(200);
-          expect(Buffer.isBuffer(res.body)).to.equal(true);
-        } else {
-          warnAndSkipTest(this, log);
-        }
+        const res = await supertest
+          .get('/api/fleet/epm/packages/apache/0.1.3/img/logo_apache.svg')
+          .set('kbn-xsrf', 'xxx')
+          .expect('Content-Type', 'image/svg+xml')
+          .expect(200);
+        expect(Buffer.isBuffer(res.body)).to.equal(true);
       });
     });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -12,7 +12,7 @@ import { INGEST_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { HTTPError } from 'superagent';
 
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 import { testUsers } from '../test_users';
 
@@ -20,7 +20,6 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
-  const dockerServers = getService('dockerServers');
   const esClient = getService('es');
 
   const testPkgArchiveTgz = path.join(
@@ -60,7 +59,6 @@ export default function (providerContext: FtrProviderContext) {
   const testPkgName = 'apache';
   const testPkgVersion = '0.1.4';
   const testPkgNewVersion = '0.1.5';
-  const server = dockerServers.get('registry');
 
   const deletePackage = async (name: string, version: string) => {
     await supertest.delete(`/api/fleet/epm/packages/${name}/${version}`).set('kbn-xsrf', 'xxxx');
@@ -71,7 +69,7 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     afterEach(async () => {
-      if (server) {
+      if (isDockerRegistryEnabledOrSkipped(providerContext)) {
         // remove the packages just in case it being installed will affect other tests
         await deletePackage(testPkgName, testPkgVersion);
       }

--- a/x-pack/test/fleet_api_integration/apis/epm/install_endpoint.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_endpoint.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 import { bundlePackage, removeBundledPackages } from './install_bundled';
 
@@ -22,8 +22,6 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     const supertest = getService('supertest');
-    const dockerServers = getService('dockerServers');
-    const server = dockerServers.get('registry');
     const es = getService('es');
     const log = getService('log');
     const pkgName = 'endpoint';
@@ -48,7 +46,7 @@ export default function (providerContext: FtrProviderContext) {
     };
 
     before(async () => {
-      if (!server.enabled) return;
+      if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
       await bundlePackage('endpoint-8.6.1');
       await installPackage('endpoint', '8.6.1');
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/install_integration_in_multiple_spaces.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_integration_in_multiple_spaces.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
 import pRetry from 'p-retry';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 const testSpaceId = 'fleet_test_space';
@@ -18,9 +18,7 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
   const esArchiver = getService('esArchiver');
-  const server = dockerServers.get('registry');
   const es = getService('es');
 
   const pkgName = 'system';
@@ -77,7 +75,9 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     before(async () => {
-      if (!server.enabled) return;
+      if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
+        return;
+      }
       await esArchiver.load('x-pack/test/functional/es_archives/fleet/empty_fleet_server');
       await installPackage(pkgName, pkgVersion);
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
@@ -7,18 +7,16 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const es = getService('es');
-  const dockerServers = getService('dockerServers');
 
   const mappingsPackage = 'overrides';
   const mappingsPackageVersion = '0.1.0';
-  const server = dockerServers.get('registry');
 
   const deletePackage = async (pkg: string, version: string) =>
     supertest.delete(`/api/fleet/epm/packages/${pkg}/${version}`).set('kbn-xsrf', 'xxxx');
@@ -28,7 +26,7 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     after(async () => {
-      if (server.enabled) {
+      if (isDockerRegistryEnabledOrSkipped(providerContext)) {
         // remove the package just in case it being installed will affect other tests
         await deletePackage(mappingsPackage, mappingsPackageVersion);
       }

--- a/x-pack/test/fleet_api_integration/apis/epm/install_prerelease.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_prerelease.ts
@@ -6,17 +6,15 @@
  */
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
 
   const testPackage = 'prerelease';
   const testPackageVersion = '0.1.0-dev.0+abc';
-  const server = dockerServers.get('registry');
 
   const deletePackage = async (pkg: string, version: string) => {
     await supertest.delete(`/api/fleet/epm/packages/${pkg}/${version}`).set('kbn-xsrf', 'xxxx');
@@ -27,7 +25,7 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     after(async () => {
-      if (server.enabled) {
+      if (isDockerRegistryEnabledOrSkipped(providerContext)) {
         // remove the package just in case it being installed will affect other tests
         await deletePackage(testPackage, testPackageVersion);
       }

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -11,7 +11,7 @@ import { sortBy } from 'lodash';
 import { AssetReference } from '@kbn/fleet-plugin/common/types';
 import { FLEET_INSTALL_FORMAT_VERSION } from '@kbn/fleet-plugin/server/constants';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 function checkErrorWithResponseDataOrThrow(err: any) {
@@ -24,8 +24,6 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
   const es: Client = getService('es');
   const pkgName = 'all_assets';
   const pkgVersion = '0.1.0';
@@ -48,11 +46,11 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('installs all assets when installing a package for the first time', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await installPackage(pkgName, pkgVersion);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage(pkgName, pkgVersion);
       });
       expectAssetsInstalled({
@@ -69,11 +67,11 @@ export default function (providerContext: FtrProviderContext) {
       // these tests ensure that uninstall works properly so make sure that the package gets installed and uninstalled
       // and then we'll test that not artifacts are left behind.
       before(() => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         return installPackage(pkgName, pkgVersion);
       });
       before(() => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         return uninstallPackage(pkgName, pkgVersion);
       });
 
@@ -298,13 +296,13 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('reinstalls all assets', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await installPackage(pkgName, pkgVersion);
         // reinstall
         await installPackage(pkgName, pkgVersion);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage(pkgName, pkgVersion);
       });
       expectAssetsInstalled({

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_kbn_assets_in_space.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_kbn_assets_in_space.ts
@@ -6,7 +6,7 @@
  */
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 const testSpaceId = 'fleet_test_space';
@@ -15,8 +15,6 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
   const pkgName = 'only_dashboard';
   const pkgVersion = '0.1.0';
 
@@ -58,11 +56,11 @@ export default function (providerContext: FtrProviderContext) {
     });
     describe('installs all assets when installing a package for the first time in non default space', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await installPackageInSpace(pkgName, pkgVersion, testSpaceId);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage(pkgName, pkgVersion);
       });
 
@@ -74,7 +72,7 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('uninstalls all assets when uninstalling a package from a different space', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await installPackageInSpace(pkgName, pkgVersion, testSpaceId);
         await uninstallPackage(pkgName, pkgVersion);
       });

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_multiple.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_multiple.ts
@@ -9,15 +9,13 @@ import expect from '@kbn/expect';
 import path from 'path';
 import fs from 'fs';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
   const pkgName = 'all_assets';
   const pkgVersion = '0.1.0';
   const experimentalPkgName = 'experimental';
@@ -64,7 +62,7 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     before(async () => {
-      if (!server.enabled) return;
+      if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
       await installPackages([
         { name: pkgName, version: pkgVersion },
         { name: experimentalPkgName, version: pkgVersion },
@@ -73,7 +71,7 @@ export default function (providerContext: FtrProviderContext) {
       await installUploadPackage(uploadPkgName);
     });
     after(async () => {
-      if (!server.enabled) return;
+      if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
       await uninstallPackages([
         { name: pkgName, version: pkgVersion },
         { name: experimentalPkgName, version: pkgVersion },

--- a/x-pack/test/fleet_api_integration/apis/epm/install_runtime_field.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_runtime_field.ts
@@ -8,18 +8,16 @@
 
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
   const es = getService('es');
 
   const testPackage = 'runtime_fields';
   const testPackageVersion = '0.0.1';
-  const server = dockerServers.get('registry');
 
   const deletePackage = async (name: string, version: string) => {
     await supertest.delete(`/api/fleet/epm/packages/${name}/${version}`).set('kbn-xsrf', 'xxxx');
@@ -30,7 +28,7 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     after(async () => {
-      if (server.enabled) {
+      if (isDockerRegistryEnabledOrSkipped(providerContext)) {
         await deletePackage(testPackage, testPackageVersion);
       }
     });

--- a/x-pack/test/fleet_api_integration/apis/epm/install_tag_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_tag_assets.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 import fs from 'fs';
 import path from 'path';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 const testSpaceId = 'fleet_test_space';
 
@@ -16,8 +16,6 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const kibanaServer = getService('kibanaServer');
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
   const pkgName = 'only_dashboard';
   const pkgVersion = '0.1.0';
 
@@ -80,12 +78,12 @@ export default function (providerContext: FtrProviderContext) {
     });
     describe('creates correct tags when installing a package in non default space after installing in default space', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await installPackageInSpace('all_assets', pkgVersion, 'default');
         await installPackageInSpace(pkgName, pkgVersion, testSpaceId);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage('all_assets', pkgVersion);
         await uninstallPackage(pkgName, pkgVersion);
       });
@@ -108,7 +106,7 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('Handles presence of legacy tags', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
 
         // first clean up any existing tag saved objects as they arent cleaned on uninstall
         await deleteTag('fleet-managed-default');
@@ -139,7 +137,7 @@ export default function (providerContext: FtrProviderContext) {
         await installPackageInSpace(pkgName, pkgVersion, 'default');
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage(pkgName, pkgVersion);
         await deleteTag('managed');
         await deleteTag('tag');
@@ -163,7 +161,7 @@ export default function (providerContext: FtrProviderContext) {
       const MIXED_TYPES_TAG = `fleet-shared-tag-${testPackage}-ef823f10-b5af-5fcb-95da-2340a5257599-default`;
 
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
 
         const testPkgArchiveZip = path.join(
           path.dirname(__filename),
@@ -178,7 +176,7 @@ export default function (providerContext: FtrProviderContext) {
           .expect(200);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage(testPackage, testPackageVersion);
         await deleteTag('managed');
       });

--- a/x-pack/test/fleet_api_integration/apis/epm/install_with_signature_verification.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_with_signature_verification.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { INGEST_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { Installation } from '@kbn/fleet-plugin/server/types';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 
 const TEST_KEY_ID = 'd2a182a7b0e00c14';
@@ -17,8 +17,6 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const es: Client = getService('es');
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
 
   const uninstallPackage = async (pkg: string, version: string) => {
     await supertest.delete(`/api/fleet/epm/packages/${pkg}/${version}`).set('kbn-xsrf', 'xxxx');
@@ -45,7 +43,7 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('verified package', async () => {
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await uninstallPackage('verified', '1.0.0');
       });
       it('should install a package with a valid signature', async () => {
@@ -58,7 +56,7 @@ export default function (providerContext: FtrProviderContext) {
     describe('unverified packages', async () => {
       describe('unverified package content', async () => {
         after(async () => {
-          if (!server.enabled) return;
+          if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
           await uninstallPackage('unverified_content', '1.0.0');
         });
         it('should return 400 for valid signature but incorrect content', async () => {
@@ -78,7 +76,7 @@ export default function (providerContext: FtrProviderContext) {
       });
       describe('package verified with wrong key', async () => {
         after(async () => {
-          if (!server.enabled) return;
+          if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
           await uninstallPackage('wrong_key', '1.0.0');
         });
         it('should return 400 for valid signature but incorrect key', async () => {

--- a/x-pack/test/fleet_api_integration/apis/epm/package_install_complete.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/package_install_complete.ts
@@ -10,7 +10,7 @@ import {
   PACKAGES_SAVED_OBJECT_TYPE,
   MAX_TIME_COMPLETE_INSTALL,
 } from '@kbn/fleet-plugin/common/constants';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { setupFleetAndAgents } from '../agents/services';
 
@@ -18,8 +18,7 @@ export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const kibanaServer = getService('kibanaServer');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
+
   const pkgName = 'multiple_versions';
   const pkgVersion = '0.1.0';
   const pkgUpdateVersion = '0.2.0';
@@ -29,7 +28,7 @@ export default function (providerContext: FtrProviderContext) {
 
     describe('package install', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await supertest
           .post(`/api/fleet/epm/packages/${pkgName}/0.1.0`)
           .set('kbn-xsrf', 'xxxx')
@@ -91,7 +90,7 @@ export default function (providerContext: FtrProviderContext) {
         expect(packageAfterSetup.attributes.install_status).equal('installing');
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await supertest
           .delete(`/api/fleet/epm/packages/multiple_versions/0.1.0`)
           .set('kbn-xsrf', 'xxxx')
@@ -100,7 +99,7 @@ export default function (providerContext: FtrProviderContext) {
     });
     describe('package update', async () => {
       before(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await supertest
           .post(`/api/fleet/epm/packages/${pkgName}/0.1.0`)
           .set('kbn-xsrf', 'xxxx')
@@ -173,7 +172,7 @@ export default function (providerContext: FtrProviderContext) {
         expect(packageAfterSetup.attributes.version).equal(pkgVersion);
       });
       after(async () => {
-        if (!server.enabled) return;
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
         await supertest
           .delete(`/api/fleet/epm/packages/multiple_versions/0.1.0`)
           .set('kbn-xsrf', 'xxxx')

--- a/x-pack/test/fleet_api_integration/apis/epm/remove_legacy_templates.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/remove_legacy_templates.ts
@@ -10,15 +10,13 @@ import path from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { setupFleetAndAgents } from '../agents/services';
 const sleep = promisify(setTimeout);
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
-  const dockerServers = getService('dockerServers');
-  const server = dockerServers.get('registry');
   const esClient = getService('es');
 
   const uploadPkgName = 'apache';
@@ -105,7 +103,7 @@ export default function (providerContext: FtrProviderContext) {
     setupFleetAndAgents(providerContext);
 
     afterEach(async () => {
-      if (!server.enabled) return;
+      if (!isDockerRegistryEnabledOrSkipped(providerContext)) return;
       await deleteLegacyComponentTemplates();
       await uninstallPackage(uploadPkgName, uploadPkgVersion);
     });

--- a/x-pack/test/fleet_api_integration/apis/integrations/elastic_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/elastic_agent.ts
@@ -21,13 +21,9 @@ export default function (providerContext: FtrProviderContext) {
 
     const kibanaServer = getService('kibanaServer');
     const supertest = getService('supertest');
-    const dockerServers = getService('dockerServers');
-    const server = dockerServers.get('registry');
-
     let pkgVersion: string;
 
     before(async () => {
-      if (!server.enabled) return;
       const getPkRes = await supertest
         .get(`/api/fleet/epm/packages/${FLEET_ELASTIC_AGENT_PACKAGE}`)
         .set('kbn-xsrf', 'xxxx')
@@ -53,7 +49,6 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     after(async () => {
-      if (!server.enabled) return;
       return supertest
         .delete(`/api/fleet/epm/packages/${FLEET_ELASTIC_AGENT_PACKAGE}/${pkgVersion}`)
         .set('kbn-xsrf', 'xxxx');

--- a/x-pack/test/fleet_api_integration/apis/package_policy/get.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/get.ts
@@ -8,18 +8,16 @@
 import expect from '@kbn/expect';
 import { INGEST_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { testUsers } from '../test_users';
 
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const superTestWithoutAuth = getService('supertestWithoutAuth');
-  const dockerServers = getService('dockerServers');
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  const server = dockerServers.get('registry');
   // use function () {} and not () => {} here
   // because `this` has to point to the Mocha context
   // see https://mochajs.org/#arrow-functions
@@ -51,7 +49,7 @@ export default function (providerContext: FtrProviderContext) {
       let endpointPackagePolicyId: string;
 
       before(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -103,7 +101,7 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       after(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -189,7 +187,7 @@ export default function (providerContext: FtrProviderContext) {
       let endpointPackagePolicyId: string;
 
       before(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -241,7 +239,7 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       after(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -361,7 +359,7 @@ export default function (providerContext: FtrProviderContext) {
       let packagePolicyId: string;
 
       before(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -404,7 +402,7 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       after(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -430,7 +428,7 @@ export default function (providerContext: FtrProviderContext) {
       let endpointPackagePolicyId: string;
 
       before(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 
@@ -464,7 +462,7 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       after(async function () {
-        if (!server.enabled) {
+        if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
           return;
         }
 

--- a/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
+++ b/x-pack/test/fleet_api_integration/apis/package_policy/update.ts
@@ -9,13 +9,12 @@ import { policyFactory } from '@kbn/security-solution-plugin/common/endpoint/mod
 import type { NewPackagePolicy } from '@kbn/fleet-plugin/common';
 import { sortBy } from 'lodash';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
-import { skipIfNoDockerRegistry } from '../../helpers';
+import { skipIfNoDockerRegistry, isDockerRegistryEnabledOrSkipped } from '../../helpers';
 import { testUsers } from '../test_users';
 export default function (providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const supertest = getService('supertest');
   const superTestWithoutAuth = getService('supertestWithoutAuth');
-  const dockerServers = getService('dockerServers');
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
   const es = getService('es');
@@ -48,7 +47,6 @@ export default function (providerContext: FtrProviderContext) {
     }
   };
 
-  const server = dockerServers.get('registry');
   // use function () {} and not () => {} here
   // because `this` has to point to the Mocha context
   // see https://mochajs.org/#arrow-functions
@@ -71,7 +69,7 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     before(async function () {
-      if (!server.enabled) {
+      if (!isDockerRegistryEnabledOrSkipped(providerContext)) {
         return;
       }
       const [{ body: agentPolicyResponse }, { body: managedAgentPolicyResponse }] =

--- a/x-pack/test/fleet_api_integration/config.base.ts
+++ b/x-pack/test/fleet_api_integration/config.base.ts
@@ -22,10 +22,12 @@ export const dockerImage = 'docker.elastic.co/package-registry/distribution:lite
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 
-export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+export default async function ({ readConfigFile, log }: FtrConfigProviderContext) {
   const xPackAPITestsConfig = await readConfigFile(require.resolve('../api_integration/config.ts'));
 
   const registryPort: string | undefined = process.env.FLEET_PACKAGE_REGISTRY_PORT;
+  const skipRunningDockerRegistry =
+    process.env.FLEET_SKIP_RUNNING_PACKAGE_REGISTRY === 'true' ? true : false;
 
   // mount the config file for the package registry as well as
   // the directories containing additional packages into the container
@@ -40,19 +42,28 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     `${getFullPath(src)}:${dest}`,
   ]);
 
+  const dockerServers = !skipRunningDockerRegistry
+    ? defineDockerServersConfig({
+        registry: {
+          enabled: !!registryPort,
+          image: dockerImage,
+          portInContainer: 8080,
+          port: registryPort,
+          args: dockerArgs,
+          waitForLogLine: 'package manifests loaded',
+          waitForLogLineTimeoutMs: 60 * 2 * 10000, // 2 minutes
+        },
+      })
+    : undefined;
+
+  if (skipRunningDockerRegistry) {
+    const cmd = `docker run ${dockerArgs.join(' ')} -p ${registryPort}:8080 ${dockerImage}`;
+    log.warning(`Not running docker registry, you can run it with the following command: ${cmd}`);
+  }
+
   return {
     servers: xPackAPITestsConfig.get('servers'),
-    dockerServers: defineDockerServersConfig({
-      registry: {
-        enabled: !!registryPort,
-        image: dockerImage,
-        portInContainer: 8080,
-        port: registryPort,
-        args: dockerArgs,
-        waitForLogLine: 'package manifests loaded',
-        waitForLogLineTimeoutMs: 60 * 2 * 10000, // 2 minutes
-      },
-    }),
+    dockerServers,
     services: xPackAPITestsConfig.get('services'),
     esTestCluster: xPackAPITestsConfig.get('esTestCluster'),
     kbnTestServer: {

--- a/x-pack/test/fleet_api_integration/helpers.ts
+++ b/x-pack/test/fleet_api_integration/helpers.ts
@@ -29,6 +29,10 @@ export function skipIfNoDockerRegistry(providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const dockerServers = getService('dockerServers');
 
+  if (process.env.FLEET_SKIP_RUNNING_PACKAGE_REGISTRY === 'true') {
+    return;
+  }
+
   const server = dockerServers.get('registry');
   const log = getService('log');
 

--- a/x-pack/test/fleet_api_integration/helpers.ts
+++ b/x-pack/test/fleet_api_integration/helpers.ts
@@ -25,6 +25,18 @@ export function warnAndSkipTest(mochaContext: Mocha.Context, log: ToolingLog) {
   mochaContext.skip();
 }
 
+export function isDockerRegistryEnabledOrSkipped(providerContext: FtrProviderContext) {
+  if (process.env.FLEET_SKIP_RUNNING_PACKAGE_REGISTRY === 'true') {
+    return true;
+  }
+
+  const { getService } = providerContext;
+  const dockerServers = getService('dockerServers');
+  const server = dockerServers.get('registry');
+
+  return server.enabled;
+}
+
 export function skipIfNoDockerRegistry(providerContext: FtrProviderContext) {
   const { getService } = providerContext;
   const dockerServers = getService('dockerServers');


### PR DESCRIPTION
## Summary

That PR intends to improve the dev workflow when writing API integrations tests, right now it could be extremely slow to write tests as each time your launch the test runner it need to launch a docker registry.

That PR allow to externalize that step, and reuse the same docker registry when writing tests, by using a new environment variable `FLEET_SKIP_RUNNING_PACKAGE_REGISTRY=true`

For example 
```
FLEET_SKIP_RUNNING_PACKAGE_REGISTRY=true FLEET_PACKAGE_REGISTRY_PORT=8081 yarn test:ftr:runner --config x-pack/test/fleet_api_integration/config.fleet.ts --grep='inputs_with_standalone_docker_agent'
```

The test will log a warning with the command to run the docker registry
<img width="987" alt="Screenshot 2024-05-29 at 11 51 45 AM" src="https://github.com/elastic/kibana/assets/1336873/bd642cea-8d49-49fe-bc96-7e5c6324b86e">

### Perf improvment running a small api integration tests

## Before 
[
<img width="158" alt="Screenshot 2024-05-29 at 12 06 46 PM" src="https://github.com/elastic/kibana/assets/1336873/b913bb14-7b87-482f-8d94-66e8ab47a5a4">
](url)

## After 
<img width="143" alt="Screenshot 2024-05-29 at 12 07 55 PM" src="https://github.com/elastic/kibana/assets/1336873/8670a40e-a985-4f4e-ab6c-c8534c4576f4">

## Todo

- [x] remove existing direct call to dockerServers and use an helper for that
- [x] Update dev doc



