### PR TITLE
feat(slo): add summary details into burn rate alert context

### DIFF
--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/executor.test.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/executor.test.ts
@@ -609,6 +609,9 @@ describe('BurnRateRuleExecutor', () => {
       esClientMock.search.mockResolvedValueOnce(
         generateEsResponse(ruleParams, [], { instanceId: 'bar' })
       );
+      // Mock summary repository es searches
+      esClientMock.search.mockResolvedValueOnce(generateEsSummaryResponse());
+      esClientMock.search.mockResolvedValueOnce(generateEsSummaryResponse());
 
       // @ts-ignore
       servicesMock.alertsClient!.report.mockImplementation(({ id }: { id: string }) => ({
@@ -673,6 +676,13 @@ describe('BurnRateRuleExecutor', () => {
           burnRateThreshold: 1,
           reason:
             'HIGH: The burn rate for the past 6h is 1.2 and for the past 30m is 1.9 for foo. Alert when above 1 for both windows',
+          sloId: slo.id,
+          sloName: slo.name,
+          sloInstanceId: 'foo',
+          sliValue: 0.9,
+          sloStatus: 'HEALTHY',
+          sloErrorBudgetRemaining: 0.4,
+          sloErrorBudgetConsumed: 0.6,
         }),
       });
 
@@ -684,6 +694,13 @@ describe('BurnRateRuleExecutor', () => {
           burnRateThreshold: 1,
           reason:
             'HIGH: The burn rate for the past 6h is 1.1 and for the past 30m is 1.5 for bar. Alert when above 1 for both windows',
+          sloId: slo.id,
+          sloName: slo.name,
+          sloInstanceId: 'bar',
+          sliValue: 0.9,
+          sloStatus: 'HEALTHY',
+          sloErrorBudgetRemaining: 0.4,
+          sloErrorBudgetConsumed: 0.6,
         }),
       });
     });
@@ -788,6 +805,26 @@ function generateEsResponse(
             )
           ),
       },
+    },
+  };
+}
+
+function generateEsSummaryResponse() {
+  return {
+    ...commonEsResponse,
+    hits: {
+      hits: [
+        {
+          _index: '.slo-observability.summary-v3.2',
+          _id: 'X19fX19fJWJbqiqq1WN9x1e_kHkXpwAA',
+          _source: {
+            sliValue: 0.9,
+            status: 'HEALTHY',
+            errorBudgetConsumed: 0.6,
+            errorBudgetRemaining: 0.4,
+          },
+        },
+      ],
     },
   };
 }

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/lib/summary_repository.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/lib/summary_repository.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core/server';
+import { SLODefinition } from '../../../../domain/models';
+import { SLO_SUMMARY_DESTINATION_INDEX_PATTERN } from '../../../../../common/constants';
+import { EsSummaryDocument } from '../../../../services/summary_transform_generator/helpers/create_temp_summary';
+
+export async function getSloSummary(
+  esClient: ElasticsearchClient,
+  slo: SLODefinition,
+  instanceId: string
+) {
+  try {
+    const res = await esClient.search<EsSummaryDocument>({
+      index: SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
+      body: {
+        query: {
+          bool: {
+            filter: [
+              {
+                term: { 'slo.id': slo.id },
+              },
+              {
+                term: { 'slo.instanceId': instanceId },
+              },
+            ],
+          },
+        },
+        size: 1,
+      },
+    });
+
+    if (res.hits.hits.length === 0) {
+      return undefined;
+    }
+
+    return res.hits.hits[0]._source;
+  } catch (err) {
+    // noop
+    return undefined;
+  }
+}

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
@@ -194,27 +194,27 @@ export const suppressedActionVariableDescription = i18n.translate(
 export const sliValueActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sliValueDescription',
   {
-    defaultMessage: 'The current SLI value.',
+    defaultMessage: 'The SLI value at the time of firing this alert.',
   }
 );
 
 export const sloStatusActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sloStatusDescription',
   {
-    defaultMessage: 'The current SLO status.',
+    defaultMessage: 'The SLO status at the time of firing this alert.',
   }
 );
 
 export const sloErrorBudgetRemainingActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sloErrorBudgetRemainingDescription',
   {
-    defaultMessage: 'The remaining error budget.',
+    defaultMessage: 'The remaining error budget at the time of firing this alert.',
   }
 );
 
 export const sloErrorBudgetConsumedActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sloErrorBudgetConsumedDescription',
   {
-    defaultMessage: 'The consumed error budget.',
+    defaultMessage: 'The consumed error budget at the time of firing this alert.',
   }
 );

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
@@ -100,6 +100,16 @@ export function sloBurnRateRuleType(
         { name: 'sloName', description: sloNameActionVariableDescription },
         { name: 'sloInstanceId', description: sloInstanceIdActionVariableDescription },
         { name: 'suppressedAction', description: suppressedActionVariableDescription },
+        { name: 'sliValue', description: sliValueActionVariableDescription },
+        { name: 'sloStatus', description: sloStatusActionVariableDescription },
+        {
+          name: 'sloErrorBudgetRemaining',
+          description: sloErrorBudgetRemainingActionVariableDescription,
+        },
+        {
+          name: 'sloErrorBudgetConsumed',
+          description: sloErrorBudgetConsumedActionVariableDescription,
+        },
       ],
     },
     alerts: {
@@ -178,5 +188,33 @@ export const suppressedActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.suppressedActionDescription',
   {
     defaultMessage: 'The suppressed action group.',
+  }
+);
+
+export const sliValueActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.sliValueDescription',
+  {
+    defaultMessage: 'The current SLI value.',
+  }
+);
+
+export const sloStatusActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.sloStatusDescription',
+  {
+    defaultMessage: 'The current SLO status.',
+  }
+);
+
+export const sloErrorBudgetRemainingActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.sloErrorBudgetRemainingDescription',
+  {
+    defaultMessage: 'The remaining error budget.',
+  }
+);
+
+export const sloErrorBudgetConsumedActionVariableDescription = i18n.translate(
+  'xpack.slo.alerting.sloErrorBudgetConsumedDescription',
+  {
+    defaultMessage: 'The consumed error budget.',
   }
 );

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/register.ts
@@ -194,27 +194,27 @@ export const suppressedActionVariableDescription = i18n.translate(
 export const sliValueActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sliValueDescription',
   {
-    defaultMessage: 'The SLI value at the time of firing this alert.',
+    defaultMessage: 'The SLI value at the time of firing the alert.',
   }
 );
 
 export const sloStatusActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sloStatusDescription',
   {
-    defaultMessage: 'The SLO status at the time of firing this alert.',
+    defaultMessage: 'The SLO status at the time of firing the alert.',
   }
 );
 
 export const sloErrorBudgetRemainingActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sloErrorBudgetRemainingDescription',
   {
-    defaultMessage: 'The remaining error budget at the time of firing this alert.',
+    defaultMessage: 'The remaining error budget at the time of firing the alert.',
   }
 );
 
 export const sloErrorBudgetConsumedActionVariableDescription = i18n.translate(
   'xpack.slo.alerting.sloErrorBudgetConsumedDescription',
   {
-    defaultMessage: 'The consumed error budget at the time of firing this alert.',
+    defaultMessage: 'The consumed error budget at the time of firing the alert.',
   }
 );


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/183747

## 🌸 Summary

This PR adds the following context variables when a SLO burn rate alert is triggered:
- SLI Value
- SLO Status
- SLO Error Budget Remaining
- SLO Error Budget Consumed

These variables have been added directly on the context object as flatten values, so they are available/discoverable from the context variable dropdown.
One could argue that we could add a summary variable context object and put them under.

### Testing plan

Create an SLO with or without instances. Edit the auto created rules, and add some log server actions that triggers on every run for every severity with the following content: 
```
{{context}}
```


You should see something like this in the console (but more compacted ;))

```
{
  "alertDetailsUrl": "http://localhost:5601/kibana/app/observability/alerts?_a=(kuery:%27kibana.alert.uuid:%20%221e31b972-451d-4665-ba26-b22dfc9b9bd9%22%27%2CrangeFrom:%272024-05-29T19:12:50.442Z%27%2CrangeTo:now%2Cstatus:all)",
  "reason": "MEDIUM: The burn rate for the past 24h is 0.74 and for the past 120m is 0.78. Alert when above 0.7 for both windows",
  "longWindow": {
    "burnRate": 0.7422857493405315,
    "duration": "24h"
  },
  "shortWindow": {
    "burnRate": 0.7829418624021305,
    "duration": "120m"
  },
  "burnRateThreshold": 0.7,
  "timestamp": "2024-05-29T19:17:50.442Z",
  "viewInAppUrl": "http://localhost:5601/kibana/app/observability/slos/6c74a7b0-7dd5-4ba7-a981-ef082ea85084",
  "sloId": "6c74a7b0-7dd5-4ba7-a981-ef082ea85084",
  "sloName": "test",
  "sloInstanceId": "*",
  "slo": {
    "name": "test",
    "description": "",
    "indicator": {
      "type": "sli.kql.custom",
      "params": {
        "index": "kbn-data-forge-fake_stack.admin-console-*",
        "filter": "",
        "good": "http.response.status_code <500",
        "total": "http.response.status_code :*",
        "timestampField": "@timestamp"
      }
    },
    "budgetingMethod": "occurrences",
    "timeWindow": {
      "duration": {
        "value": 7,
        "unit": "d"
      },
      "type": "rolling"
    },
    "objective": {
      "target": 0.99
    },
    "tags": [],
    "groupBy": [
      "*"
    ],
    "settings": {
      "syncDelay": {
        "value": 1,
        "unit": "m"
      },
      "frequency": {
        "value": 1,
        "unit": "m"
      },
      "preventInitialBackfill": true
    },
    "id": "6c74a7b0-7dd5-4ba7-a981-ef082ea85084",
    "revision": 1,
    "enabled": true,
    "createdAt": "2024-05-29T13:50:58.639Z",
    "updatedAt": "2024-05-29T13:50:58.639Z",
    "version": 2
  },
  "sliValue": 0.9925771425065947,
  "sloStatus": "HEALTHY",
  "sloErrorBudgetRemaining": 0.2577142506594685,
  "sloErrorBudgetConsumed": 0.7422857493405315,
  "suppressedAction": null
}
```

## Release notes

Add SLO status, SLI value, error budget remaining and consumed in burn rate alert context