### PR TITLE
[Security Solution] - remove tGridEventRenderedViewEnabled feature flag

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -13,7 +13,6 @@ export type ExperimentalFeatures = { [K in keyof typeof allowedExperimentalValue
  */
 export const allowedExperimentalValues = Object.freeze({
   tGridEnabled: true,
-  tGridEventRenderedViewEnabled: true,
 
   // FIXME:PT delete?
   excludePoliciesInFilterEnabled: false,

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/right_top_menu.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/right_top_menu.tsx
@@ -10,7 +10,6 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import React, { useMemo } from 'react';
 import type { CSSProperties } from 'styled-components';
 import styled from 'styled-components';
-import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 import { InspectButton } from '../inspect';
 import { UpdatedFlexGroup, UpdatedFlexItem } from './styles';
 import { SummaryViewSelector } from './summary_view_select';
@@ -47,10 +46,6 @@ export const RightTopMenu = ({
   const alignItems = tableView === 'gridView' ? 'baseline' : 'center';
   const justTitle = useMemo(() => <TitleText data-test-subj="title">{title}</TitleText>, [title]);
 
-  const tGridEventRenderedViewEnabled = useIsExperimentalFeatureEnabled(
-    'tGridEventRenderedViewEnabled'
-  );
-
   const menuOptions = useMemo(
     () =>
       additionalMenuOptions.length
@@ -82,12 +77,11 @@ export const RightTopMenu = ({
       <UpdatedFlexItem grow={false} $show={!loading}>
         {additionalFilters}
       </UpdatedFlexItem>
-      {tGridEventRenderedViewEnabled &&
-        [TableId.alertsOnRuleDetailsPage, TableId.alertsOnAlertsPage].includes(tableId) && (
-          <UpdatedFlexItem grow={false} $show={!loading} data-test-subj="summary-view-selector">
-            <SummaryViewSelector viewSelected={tableView} onViewChange={onViewChange} />
-          </UpdatedFlexItem>
-        )}
+      {[TableId.alertsOnRuleDetailsPage, TableId.alertsOnAlertsPage].includes(tableId) && (
+        <UpdatedFlexItem grow={false} $show={!loading} data-test-subj="summary-view-selector">
+          <SummaryViewSelector viewSelected={tableView} onViewChange={onViewChange} />
+        </UpdatedFlexItem>
+      )}
       {menuOptions}
     </UpdatedFlexGroup>
   );


### PR DESCRIPTION
## Summary

The `tGridEventRenderedViewEnabled` feature flag was last modified on August 2021 (see [PR](https://github.com/elastic/kibana/pull/108644)). Since then, the value has been `true`.

This PR removes the feature flag entirely, as I don't think we should need it, after nearly 3 years of it being enabled.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
