### PR TITLE
[Security Solution] - remove insightsRelatedAlertsByProcessAncestry feature flag

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -31,11 +31,6 @@ export const allowedExperimentalValues = Object.freeze({
   previewTelemetryUrlEnabled: false,
 
   /**
-   * Enables the insights module for related alerts by process ancestry
-   */
-  insightsRelatedAlertsByProcessAncestry: true,
-
-  /**
    * Enables extended rule execution logging to Event Log. When this setting is enabled:
    * - Rules write their console error, info, debug, and trace messages to Event Log,
    *   in addition to other events they log there (status changes and execution metrics).

--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.test.tsx
@@ -12,7 +12,6 @@ import { TestProviders } from '../../../mock';
 
 import type { TimelineEventsDetailsItem } from '../../../../../common/search_strategy/timeline';
 import { useKibana as mockUseKibana } from '../../../lib/kibana/__mocks__';
-import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
 import { licenseService } from '../../../hooks/use_license';
 import { noCasesPermissions, readCasesPermissions } from '../../../../cases_test_utils';
 import { Insights } from './insights';
@@ -55,11 +54,6 @@ jest.mock('../../../hooks/use_license', () => {
   };
 });
 const licenseServiceMock = licenseService as jest.Mocked<typeof licenseService>;
-
-jest.mock('../../../hooks/use_experimental_features', () => ({
-  useIsExperimentalFeatureEnabled: jest.fn().mockReturnValue(true),
-}));
-const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 const dataWithoutAgentType: TimelineEventsDetailsItem[] = [
   {
@@ -178,23 +172,6 @@ describe('Insights', () => {
         ).toBeInTheDocument();
         expect(screen.queryByTestId('related-alerts-by-ancestry')).not.toBeInTheDocument();
       });
-    });
-  });
-
-  describe('with feature flag disabled', () => {
-    it('should not render neither the upsell, nor the insights for alerts by process ancestry', () => {
-      useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
-
-      render(
-        <TestProviders>
-          <Insights browserFields={{}} eventId="test" data={data} scopeId="" />
-        </TestProviders>
-      );
-
-      expect(screen.queryByTestId('related-alerts-by-ancestry')).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: new RegExp(i18n.INSIGHTS_UPSELL) })
-      ).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/event_details/insights/insights.tsx
@@ -17,7 +17,6 @@ import * as i18n from './translations';
 import type { BrowserFields } from '../../../containers/source';
 import type { TimelineEventsDetailsItem } from '../../../../../common/search_strategy/timeline';
 import { hasData } from './helpers';
-import { useIsExperimentalFeatureEnabled } from '../../../hooks/use_experimental_features';
 import { useLicense } from '../../../hooks/use_license';
 import { RelatedAlertsByProcessAncestry } from './related_alerts_by_process_ancestry';
 import { RelatedCases } from './related_cases';
@@ -47,9 +46,6 @@ interface Props {
 export const Insights = React.memo<Props>(
   ({ browserFields, eventId, data, isReadOnly, scopeId }) => {
     const { cases } = useKibana().services;
-    const isRelatedAlertsByProcessAncestryEnabled = useIsExperimentalFeatureEnabled(
-      'insightsRelatedAlertsByProcessAncestry'
-    );
     const hasAtLeastPlatinum = useLicense().isPlatinumPlus();
     const originalDocumentId = find(
       { category: 'kibana', field: 'kibana.alert.ancestors.id' },
@@ -70,8 +66,7 @@ export const Insights = React.memo<Props>(
       { category: 'process', field: 'process.entry_leader.entity_id' },
       data
     );
-    const hasProcessSessionInfo =
-      isRelatedAlertsByProcessAncestryEnabled && hasData(processSessionField);
+    const hasProcessSessionInfo = hasData(processSessionField);
 
     const sourceEventField = find(
       { category: 'kibana', field: 'kibana.alert.original_event.id' },
@@ -98,10 +93,7 @@ export const Insights = React.memo<Props>(
       hasProcessSessionInfo;
 
     const canShowAncestryInsight =
-      isRelatedAlertsByProcessAncestryEnabled &&
-      hasProcessEntityInfo &&
-      originalDocumentId &&
-      originalDocumentIndex;
+      hasProcessEntityInfo && originalDocumentId && originalDocumentIndex;
 
     // If we're in read-only mode or don't have any insight-related data,
     // don't render anything.

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.test.tsx
@@ -12,12 +12,10 @@ import type {
   UseShowRelatedAlertsByAncestryResult,
 } from './use_show_related_alerts_by_ancestry';
 import { useShowRelatedAlertsByAncestry } from './use_show_related_alerts_by_ancestry';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { licenseService } from '../../../../common/hooks/use_license';
 import { mockDataAsNestedObject } from '../mocks/mock_data_as_nested_object';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 
-jest.mock('../../../../common/hooks/use_experimental_features');
 jest.mock('../../../../common/hooks/use_license', () => {
   const licenseServiceInstance = {
     isPlatinumPlus: jest.fn(),
@@ -43,7 +41,6 @@ describe('useShowRelatedAlertsByAncestry', () => {
   >;
 
   it('should return false if Process Entity Info is not available', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(false);
     licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
     const getFieldsData = () => null;
@@ -62,27 +59,7 @@ describe('useShowRelatedAlertsByAncestry', () => {
     });
   });
 
-  it(`should return false if feature isn't enabled`, () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
-    licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
-    const getFieldsData = () => 'value';
-    hookResult = renderHook(() =>
-      useShowRelatedAlertsByAncestry({
-        getFieldsData,
-        dataAsNestedObject,
-        eventId,
-        isPreview: false,
-      })
-    );
-
-    expect(hookResult.result.current).toEqual({
-      show: false,
-      documentId: 'event-id',
-    });
-  });
-
   it(`should return false if license is lower than platinum`, () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     licenseServiceMock.isPlatinumPlus.mockReturnValue(false);
     const getFieldsData = () => 'value';
     hookResult = renderHook(() =>
@@ -101,7 +78,6 @@ describe('useShowRelatedAlertsByAncestry', () => {
   });
 
   it('should return true and event id as document id by default ', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
     licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
     const getFieldsData = () => 'ancestors-id';
@@ -121,7 +97,6 @@ describe('useShowRelatedAlertsByAncestry', () => {
   });
 
   it('should return true and ancestor id as document id if flyout is open in preview', () => {
-    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
     (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
     licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
     const getFieldsData = () => 'ancestors-id';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.ts
@@ -8,7 +8,6 @@
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { ANCESTOR_ID } from '../constants/field_names';
 import { getField } from '../utils';
@@ -52,9 +51,6 @@ export const useShowRelatedAlertsByAncestry = ({
   eventId,
   isPreview,
 }: UseShowRelatedAlertsByAncestryParams): UseShowRelatedAlertsByAncestryResult => {
-  const isRelatedAlertsByProcessAncestryEnabled = useIsExperimentalFeatureEnabled(
-    'insightsRelatedAlertsByProcessAncestry'
-  );
   const hasProcessEntityInfo = useIsInvestigateInResolverActionEnabled(dataAsNestedObject);
 
   const ancestorId = getField(getFieldsData(ANCESTOR_ID)) ?? '';
@@ -62,8 +58,7 @@ export const useShowRelatedAlertsByAncestry = ({
 
   const hasAtLeastPlatinum = useLicense().isPlatinumPlus();
 
-  const show =
-    isRelatedAlertsByProcessAncestryEnabled && hasProcessEntityInfo && hasAtLeastPlatinum;
+  const show = hasProcessEntityInfo && hasAtLeastPlatinum;
 
   return {
     show,

--- a/x-pack/plugins/security_solution/server/endpoint/routes/resolver.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/resolver.ts
@@ -38,7 +38,7 @@ export const registerResolverRoutes = (
       validate: validateTree,
       options: { authRequired: true },
     },
-    handleTree(getRuleRegistry, config, getLicensing)
+    handleTree(getRuleRegistry, getLicensing)
   );
 
   router.post(

--- a/x-pack/plugins/security_solution/server/endpoint/routes/resolver/tree/handler.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/resolver/tree/handler.ts
@@ -12,7 +12,6 @@ import type { TypeOf } from '@kbn/config-schema';
 import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/server';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ANALYZER } from '../../../../../common/constants';
-import type { ConfigType } from '../../../../config';
 
 import type { validateTree } from '../../../../../common/endpoint/schema/resolver';
 import { featureUsageService } from '../../../services/feature_usage';
@@ -20,18 +19,13 @@ import { Fetcher } from './utils/fetch';
 
 export function handleTree(
   getRuleRegistry: () => Promise<RuleRegistryPluginStartContract>,
-  config: ConfigType,
   getLicensing: () => Promise<LicensingPluginStart>
 ): RequestHandler<unknown, unknown, TypeOf<typeof validateTree.body>> {
   return async (context, req, res) => {
     const client = (await context.core).elasticsearch.client;
-    const {
-      experimentalFeatures: { insightsRelatedAlertsByProcessAncestry },
-    } = config;
     const licensing = await getLicensing();
     const license = await firstValueFrom(licensing.license$);
-    const hasAccessToInsightsRelatedByProcessAncestry =
-      insightsRelatedAlertsByProcessAncestry && license.hasAtLeast('platinum');
+    const hasAccessToInsightsRelatedByProcessAncestry = license.hasAtLeast('platinum');
     const shouldExcludeColdAndFrozenTiers = await (
       await context.core
     ).uiSettings.client.get<boolean>(EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ANALYZER);


### PR DESCRIPTION
## Summary

The `insightsRelatedAlertsByProcessAncestry` feature flag was last modified on September 2022 (see https://github.com/elastic/kibana/pull/140006). Since then, the value has been `true`.

This PR removes the feature flag entirely, as I don't think we should need it, after nearly two years of it being enabled.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
