### PR TITLE
[ES|QL] Adds `METRICS` source command AST node support in parsing

### DIFF
--- a/packages/kbn-esql-ast/index.ts
+++ b/packages/kbn-esql-ast/index.ts
@@ -9,6 +9,8 @@
 export type {
   ESQLAst,
   ESQLAstItem,
+  ESQLAstCommand,
+  ESQLAstMetricsCommand,
   ESQLCommand,
   ESQLCommandOption,
   ESQLCommandMode,

--- a/packages/kbn-esql-ast/index.ts
+++ b/packages/kbn-esql-ast/index.ts
@@ -9,7 +9,6 @@
 export type {
   ESQLAst,
   ESQLAstItem,
-  ESQLAstCommand,
   ESQLCommand,
   ESQLCommandOption,
   ESQLCommandMode,

--- a/packages/kbn-esql-ast/index.ts
+++ b/packages/kbn-esql-ast/index.ts
@@ -9,6 +9,7 @@
 export type {
   ESQLAst,
   ESQLAstItem,
+  ESQLAstCommand,
   ESQLCommand,
   ESQLCommandOption,
   ESQLCommandMode,

--- a/packages/kbn-esql-ast/jest.config.js
+++ b/packages/kbn-esql-ast/jest.config.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../..',
+  roots: ['<rootDir>/packages/kbn-esql-ast'],
+};

--- a/packages/kbn-esql-ast/src/__tests__/ast_parser.from.test.ts
+++ b/packages/kbn-esql-ast/src/__tests__/ast_parser.from.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getAstAndSyntaxErrors as parse } from '../ast_parser';
+
+describe('FROM', () => {
+  it('can parse basic FROM query', () => {
+    const text = 'FROM kibana_ecommerce_data';
+    const { ast } = parse(text);
+
+    expect(ast).toMatchObject([
+      {
+        type: 'command',
+        name: 'from',
+        args: [
+          {
+            type: 'source',
+            name: 'kibana_ecommerce_data',
+            sourceType: 'index',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('can parse FROM query with metadata', () => {
+    const text = 'from kibana_sample_data_ecommerce METADATA _index, \n _id\n';
+    const { ast } = parse(text);
+
+    expect(ast).toMatchObject([
+      {
+        type: 'command',
+        name: 'from',
+        args: [
+          {
+            type: 'source',
+            name: 'kibana_sample_data_ecommerce',
+            sourceType: 'index',
+          },
+          {
+            type: 'option',
+            name: 'metadata',
+            args: [
+              {
+                type: 'column',
+                name: '_index',
+                quoted: false,
+              },
+              {
+                type: 'column',
+                name: '_id',
+                quoted: false,
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/kbn-esql-ast/src/__tests__/ast_parser.from.test.ts
+++ b/packages/kbn-esql-ast/src/__tests__/ast_parser.from.test.ts
@@ -9,57 +9,152 @@
 import { getAstAndSyntaxErrors as parse } from '../ast_parser';
 
 describe('FROM', () => {
-  it('can parse basic FROM query', () => {
-    const text = 'FROM kibana_ecommerce_data';
-    const { ast } = parse(text);
+  describe('correctly formatted', () => {
+    it('can parse basic FROM query', () => {
+      const text = 'FROM kibana_ecommerce_data';
+      const { ast, errors } = parse(text);
 
-    expect(ast).toMatchObject([
-      {
-        type: 'command',
-        name: 'from',
-        args: [
-          {
-            type: 'source',
-            name: 'kibana_ecommerce_data',
-            sourceType: 'index',
-          },
-        ],
-      },
-    ]);
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'from',
+          args: [
+            {
+              type: 'source',
+              name: 'kibana_ecommerce_data',
+              sourceType: 'index',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse FROM query with multiple index identifiers', () => {
+      const text = '\tFROM foo, bar \t\t, \n  baz';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'from',
+          args: [
+            {
+              type: 'source',
+              name: 'foo',
+              sourceType: 'index',
+            },
+            {
+              type: 'source',
+              name: 'bar',
+              sourceType: 'index',
+            },
+            {
+              type: 'source',
+              name: 'baz',
+              sourceType: 'index',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse FROM query with a single metadata column', () => {
+      const text = 'from foo METADATA bar';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'from',
+          args: [
+            {
+              type: 'source',
+              name: 'foo',
+              sourceType: 'index',
+            },
+            {
+              type: 'option',
+              name: 'metadata',
+              args: [
+                {
+                  type: 'column',
+                  name: 'bar',
+                  quoted: false,
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse FROM query with multiple metadata columns', () => {
+      const text = 'from kibana_sample_data_ecommerce METADATA _index, \n _id\n';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'from',
+          args: [
+            {
+              type: 'source',
+              name: 'kibana_sample_data_ecommerce',
+              sourceType: 'index',
+            },
+            {
+              type: 'option',
+              name: 'metadata',
+              args: [
+                {
+                  type: 'column',
+                  name: '_index',
+                  quoted: false,
+                },
+                {
+                  type: 'column',
+                  name: '_id',
+                  quoted: false,
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
   });
 
-  it('can parse FROM query with metadata', () => {
-    const text = 'from kibana_sample_data_ecommerce METADATA _index, \n _id\n';
-    const { ast } = parse(text);
+  describe('when incorrectly formatted, returns errors', () => {
+    it('when no index identifier specified', () => {
+      const text = 'FROM \n\t';
+      const { errors } = parse(text);
 
-    expect(ast).toMatchObject([
-      {
-        type: 'command',
-        name: 'from',
-        args: [
-          {
-            type: 'source',
-            name: 'kibana_sample_data_ecommerce',
-            sourceType: 'index',
-          },
-          {
-            type: 'option',
-            name: 'metadata',
-            args: [
-              {
-                type: 'column',
-                name: '_index',
-                quoted: false,
-              },
-              {
-                type: 'column',
-                name: '_id',
-                quoted: false,
-              },
-            ],
-          },
-        ],
-      },
-    ]);
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when comma is not followed by an index identifier', () => {
+      const text = '\tFROM foo, ';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when metadata has not columns', () => {
+      const text = 'from foo METADATA \t';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when metadata columns finish with a trailing comma', () => {
+      const text = 'from kibana_sample_data_ecommerce METADATA _index,';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
   });
 });

--- a/packages/kbn-esql-ast/src/__tests__/ast_parser.metrics.test.ts
+++ b/packages/kbn-esql-ast/src/__tests__/ast_parser.metrics.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getAstAndSyntaxErrors as parse } from '../ast_parser';
+
+describe('METRICS', () => {
+  describe('correctly formatted', () => {
+    it('can parse a basic query', () => {
+      const text = 'METRICS foo';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'metrics',
+          indices: [
+            {
+              type: 'source',
+              name: 'foo',
+              sourceType: 'index',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse multiple "indices"', () => {
+      const text = 'METRICS foo ,\nbar\t,\t\nbaz \n';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'metrics',
+          indices: [
+            {
+              type: 'source',
+              name: 'foo',
+              sourceType: 'index',
+            },
+            {
+              type: 'source',
+              name: 'bar',
+              sourceType: 'index',
+            },
+            {
+              type: 'source',
+              name: 'baz',
+              sourceType: 'index',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse "aggregates"', () => {
+      const text = 'metrics foo agg1, agg2';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'metrics',
+          indices: [
+            {
+              type: 'source',
+              name: 'foo',
+              sourceType: 'index',
+            },
+          ],
+          aggregates: [
+            {
+              type: 'column',
+              text: 'agg1',
+            },
+            {
+              type: 'column',
+              text: 'agg2',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse "grouping"', () => {
+      const text = 'mEtRiCs foo agg BY grp1, grp2';
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'metrics',
+          indices: [
+            {
+              type: 'source',
+              name: 'foo',
+              sourceType: 'index',
+            },
+          ],
+          aggregates: [
+            {
+              type: 'column',
+              text: 'agg',
+            },
+          ],
+          grouping: [
+            {
+              type: 'column',
+              text: 'grp1',
+            },
+            {
+              type: 'column',
+              text: 'grp2',
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('when incorrectly formatted, returns errors', () => {
+    it('when no index identifier specified', () => {
+      const text = 'METRICS \n\t';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when comma follows index identifier', () => {
+      const text = 'METRICS foo, ';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when comma follows "aggregates"', () => {
+      const text = 'from foo agg1, agg2';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when "grouping" in BY clause is empty', () => {
+      const text = 'from foo agg1, agg2 BY \t';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+
+    it('when "grouping" has trailing comma', () => {
+      const text = 'from foo agg1, agg2 BY grp1, grp2,';
+      const { errors } = parse(text);
+
+      expect(errors.length > 0).toBe(true);
+    });
+  });
+});

--- a/packages/kbn-esql-ast/src/ast_factory.ts
+++ b/packages/kbn-esql-ast/src/ast_factory.ts
@@ -28,6 +28,8 @@ import {
   type WhereCommandContext,
   default as esql_parser,
   type MetaCommandContext,
+  type MetricsCommandContext,
+  IndexIdentifierContext,
 } from './antlr/esql_parser';
 import { default as ESQLParserListener } from './antlr/esql_parser_listener';
 import {
@@ -36,6 +38,8 @@ import {
   createOption,
   createLiteral,
   textExistsAndIsValid,
+  createSource,
+  crateAstBaseItem,
 } from './ast_helpers';
 import { getPosition } from './ast_position_utils';
 import {
@@ -52,7 +56,7 @@ import {
   getMatchField,
   getEnrichClauses,
 } from './ast_walker';
-import type { ESQLAst } from './types';
+import type { ESQLAst, ESQLAstMetricsCommand } from './types';
 
 export class AstListener implements ESQLParserListener {
   private ast: ESQLAst = [];
@@ -137,6 +141,29 @@ export class AstListener implements ESQLParserListener {
       );
       commandAst.args.push(option);
       option.args.push(...collectAllColumnIdentifiers(metadataContent));
+    }
+  }
+
+  /**
+   * Exit a parse tree produced by `esql_parser.metricsCommand`.
+   * @param ctx the parse tree
+   */
+  exitMetricsCommand(ctx: MetricsCommandContext): void {
+    const node: ESQLAstMetricsCommand = {
+      ...crateAstBaseItem('metrics', ctx),
+      type: 'command',
+      indices: ctx
+        .getTypedRuleContexts(IndexIdentifierContext)
+        .map((sourceCtx) => createSource(sourceCtx)),
+    };
+    this.ast.push(node);
+    const aggregates = collectAllFieldsStatements(ctx.fields(0));
+    const grouping = collectAllFieldsStatements(ctx.fields(1));
+    if (aggregates && aggregates.length) {
+      node.aggregates = aggregates;
+    }
+    if (grouping && grouping.length) {
+      node.grouping = grouping;
     }
   }
 

--- a/packages/kbn-esql-ast/src/ast_factory.ts
+++ b/packages/kbn-esql-ast/src/ast_factory.ts
@@ -39,7 +39,7 @@ import {
   createLiteral,
   textExistsAndIsValid,
   createSource,
-  crateAstBaseItem,
+  createAstBaseItem,
 } from './ast_helpers';
 import { getPosition } from './ast_position_utils';
 import {
@@ -150,7 +150,7 @@ export class AstListener implements ESQLParserListener {
    */
   exitMetricsCommand(ctx: MetricsCommandContext): void {
     const node: ESQLAstMetricsCommand = {
-      ...crateAstBaseItem('metrics', ctx),
+      ...createAstBaseItem('metrics', ctx),
       type: 'command',
       args: [],
       indices: ctx

--- a/packages/kbn-esql-ast/src/ast_factory.ts
+++ b/packages/kbn-esql-ast/src/ast_factory.ts
@@ -152,6 +152,7 @@ export class AstListener implements ESQLParserListener {
     const node: ESQLAstMetricsCommand = {
       ...crateAstBaseItem('metrics', ctx),
       type: 'command',
+      args: [],
       indices: ctx
         .getTypedRuleContexts(IndexIdentifierContext)
         .map((sourceCtx) => createSource(sourceCtx)),
@@ -165,6 +166,7 @@ export class AstListener implements ESQLParserListener {
     if (grouping && grouping.length) {
       node.grouping = grouping;
     }
+    node.args.push(...node.indices, ...aggregates, ...grouping);
   }
 
   /**

--- a/packages/kbn-esql-ast/src/ast_helpers.ts
+++ b/packages/kbn-esql-ast/src/ast_helpers.ts
@@ -38,7 +38,7 @@ export function nonNullable<T>(v: T): v is NonNullable<T> {
   return v != null;
 }
 
-export function crateAstBaseItem<Name = string>(
+export function createAstBaseItem<Name = string>(
   name: Name,
   ctx: ParserRuleContext
 ): ESQLAstBaseItem<Name> {

--- a/packages/kbn-esql-ast/src/ast_helpers.ts
+++ b/packages/kbn-esql-ast/src/ast_helpers.ts
@@ -20,6 +20,7 @@ import type {
 import { getPosition } from './ast_position_utils';
 import { DOUBLE_TICKS_REGEX, SINGLE_BACKTICK, TICKS_REGEX } from './constants';
 import type {
+  ESQLAstBaseItem,
   ESQLCommand,
   ESQLLiteral,
   ESQLList,
@@ -35,6 +36,18 @@ import type {
 
 export function nonNullable<T>(v: T): v is NonNullable<T> {
   return v != null;
+}
+
+export function crateAstBaseItem<Name = string>(
+  name: Name,
+  ctx: ParserRuleContext
+): ESQLAstBaseItem<Name> {
+  return {
+    name,
+    text: ctx.getText(),
+    location: getPosition(ctx.start, ctx.stop),
+    incomplete: Boolean(ctx.exception),
+  };
 }
 
 export function createCommand(name: string, ctx: ParserRuleContext): ESQLCommand {

--- a/packages/kbn-esql-ast/src/types.ts
+++ b/packages/kbn-esql-ast/src/types.ts
@@ -34,14 +34,12 @@ export interface ESQLAstBaseItem<Name = string> {
   incomplete: boolean;
 }
 
-export interface ESQLCommand extends ESQLAstBaseItem {
+export interface ESQLCommand<Name = string> extends ESQLAstBaseItem<Name> {
   type: 'command';
   args: ESQLAstItem[];
 }
 
-export interface ESQLAstMetricsCommand extends ESQLAstBaseItem {
-  type: 'command';
-  name: 'metrics';
+export interface ESQLAstMetricsCommand extends ESQLCommand<'metrics'> {
   indices: ESQLSource[];
   aggregates?: ESQLAstItem[];
   grouping?: ESQLAstItem[];

--- a/packages/kbn-esql-ast/src/types.ts
+++ b/packages/kbn-esql-ast/src/types.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-export type ESQLAst = ESQLAstCommand[];
+export type ESQLAst = ESQLAstCommands[];
 
-export type ESQLAstCommand = ESQLCommand | ESQLAstMetricsCommand;
+export type ESQLAstCommands = ESQLCommand | ESQLAstMetricsCommand;
 
 export type ESQLSingleAstItem =
   | ESQLFunction

--- a/packages/kbn-esql-ast/src/types.ts
+++ b/packages/kbn-esql-ast/src/types.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-export type ESQLAst = ESQLAstCommands[];
+export type ESQLAst = ESQLAstCommand[];
 
-export type ESQLAstCommands = ESQLCommand | ESQLAstMetricsCommand;
+export type ESQLAstCommand = ESQLCommand | ESQLAstMetricsCommand;
 
 export type ESQLSingleAstItem =
   | ESQLFunction

--- a/packages/kbn-esql-ast/src/types.ts
+++ b/packages/kbn-esql-ast/src/types.ts
@@ -6,7 +6,9 @@
  * Side Public License, v 1.
  */
 
-export type ESQLAst = ESQLCommand[];
+export type ESQLAst = ESQLAstCommands[];
+
+export type ESQLAstCommands = ESQLCommand | ESQLAstMetricsCommand;
 
 export type ESQLSingleAstItem =
   | ESQLFunction
@@ -25,8 +27,8 @@ export interface ESQLLocation {
   max: number;
 }
 
-interface ESQLAstBaseItem {
-  name: string;
+export interface ESQLAstBaseItem<Name = string> {
+  name: Name;
   text: string;
   location: ESQLLocation;
   incomplete: boolean;
@@ -35,6 +37,14 @@ interface ESQLAstBaseItem {
 export interface ESQLCommand extends ESQLAstBaseItem {
   type: 'command';
   args: ESQLAstItem[];
+}
+
+export interface ESQLAstMetricsCommand extends ESQLAstBaseItem {
+  type: 'command';
+  name: 'metrics';
+  indices: ESQLSource[];
+  aggregates?: ESQLAstItem[];
+  grouping?: ESQLAstItem[];
 }
 
 export interface ESQLCommandOption extends ESQLAstBaseItem {

--- a/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -15,6 +15,7 @@ import type {
   ESQLCommandOption,
   ESQLCommandMode,
 } from '@kbn/esql-ast';
+import { ESQLAstCommand } from '@kbn/esql-ast/src/types';
 import { ENRICH_MODES } from '../definitions/settings';
 import { EDITOR_MARKER } from './constants';
 import {
@@ -101,16 +102,20 @@ function mapToNonMarkerNode(arg: ESQLAstItem): ESQLAstItem {
   return Array.isArray(arg) ? arg.filter(isNotMarkerNodeOrArray).map(mapToNonMarkerNode) : arg;
 }
 
-export function removeMarkerArgFromArgsList<T extends ESQLSingleAstItem | ESQLCommand>(
+export function removeMarkerArgFromArgsList<T extends ESQLSingleAstItem | ESQLAstCommand>(
   node: T | undefined
 ) {
   if (!node) {
     return;
   }
-  if (node.type === 'command' || node.type === 'option' || node.type === 'function') {
+  if (
+    (node.type === 'command' && (node as ESQLCommand).args) ||
+    node.type === 'option' ||
+    node.type === 'function'
+  ) {
     return {
       ...node,
-      args: node.args.filter(isNotMarkerNodeOrArray).map(mapToNonMarkerNode),
+      args: (node as ESQLCommand).args.filter(isNotMarkerNodeOrArray).map(mapToNonMarkerNode),
     };
   }
   return node;

--- a/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -15,7 +15,6 @@ import type {
   ESQLCommandOption,
   ESQLCommandMode,
 } from '@kbn/esql-ast';
-import { ESQLAstCommand } from '@kbn/esql-ast/src/types';
 import { ENRICH_MODES } from '../definitions/settings';
 import { EDITOR_MARKER } from './constants';
 import {
@@ -102,20 +101,16 @@ function mapToNonMarkerNode(arg: ESQLAstItem): ESQLAstItem {
   return Array.isArray(arg) ? arg.filter(isNotMarkerNodeOrArray).map(mapToNonMarkerNode) : arg;
 }
 
-export function removeMarkerArgFromArgsList<T extends ESQLSingleAstItem | ESQLAstCommand>(
+export function removeMarkerArgFromArgsList<T extends ESQLSingleAstItem | ESQLCommand>(
   node: T | undefined
 ) {
   if (!node) {
     return;
   }
-  if (
-    (node.type === 'command' && (node as ESQLCommand).args) ||
-    node.type === 'option' ||
-    node.type === 'function'
-  ) {
+  if (node.type === 'command' || node.type === 'option' || node.type === 'function') {
     return {
       ...node,
-      args: (node as ESQLCommand).args.filter(isNotMarkerNodeOrArray).map(mapToNonMarkerNode),
+      args: node.args.filter(isNotMarkerNodeOrArray).map(mapToNonMarkerNode),
     };
   }
   return node;

--- a/packages/kbn-esql-validation-autocomplete/src/shared/variables.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/variables.ts
@@ -6,13 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type {
-  ESQLAstItem,
-  ESQLAstCommand,
-  ESQLCommand,
-  ESQLCommandOption,
-  ESQLFunction,
-} from '@kbn/esql-ast';
+import type { ESQLAstItem, ESQLCommand, ESQLCommandOption, ESQLFunction } from '@kbn/esql-ast';
 import type { ESQLVariable, ESQLRealField } from '../validation/types';
 import { DOUBLE_BACKTICK, EDITOR_MARKER, SINGLE_BACKTICK } from './constants';
 import {
@@ -141,14 +135,14 @@ function addVariableFromExpression(
 }
 
 export function collectVariables(
-  commands: ESQLAstCommand[],
+  commands: ESQLCommand[],
   fields: Map<string, ESQLRealField>,
   queryString: string
 ): Map<string, ESQLVariable[]> {
   const variables = new Map<string, ESQLVariable[]>();
   for (const command of commands) {
-    if (['row', 'eval', 'stats'].includes(command.name) && (command as ESQLCommand).args) {
-      for (const arg of (command as ESQLCommand).args) {
+    if (['row', 'eval', 'stats'].includes(command.name)) {
+      for (const arg of command.args) {
         if (isAssignment(arg)) {
           addVariableFromAssignment(arg, variables, fields);
         }

--- a/packages/kbn-esql-validation-autocomplete/src/shared/variables.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/variables.ts
@@ -6,7 +6,13 @@
  * Side Public License, v 1.
  */
 
-import type { ESQLAstItem, ESQLCommand, ESQLCommandOption, ESQLFunction } from '@kbn/esql-ast';
+import type {
+  ESQLAstItem,
+  ESQLAstCommand,
+  ESQLCommand,
+  ESQLCommandOption,
+  ESQLFunction,
+} from '@kbn/esql-ast';
 import type { ESQLVariable, ESQLRealField } from '../validation/types';
 import { DOUBLE_BACKTICK, EDITOR_MARKER, SINGLE_BACKTICK } from './constants';
 import {
@@ -135,14 +141,14 @@ function addVariableFromExpression(
 }
 
 export function collectVariables(
-  commands: ESQLCommand[],
+  commands: ESQLAstCommand[],
   fields: Map<string, ESQLRealField>,
   queryString: string
 ): Map<string, ESQLVariable[]> {
   const variables = new Map<string, ESQLVariable[]>();
   for (const command of commands) {
-    if (['row', 'eval', 'stats'].includes(command.name)) {
-      for (const arg of command.args) {
+    if (['row', 'eval', 'stats'].includes(command.name) && (command as ESQLCommand).args) {
+      for (const arg of (command as ESQLCommand).args) {
         if (isAssignment(arg)) {
           addVariableFromAssignment(arg, variables, fields);
         }

--- a/packages/kbn-esql-validation-autocomplete/src/validation/resources.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/resources.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { ESQLAstCommand, ESQLCommand } from '@kbn/esql-ast';
+import type { ESQLCommand } from '@kbn/esql-ast';
 import { createMapFromList, isSourceItem, nonNullable } from '../shared/helpers';
 import {
   getFieldsByTypeHelper,
@@ -23,7 +23,7 @@ import type { ESQLRealField, ESQLPolicy } from './types';
 
 export async function retrieveFields(
   queryString: string,
-  commands: ESQLAstCommand[],
+  commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
 ): Promise<Map<string, ESQLRealField>> {
   if (!callbacks || commands.length < 1) {
@@ -37,7 +37,7 @@ export async function retrieveFields(
 }
 
 export async function retrievePolicies(
-  commands: ESQLAstCommand[],
+  commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
 ): Promise<Map<string, ESQLPolicy>> {
   if (!callbacks || commands.every(({ name }) => name !== 'enrich')) {
@@ -49,7 +49,7 @@ export async function retrievePolicies(
 }
 
 export async function retrieveSources(
-  commands: ESQLAstCommand[],
+  commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
 ): Promise<Set<string>> {
   if (!callbacks || commands.length < 1) {
@@ -63,7 +63,7 @@ export async function retrieveSources(
 }
 
 export async function retrievePoliciesFields(
-  commands: ESQLAstCommand[],
+  commands: ESQLCommand[],
   policies: Map<string, ESQLPolicy>,
   callbacks?: ESQLCallbacks
 ): Promise<Map<string, ESQLRealField>> {
@@ -75,11 +75,7 @@ export async function retrievePoliciesFields(
     return new Map();
   }
   const policyNames = enrichCommands
-    .map((command) => {
-      if (!(command as ESQLCommand).args) return undefined;
-      const genericCommand = command as ESQLCommand;
-      return isSourceItem(genericCommand.args[0]) ? genericCommand.args[0].name : undefined;
-    })
+    .map(({ args }) => (isSourceItem(args[0]) ? args[0].name : undefined))
     .filter(nonNullable);
   if (!policyNames.every((name) => policies.has(name))) {
     return new Map();
@@ -93,7 +89,7 @@ export async function retrievePoliciesFields(
 
 export async function retrieveFieldsFromStringSources(
   queryString: string,
-  commands: ESQLAstCommand[],
+  commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
 ): Promise<Map<string, ESQLRealField>> {
   if (!callbacks) {


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/elastic/kibana/issues/184498

- Sets up unit testing for the `@kbn/esql-ast` package.
- Adds unit tests for `FROM` command parsing.
- Adds `METRICS` command to AST node generation.
- Adds unit tests for `METRICS` command parsing.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
 
### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
