### PR TITLE
[LogsUI] Fix log stream embeddable rendering

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/log_stream/log_stream_embeddable.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/log_stream/log_stream_embeddable.tsx
@@ -89,7 +89,7 @@ export class LogStreamEmbeddable extends Embeddable<LogStreamEmbeddableInput> {
         theme$={this.core.theme.theme$}
       >
         <EuiThemeProvider darkMode={this.isDarkMode}>
-          <div style={{ width: '100%' }}>
+          <div style={{ width: '100%', height: '100%' }}>
             <LogStream
               logView={{ type: 'log-view-reference', logViewId: 'default' }}
               startTimestamp={startTimestamp}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/184450.

## Review notes

- The embeddable should render correctly in dashboard and solution contexts, e.g:

<img width="918" alt="Screenshot 2024-05-30 at 12 03 21" src="https://github.com/elastic/kibana/assets/471693/50e0fb59-067f-4950-9cef-5f1a65d5a6de">

<img width="1253" alt="Screenshot 2024-05-30 at 12 06 57" src="https://github.com/elastic/kibana/assets/471693/d7cb3213-6d08-4957-8ff6-b85947676a5e">
