### PR TITLE
[Serverless] Update custom role deletion modal text to reflect multiple roles

### DIFF
--- a/x-pack/plugins/security/public/management/roles/edit_role/delete_role_button.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/delete_role_button.tsx
@@ -91,7 +91,7 @@ export class DeleteRoleButton extends Component<Props, State> {
           ) : (
             <FormattedMessage
               id="xpack.security.management.roles.confirmDelete.serverless.removingSingleRoleDescription"
-              defaultMessage="Users with the {roleName} role assigned will lose access to the project."
+              defaultMessage="Users with the {roleName} role assigned may lose access to the project if they are not assigned any other roles."
               values={{ roleName }}
             />
           )}

--- a/x-pack/plugins/security/public/management/roles/roles_grid/confirm_delete/confirm_delete.tsx
+++ b/x-pack/plugins/security/public/management/roles/roles_grid/confirm_delete/confirm_delete.tsx
@@ -83,7 +83,7 @@ export class ConfirmDelete extends Component<Props, State> {
                   <p>
                     <FormattedMessage
                       id="xpack.security.management.roles.confirmDelete.serverless.removingRolesDescription"
-                      defaultMessage="Users with the following roles assigned will lose access to the project:"
+                      defaultMessage="Users with the following roles assigned may lose access to the project if they are not assigned any other roles:"
                     />
                   </p>
                 )}
@@ -99,7 +99,7 @@ export class ConfirmDelete extends Component<Props, State> {
                   <p>
                     <FormattedMessage
                       id="xpack.security.management.roles.confirmDelete.serverless.removingSingleRoleDescription"
-                      defaultMessage="Users with the {roleName} role assigned will lose access to the project."
+                      defaultMessage="Users with the {roleName} role assigned may lose access to the project if they are not assigned any other roles."
                       values={{ roleName: rolesToDelete[0] }}
                     />
                   </p>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/184116

## Summary

Update the text in the role deletion confirmation modal in Serverless to clearly indicate possible consequences for users when multiple roles are being deleted.


