### PR TITLE
[Dataset quality] Improved findability in global search

### DIFF
--- a/x-pack/plugins/data_quality/public/plugin.ts
+++ b/x-pack/plugins/data_quality/public/plugin.ts
@@ -34,6 +34,7 @@ export class DataQualityPlugin
       id: PLUGIN_ID,
       title: PLUGIN_NAME,
       order: 2,
+      keywords: ['data', 'quality', 'data quality', 'datasets', 'datasets quality'],
       async mount(params: ManagementAppMountParams) {
         const [{ renderApp }, [coreStart, pluginsStartDeps, pluginStart]] = await Promise.all([
           import('./application'),


### PR DESCRIPTION
As part of registering the new `Data quality` plugin in `Management > Data` a new item was added to the global search.

<img width="1977" alt="image" src="https://github.com/elastic/kibana/assets/1313018/165cc75b-3727-4b1f-b625-ab81dfb8b58a">

This PR aims to improve the findability adding more keywords.