### PR TITLE
[ResponseOps] Reduce triggers actions UI bundle size

### DIFF
--- a/packages/kbn-alerts-ui-shared/index.ts
+++ b/packages/kbn-alerts-ui-shared/index.ts
@@ -17,8 +17,5 @@ export { AlertsSearchBar } from './src/alerts_search_bar';
 export type { AlertsSearchBarProps } from './src/alerts_search_bar/types';
 
 export * from './src/alert_fields_table';
-
-export * from './src/rule_type_modal';
 export * from './src/alert_filter_controls/types';
-export * from './src/rule_form';
 export * from './src/common/hooks';

--- a/x-pack/examples/triggers_actions_ui_example/public/components/rule_form/rule_definition_sandbox.tsx
+++ b/x-pack/examples/triggers_actions_ui_example/public/components/rule_form/rule_definition_sandbox.tsx
@@ -17,12 +17,8 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import { AlertConsumers, RuleCreationValidConsumer } from '@kbn/rule-data-utils';
-import {
-  RuleDefinition,
-  useLoadRuleTypesQuery,
-  getRuleErrors,
-  InitialRule,
-} from '@kbn/alerts-ui-shared';
+import { RuleDefinition, getRuleErrors, InitialRule } from '@kbn/alerts-ui-shared/src/rule_form';
+import { useLoadRuleTypesQuery } from '@kbn/alerts-ui-shared/src/common/hooks';
 
 interface RuleDefinitionSandboxProps {
   data: DataPublicPluginStart;

--- a/x-pack/plugins/observability_solution/observability/public/pages/rules/rules.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/rules/rules.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EuiButton, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { RuleTypeModal } from '@kbn/alerts-ui-shared';
+import { RuleTypeModal } from '@kbn/alerts-ui-shared/src/rule_type_modal';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -13,7 +13,7 @@ import { KueryNode } from '@kbn/es-query';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { parseRuleCircuitBreakerErrorMessage } from '@kbn/alerting-plugin/common';
-import { RuleTypeModal } from '@kbn/alerts-ui-shared';
+import { RuleTypeModal } from '@kbn/alerts-ui-shared/src/rule_type_modal';
 import React, {
   lazy,
   useEffect,


### PR DESCRIPTION
## Summary

Reduce `triggersActionsUi` bundle size by removing import from `alerting-ui-shared` index files. 

### Before
<img width="467" alt="Screenshot 2024-05-30 at 9 38 26 PM" src="https://github.com/elastic/kibana/assets/74562234/6d8b6744-3598-4439-9c30-3d81f7a90ab0">

### After
<img width="437" alt="Screenshot 2024-05-30 at 9 37 12 PM" src="https://github.com/elastic/kibana/assets/74562234/4fc7e4e6-8efd-4911-a25a-149a664ca105">
