### PR TITLE
[Search] [Playground] add urls for serverless docs

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -962,11 +962,21 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       settings: `${KIBANA_DOCS}telemetry-settings-kbn.html`,
     },
     playground: {
-      chatPlayground: `${KIBANA_DOCS}playground.html`,
-      retrievalOptimize: `${KIBANA_DOCS}playground-query.html#playground-query-relevance`,
-      retrieval: `${KIBANA_DOCS}playground-query.html`,
-      context: `${KIBANA_DOCS}playground-context.html`,
-      hiddenFields: `${KIBANA_DOCS}playground-query.html#playground-hidden-fields`,
+      chatPlayground: isServerless
+        ? `${SERVERLESS_ELASTICSEARCH_DOCS}playground`
+        : `${KIBANA_DOCS}playground.html`,
+      retrievalOptimize: isServerless
+        ? `${SERVERLESS_ELASTICSEARCH_DOCS}playground/query#playground-query-relevance`
+        : `${KIBANA_DOCS}playground-query.html#playground-query-relevance`,
+      retrieval: isServerless
+        ? `${SERVERLESS_ELASTICSEARCH_DOCS}playground/query`
+        : `${KIBANA_DOCS}playground-query.html`,
+      context: isServerless
+        ? `${SERVERLESS_ELASTICSEARCH_DOCS}playground/context`
+        : `${KIBANA_DOCS}playground-context.html`,
+      hiddenFields: isServerless
+        ? `${SERVERLESS_ELASTICSEARCH_DOCS}playground/query#playground-hidden-fields`
+        : `${KIBANA_DOCS}playground-query.html#playground-hidden-fields`,
     },
   });
 };


### PR DESCRIPTION
## Summary

This updates the urls for playground, depending if running on serverless or stateful

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
