### PR TITLE
[CDN] Allow disabling CDN by passing "null"

### DIFF
--- a/packages/core/http/core-http-server-internal/src/__snapshots__/http_config.test.ts.snap
+++ b/packages/core/http/core-http-server-internal/src/__snapshots__/http_config.test.ts.snap
@@ -41,7 +41,9 @@ exports[`basePath throws if not specified, but rewriteBasePath is set 1`] = `"ca
 exports[`has defaults for config 1`] = `
 Object {
   "autoListen": true,
-  "cdn": Object {},
+  "cdn": Object {
+    "url": null,
+  },
   "compression": Object {
     "brotli": Object {
       "enabled": false,

--- a/packages/core/http/core-http-server-internal/src/cdn_config/cdn_config.test.ts
+++ b/packages/core/http/core-http-server-internal/src/cdn_config/cdn_config.test.ts
@@ -54,4 +54,11 @@ describe('CdnConfig', () => {
     const cdnConfig = CdnConfig.from({ url: '' });
     expect(cdnConfig.getCspConfig()).toEqual({});
   });
+
+  it('accepts "null" URL', () => {
+    const cdnConfig = CdnConfig.from({ url: null });
+    expect(cdnConfig.baseHref).toBeUndefined();
+    expect(cdnConfig.host).toBeUndefined();
+    expect(cdnConfig.getCspConfig()).toEqual({});
+  });
 });

--- a/packages/core/http/core-http-server-internal/src/cdn_config/cdn_config.ts
+++ b/packages/core/http/core-http-server-internal/src/cdn_config/cdn_config.ts
@@ -10,12 +10,12 @@ import { URL, format } from 'node:url';
 import type { CspAdditionalConfig } from '../csp';
 
 export interface Input {
-  url?: string;
+  url?: null | string;
 }
 
 export class CdnConfig {
   private readonly url: undefined | URL;
-  constructor(url?: string) {
+  constructor(url?: null | string) {
     if (url) {
       this.url = new URL(url); // This will throw for invalid URLs, although should be validated before reaching this point
     }

--- a/packages/core/http/core-http-server-internal/src/http_config.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_config.test.ts
@@ -555,8 +555,8 @@ describe('cdn', () => {
     });
   });
   it.each([['foo'], ['http:./']])('throws for invalid URL %s', (url) => {
-    expect(() => config.schema.validate({ cdn: { url } })).toThrowErrorMatchingInlineSnapshot(
-      `"[cdn.url]: expected URI with scheme [http|https]."`
+    expect(() => config.schema.validate({ cdn: { url } })).toThrow(
+      /expected URI with scheme \[http\|https\]/
     );
   });
   it.each([

--- a/packages/core/http/core-http-server-internal/src/http_config.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_config.test.ts
@@ -549,6 +549,11 @@ describe('cdn', () => {
       cdn: { url: 'https://cdn.example.com' },
     });
   });
+  it('can be "unset" using "null"', () => {
+    expect(config.schema.validate({ cdn: { url: null } })).toMatchObject({
+      cdn: { url: null },
+    });
+  });
   it.each([['foo'], ['http:./']])('throws for invalid URL %s', (url) => {
     expect(() => config.schema.validate({ cdn: { url } })).toThrowErrorMatchingInlineSnapshot(
       `"[cdn.url]: expected URI with scheme [http|https]."`

--- a/packages/core/http/core-http-server-internal/src/http_config.ts
+++ b/packages/core/http/core-http-server-internal/src/http_config.ts
@@ -80,7 +80,9 @@ const configSchema = schema.object(
       },
     }),
     cdn: schema.object({
-      url: schema.maybe(schema.uri({ scheme: ['http', 'https'], validate: validateCdnURL })),
+      url: schema.nullable(
+        schema.maybe(schema.uri({ scheme: ['http', 'https'], validate: validateCdnURL }))
+      ),
     }),
     oas: schema.object({
       enabled: schema.boolean({ defaultValue: false }),

--- a/packages/core/http/core-http-server-internal/src/static_assets/static_assets.test.ts
+++ b/packages/core/http/core-http-server-internal/src/static_assets/static_assets.test.ts
@@ -46,6 +46,12 @@ describe('StaticAssets', () => {
       staticAssets = new StaticAssets(args);
       expect(staticAssets.isUsingCdn()).toBe(true);
     });
+
+    it('returns false when CDN config contains "null" URL', () => {
+      args.cdnConfig = CdnConfig.from({ url: null });
+      staticAssets = new StaticAssets(args);
+      expect(staticAssets.isUsingCdn()).toBe(false);
+    });
   });
 
   describe('#getPluginAssetHref()', () => {


### PR DESCRIPTION
Close https://github.com/elastic/kibana/issues/184575

## How to test

1. Add `server.cdn.url: null` to kibana.dev.yml
2. Start ES + Kibana
3. Open Kibana, should work as usual by loading assets from Kibana server