### PR TITLE
[Fleet] Fix bulk install package with force flag when package is already installed

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
@@ -29,6 +29,7 @@ interface BulkInstallPackagesParams {
   preferredSource?: 'registry' | 'bundled';
   prerelease?: boolean;
   authorizationHeader?: HTTPAuthorizationHeader | null;
+  skipIfInstalled?: boolean;
 }
 
 export async function bulkInstallPackages({
@@ -39,6 +40,7 @@ export async function bulkInstallPackages({
   force,
   prerelease,
   authorizationHeader,
+  skipIfInstalled,
 }: BulkInstallPackagesParams): Promise<BulkInstallResponse[]> {
   const logger = appContextService.getLogger();
 
@@ -91,7 +93,7 @@ export async function bulkInstallPackages({
       }
 
       const pkgKeyProps = result.value;
-      if (!force) {
+      if (!force || skipIfInstalled) {
         const installedPackageResult = await isPackageVersionOrLaterInstalled({
           savedObjectsClient,
           pkgName: pkgKeyProps.name,

--- a/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
@@ -91,28 +91,30 @@ export async function bulkInstallPackages({
       }
 
       const pkgKeyProps = result.value;
-      const installedPackageResult = await isPackageVersionOrLaterInstalled({
-        savedObjectsClient,
-        pkgName: pkgKeyProps.name,
-        pkgVersion: pkgKeyProps.version,
-      });
+      if (!force) {
+        const installedPackageResult = await isPackageVersionOrLaterInstalled({
+          savedObjectsClient,
+          pkgName: pkgKeyProps.name,
+          pkgVersion: pkgKeyProps.version,
+        });
 
-      if (installedPackageResult) {
-        const {
-          name,
-          version,
-          installed_es: installedEs,
-          installed_kibana: installedKibana,
-        } = installedPackageResult.package;
-        return {
-          name,
-          version,
-          result: {
-            assets: [...installedEs, ...installedKibana],
-            status: 'already_installed',
-            installType: 'unknown',
-          } as InstallResult,
-        };
+        if (installedPackageResult) {
+          const {
+            name,
+            version,
+            installed_es: installedEs,
+            installed_kibana: installedKibana,
+          } = installedPackageResult.package;
+          return {
+            name,
+            version,
+            result: {
+              assets: [...installedEs, ...installedKibana],
+              status: 'already_installed',
+              installType: 'unknown',
+            } as InstallResult,
+          };
+        }
       }
 
       const pkgkey = Registry.pkgToPkgKey(pkgKeyProps);

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -100,6 +100,7 @@ export async function ensurePreconfiguredPackagesAndPolicies(
     esClient,
     packagesToInstall,
     force: true, // Always force outdated packages to be installed if a later version isn't installed
+    skipIfInstalled: true, // force flag alone would reinstall packages that are already installed
     spaceId,
   });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/index.js
+++ b/x-pack/test/fleet_api_integration/apis/epm/index.js
@@ -32,6 +32,7 @@ export default function loadTests({ loadTestFile, getService }) {
     loadTestFile(require.resolve('./install_tsds_disable'));
     loadTestFile(require.resolve('./install_tag_assets'));
     loadTestFile(require.resolve('./bulk_upgrade'));
+    loadTestFile(require.resolve('./bulk_install'));
     loadTestFile(require.resolve('./update_assets'));
     loadTestFile(require.resolve('./data_stream'));
     loadTestFile(require.resolve('./package_install_complete'));


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/184491

Small fix for bulk install package API force flag, to allow reinstalling a package if already installed.

To verify:
```
# Install Apache integration 
POST kbn:/api/fleet/epm/packages/apache

# Install older version with force
POST kbn:/api/fleet/epm/packages/_bulk
{
  "packages": [
    {
      "name": "apache",
      "version": "1.17.2"
    }
  ],
  "force": true
}

# Expect 1.17.2 to be installed
{
  "items": [
    {
      "name": "apache",
      "version": "1.17.2",
      "result": {
        "assets": [
          ...
        ],
        "status": "installed",
        "installType": "install",
        "installSource": "registry"
      }
    }
  ],
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->