### PR TITLE
[CI] Prevent deployment of missing/failed serverless docker images

### DIFF
--- a/.buildkite/pipelines/pull_request/deploy_project.yml
+++ b/.buildkite/pipelines/pull_request/deploy_project.yml
@@ -9,7 +9,6 @@ steps:
       machineType: n2-standard-16
       preemptible: true
     timeout_in_minutes: 60
-    soft_fail: true
     retry:
       automatic:
         - exit_status: '-1'
@@ -29,4 +28,3 @@ steps:
       - linting_with_types
       - checks
       - check_types
-    soft_fail: true


### PR DESCRIPTION
## Summary
Removes `soft_fail` to prevent the run of the deploy script if something about the image build fails.

Closes: https://github.com/elastic/kibana/issues/184591