### PR TITLE
[Reporting] Ensure ILM call is made only in stateful

### DIFF
--- a/packages/kbn-reporting/mocks_server/index.ts
+++ b/packages/kbn-reporting/mocks_server/index.ts
@@ -43,6 +43,9 @@ export const createMockConfigSchema = (
       csv: { enabled: true },
       ...overrides.export_types,
     },
-    statefulSettings: { enabled: true },
+    statefulSettings: {
+      enabled: true,
+      ...overrides.statefulSettings,
+    },
   } as ReportingConfigType;
 };

--- a/x-pack/plugins/reporting/server/lib/store/store.ts
+++ b/x-pack/plugins/reporting/server/lib/store/store.ts
@@ -119,7 +119,7 @@ export class ReportingStore {
     return this.client;
   }
 
-  private async createIlmPolicy() {
+  protected async createIlmPolicy() {
     const client = await this.getClient();
     const ilmPolicyManager = IlmPolicyManager.create({ client });
     if (await ilmPolicyManager.doesIlmPolicyExist()) {
@@ -159,8 +159,11 @@ export class ReportingStore {
    * configured for storage of reports.
    */
   public async start() {
+    const { statefulSettings } = this.reportingCore.getConfig();
     try {
-      await this.createIlmPolicy();
+      if (statefulSettings.enabled) {
+        await this.createIlmPolicy();
+      }
     } catch (e) {
       this.logger.error('Error in start phase');
       this.logger.error(e);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/923

This solves a (harmless) error that is logged in serverless:
```
[2024-05-31T09:50:36.518-07:00][ERROR][plugins.reporting.store] Error in start phase
[2024-05-31T09:50:36.518-07:00][ERROR][plugins.reporting.store] ResponseError: {"error":"no handler found for uri [/_ilm/policy/kibana-reporting] and method [GET]"}
    at KibanaTransport.request (/Users/tim/elastic/kibana/node_modules/@elastic/transport/src/Transport.ts:553:17)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
[2024-05-31T09:50:36.524-07:00][ERROR][plugins.reporting] Error in Reporting start, reporting may not function properly
[2024-05-31T09:50:36.524-07:00][ERROR][plugins.reporting] ResponseError: {"error":"no handler found for uri [/_ilm/policy/kibana-reporting] and method [GET]"}
    at KibanaTransport.request (/Users/tim/elastic/kibana/node_modules/@elastic/transport/src/Transport.ts:553:17)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
