### PR TITLE
[UII] On serverless, remove `manage_service_account` and `read_cross_cluster` privileges

### DIFF
--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -17,6 +17,7 @@ import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
 import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
 
 import type { PackagePolicyClient } from '../services/package_policy_service';
 import type { AgentPolicyServiceInterface } from '../services';
@@ -55,7 +56,8 @@ export interface MockedFleetAppContext extends FleetAppContext {
 }
 
 export const createAppContextStartContractMock = (
-  configOverrides: Partial<FleetConfigType> = {}
+  configOverrides: Partial<FleetConfigType> = {},
+  isServerless: boolean = false
 ): MockedFleetAppContext => {
   const config = {
     agents: { enabled: true, elasticsearch: {} },
@@ -93,6 +95,16 @@ export const createAppContextStartContractMock = (
     bulkActionsResolver: {} as any,
     messageSigningService: createMessageSigningServiceMock(),
     uninstallTokenService: createUninstallTokenServiceMock(),
+    ...(isServerless
+      ? {
+          cloud: {
+            ...cloudMock.createSetup(),
+            apm: {},
+            isCloudEnabled: true,
+            isServerlessEnabled: true,
+          },
+        }
+      : {}),
   };
 };
 

--- a/x-pack/plugins/fleet/server/routes/app/index.ts
+++ b/x-pack/plugins/fleet/server/routes/app/index.ts
@@ -28,6 +28,7 @@ export const getCheckPermissionsHandler: FleetRequestHandler<
     error: 'MISSING_SECURITY',
   };
 
+  const isServerless = appContextService.getCloud()?.isServerlessEnabled;
   const isSubfeaturePrivilegesEnabled =
     appContextService.getExperimentalFeatures().subfeaturePrivileges ?? false;
 
@@ -47,7 +48,9 @@ export const getCheckPermissionsHandler: FleetRequestHandler<
           error: 'MISSING_PRIVILEGES',
         } as CheckPermissionsResponse,
       });
-    } else if (request.query.fleetServerSetup) {
+    }
+    // check the manage_service_account cluster privilege only on stateful
+    else if (request.query.fleetServerSetup && !isServerless) {
       const esClient = (await context.core).elasticsearch.client.asCurrentUser;
       const { has_all_requested: hasAllPrivileges } = await esClient.security.hasPrivileges({
         body: { cluster: ['manage_service_account'] },
@@ -74,8 +77,8 @@ export const getCheckPermissionsHandler: FleetRequestHandler<
         } as CheckPermissionsResponse,
       });
     }
-    // check the manage_service_account cluster privilege
-    else if (request.query.fleetServerSetup) {
+    // check the manage_service_account cluster privilege only on stateful
+    else if (request.query.fleetServerSetup && !isServerless) {
       const esClient = (await context.core).elasticsearch.client.asCurrentUser;
       const { has_all_requested: hasAllPrivileges } = await esClient.security.hasPrivileges({
         body: { cluster: ['manage_service_account'] },

--- a/x-pack/plugins/fleet/server/services/package_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.test.ts
@@ -5196,6 +5196,14 @@ describe('_applyIndexPrivileges()', () => {
     };
   }
 
+  beforeEach(() => {
+    appContextService.start(createAppContextStartContractMock());
+  });
+
+  afterEach(() => {
+    appContextService.stop();
+  });
+
   it('should do nothing if packageStream has no privileges', () => {
     const packageStream = createPackageStream();
     const inputStream = createInputStream();
@@ -5298,6 +5306,34 @@ describe('_applyIndexPrivileges()', () => {
         elasticsearch: {
           privileges: {
             indices: ['auto_configure', 'read_cross_cluster'],
+          },
+        },
+      },
+    };
+
+    const streamOut = _applyIndexPrivileges(packageStream, inputStream);
+    expect(streamOut).toEqual(expectedStream);
+  });
+
+  it('should apply correct privileges for serverless', () => {
+    appContextService.start(createAppContextStartContractMock({}, true));
+    const mixedPrivileges = [
+      'create_doc',
+      'auto_configure',
+      'read_cross_cluster',
+      'idontexist',
+      'delete',
+    ];
+
+    const packageStream = createPackageStream(mixedPrivileges);
+    const inputStream = createInputStream();
+    const expectedStream = {
+      ...inputStream,
+      data_stream: {
+        ...inputStream.data_stream,
+        elasticsearch: {
+          privileges: {
+            indices: ['create_doc', 'auto_configure'],
           },
         },
       },

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -172,15 +172,6 @@ async function getPkgInfoAssetsMap({
   return packageInfosandAssetsMap;
 }
 
-export const DATA_STREAM_ALLOWED_INDEX_PRIVILEGES = new Set([
-  'auto_configure',
-  'create_doc',
-  'maintenance',
-  'monitor',
-  'read',
-  'read_cross_cluster',
-]);
-
 class PackagePolicyClientImpl implements PackagePolicyClient {
   public async create(
     soClient: SavedObjectsClientContract,
@@ -2204,6 +2195,15 @@ export function _applyIndexPrivileges(
     return streamOut;
   }
 
+  const isServerless = appContextService.getCloud()?.isServerlessEnabled;
+  const DATA_STREAM_ALLOWED_INDEX_PRIVILEGES = new Set([
+    'auto_configure',
+    'create_doc',
+    'maintenance',
+    'monitor',
+    'read',
+    ...(isServerless ? [] : ['read_cross_cluster']),
+  ]);
   const [valid, invalid] = partition(indexPrivileges, (permission) =>
     DATA_STREAM_ALLOWED_INDEX_PRIVILEGES.has(permission)
   );


### PR DESCRIPTION
## Summary

Resolves [#181909](https://github.com/elastic/kibana/issues/181909).

For serverless, some privileges are not supported. This PR:

- Removes `manage_service_account` as a required cluster privilege for accessing Fleet
- Removes `read_cross_cluster` from the list of index/data stream privileges that is generated for an agent policy


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios