### PR TITLE
[8.14] [Search] Add last_seen status for the connector (#184653)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -41,6 +41,7 @@ import { LicensingLogic } from '../../../shared/licensing';
 import { EuiButtonTo, EuiLinkTo } from '../../../shared/react_router_helpers';
 import { GenerateConnectorApiKeyApiLogic } from '../../api/connector/generate_connector_api_key_api_logic';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
+import { isLastSeenOld } from '../../utils/connector_status_helpers';
 import { isAdvancedSyncRuleSnippetEmpty } from '../../utils/sync_rules_helpers';
 import { SyncsContextMenu } from '../search_index/components/header_actions/syncs_context_menu';
 import { ApiKeyConfig } from '../search_index/connector/api_key_configuration';
@@ -282,18 +283,20 @@ export const ConnectorConfiguration: React.FC = () => {
                               </EuiButton>
                             </EuiCallOut>
                           ) : (
-                            <EuiCallOut
-                              iconType="check"
-                              color="success"
-                              title={i18n.translate(
-                                'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.connectorConnected',
-                                {
-                                  defaultMessage:
-                                    'Your connector {name} has connected to Search successfully.',
-                                  values: { name: connector.name },
-                                }
-                              )}
-                            />
+                            !isLastSeenOld(connector) && (
+                              <EuiCallOut
+                                iconType="check"
+                                color="success"
+                                title={i18n.translate(
+                                  'xpack.enterpriseSearch.content.connector_detail.configurationConnector.connectorPackage.connectorConnected',
+                                  {
+                                    defaultMessage:
+                                      'Your connector {name} has connected to Search successfully.',
+                                    values: { name: connector.name },
+                                  }
+                                )}
+                              />
+                            )
                           )}
                           <EuiSpacer size="s" />
                           {connector.status &&

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_view_logic.ts
@@ -30,6 +30,8 @@ import {
 import { FetchIndexActions, FetchIndexApiLogic } from '../../api/index/fetch_index_api_logic';
 import { ElasticsearchViewIndex } from '../../types';
 
+import { getConnectorLastSeenError, isLastSeenOld } from '../../utils/connector_status_helpers';
+
 import {
   ConnectorNameAndDescriptionLogic,
   ConnectorNameAndDescriptionActions,
@@ -53,7 +55,6 @@ export interface ConnectorViewActions {
 }
 
 export interface ConnectorViewValues {
-  updateConnectorConfigurationStatus: Status;
   connector: Connector | undefined;
   connectorData: CachedFetchConnectorByIdApiLogicValues['connectorData'];
   connectorError: string | undefined;
@@ -81,6 +82,7 @@ export interface ConnectorViewValues {
   pipelineData: IngestPipelineParams | undefined;
   recheckIndexLoading: boolean;
   syncTriggeredLocally: boolean; // holds local value after update so UI updates correctly
+  updateConnectorConfigurationStatus: Status;
 }
 
 export const ConnectorViewLogic = kea<MakeLogicType<ConnectorViewValues, ConnectorViewActions>>({
@@ -162,13 +164,8 @@ export const ConnectorViewLogic = kea<MakeLogicType<ConnectorViewValues, Connect
         connector?.error ||
         connector?.last_sync_error ||
         connector?.last_access_control_sync_error ||
+        (connector && isLastSeenOld(connector) && getConnectorLastSeenError(connector)) ||
         null,
-    ],
-    indexName: [
-      () => [selectors.connector],
-      (connector: Connector | undefined) => {
-        return connector?.index_name || undefined;
-      },
     ],
     hasAdvancedFilteringFeature: [
       () => [selectors.connector],
@@ -204,6 +201,12 @@ export const ConnectorViewLogic = kea<MakeLogicType<ConnectorViewValues, Connect
       () => [selectors.connector],
       (connector: Connector | undefined) =>
         connector?.configuration.extract_full_html?.value ?? undefined,
+    ],
+    indexName: [
+      () => [selectors.connector],
+      (connector: Connector | undefined) => {
+        return connector?.index_name || undefined;
+      },
     ],
     isLoading: [
       () => [selectors.fetchConnectorApiStatus, selectors.fetchIndexApiStatus, selectors.index],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/connector_status_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/connector_status_helpers.ts
@@ -5,8 +5,26 @@
  * 2.0.
  */
 
+import moment from 'moment';
+
 import { i18n } from '@kbn/i18n';
 import { Connector, ConnectorStatus, SyncStatus } from '@kbn/search-connectors';
+
+export const isLastSeenOld = (connector: Connector): boolean =>
+  connector.last_seen
+    ? moment(connector.last_seen).isBefore(moment().subtract(30, 'minutes'))
+    : false;
+
+export const getConnectorLastSeenError = (connector: Connector): string => {
+  return i18n.translate(
+    'xpack.enterpriseSearch.content.searchIndices.connectorStatus.lastSeenError.label',
+    {
+      defaultMessage:
+        'Your connector has not checked in for over 30 minutes. (last_seen: {lastSeen})',
+      values: { lastSeen: connector.last_seen },
+    }
+  );
+};
 
 const incompleteText = i18n.translate(
   'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.incomplete.label',
@@ -35,7 +53,7 @@ export function connectorStatusToText(connector: Connector): string {
       { defaultMessage: 'Sync Failure' }
     );
   }
-  if (connectorStatus === ConnectorStatus.ERROR) {
+  if (isLastSeenOld(connector) || connectorStatus === ConnectorStatus.ERROR) {
     return i18n.translate(
       'xpack.enterpriseSearch.content.searchIndices.connectorStatus.connectorFailure.label',
       { defaultMessage: 'Connector Failure' }
@@ -67,6 +85,7 @@ export function connectorStatusToColor(connector: Connector): 'warning' | 'dange
     return 'warning';
   }
   if (
+    isLastSeenOld(connector) ||
     connectorStatus === ConnectorStatus.ERROR ||
     connector.error === SyncStatus.ERROR ||
     connector.last_sync_error !== null ||


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Search] Add last_seen status for the connector (#184653)](https://github.com/elastic/kibana/pull/184653)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2024-06-03T21:23:43Z","message":"[Search] Add last_seen status for the connector (#184653)\n\n## Summary\r\n\r\n- Adds error message when connector `last_seen` is less than 30 mins.\r\n- Makes status consistent in between indices and connectors lists.\r\n<img width=\"1271\" alt=\"Screenshot 2024-06-03 at 15 33 54\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/e690e7c5-fc6b-4ab4-ad10-febc8dd7e8f9\">\r\n<img width=\"877\" alt=\"Screenshot 2024-06-03 at 15 33 59\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/1afbc8b3-287a-4da9-8f9f-28f0451c945d\">\r\n<img width=\"792\" alt=\"Screenshot 2024-06-03 at 15 34 06\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/39f3e7fb-531f-40da-a7d8-0e70b85f46a4\">\r\n\r\nStill showing banners if `last_seen` is recent\r\n<img width=\"789\" alt=\"Screenshot 2024-06-03 at 15 34 49\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/4e071bab-9bf8-47cf-8c9b-c6610c1b8095\">\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d5f2c13e5512de1d65d0cec262e028914a942713","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.15.0","v8.14.1"],"number":184653,"url":"https://github.com/elastic/kibana/pull/184653","mergeCommit":{"message":"[Search] Add last_seen status for the connector (#184653)\n\n## Summary\r\n\r\n- Adds error message when connector `last_seen` is less than 30 mins.\r\n- Makes status consistent in between indices and connectors lists.\r\n<img width=\"1271\" alt=\"Screenshot 2024-06-03 at 15 33 54\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/e690e7c5-fc6b-4ab4-ad10-febc8dd7e8f9\">\r\n<img width=\"877\" alt=\"Screenshot 2024-06-03 at 15 33 59\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/1afbc8b3-287a-4da9-8f9f-28f0451c945d\">\r\n<img width=\"792\" alt=\"Screenshot 2024-06-03 at 15 34 06\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/39f3e7fb-531f-40da-a7d8-0e70b85f46a4\">\r\n\r\nStill showing banners if `last_seen` is recent\r\n<img width=\"789\" alt=\"Screenshot 2024-06-03 at 15 34 49\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/4e071bab-9bf8-47cf-8c9b-c6610c1b8095\">\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d5f2c13e5512de1d65d0cec262e028914a942713"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/184653","number":184653,"mergeCommit":{"message":"[Search] Add last_seen status for the connector (#184653)\n\n## Summary\r\n\r\n- Adds error message when connector `last_seen` is less than 30 mins.\r\n- Makes status consistent in between indices and connectors lists.\r\n<img width=\"1271\" alt=\"Screenshot 2024-06-03 at 15 33 54\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/e690e7c5-fc6b-4ab4-ad10-febc8dd7e8f9\">\r\n<img width=\"877\" alt=\"Screenshot 2024-06-03 at 15 33 59\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/1afbc8b3-287a-4da9-8f9f-28f0451c945d\">\r\n<img width=\"792\" alt=\"Screenshot 2024-06-03 at 15 34 06\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/39f3e7fb-531f-40da-a7d8-0e70b85f46a4\">\r\n\r\nStill showing banners if `last_seen` is recent\r\n<img width=\"789\" alt=\"Screenshot 2024-06-03 at 15 34 49\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/4e071bab-9bf8-47cf-8c9b-c6610c1b8095\">\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d5f2c13e5512de1d65d0cec262e028914a942713"}},{"branch":"8.14","label":"v8.14.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->