### PR TITLE
[Project sidenav] Refactor NavigationSectionUI component

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/project_navigation/project_navigation_service.test.ts
+++ b/packages/core/chrome/core-chrome-browser-internal/src/project_navigation/project_navigation_service.test.ts
@@ -1002,32 +1002,4 @@ describe('solution navigations', () => {
       expect(activeSolution).toEqual(solution1);
     }
   });
-
-  it('should change the active solution if no node match the current Location', async () => {
-    const { projectNavigation, navLinksService, application } = setup({
-      locationPathName: '/app/app3', // we are on app3 which only exists in solution3
-      navLinkIds: ['app1', 'app2', 'app3'],
-    });
-
-    navLinksService.get.mockReturnValue({ url: '/app/app3', href: '/app/app3' } as any);
-
-    const getActiveDefinition = () =>
-      firstValueFrom(projectNavigation.getActiveSolutionNavDefinition$());
-
-    projectNavigation.updateSolutionNavigations({ solution1, solution2, solution3 });
-
-    {
-      const definition = await getActiveDefinition();
-      expect(definition).toBe(null); // No active solution id yet
-    }
-
-    // Change to solution 2, but we are still on '/app/app3' which only exists in solution3
-    projectNavigation.changeActiveSolutionNavigation('solution2');
-
-    {
-      const definition = await getActiveDefinition();
-      expect(definition?.id).toBe('solution3'); // The solution3 was activated as it matches the "/app/app3" location
-      expect(application.navigateToUrl).toHaveBeenCalled(); // Redirect
-    }
-  });
 });

--- a/packages/core/chrome/core-chrome-browser-internal/src/project_navigation/project_navigation_service.ts
+++ b/packages/core/chrome/core-chrome-browser-internal/src/project_navigation/project_navigation_service.ts
@@ -32,7 +32,6 @@ import {
   of,
   type Observable,
   type Subscription,
-  take,
 } from 'rxjs';
 import { type Location, createLocation } from 'history';
 import deepEqual from 'react-fast-compare';
@@ -224,22 +223,9 @@ export class ProjectNavigationService {
           this.navigationTree$.next(navigationTree);
           this.navigationTreeUi$.next(navigationTreeUI);
           this.projectNavigationNavTreeFlattened = flattenNav(navigationTree);
+          this.updateActiveProjectNavigationNodes();
 
-          // Verify if the current location is part of the navigation tree of
-          // the initiated solution. If not, we need to find the correct solution
-          const activeNodes = this.updateActiveProjectNavigationNodes();
-          let willChangeSolution = false;
-
-          if (activeNodes.length === 0) {
-            const solutionForCurrentLocation = this.findSolutionForCurrentLocation();
-            if (solutionForCurrentLocation) {
-              willChangeSolution = true;
-              this.goToSolutionHome(solutionForCurrentLocation);
-              this.changeActiveSolutionNavigation(solutionForCurrentLocation);
-            }
-          }
-
-          if (!initialised && !willChangeSolution) {
+          if (!initialised) {
             this.activeSolutionNavDefinitionId$.next(id);
             initialised = true;
           }
@@ -318,48 +304,6 @@ export class ProjectNavigationService {
       });
   }
 
-  /**
-   * When we are in stateful Kibana with multiple solution navigations, it is possible that a user
-   * lands on a page that does not belong to the current active solution navigation. In this case,
-   * we need to find the correct solution navigation based on the current location and switch to it.
-   */
-  private findSolutionForCurrentLocation(): string | null {
-    if (Object.keys(this.solutionNavDefinitions$.getValue()).length === 0) return null;
-
-    let idFound: string | null = null;
-
-    combineLatest([this.solutionNavDefinitions$, this.location$])
-      .pipe(take(1))
-      .subscribe(([definitions, location]) => {
-        Object.entries(definitions).forEach(([id, definition]) => {
-          if (idFound) return;
-
-          combineLatest([definition.navigationTree$, this.deepLinksMap$, this.cloudLinks$])
-            .pipe(
-              take(1),
-              map(([def, deepLinksMap, cloudLinks]) =>
-                parseNavigationTree(def, {
-                  deepLinks: deepLinksMap,
-                  cloudLinks,
-                })
-              )
-            )
-            .subscribe(({ navigationTree }) => {
-              const maybeActiveNodes = this.findActiveNodes({
-                location,
-                flattendTree: flattenNav(navigationTree),
-              });
-
-              if (maybeActiveNodes.length > 0) {
-                idFound = id;
-              }
-            });
-        });
-      });
-
-    return idFound;
-  }
-
   private setSideNavComponent(component: SideNavComponent | null) {
     this.customProjectSideNavComponent$.next({ current: component });
   }
@@ -398,24 +342,6 @@ export class ProjectNavigationService {
 
   private setProjectHome(homeHref: string) {
     this.projectHome$.next(homeHref);
-  }
-
-  private goToSolutionHome(id: string) {
-    const definitions = this.solutionNavDefinitions$.getValue();
-    const definition = definitions[id];
-    if (!definition) {
-      throw new Error(`No solution navigation definition found for id ${id}`);
-    }
-
-    // Navigate to the new home page if it's defined
-    const link = this.navLinksService?.get(definition.homePage ?? 'undefined');
-    if (!link) {
-      throw new Error(`No home page defined for solution navigation ${definition.id}`);
-    }
-
-    const location = createLocation(link.url);
-    this.location$.next(location);
-    this.application?.navigateToUrl(link.url);
   }
 
   private changeActiveSolutionNavigation(id: string | null) {

--- a/packages/core/chrome/core-chrome-browser/index.ts
+++ b/packages/core/chrome/core-chrome-browser/index.ts
@@ -57,4 +57,5 @@ export type {
   SolutionNavigationDefinition,
   SolutionNavigationDefinitions,
   EuiSideNavItemTypeEnhanced,
+  RenderAs,
 } from './src';

--- a/packages/core/chrome/core-chrome-browser/src/index.ts
+++ b/packages/core/chrome/core-chrome-browser/src/index.ts
@@ -56,4 +56,5 @@ export type {
   SolutionNavigationDefinition,
   SolutionNavigationDefinitions,
   EuiSideNavItemTypeEnhanced,
+  RenderAs,
 } from './project_navigation';

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
@@ -374,7 +374,7 @@ export const NavigationSectionUI: FC<Props> = React.memo(({ navNode: _navNode })
   const { navNode } = useMemo(
     () =>
       serializeNavNode({
-        renderAs: 'accordion', // Top level nodes are always rendered as accordion
+        renderAs: _navNode.children ? 'accordion' : 'item', // Top level nodes are either item or accordion
         ..._navNode,
       }),
     [_navNode]

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
@@ -202,9 +202,10 @@ const getEuiProps = (
   const onlyIfHighestMatch = isAccordion && !isCollapsible;
   const isActive = isActiveFromUrl(navNode.path, activeNodes, onlyIfHighestMatch);
   const isExternal = Boolean(href) && !navNode.isElasticInternalLink && isAbsoluteLink(href!);
+  const isAccordionExpanded = !getIsCollapsed(path);
 
   let isSelected = isActive;
-  if (isAccordion && !getIsCollapsed(path)) {
+  if (isAccordion && isAccordionExpanded) {
     // For accordions that are collapsible, we don't want to mark the parent button as selected
     // when it is expanded. If the accordion is **not** collapsible then we do.
     isSelected = isCollapsible ? false : isActive;

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
@@ -177,19 +177,9 @@ const renderPanelOpener = (
 
 const getEuiProps = (
   _navNode: ChromeProjectNavigationNode,
-  {
-    navigateToUrl,
-    openPanel,
-    closePanel,
-    isSideNavCollapsed,
-    treeDepth,
-    getIsCollapsed,
-    activeNodes,
-  }: {
+  deps: {
     navigateToUrl: NavigateToUrlFn;
-    openPanel: PanelContext['open'];
     closePanel: PanelContext['close'];
-    isSideNavCollapsed: boolean;
     treeDepth: number;
     getIsCollapsed: (path: string) => boolean;
     activeNodes: ChromeProjectNavigationNode[][];
@@ -202,6 +192,7 @@ const getEuiProps = (
   dataTestSubj: string;
   spaceBefore?: EuiThemeSize | null;
 } & Pick<EuiCollapsibleNavItemProps, 'linkProps' | 'onClick'> => {
+  const { navigateToUrl, closePanel, treeDepth, getIsCollapsed, activeNodes } = deps;
   const { navNode, isItem, hasChildren, hasLink } = serializeNavNode(_navNode);
   const { path, href, onClick: customOnClick, isCollapsible = DEFAULT_IS_COLLAPSIBLE } = navNode;
 
@@ -233,15 +224,7 @@ const getEuiProps = (
     : navNode.children
         ?.map((child) =>
           // Recursively convert the children to EuiCollapsibleNavSubItemProps
-          nodeToEuiCollapsibleNavProps(child, {
-            navigateToUrl,
-            openPanel,
-            closePanel,
-            isSideNavCollapsed,
-            treeDepth: treeDepth + 1,
-            getIsCollapsed,
-            activeNodes,
-          })
+          nodeToEuiCollapsibleNavProps(child, { ...deps, treeDepth: treeDepth + 1 })
         )
         .filter(({ isVisible }) => isVisible)
         .map((res) => {
@@ -305,9 +288,7 @@ function nodeToEuiCollapsibleNavProps(
   _navNode: ChromeProjectNavigationNode,
   deps: {
     navigateToUrl: NavigateToUrlFn;
-    openPanel: PanelContext['open'];
     closePanel: PanelContext['close'];
-    isSideNavCollapsed: boolean;
     treeDepth: number;
     getIsCollapsed: (path: string) => boolean;
     activeNodes: ChromeProjectNavigationNode[][];
@@ -387,7 +368,7 @@ interface Props {
 
 export const NavigationSectionUI: FC<Props> = React.memo(({ navNode: _navNode }) => {
   const { activeNodes } = useNavigation();
-  const { navigateToUrl, isSideNavCollapsed } = useServices();
+  const { navigateToUrl } = useServices();
   const [items, setItems] = useState<EuiCollapsibleNavSubItemProps[] | undefined>();
 
   const { navNode } = useMemo(
@@ -398,7 +379,7 @@ export const NavigationSectionUI: FC<Props> = React.memo(({ navNode: _navNode })
       }),
     [_navNode]
   );
-  const { open: openPanel, close: closePanel } = usePanel();
+  const { close: closePanel } = usePanel();
 
   const { getIsCollapsed, getAccordionProps } = useAccordionState({ navNode });
 
@@ -408,22 +389,12 @@ export const NavigationSectionUI: FC<Props> = React.memo(({ navNode: _navNode })
   } = useMemo(() => {
     return nodeToEuiCollapsibleNavProps(navNode, {
       navigateToUrl,
-      openPanel,
       closePanel,
-      isSideNavCollapsed,
       treeDepth: 0,
       getIsCollapsed,
       activeNodes,
     });
-  }, [
-    navNode,
-    navigateToUrl,
-    openPanel,
-    closePanel,
-    isSideNavCollapsed,
-    getIsCollapsed,
-    activeNodes,
-  ]);
+  }, [navNode, navigateToUrl, closePanel, getIsCollapsed, activeNodes]);
 
   const { items: topLevelItems } = props;
 

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
@@ -299,7 +299,7 @@ function nodeToEuiCollapsibleNavProps(
 } {
   const { navNode, subItems, dataTestSubj, isSelected, isItem, spaceBefore, linkProps, onClick } =
     getEuiProps(_navNode, deps);
-  const { id, path, href, renderAs } = navNode;
+  const { id, path, href, renderAs, isCollapsible } = navNode;
 
   if (navNode.renderItem) {
     // Leave the rendering to the consumer
@@ -340,7 +340,7 @@ function nodeToEuiCollapsibleNavProps(
       // Render as an accordion or a link (handled by EUI) depending if
       // "items" is undefined or not. If it is undefined --> a link, otherwise an
       // accordion is rendered.
-      ...(subItems ? { items: subItems } : { href, linkProps }),
+      ...(subItems ? { items: subItems, isCollapsible } : { href, linkProps }),
     },
   ];
 

--- a/packages/shared-ux/chrome/navigation/src/ui/constants.ts
+++ b/packages/shared-ux/chrome/navigation/src/ui/constants.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import type { EuiThemeSize, RenderAs } from '@kbn/core-chrome-browser';
+
+export const DEFAULT_SPACE_BETWEEN_LEVEL_1_GROUPS: EuiThemeSize = 'm';
+export const DEFAULT_IS_COLLAPSED = true;
+export const DEFAULT_IS_COLLAPSIBLE = true;
+export const DEFAULT_RENDER_AS: RenderAs = 'block';

--- a/packages/shared-ux/chrome/navigation/src/ui/hooks/index.ts
+++ b/packages/shared-ux/chrome/navigation/src/ui/hooks/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { useAccordionState, type AccordionItemsState } from './use_accordion_state';

--- a/packages/shared-ux/chrome/navigation/src/ui/hooks/use_accordion_state.ts
+++ b/packages/shared-ux/chrome/navigation/src/ui/hooks/use_accordion_state.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useCallback, useMemo, useState, useEffect } from 'react';
+import classNames from 'classnames';
+import { type EuiAccordionProps } from '@elastic/eui';
+import type { ChromeProjectNavigationNode } from '@kbn/core-chrome-browser';
+
+import { isAccordionNode, isActiveFromUrl } from '../../utils';
+import { DEFAULT_IS_COLLAPSED, DEFAULT_IS_COLLAPSIBLE } from '../constants';
+import { useNavigation } from '../navigation';
+
+export interface AccordionItemsState {
+  [navNodeId: string]: {
+    isCollapsible: boolean;
+    isCollapsed: boolean;
+    // We want to auto expand the group automatically if the node is active (URL match)
+    // but once the user manually expand a group we don't want to close it afterward automatically.
+    doCollapseFromActiveState: boolean;
+  };
+}
+
+export const useAccordionState = ({ navNode }: { navNode: ChromeProjectNavigationNode }) => {
+  const { activeNodes } = useNavigation();
+
+  const navNodesById = useMemo(() => {
+    const byId = {
+      [navNode.path]: navNode,
+    };
+
+    const parse = (navNodes?: ChromeProjectNavigationNode[]) => {
+      if (!navNodes) return;
+      navNodes.forEach((childNode) => {
+        byId[childNode.path] = childNode;
+        parse(childNode.children);
+      });
+    };
+    parse(navNode.children);
+
+    return byId;
+  }, [navNode]);
+
+  const [accordionStateById, setAccordionStateById] = useState<AccordionItemsState>(() => {
+    return Object.entries(navNodesById).reduce<AccordionItemsState>((acc, [_id, node]) => {
+      if (isAccordionNode(node)) {
+        let isCollapsed = DEFAULT_IS_COLLAPSED;
+        let doCollapseFromActiveState = true;
+
+        if (node.defaultIsCollapsed !== undefined) {
+          isCollapsed = node.defaultIsCollapsed;
+          doCollapseFromActiveState = false;
+        }
+
+        acc[_id] = {
+          isCollapsed,
+          isCollapsible: node.isCollapsible ?? DEFAULT_IS_COLLAPSIBLE,
+          doCollapseFromActiveState,
+        };
+      }
+
+      return acc;
+    }, {});
+  });
+
+  const toggleAccordion = useCallback((path: string) => {
+    setAccordionStateById((prev) => {
+      const prevState = prev[path];
+      const prevValue = prevState?.isCollapsed ?? DEFAULT_IS_COLLAPSED;
+      const { isCollapsible } = prevState;
+      return {
+        ...prev,
+        [path]: {
+          ...prev[path],
+          isCollapsed: !prevValue,
+          doCollapseFromActiveState: isCollapsible
+            ? // if the accordion is collapsible & the user has interacted with the accordion
+              // we don't want to auto-close it when URL changes to not interfere with the user's choice
+              false
+            : // if the accordion is **not** collapsible we do want to auto-close it when the URL changes
+              prevState.doCollapseFromActiveState,
+        },
+      };
+    });
+  }, []);
+
+  const getAccordionProps = useCallback(
+    (
+      path: string,
+      _accordionProps?: Partial<EuiAccordionProps>
+    ): Partial<EuiAccordionProps> | undefined => {
+      const isCollapsed = accordionStateById[path]?.isCollapsed;
+      const isCollapsible = accordionStateById[path]?.isCollapsible;
+
+      if (isCollapsed === undefined) return _accordionProps; // No state set yet
+
+      let forceState: EuiAccordionProps['forceState'] = isCollapsed ? 'closed' : 'open';
+      if (!isCollapsible) forceState = 'open'; // Allways open if the accordion is not collapsible
+
+      const arrowProps: EuiAccordionProps['arrowProps'] = {
+        css: isCollapsible ? undefined : { display: 'none' },
+        'data-test-subj': classNames(`accordionArrow`, `accordionArrow-${path}`),
+      };
+
+      const updated: Partial<EuiAccordionProps & { isCollapsible?: boolean }> = {
+        ..._accordionProps,
+        arrowProps,
+        isCollapsible,
+        forceState,
+        onToggle: isCollapsible
+          ? () => {
+              toggleAccordion(path);
+            }
+          : undefined,
+      };
+
+      return updated;
+    },
+    [accordionStateById, toggleAccordion]
+  );
+
+  const getIsCollapsed = useCallback(
+    (path: string) => {
+      return accordionStateById[path]?.isCollapsed ?? DEFAULT_IS_COLLAPSED;
+    },
+    [accordionStateById]
+  );
+
+  /**
+   * Effect to set the internal state of each of the accordions (isCollapsed) based on the
+   * "isActive" state of the navNode or if its path matches the URL location
+   */
+  useEffect(() => {
+    setAccordionStateById((prev) => {
+      return Object.entries(navNodesById).reduce<AccordionItemsState>(
+        (acc, [_id, node]) => {
+          const prevState = prev[_id];
+
+          if (
+            isAccordionNode(node) &&
+            (!prevState || prevState.doCollapseFromActiveState === true)
+          ) {
+            let nextIsActive = false;
+            let doCollapseFromActiveState = true;
+
+            if (!prevState && node.defaultIsCollapsed !== undefined) {
+              nextIsActive = !node.defaultIsCollapsed;
+              doCollapseFromActiveState = false;
+            } else {
+              if (prevState?.doCollapseFromActiveState !== false) {
+                nextIsActive = isActiveFromUrl(node.path, activeNodes);
+              } else if (nextIsActive === undefined) {
+                nextIsActive = !DEFAULT_IS_COLLAPSED;
+              }
+            }
+
+            acc[_id] = {
+              ...prevState,
+              isCollapsed: !nextIsActive,
+              isCollapsible: node.isCollapsible ?? DEFAULT_IS_COLLAPSIBLE,
+              doCollapseFromActiveState,
+            };
+          }
+          return acc;
+        },
+        { ...prev }
+      );
+    });
+  }, [navNodesById, activeNodes]);
+
+  return {
+    /** Get the EUI accordion props for the node at a specific path */
+    getAccordionProps,
+    /** Get the isCollapsed state for a node at a specific path */
+    getIsCollapsed,
+  };
+};

--- a/packages/shared-ux/chrome/navigation/src/ui/types.ts
+++ b/packages/shared-ux/chrome/navigation/src/ui/types.ts
@@ -6,12 +6,17 @@
  * Side Public License, v 1.
  */
 import type { ReactNode } from 'react';
+import { type EuiCollapsibleNavSubItemProps } from '@elastic/eui';
 
 import type {
   AppDeepLinkId,
   ChromeProjectNavigationNode,
   NodeDefinition,
 } from '@kbn/core-chrome-browser';
+
+export type EuiCollapsibleNavSubItemPropsEnhanced = EuiCollapsibleNavSubItemProps & {
+  path?: string;
+};
 
 /**
  * @public

--- a/packages/shared-ux/chrome/navigation/src/ui/types.ts
+++ b/packages/shared-ux/chrome/navigation/src/ui/types.ts
@@ -5,58 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type { ReactNode } from 'react';
 import { type EuiCollapsibleNavSubItemProps } from '@elastic/eui';
-
-import type {
-  AppDeepLinkId,
-  ChromeProjectNavigationNode,
-  NodeDefinition,
-} from '@kbn/core-chrome-browser';
 
 export type EuiCollapsibleNavSubItemPropsEnhanced = EuiCollapsibleNavSubItemProps & {
   path?: string;
 };
-
-/**
- * @public
- *
- * A navigation node definition with its unique id, title, path in the tree and optional deep link.
- * Those are the props that can be passed to the Navigation.Group and Navigation.Item components.
- */
-export interface NodeProps<
-  LinkId extends AppDeepLinkId = AppDeepLinkId,
-  Id extends string = string,
-  ChildrenId extends string = Id
-> extends Omit<NodeDefinition<LinkId, Id, ChildrenId>, 'children'> {
-  /**
-   * Children of the node. For Navigation.Item (only) it allows a function to be set.
-   * This function will receive the ChromeProjectNavigationNode object
-   */
-  children?: ReactNode;
-  /** @internal - Prop internally controlled, don't use it. */
-  parentNodePath?: string;
-  /** @internal - Prop internally controlled, don't use it. */
-  rootIndex?: number;
-  /** @internal - Prop internally controlled, don't use it. */
-  treeDepth?: number;
-  /** @internal - Prop internally controlled, don't use it. */
-  index?: number;
-}
-
-/**
- * @internal
- *
- * Function to unregister a navigation node from its parent.
- */
-export type UnRegisterFunction = () => void;
-
-/**
- * @internal
- *
- * A function to register a navigation node on its parent.
- */
-export type RegisterFunction = (
-  navNode: ChromeProjectNavigationNode,
-  order?: number
-) => UnRegisterFunction;

--- a/packages/shared-ux/chrome/navigation/src/utils.ts
+++ b/packages/shared-ux/chrome/navigation/src/utils.ts
@@ -39,3 +39,9 @@ export function isActiveFromUrl(
       : nodesBranch.some((branch) => isSamePath(branch.path, nodePath));
   }, false);
 }
+
+export const isAccordionNode = (
+  node: Pick<ChromeProjectNavigationNode, 'renderAs' | 'defaultIsCollapsed' | 'isCollapsible'>
+) =>
+  node.renderAs === 'accordion' ||
+  ['defaultIsCollapsed', 'isCollapsible'].some((prop) => node.hasOwnProperty(prop));

--- a/x-pack/test_serverless/functional/test_suites/observability/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/navigation.ts
@@ -33,7 +33,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await svlCommonNavigation.breadcrumbs.expectExists();
 
       // check side nav links
-      await svlCommonNavigation.sidenav.expectSectionOpen('observability_project_nav');
       await svlCommonNavigation.breadcrumbs.expectBreadcrumbExists({
         deepLinkId: 'observabilityOnboarding',
       });

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -37,7 +37,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
 
       // check side nav links
       await testSubjects.existOrFail(`svlSearchOverviewPage`);
-      await svlCommonNavigation.sidenav.expectSectionOpen('search_project_nav');
       await svlCommonNavigation.sidenav.expectLinkActive({
         deepLinkId: 'serverlessElasticsearch',
       });


### PR DESCRIPTION
While working in previous PRs that touched the `<NavigationSectionUI />` component I realized that the component readibility could be improved. This PR aims to improve that by refactoring the component and export part of it's logic to a new hook called `useAccordionState()` that handles all the EUI accordions logic.

## Other improvements

I also fixed a few issues that I found while working on this PR:

* Remove the automatic redirect to a different solution when a page is not found in the current solution nav. With the new space solution property we don't want that behavior anymore.
* Fix the selected state in the side nav for top level links

<img width="252" alt="Screenshot 2024-06-05 at 15 29 54" src="https://github.com/elastic/kibana/assets/2854616/c7cdca01-b852-41a5-81c2-20dc7ee019d3">

* Correctly set `isCollapsible: false` for the Solution Nav, which removes any mouse interaction.

## How to test

The easiest way to manually test that they are no regression is to launch the es, oblt or security project locally.
I did test that they weren't any regression in serverless and stateful.