### PR TITLE
[Search] [Playground] increase conversational chain tests timeout

### DIFF
--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -172,7 +172,7 @@ describe('conversational chain', () => {
         },
       ],
     });
-  });
+  }, 10000);
 
   it('should be able to create a conversational chain with nested field', async () => {
     await createTestChain({
@@ -207,7 +207,7 @@ describe('conversational chain', () => {
       ],
       contentField: { index: 'field', website: 'metadata.source' },
     });
-  });
+  }, 10000);
 
   it('asking with chat history should re-write the question', async () => {
     await createTestChain({
@@ -251,7 +251,7 @@ describe('conversational chain', () => {
         },
       ],
     });
-  });
+  }, 10000);
 
   it('should cope with quotes in the query', async () => {
     await createTestChain({
@@ -295,7 +295,7 @@ describe('conversational chain', () => {
         },
       ],
     });
-  });
+  }, 10000);
 
   it('should work with an LLM based model', async () => {
     await createTestChain({
@@ -340,7 +340,7 @@ describe('conversational chain', () => {
       ],
       isChatModel: false,
     });
-  });
+  }, 10000);
 
   it('should clip the conversation', async () => {
     await createTestChain({
@@ -407,7 +407,7 @@ describe('conversational chain', () => {
       ],
       isChatModel: false,
     });
-  });
+  }, 10000);
 
   describe('clipContext', () => {
     const prompt = ChatPromptTemplate.fromTemplate(


### PR DESCRIPTION
## Summary

Increase conversational chain test timeout to 10 secs whilst I investigate why these tests take a while to run on CI. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

