### PR TITLE
[data views editor] Disable loading rollups when rollups are disabled

### DIFF
--- a/src/plugins/data_view_editor/public/data_view_editor_service.test.ts
+++ b/src/plugins/data_view_editor/public/data_view_editor_service.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { DataViewEditorService } from './data_view_editor_service';
+import { HttpSetup } from '@kbn/core/public';
+import { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
+
+describe('DataViewEditorService', () => {
+  it('should check for rollup indices when rolls are enabled', () => {
+    const http = { get: jest.fn() } as unknown as HttpSetup;
+    new DataViewEditorService({
+      services: {
+        http,
+        dataViews: {
+          getIdsWithTitle: jest.fn().mockResolvedValue([]),
+          getRollupsEnabled: jest.fn().mockReturnValue(true),
+        } as unknown as DataViewsServicePublic,
+      },
+      initialValues: {},
+    });
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+  });
+  it('should skip check for rollup indices when rollups are disabled', () => {
+    const http = { get: jest.fn() } as unknown as HttpSetup;
+    new DataViewEditorService({
+      services: {
+        http,
+        dataViews: {
+          getIdsWithTitle: jest.fn().mockResolvedValue([]),
+          getRollupsEnabled: jest.fn().mockReturnValue(false),
+        } as unknown as DataViewsServicePublic,
+      },
+      initialValues: {},
+    });
+
+    expect(http.get).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/plugins/data_view_editor/public/data_view_editor_service.test.ts
+++ b/src/plugins/data_view_editor/public/data_view_editor_service.test.ts
@@ -12,7 +12,8 @@ import { DataViewsServicePublic } from '@kbn/data-views-plugin/public';
 
 describe('DataViewEditorService', () => {
   it('should check for rollup indices when rolls are enabled', () => {
-    const http = { get: jest.fn() } as unknown as HttpSetup;
+    const get = jest.fn();
+    const http = { get } as unknown as HttpSetup;
     new DataViewEditorService({
       services: {
         http,
@@ -24,7 +25,8 @@ describe('DataViewEditorService', () => {
       initialValues: {},
     });
 
-    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toEqual('/api/rollup/indices');
   });
   it('should skip check for rollup indices when rollups are disabled', () => {
     const http = { get: jest.fn() } as unknown as HttpSetup;

--- a/src/plugins/data_view_editor/public/data_view_editor_service.ts
+++ b/src/plugins/data_view_editor/public/data_view_editor_service.ts
@@ -179,6 +179,9 @@ export class DataViewEditorService {
   };
 
   private getRollupIndexCaps = async () => {
+    if (this.dataViews.getRollupsEnabled() === false) {
+      return {};
+    }
     let rollupIndicesCaps: RollupIndicesCapsResponse = {};
     try {
       rollupIndicesCaps = await this.http.get<RollupIndicesCapsResponse>('/api/rollup/indices');


### PR DESCRIPTION
## Summary

Previously we were checking the `/api/rollup/indices` endpoint when the data view editor was loaded. If rollups were disabled, it would harmlessly handle a 404 error. Still, people justifiably wonder whether something is wrong. 

This PR skips checking the endpoint as one would expect. A unit test has been added. I also manually verified the behavior is as expected.

Follow up to https://github.com/elastic/kibana/pull/162674