### PR TITLE
[EntSearch] standardize side nav header to search for all apps

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/ai_search/components/layout/page_template.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/ai_search/components/layout/page_template.test.tsx
@@ -28,7 +28,7 @@ describe('EnterpriseSearchAISearchPageTemplate', () => {
     );
 
     expect(wrapper.type()).toEqual(EnterpriseSearchPageTemplateWrapper);
-    expect(wrapper.prop('solutionNav')).toEqual({ name: 'AI Search', items: [] });
+    expect(wrapper.prop('solutionNav')).toEqual({ name: 'Search', items: [] });
     expect(wrapper.find('.hello').text()).toEqual('world');
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/ai_search/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/ai_search/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { AI_SEARCH_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { SetAiSearchChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
 import { useEnterpriseSearchNav } from '../../../shared/layout';
@@ -23,7 +23,7 @@ export const EnterpriseSearchAISearchPageTemplate: React.FC<PageTemplateProps> =
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}
       solutionNav={{
-        name: AI_SEARCH_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
         items: useEnterpriseSearchNav(),
       }}
       setPageChrome={pageChrome && <SetAiSearchChrome trail={pageChrome} />}

--- a/x-pack/plugins/enterprise_search/public/applications/analytics/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/analytics/components/layout/page_template.tsx
@@ -13,7 +13,7 @@ import useObservable from 'react-use/lib/useObservable';
 
 import type { EuiSideNavItemTypeEnhanced } from '@kbn/core-chrome-browser';
 
-import { ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { KibanaLogic } from '../../../shared/kibana';
 import { SetAnalyticsChrome } from '../../../shared/kibana_chrome';
@@ -87,7 +87,7 @@ export const EnterpriseSearchAnalyticsPageTemplate: React.FC<
       {...pageTemplateProps}
       solutionNav={{
         items: chromeStyle === 'classic' ? navItems : undefined,
-        name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
       }}
       setPageChrome={pageChrome && <SetAnalyticsChrome trail={pageChrome} />}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/applications/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/applications/components/layout/page_template.tsx
@@ -13,7 +13,7 @@ import useObservable from 'react-use/lib/useObservable';
 
 import type { EuiSideNavItemTypeEnhanced } from '@kbn/core-chrome-browser';
 
-import { ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { KibanaLogic } from '../../../shared/kibana';
 import { SetEnterpriseSearchApplicationsChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
@@ -99,7 +99,7 @@ export const EnterpriseSearchApplicationsPageTemplate: React.FC<
       {...pageTemplateProps}
       solutionNav={{
         items: chromeStyle === 'classic' ? navItems : undefined,
-        name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
       }}
       restrictWidth={restrictWidth}
       setPageChrome={pageChrome && <SetEnterpriseSearchApplicationsChrome trail={pageChrome} />}

--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/layout/page_template.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/layout/page_template.test.tsx
@@ -28,7 +28,7 @@ describe('EnterpriseSearchElasticsearchPageTemplate', () => {
     );
 
     expect(wrapper.type()).toEqual(EnterpriseSearchPageTemplateWrapper);
-    expect(wrapper.prop('solutionNav')).toEqual({ name: 'Elasticsearch', items: [] });
+    expect(wrapper.prop('solutionNav')).toEqual({ name: 'Search', items: [] });
     expect(wrapper.find('.hello').text()).toEqual('world');
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { ELASTICSEARCH_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { SetElasticsearchChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
 import { useEnterpriseSearchNav } from '../../../shared/layout';
@@ -24,7 +24,7 @@ export const EnterpriseSearchElasticsearchPageTemplate: React.FC<PageTemplatePro
       {...pageTemplateProps}
       restrictWidth
       solutionNav={{
-        name: ELASTICSEARCH_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
         items: useEnterpriseSearchNav(),
       }}
       setPageChrome={pageChrome && <SetElasticsearchChrome trail={pageChrome} />}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { SetEnterpriseSearchContentChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
 import { useEnterpriseSearchNav } from '../../../shared/layout';
@@ -24,7 +24,7 @@ export const EnterpriseSearchContentPageTemplate: React.FC<PageTemplateProps> = 
       {...pageTemplateProps}
       solutionNav={{
         items: useEnterpriseSearchNav(),
-        name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
       }}
       setPageChrome={pageChrome && <SetEnterpriseSearchContentChrome trail={pageChrome} />}
     >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { SetSearchChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
 import { useEnterpriseSearchNav } from '../../../shared/layout';
@@ -23,7 +23,7 @@ export const EnterpriseSearchOverviewPageTemplate: React.FC<PageTemplateProps> =
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}
       solutionNav={{
-        name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
         items: useEnterpriseSearchNav(),
       }}
       setPageChrome={pageChrome && <SetSearchChrome trail={pageChrome} />}

--- a/x-pack/plugins/enterprise_search/public/applications/search_experiences/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/search_experiences/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { SetSearchExperiencesChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
 import { useEnterpriseSearchNav } from '../../../shared/layout';
@@ -23,7 +23,7 @@ export const EnterpriseSearchSearchExperiencesPageTemplate: React.FC<PageTemplat
     <EnterpriseSearchPageTemplateWrapper
       {...pageTemplateProps}
       solutionNav={{
-        name: ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME,
+        name: SEARCH_PRODUCT_NAME,
         items: useEnterpriseSearchNav(),
       }}
       setPageChrome={pageChrome && <SetSearchExperiencesChrome trail={pageChrome} />}

--- a/x-pack/plugins/enterprise_search/public/applications/vector_search/components/layout/page_template.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/vector_search/components/layout/page_template.test.tsx
@@ -28,7 +28,7 @@ describe('EnterpriseSearchVectorSearchPageTemplate', () => {
     );
 
     expect(wrapper.type()).toEqual(EnterpriseSearchPageTemplateWrapper);
-    expect(wrapper.prop('solutionNav')).toEqual({ items: [], name: 'Vector Search' });
+    expect(wrapper.prop('solutionNav')).toEqual({ items: [], name: 'Search' });
     expect(wrapper.find('.hello').text()).toEqual('world');
   });
 

--- a/x-pack/plugins/enterprise_search/public/applications/vector_search/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/vector_search/components/layout/page_template.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { VECTOR_SEARCH_PLUGIN } from '../../../../../common/constants';
+import { SEARCH_PRODUCT_NAME } from '../../../../../common/constants';
 import { SetVectorSearchChrome } from '../../../shared/kibana_chrome';
 import {
   EnterpriseSearchPageTemplateWrapper,
@@ -26,7 +26,7 @@ export const EnterpriseSearchVectorSearchPageTemplate: React.FC<PageTemplateProp
     {...pageTemplateProps}
     solutionNav={{
       items: useEnterpriseSearchNav(),
-      name: VECTOR_SEARCH_PLUGIN.NAME,
+      name: SEARCH_PRODUCT_NAME,
     }}
     setPageChrome={pageChrome && <SetVectorSearchChrome trail={pageChrome} />}
   >


### PR DESCRIPTION
## Summary

Fix to ensure the solution nav name is consistent for all Search pages.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->