### PR TITLE
[Synthetics] Fix editing enabled state for project monitor

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/state/monitor_list/api.ts
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/state/monitor_list/api.ts
@@ -72,6 +72,7 @@ export const fetchUpsertMonitor = async ({
       null,
       {
         version: INITIAL_REST_VERSION,
+        ui: true,
       }
     );
   } else {


### PR DESCRIPTION
## Summary

Fix editing enabled state for project monitor !!

Fixes https://github.com/elastic/kibana/issues/184660

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->