### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "ignorePaths": [
-    "**/__fixtures__/**",
-    "**/fixtures/**"
-  ],
-  "enabledManagers": [
-    "npm"
-  ],
-  "baseBranches": [
-    "main",
-    "7.17"
-  ],
+  "extends": ["config:recommended"],
+  "ignorePaths": ["**/__fixtures__/**", "**/fixtures/**"],
+  "enabledManagers": ["npm"],
+  "baseBranches": ["main", "7.17"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "separateMajorMinor": false,
@@ -27,307 +17,156 @@
   },
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        ".*"
-      ],
-      "enabled": false,
-      "prCreation": "not-pending",
-      "stabilityDays": 7
+      "matchDepPatterns": [".*"],
+      "enabled": false
     },
     {
       "groupName": "@elastic/charts",
-      "matchPackageNames": [
-        "@elastic/charts"
-      ],
-      "reviewers": [
-        "team:visualizations",
-        "markov00",
-        "nickofthyme"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip",
-        "Team:Visualizations"
-      ],
-      "draftPR": true,
-      "enabled": true,
-      "assignAutomerge": true,
-      "prCreation": "immediate"
-    },
-    {
-      "groupName": "@elastic/elasticsearch",
-      "matchPackageNames": [
-        "@elastic/elasticsearch"
-      ],
-      "reviewers": [
-        "team:kibana-operations",
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip",
-        "Team:Operations",
-        "Team:Core"
-      ],
+      "matchDepNames": ["@elastic/charts"],
+      "reviewers": ["team:visualizations", "markov00", "nickofthyme"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip", "Team:Visualizations"],
       "enabled": true
     },
     {
       "groupName": "@elastic/elasticsearch",
-      "matchPackageNames": [
-        "@elastic/elasticsearch"
-      ],
-      "reviewers": [
-        "team:kibana-operations",
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "7.17"
-      ],
-      "labels": [
-        "release_note:skip",
-        "Team:Operations",
-        "Team:Core",
-        "backport:skip"
-      ],
+      "matchDepNames": ["@elastic/elasticsearch"],
+      "reviewers": ["team:kibana-operations", "team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip", "Team:Operations", "Team:Core"],
+      "enabled": true
+    },
+    {
+      "groupName": "@elastic/elasticsearch",
+      "matchDepNames": ["@elastic/elasticsearch"],
+      "reviewers": ["team:kibana-operations", "team:kibana-core"],
+      "matchBaseBranches": ["7.17"],
+      "labels": ["release_note:skip", "Team:Operations", "Team:Core", "backport:skip"],
       "enabled": true
     },
     {
       "groupName": "LaunchDarkly",
-      "matchPackageNames": [
-        "launchdarkly-js-client-sdk",
-        "launchdarkly-node-server-sdk"
-      ],
-      "reviewers": [
-        "team:kibana-security",
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "Team:Security",
-        "Team:Core",
-        "backport:prev-minor"
-      ],
+      "matchDepNames": ["launchdarkly-js-client-sdk", "launchdarkly-node-server-sdk"],
+      "reviewers": ["team:kibana-security", "team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Security", "Team:Core", "backport:prev-minor"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "APM",
-      "matchPackageNames": [
-        "elastic-apm-node",
-        "@elastic/apm-rum",
-        "@elastic/apm-rum-react"
-      ],
-      "reviewers": [
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "Team:Core",
-        "backport:skip"
-      ],
-      "enabled": true,
-      "prCreation": "immediate"
+      "matchDepNames": ["elastic-apm-node", "@elastic/apm-rum", "@elastic/apm-rum-react"],
+      "reviewers": ["team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "enabled": true
     },
     {
       "groupName": "ansi-regex",
-      "matchPackageNames": [
-        "ansi-regex"
-      ],
-      "reviewers": [
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "Team:Core",
-        "backport:skip"
-      ],
+      "matchDepNames": ["ansi-regex"],
+      "reviewers": ["team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "OpenAPI Spec",
-      "matchPackageNames": [
-        "@redocly/cli"
-      ],
-      "reviewers": [
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "Team:Core",
-        "backport:all-open"
-      ],
+      "matchDepNames": ["@redocly/cli"],
+      "reviewers": ["team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Core", "backport:all-open"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "babel",
-      "matchPackageNames": [
-        "@types/babel__core"
-      ],
-      "matchPackagePatterns": [
-        "^@babel",
-        "^babel-plugin"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "matchDepNames": ["@types/babel__core"],
+      "matchDepPatterns": ["^@babel", "^babel-plugin"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "typescript",
-      "matchPackageNames": [
-        "typescript",
-        "prettier",
-        "@types/jsdom"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "matchDepNames": ["typescript", "prettier", "@types/jsdom"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "typescript-eslint",
-      "matchPackagePatterns": [
-        "^@typescript-eslint"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "matchDepPatterns": ["^@typescript-eslint"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "polyfills",
-      "matchPackageNames": [
-        "core-js"
-      ],
-      "matchPackagePatterns": [
-        "polyfill"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "matchDepNames": ["core-js"],
+      "matchDepPatterns": ["polyfill"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "CLI tooling",
-      "matchPackageNames": [
-        "listr2"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "backport:all-open",
-        "release_note:skip"
-      ],
+      "matchDepNames": ["listr2"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "backport:all-open", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "vega related modules",
-      "matchPackageNames": [
-        "vega",
-        "vega-lite",
-        "vega-schema-url-parser",
-        "vega-tooltip"
-      ],
-      "reviewers": [
-        "team:kibana-visualizations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Feature:Vega",
-        "Team:Visualizations"
-      ],
+      "matchDepNames": ["vega", "vega-lite", "vega-schema-url-parser", "vega-tooltip"],
+      "reviewers": ["team:kibana-visualizations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Feature:Vega", "Team:Visualizations"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "cypress",
-      "matchPackagePatterns": [
-        "cypress"
-      ],
-      "reviewers": [
-        "Team:apm",
-        "Team: SecuritySolution"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "buildkite-ci",
-        "ci:all-cypress-suites"
-      ],
+      "matchDepPatterns": ["cypress"],
+      "reviewers": ["Team:apm", "Team: SecuritySolution"],
+      "matchBaseBranches": ["main"],
+      "labels": ["buildkite-ci", "ci:all-cypress-suites"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "security solution modules",
-      "matchPackageNames": [
-        "zod",
-        "langchain"
-      ],
-      "reviewers": [
-        "Team: SecuritySolution"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team: SecuritySolution"
-      ],
+      "matchDepNames": ["zod", "langchain"],
+      "reviewers": ["Team: SecuritySolution"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team: SecuritySolution"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "platform security modules",
-      "matchPackageNames": [
+      "matchDepNames": [
         "css.escape",
         "node-forge",
         "formik",
@@ -339,22 +178,16 @@
         "@types/xml-crypto",
         "@kayahr/text-encoding"
       ],
-      "reviewers": [
-        "team:kibana-security"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Security",
-        "release_note:skip",
-        "backport:all-open"
-      ],
+      "reviewers": ["team:kibana-security"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Security", "release_note:skip", "backport:all-open"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "ftr",
-      "packageNames": [
+      "matchDepNames": [
         "@types/chromedriver",
         "@types/selenium-webdriver",
         "chromedriver",
@@ -362,57 +195,36 @@
         "ms-chromium-edge-driver",
         "selenium-webdriver"
       ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "scss",
-      "packageNames": [
-        "sass-embedded"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip",
-        "backport:all-open"
-      ],
+      "matchDepNames": ["sass-embedded"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip", "backport:all-open"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "minify",
-      "packageNames": [
-        "gulp-terser",
-        "terser"
-      ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "matchDepNames": ["gulp-terser", "terser"],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "@testing-library",
-      "packageNames": [
+      "matchDepNames": [
         "@testing-library/dom",
         "@testing-library/jest-dom",
         "@testing-library/react",
@@ -420,21 +232,16 @@
         "@testing-library/user-event",
         "@types/testing-library__jest-dom"
       ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "jest",
-      "packageNames": [
+      "matchDepNames": [
         "@jest/console",
         "@jest/reporters",
         "@jest/types",
@@ -450,67 +257,39 @@
         "jest-runtime",
         "jest-snapshot"
       ],
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip"
-      ],
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Operations", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "@storybook",
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "matchPackagePatterns": [
-        "^@storybook"
-      ],
-      "excludePackageNames": [
-        "@storybook/testing-react"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip",
-        "ci:build-storybooks",
-        "backport:skip"
-      ],
-      "enabled": true,
-      "allowedVersions": "<7.0"
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "matchDepPatterns": ["^@storybook"],
+      "excludeDepNames": ["@storybook/testing-react"],
+      "labels": ["Team:Operations", "release_note:skip", "ci:build-storybooks", "backport:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
+      "allowedVersions": "<7.0",
+      "enabled": true
     },
     {
       "groupName": "@storybook/testing-react",
-      "reviewers": [
-        "team:kibana-operations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "matchPackageNames": [
-        "@storybook/testing-react"
-      ],
-      "labels": [
-        "Team:Operations",
-        "release_note:skip",
-        "ci:build-storybooks",
-        "backport:skip"
-      ],
-      "enabled": true,
-      "allowedVersions": "<2.0"
+      "reviewers": ["team:kibana-operations"],
+      "matchBaseBranches": ["main"],
+      "matchDepNames": ["@storybook/testing-react"],
+      "labels": ["Team:Operations", "release_note:skip", "ci:build-storybooks", "backport:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
+      "allowedVersions": "<2.0",
+      "enabled": true
     },
     {
       "groupName": "react-query",
-      "packageNames": [
-        "@tanstack/react-query",
-        "@tanstack/react-query-devtools"
-      ],
+      "matchDepNames": ["@tanstack/react-query", "@tanstack/react-query-devtools"],
       "reviewers": [
         "team:response-ops",
         "team:kibana-cloud-security-posture",
@@ -519,41 +298,25 @@
         "team:awp-platform",
         "team:security-onboarding-and-lifecycle-mgt"
       ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip",
-        "ci:all-cypress-suites"
-      ],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip", "ci:all-cypress-suites"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "react-hook-form",
-      "packageNames": [
-        "react-hook-form"
-      ],
-      "reviewers": [
-        "team:security-asset-management",
-        "team:uptime"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip",
-        "ci:all-cypress-suites"
-      ],
+      "matchDepNames": ["react-hook-form"],
+      "reviewers": ["team:security-asset-management", "team:uptime"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip", "ci:all-cypress-suites"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "redux",
-      "packageNames": [
-        "redux",
-        "react-redux"
-      ],
+      "matchDepNames": ["redux", "react-redux"],
       "reviewers": [
         "team:search-kibana",
         "team:kibana-presentation",
@@ -562,199 +325,107 @@
         "team:kibana-gis",
         "team:security-solution"
       ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip",
-        "ci:all-cypress-suites"
-      ],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip", "ci:all-cypress-suites"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "Profiling",
-      "matchPackageNames": [
-        "peggy",
-        "@types/dagre"
-      ],
-      "reviewers": [
-        "team:profiling-ui"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip"
-      ],
-      "enabled": true,
-      "prCreation": "immediate"
+      "matchDepNames": ["peggy", "@types/dagre"],
+      "reviewers": ["team:profiling-ui"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip"],
+      "minimumReleaseAge": "7 days",
+      "enabled": true
     },
     {
       "groupName": "TTY Output",
-      "matchPackageNames": [
-        "xterm",
-        "byte-size",
-        "@types/byte-size"
-      ],
-      "reviewers": [
-        "team:sec-cloudnative-integrations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team: AWP: Visualization",
-        "release_note:skip",
-        "backport:skip"
-      ],
-      "enabled": true,
-      "prCreation": "immediate"
+      "matchDepNames": ["xterm", "byte-size", "@types/byte-size"],
+      "reviewers": ["team:sec-cloudnative-integrations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team: AWP: Visualization", "release_note:skip", "backport:skip"],
+      "minimumReleaseAge": "7 days",
+      "enabled": true
     },
     {
       "groupName": "Cloud Defend",
-      "matchPackageNames": [
-        "monaco-yaml"
-      ],
-      "reviewers": [
-        "team:sec-cloudnative-integrations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team: Cloud Native Integrations",
-        "release_note:skip",
-        "backport:skip"
-      ],
-      "enabled": true,
-      "prCreation": "immediate"
+      "matchDepNames": ["monaco-yaml"],
+      "reviewers": ["team:sec-cloudnative-integrations"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team: Cloud Native Integrations", "release_note:skip", "backport:skip"],
+      "minimumReleaseAge": "7 days",
+      "enabled": true
     },
     {
       "groupName": "JSON Web Token",
-      "matchPackageNames": [
-        "jsonwebtoken"
-      ],
-      "reviewers": [
-        "team:response-ops",
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:all-open"
-      ],
+      "matchDepNames": ["jsonwebtoken"],
+      "reviewers": ["team:response-ops", "team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:all-open"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "XState",
-      "matchPackageNames": [
-        "xstate"
-      ],
-      "matchPackagePrefixes": [
-        "@xstate/"
-      ],
-      "reviewers": [
-        "team:obs-ux-logs"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Obs UX Logs",
-        "release_note:skip"
-      ],
-      "enabled": true,
-      "prCreation": "immediate"
+      "matchDepNames": ["xstate"],
+      "matchDepPrefixes": ["@xstate/"],
+      "reviewers": ["team:obs-ux-logs"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Obs UX Logs", "release_note:skip"],
+      "minimumReleaseAge": "7 days",
+      "enabled": true
     },
     {
       "groupName": "OpenTelemetry modules",
-      "matchPackagePrefixes": [
-        "@opentelemetry/"
-      ],
-      "reviewers": [
-        "team:monitoring"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Monitoring"
-      ],
+      "matchDepPrefixes": ["@opentelemetry/"],
+      "reviewers": ["team:monitoring"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:Monitoring"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "csp",
-      "packageNames": [
-        "content-security-policy-parser"
-      ],
-      "reviewers": [
-        "team:kibana-security",
-        "team:kibana-core"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:skip",
-        "ci:serverless-test-all"
-      ],
+      "matchDepNames": ["content-security-policy-parser"],
+      "reviewers": ["team:kibana-security", "team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:skip", "ci:serverless-test-all"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "AlertingEmails",
-      "matchPackageNames": [
-        "nodemailer"
-      ],
-      "reviewers": [
-        "team:response-ops"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:prev-minor"
-      ],
+      "matchDepNames": ["nodemailer"],
+      "reviewers": ["team:response-ops"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "backport:prev-minor"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "machine learning modules",
-      "matchPackageNames": [
-        "apidoc-markdown"
-      ],
-      "reviewers": [
-        "team:ml-ui"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:ML",
-        "release_note:skip",
-        "backport:all-open"
-      ],
+      "matchDepNames": ["apidoc-markdown"],
+      "reviewers": ["team:ml-ui"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:ML", "release_note:skip", "backport:all-open"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     },
     {
       "groupName": "Kibana ES|QL Team",
-      "matchPackageNames": [
-        "recast"
-      ],
-      "reviewers": [
-        "team:kibana-esql"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:ESQL",
-        "release_note:skip"
-      ],
+      "matchDepNames": ["recast"],
+      "reviewers": ["team:kibana-esql"],
+      "matchBaseBranches": ["main"],
+      "labels": ["Team:ESQL", "release_note:skip"],
+      "prCreation": "not-pending",
+      "minimumReleaseAge": "7 days",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Summary

This PR updates and changes a few things on the `renovate.json` config. The changes should have no affect to the current package update groups.

The changes include:
- Replace the `extends` config from the deprecated `config:base` to `config:recommended`.
- Removes global defaults from top-level group and applies the `prCreation` and `stabilityDays` options only to non-elastic dependency groups.
- Replaces deprecated `stabilityDays` option with new [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage).
- Replaces all `matchPackage*` options to `matchDep*` options.
- Format entire config file with prettier.


Config was validated using [cli tool](https://docs.renovatebot.com/config-validation/#strict-mode).

```
npx --yes --package renovate -- renovate-config-validator --strict
```