### PR TITLE
Add advanced Elastic Defend policy option: advanced.events.process_ancestry_events

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -1275,6 +1275,39 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
+    key: 'windows.advanced.events.process_ancestry_length',
+    first_supported_version: '8.15',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.process_ancestry_length',
+      {
+        defaultMessage:
+          'Maximum number of process ancestry entries to include in process events. Default: 5',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.events.process_ancestry_length',
+    first_supported_version: '8.15',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.process_ancestry_length',
+      {
+        defaultMessage:
+          'Maximum number of process ancestry entries to include in process events. Default: 5',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.events.process_ancestry_length',
+    first_supported_version: '8.15',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.process_ancestry_length',
+      {
+        defaultMessage:
+          'Maximum number of process ancestry entries to include in process events. Default: 5',
+      }
+    ),
+  },
+  {
     key: 'windows.advanced.artifacts.global.proxy_url',
     first_supported_version: '8.8',
     documentation: i18n.translate(


### PR DESCRIPTION
## Summary

Adds an advanced policy option for specifying the maximum number of process ancestry entries to include in process events

Corresponding Endpoint PR: https://github.com/elastic/endpoint-dev/pull/14531
Security Team Issue: https://github.com/elastic/security-team/issues/9340


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
