### PR TITLE
[ES|QL] Fix function definition generator script

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/package.json
+++ b/packages/kbn-esql-validation-autocomplete/package.json
@@ -5,10 +5,10 @@
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "sideEffects": false,
   "scripts": {
-    "make:tests": "ts-node --transpileOnly ./scripts/generate_function_validation_tests.ts",
+    "make:tests": "ts-node --transpileOnly ./scripts/generate_function_validation_tests.ts && yarn run test:validation",
     "postmake:tests": "yarn run lint:fix",
     "make:defs": "ts-node --transpileOnly ./scripts/generate_function_definitions.ts",
-    "postmake:defs": "yarn run lint:fix && yarn run test:validation && yarn run i18n:fix",
+    "postmake:defs": "yarn run lint:fix && yarn run i18n:fix",
     "lint:fix": "cd ../.. && node ./scripts/eslint --fix ./packages/kbn-esql-validation-autocomplete/src/**/*.ts",
     "i18n:fix": "cd ../.. && node ./scripts/i18n_check.js --fix",
     "test:validation": "cd ../.. && yarn test:jest ./packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts"

--- a/packages/kbn-esql-validation-autocomplete/package.json
+++ b/packages/kbn-esql-validation-autocomplete/package.json
@@ -8,8 +8,9 @@
     "make:tests": "ts-node --transpileOnly ./scripts/generate_function_validation_tests.ts",
     "postmake:tests": "yarn run lint:fix",
     "make:defs": "ts-node --transpileOnly ./scripts/generate_function_definitions.ts",
-    "postmake:defs": "yarn run lint:fix && yarn run i18n:fix",
+    "postmake:defs": "yarn run lint:fix && yarn run test:validation && yarn run i18n:fix",
     "lint:fix": "cd ../.. && node ./scripts/eslint --fix ./packages/kbn-esql-validation-autocomplete/src/**/*.ts",
-    "i18n:fix": "cd ../.. && node ./scripts/i18n_check.js --fix"
+    "i18n:fix": "cd ../.. && node ./scripts/i18n_check.js --fix",
+    "test:validation": "cd ../.. && yarn test:jest ./packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts"
   }
 }

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -278,6 +278,11 @@ const coalesceDefinition: FunctionDefinition = {
           type: 'date',
           optional: false,
         },
+        {
+          name: 'rest',
+          type: 'cartesian_point',
+          optional: true,
+        },
       ],
       returnType: 'date',
       minParams: 1,
@@ -305,6 +310,11 @@ const coalesceDefinition: FunctionDefinition = {
           type: 'string',
           optional: false,
         },
+        {
+          name: 'rest',
+          type: 'date',
+          optional: true,
+        },
       ],
       returnType: 'string',
       minParams: 1,
@@ -332,6 +342,11 @@ const coalesceDefinition: FunctionDefinition = {
           type: 'boolean',
           optional: false,
         },
+        {
+          name: 'rest',
+          type: 'geo_shape',
+          optional: true,
+        },
       ],
       returnType: 'boolean',
       minParams: 1,
@@ -358,6 +373,11 @@ const coalesceDefinition: FunctionDefinition = {
           name: 'first',
           type: 'ip',
           optional: false,
+        },
+        {
+          name: 'rest',
+          type: 'number',
+          optional: true,
         },
       ],
       returnType: 'ip',
@@ -953,8 +973,7 @@ const greatestDefinition: FunctionDefinition = {
   name: 'greatest',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.greatest', {
     defaultMessage:
-      'Returns the maximum value from multiple columns. This is similar to <<esql-mv_max>>\nexcept it is intended to run on multiple columns at once.',
-    ignoreTag: true,
+      'Returns the maximum value from multiple columns. This is similar to `MV_MAX`\nexcept it is intended to run on multiple columns at once.',
   }),
   alias: undefined,
   signatures: [
@@ -1078,13 +1097,49 @@ const greatestDefinition: FunctionDefinition = {
   examples: ['ROW a = 10, b = 20\n| EVAL g = GREATEST(a, b)'],
 };
 
+const ipPrefixDefinition: FunctionDefinition = {
+  type: 'eval',
+  name: 'ip_prefix',
+  description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.ip_prefix', {
+    defaultMessage: 'Truncates an IP to a given prefix length.',
+  }),
+  alias: undefined,
+  signatures: [
+    {
+      params: [
+        {
+          name: 'ip',
+          type: 'ip',
+          optional: false,
+        },
+        {
+          name: 'prefixLengthV4',
+          type: 'number',
+          optional: false,
+        },
+        {
+          name: 'prefixLengthV6',
+          type: 'number',
+          optional: false,
+        },
+      ],
+      returnType: 'ip',
+    },
+  ],
+  supportedCommands: ['stats', 'eval', 'where', 'row', 'sort'],
+  supportedOptions: ['by'],
+  validate: undefined,
+  examples: [
+    'row ip4 = to_ip("1.2.3.4"), ip6 = to_ip("fe80::cae2:65ff:fece:feb9")\n| eval ip4_prefix = ip_prefix(ip4, 24, 0), ip6_prefix = ip_prefix(ip6, 0, 112);',
+  ],
+};
+
 const leastDefinition: FunctionDefinition = {
   type: 'eval',
   name: 'least',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.least', {
     defaultMessage:
-      'Returns the minimum value from multiple columns. This is similar to <<esql-mv_min>> except it is intended to run on multiple columns at once.',
-    ignoreTag: true,
+      'Returns the minimum value from multiple columns. This is similar to `MV_MIN` except it is intended to run on multiple columns at once.',
   }),
   alias: undefined,
   signatures: [
@@ -1460,6 +1515,171 @@ const ltrimDefinition: FunctionDefinition = {
   ],
 };
 
+const mvAppendDefinition: FunctionDefinition = {
+  type: 'eval',
+  name: 'mv_append',
+  description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mv_append', {
+    defaultMessage: 'Concatenates values of two multi-value fields.',
+  }),
+  alias: undefined,
+  signatures: [
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'boolean',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'boolean',
+          optional: false,
+        },
+      ],
+      returnType: 'boolean',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'cartesian_point',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'cartesian_point',
+          optional: false,
+        },
+      ],
+      returnType: 'cartesian_point',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'cartesian_shape',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'cartesian_shape',
+          optional: false,
+        },
+      ],
+      returnType: 'cartesian_shape',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'date',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'date',
+          optional: false,
+        },
+      ],
+      returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'number',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'number',
+          optional: false,
+        },
+      ],
+      returnType: 'number',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'geo_point',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'geo_point',
+          optional: false,
+        },
+      ],
+      returnType: 'geo_point',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'geo_shape',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'geo_shape',
+          optional: false,
+        },
+      ],
+      returnType: 'geo_shape',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'ip',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'ip',
+          optional: false,
+        },
+      ],
+      returnType: 'ip',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'string',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'string',
+          optional: false,
+        },
+      ],
+      returnType: 'string',
+    },
+    {
+      params: [
+        {
+          name: 'field1',
+          type: 'version',
+          optional: false,
+        },
+        {
+          name: 'field2',
+          type: 'version',
+          optional: false,
+        },
+      ],
+      returnType: 'version',
+    },
+  ],
+  supportedCommands: ['stats', 'eval', 'where', 'row', 'sort'],
+  supportedOptions: ['by'],
+  validate: undefined,
+  examples: [],
+};
+
 const mvAvgDefinition: FunctionDefinition = {
   type: 'eval',
   name: 'mv_avg',
@@ -1756,8 +1976,7 @@ const mvFirstDefinition: FunctionDefinition = {
   name: 'mv_first',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mv_first', {
     defaultMessage:
-      "Converts a multivalued expression into a single valued column containing the\nfirst value. This is most useful when reading from a function that emits\nmultivalued columns in a known order like <<esql-split>>.\n\nThe order that <<esql-multivalued-fields, multivalued fields>> are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the minimum value use <<esql-mv_min>> instead of\n`MV_FIRST`. `MV_MIN` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_FIRST`.",
-    ignoreTag: true,
+      "Converts a multivalued expression into a single valued column containing the\nfirst value. This is most useful when reading from a function that emits\nmultivalued columns in a known order like `SPLIT`.\n\nThe order that  multivalued fields are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the minimum value use `MV_MIN` instead of\n`MV_FIRST`. `MV_MIN` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_FIRST`.",
   }),
   alias: undefined,
   signatures: [
@@ -1873,8 +2092,7 @@ const mvLastDefinition: FunctionDefinition = {
   name: 'mv_last',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mv_last', {
     defaultMessage:
-      "Converts a multivalue expression into a single valued column containing the last\nvalue. This is most useful when reading from a function that emits multivalued\ncolumns in a known order like <<esql-split>>.\n\nThe order that <<esql-multivalued-fields, multivalued fields>> are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the maximum value use <<esql-mv_max>> instead of\n`MV_LAST`. `MV_MAX` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_LAST`.",
-    ignoreTag: true,
+      "Converts a multivalue expression into a single valued column containing the last\nvalue. This is most useful when reading from a function that emits multivalued\ncolumns in a known order like `SPLIT`.\n\nThe order that  multivalued fields are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the maximum value use `MV_MAX` instead of\n`MV_LAST`. `MV_MAX` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_LAST`.",
   }),
   alias: undefined,
   signatures: [
@@ -2913,8 +3131,7 @@ const stContainsDefinition: FunctionDefinition = {
   name: 'st_contains',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_contains', {
     defaultMessage:
-      'Returns whether the first geometry contains the second geometry.\nThis is the inverse of the <<esql-st_within,ST_WITHIN>> function.',
-    ignoreTag: true,
+      'Returns whether the first geometry contains the second geometry.\nThis is the inverse of the `ST_WITHIN` function.',
   }),
   alias: undefined,
   signatures: [
@@ -3052,8 +3269,7 @@ const stDisjointDefinition: FunctionDefinition = {
   name: 'st_disjoint',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_disjoint', {
     defaultMessage:
-      'Returns whether the two geometries or geometry columns are disjoint.\nThis is the inverse of the <<esql-st_intersects,ST_INTERSECTS>> function.\nIn mathematical terms: ST_Disjoint(A, B) ⇔ A ⋂ B = ∅',
-    ignoreTag: true,
+      'Returns whether the two geometries or geometry columns are disjoint.\nThis is the inverse of the `ST_INTERSECTS` function.\nIn mathematical terms: ST_Disjoint(A, B) ⇔ A ⋂ B = ∅',
   }),
   alias: undefined,
   signatures: [
@@ -3191,8 +3407,7 @@ const stIntersectsDefinition: FunctionDefinition = {
   name: 'st_intersects',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_intersects', {
     defaultMessage:
-      'Returns true if two geometries intersect.\nThey intersect if they have any point in common, including their interior points\n(points along lines or within polygons).\nThis is the inverse of the <<esql-st_disjoint,ST_DISJOINT>> function.\nIn mathematical terms: ST_Intersects(A, B) ⇔ A ⋂ B ≠ ∅',
-    ignoreTag: true,
+      'Returns true if two geometries intersect.\nThey intersect if they have any point in common, including their interior points\n(points along lines or within polygons).\nThis is the inverse of the `ST_DISJOINT` function.\nIn mathematical terms: ST_Intersects(A, B) ⇔ A ⋂ B ≠ ∅',
   }),
   alias: undefined,
   signatures: [
@@ -3330,8 +3545,7 @@ const stWithinDefinition: FunctionDefinition = {
   name: 'st_within',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_within', {
     defaultMessage:
-      'Returns whether the first geometry is within the second geometry.\nThis is the inverse of the <<esql-st_contains,ST_CONTAINS>> function.',
-    ignoreTag: true,
+      'Returns whether the first geometry is within the second geometry.\nThis is the inverse of the `ST_CONTAINS` function.',
   }),
   alias: undefined,
   signatures: [
@@ -3848,8 +4062,7 @@ const toDatetimeDefinition: FunctionDefinition = {
   name: 'to_datetime',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.to_datetime', {
     defaultMessage:
-      "Converts an input value to a date value.\nA string will only be successfully converted if it's respecting the format `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.\nTo convert dates in other formats, use <<esql-date_parse>>.",
-    ignoreTag: true,
+      "Converts an input value to a date value.\nA string will only be successfully converted if it's respecting the format `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.\nTo convert dates in other formats, use `DATE_PARSE`.",
   }),
   alias: ['to_dt'],
   signatures: [
@@ -4578,6 +4791,7 @@ export const evalFunctionDefinitions = [
   floorDefinition,
   fromBase64Definition,
   greatestDefinition,
+  ipPrefixDefinition,
   leastDefinition,
   leftDefinition,
   lengthDefinition,
@@ -4585,6 +4799,7 @@ export const evalFunctionDefinitions = [
   logDefinition,
   log10Definition,
   ltrimDefinition,
+  mvAppendDefinition,
   mvAvgDefinition,
   mvConcatDefinition,
   mvCountDefinition,

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/functions.ts
@@ -278,11 +278,6 @@ const coalesceDefinition: FunctionDefinition = {
           type: 'date',
           optional: false,
         },
-        {
-          name: 'rest',
-          type: 'cartesian_point',
-          optional: true,
-        },
       ],
       returnType: 'date',
       minParams: 1,
@@ -310,11 +305,6 @@ const coalesceDefinition: FunctionDefinition = {
           type: 'string',
           optional: false,
         },
-        {
-          name: 'rest',
-          type: 'date',
-          optional: true,
-        },
       ],
       returnType: 'string',
       minParams: 1,
@@ -341,11 +331,6 @@ const coalesceDefinition: FunctionDefinition = {
           name: 'first',
           type: 'boolean',
           optional: false,
-        },
-        {
-          name: 'rest',
-          type: 'geo_shape',
-          optional: true,
         },
       ],
       returnType: 'boolean',
@@ -373,11 +358,6 @@ const coalesceDefinition: FunctionDefinition = {
           name: 'first',
           type: 'ip',
           optional: false,
-        },
-        {
-          name: 'rest',
-          type: 'number',
-          optional: true,
         },
       ],
       returnType: 'ip',
@@ -973,7 +953,8 @@ const greatestDefinition: FunctionDefinition = {
   name: 'greatest',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.greatest', {
     defaultMessage:
-      'Returns the maximum value from multiple columns. This is similar to `MV_MAX`\nexcept it is intended to run on multiple columns at once.',
+      'Returns the maximum value from multiple columns. This is similar to <<esql-mv_max>>\nexcept it is intended to run on multiple columns at once.',
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -1097,49 +1078,13 @@ const greatestDefinition: FunctionDefinition = {
   examples: ['ROW a = 10, b = 20\n| EVAL g = GREATEST(a, b)'],
 };
 
-const ipPrefixDefinition: FunctionDefinition = {
-  type: 'eval',
-  name: 'ip_prefix',
-  description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.ip_prefix', {
-    defaultMessage: 'Truncates an IP to a given prefix length.',
-  }),
-  alias: undefined,
-  signatures: [
-    {
-      params: [
-        {
-          name: 'ip',
-          type: 'ip',
-          optional: false,
-        },
-        {
-          name: 'prefixLengthV4',
-          type: 'number',
-          optional: false,
-        },
-        {
-          name: 'prefixLengthV6',
-          type: 'number',
-          optional: false,
-        },
-      ],
-      returnType: 'ip',
-    },
-  ],
-  supportedCommands: ['stats', 'eval', 'where', 'row', 'sort'],
-  supportedOptions: ['by'],
-  validate: undefined,
-  examples: [
-    'row ip4 = to_ip("1.2.3.4"), ip6 = to_ip("fe80::cae2:65ff:fece:feb9")\n| eval ip4_prefix = ip_prefix(ip4, 24, 0), ip6_prefix = ip_prefix(ip6, 0, 112);',
-  ],
-};
-
 const leastDefinition: FunctionDefinition = {
   type: 'eval',
   name: 'least',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.least', {
     defaultMessage:
-      'Returns the minimum value from multiple columns. This is similar to `MV_MIN` except it is intended to run on multiple columns at once.',
+      'Returns the minimum value from multiple columns. This is similar to <<esql-mv_min>> except it is intended to run on multiple columns at once.',
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -1515,171 +1460,6 @@ const ltrimDefinition: FunctionDefinition = {
   ],
 };
 
-const mvAppendDefinition: FunctionDefinition = {
-  type: 'eval',
-  name: 'mv_append',
-  description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mv_append', {
-    defaultMessage: 'Concatenates values of two multi-value fields.',
-  }),
-  alias: undefined,
-  signatures: [
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'boolean',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'boolean',
-          optional: false,
-        },
-      ],
-      returnType: 'boolean',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'cartesian_point',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'cartesian_point',
-          optional: false,
-        },
-      ],
-      returnType: 'cartesian_point',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'cartesian_shape',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'cartesian_shape',
-          optional: false,
-        },
-      ],
-      returnType: 'cartesian_shape',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'date',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'date',
-          optional: false,
-        },
-      ],
-      returnType: 'date',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'number',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'number',
-          optional: false,
-        },
-      ],
-      returnType: 'number',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'geo_point',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'geo_point',
-          optional: false,
-        },
-      ],
-      returnType: 'geo_point',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'geo_shape',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'geo_shape',
-          optional: false,
-        },
-      ],
-      returnType: 'geo_shape',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'ip',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'ip',
-          optional: false,
-        },
-      ],
-      returnType: 'ip',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'string',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'string',
-          optional: false,
-        },
-      ],
-      returnType: 'string',
-    },
-    {
-      params: [
-        {
-          name: 'field1',
-          type: 'version',
-          optional: false,
-        },
-        {
-          name: 'field2',
-          type: 'version',
-          optional: false,
-        },
-      ],
-      returnType: 'version',
-    },
-  ],
-  supportedCommands: ['stats', 'eval', 'where', 'row', 'sort'],
-  supportedOptions: ['by'],
-  validate: undefined,
-  examples: [],
-};
-
 const mvAvgDefinition: FunctionDefinition = {
   type: 'eval',
   name: 'mv_avg',
@@ -1976,7 +1756,8 @@ const mvFirstDefinition: FunctionDefinition = {
   name: 'mv_first',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mv_first', {
     defaultMessage:
-      "Converts a multivalued expression into a single valued column containing the\nfirst value. This is most useful when reading from a function that emits\nmultivalued columns in a known order like `SPLIT`.\n\nThe order that  multivalued fields are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the minimum value use `MV_MIN` instead of\n`MV_FIRST`. `MV_MIN` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_FIRST`.",
+      "Converts a multivalued expression into a single valued column containing the\nfirst value. This is most useful when reading from a function that emits\nmultivalued columns in a known order like <<esql-split>>.\n\nThe order that <<esql-multivalued-fields, multivalued fields>> are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the minimum value use <<esql-mv_min>> instead of\n`MV_FIRST`. `MV_MIN` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_FIRST`.",
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -2092,7 +1873,8 @@ const mvLastDefinition: FunctionDefinition = {
   name: 'mv_last',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.mv_last', {
     defaultMessage:
-      "Converts a multivalue expression into a single valued column containing the last\nvalue. This is most useful when reading from a function that emits multivalued\ncolumns in a known order like `SPLIT`.\n\nThe order that  multivalued fields are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the maximum value use `MV_MAX` instead of\n`MV_LAST`. `MV_MAX` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_LAST`.",
+      "Converts a multivalue expression into a single valued column containing the last\nvalue. This is most useful when reading from a function that emits multivalued\ncolumns in a known order like <<esql-split>>.\n\nThe order that <<esql-multivalued-fields, multivalued fields>> are read from\nunderlying storage is not guaranteed. It is *frequently* ascending, but don't\nrely on that. If you need the maximum value use <<esql-mv_max>> instead of\n`MV_LAST`. `MV_MAX` has optimizations for sorted values so there isn't a\nperformance benefit to `MV_LAST`.",
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -3131,7 +2913,8 @@ const stContainsDefinition: FunctionDefinition = {
   name: 'st_contains',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_contains', {
     defaultMessage:
-      'Returns whether the first geometry contains the second geometry.\nThis is the inverse of the `ST_WITHIN` function.',
+      'Returns whether the first geometry contains the second geometry.\nThis is the inverse of the <<esql-st_within,ST_WITHIN>> function.',
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -3269,7 +3052,8 @@ const stDisjointDefinition: FunctionDefinition = {
   name: 'st_disjoint',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_disjoint', {
     defaultMessage:
-      'Returns whether the two geometries or geometry columns are disjoint.\nThis is the inverse of the `ST_INTERSECTS` function.\nIn mathematical terms: ST_Disjoint(A, B) ⇔ A ⋂ B = ∅',
+      'Returns whether the two geometries or geometry columns are disjoint.\nThis is the inverse of the <<esql-st_intersects,ST_INTERSECTS>> function.\nIn mathematical terms: ST_Disjoint(A, B) ⇔ A ⋂ B = ∅',
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -3407,7 +3191,8 @@ const stIntersectsDefinition: FunctionDefinition = {
   name: 'st_intersects',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_intersects', {
     defaultMessage:
-      'Returns true if two geometries intersect.\nThey intersect if they have any point in common, including their interior points\n(points along lines or within polygons).\nThis is the inverse of the `ST_DISJOINT` function.\nIn mathematical terms: ST_Intersects(A, B) ⇔ A ⋂ B ≠ ∅',
+      'Returns true if two geometries intersect.\nThey intersect if they have any point in common, including their interior points\n(points along lines or within polygons).\nThis is the inverse of the <<esql-st_disjoint,ST_DISJOINT>> function.\nIn mathematical terms: ST_Intersects(A, B) ⇔ A ⋂ B ≠ ∅',
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -3545,7 +3330,8 @@ const stWithinDefinition: FunctionDefinition = {
   name: 'st_within',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.st_within', {
     defaultMessage:
-      'Returns whether the first geometry is within the second geometry.\nThis is the inverse of the `ST_CONTAINS` function.',
+      'Returns whether the first geometry is within the second geometry.\nThis is the inverse of the <<esql-st_contains,ST_CONTAINS>> function.',
+    ignoreTag: true,
   }),
   alias: undefined,
   signatures: [
@@ -4062,7 +3848,8 @@ const toDatetimeDefinition: FunctionDefinition = {
   name: 'to_datetime',
   description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.to_datetime', {
     defaultMessage:
-      "Converts an input value to a date value.\nA string will only be successfully converted if it's respecting the format `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.\nTo convert dates in other formats, use `DATE_PARSE`.",
+      "Converts an input value to a date value.\nA string will only be successfully converted if it's respecting the format `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.\nTo convert dates in other formats, use <<esql-date_parse>>.",
+    ignoreTag: true,
   }),
   alias: ['to_dt'],
   signatures: [
@@ -4791,7 +4578,6 @@ export const evalFunctionDefinitions = [
   floorDefinition,
   fromBase64Definition,
   greatestDefinition,
-  ipPrefixDefinition,
   leastDefinition,
   leftDefinition,
   lengthDefinition,
@@ -4799,7 +4585,6 @@ export const evalFunctionDefinitions = [
   logDefinition,
   log10Definition,
   ltrimDefinition,
-  mvAppendDefinition,
   mvAvgDefinition,
   mvConcatDefinition,
   mvCountDefinition,


### PR DESCRIPTION
## Summary

Two fixes based on the results of the last function-definition-generation PR: https://github.com/elastic/kibana/pull/184626
- Asciidoc [cross-references](https://docs.asciidoctor.org/asciidoc/latest/macros/xref/) are now being stripped out of function definitions.
- Meta tests will now be created for all new validation tests (`packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json`)