### PR TITLE
[data views] Fix single quotes on field save confirm toast

### DIFF
--- a/packages/kbn-i18n/GUIDELINE.md
+++ b/packages/kbn-i18n/GUIDELINE.md
@@ -58,8 +58,8 @@ Messages can contain placeholders for embedding a value of a variable. For examp
 
 ```js
 {
-  'kbn.management.editIndexPattern.scripted.deleteFieldLabel': "Delete scripted field '{fieldName}'?"
-  'kbn.management.editIndexPattern.scripted.noFieldLabel': "'{indexPatternTitle}' index pattern doesn't have a scripted field called '{fieldName}'"
+  'kbn.management.editIndexPattern.scripted.deleteFieldLabel': "Delete scripted field ''{fieldName}''?"
+  'kbn.management.editIndexPattern.scripted.noFieldLabel': "''{indexPatternTitle}'' index pattern doesn't have a scripted field called ''{fieldName}''"
 }
 ```
 

--- a/src/plugins/data_view_field_editor/public/components/preview/preview_controller.tsx
+++ b/src/plugins/data_view_field_editor/public/components/preview/preview_controller.tsx
@@ -253,7 +253,7 @@ export class PreviewController {
 
       const afterSave = () => {
         const message = i18n.translate('indexPatternFieldEditor.deleteField.savedHeader', {
-          defaultMessage: "Saved '{fieldName}'",
+          defaultMessage: "Saved ''{fieldName}''",
           values: { fieldName: updatedField.name },
         });
         this.deps.notifications.toasts.addSuccess(message);

--- a/src/plugins/data_view_management/public/components/edit_index_pattern/create_edit_field/create_edit_field.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/create_edit_field/create_edit_field.tsx
@@ -50,7 +50,7 @@ export const CreateEditField = withRouter(
     if (mode === 'edit' && !spec) {
       const message = i18n.translate('indexPatternManagement.editDataView.scripted.noFieldLabel', {
         defaultMessage:
-          "'{dataViewTitle}' data view doesn't have a scripted field called '{fieldName}'",
+          "'{dataViewTitle}' data view doesn't have a scripted field called ''{fieldName}''",
         values: { dataViewTitle: indexPattern.title, fieldName },
       });
       notifications.toasts.addWarning(message);

--- a/src/plugins/data_view_management/public/components/edit_index_pattern/create_edit_field/create_edit_field.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/create_edit_field/create_edit_field.tsx
@@ -50,7 +50,7 @@ export const CreateEditField = withRouter(
     if (mode === 'edit' && !spec) {
       const message = i18n.translate('indexPatternManagement.editDataView.scripted.noFieldLabel', {
         defaultMessage:
-          "'{dataViewTitle}' data view doesn't have a scripted field called ''{fieldName}''",
+          "''{dataViewTitle}'' data view doesn't have a scripted field called ''{fieldName}''",
         values: { dataViewTitle: indexPattern.title, fieldName },
       });
       notifications.toasts.addWarning(message);


### PR DESCRIPTION
## Summary

Address two cases where single quotes needed to be doubled up to prevent escaping of string interpolation. Also addressed some doc examples.

Verify confirm toasts after saving field in discover and creating a scripted field in data view management.

Follow up to https://github.com/elastic/kibana/pull/179506


