### PR TITLE
[Security Solution] [Security Solution] Fix Timeline date picker to honor the date format config

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/super_date_picker/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/super_date_picker/index.tsx
@@ -23,7 +23,7 @@ import type { Dispatch } from 'redux';
 import deepEqual from 'fast-deep-equal';
 
 import { isQueryInput } from '../../store/inputs/helpers';
-import { DEFAULT_TIMEPICKER_QUICK_RANGES } from '../../../../common/constants';
+import { DEFAULT_DATE_FORMAT, DEFAULT_TIMEPICKER_QUICK_RANGES } from '../../../../common/constants';
 import { timelineActions } from '../../../timelines/store';
 import { useUiSetting$ } from '../../lib/kibana';
 import type { inputsModel, State } from '../../store';
@@ -200,6 +200,8 @@ export const SuperDatePickerComponent = React.memo<SuperDatePickerProps>(
     const startDate = fromStr != null ? fromStr : new Date(start).toISOString();
 
     const [quickRanges] = useUiSetting$<Range[]>(DEFAULT_TIMEPICKER_QUICK_RANGES);
+    const [dateFormat] = useUiSetting$<string>(DEFAULT_DATE_FORMAT);
+
     const commonlyUsedRanges = isEmpty(quickRanges)
       ? []
       : quickRanges.map(({ from, to, display }) => ({
@@ -225,6 +227,7 @@ export const SuperDatePickerComponent = React.memo<SuperDatePickerProps>(
         width={width}
         compressed={compressed}
         updateButtonProps={refreshButtonProps}
+        dateFormat={dateFormat}
       />
     );
   },


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/184798

Use dateFormat from ui config in the `SuperDatePicker` component Timeline uses.

#### Screenshots
With config:

<img width="1062" alt="config" src="https://github.com/elastic/kibana/assets/17747913/d0bdf8da-c715-451e-ab29-e61545c0e95c">



Before:
<img width="1316" alt="before" src="https://github.com/elastic/kibana/assets/17747913/ff34e7e1-8137-494d-9fc7-c006acb87fbb">


After:
<img width="1316" alt="before" src="https://github.com/elastic/kibana/assets/17747913/63646df5-3304-45f7-8de2-8a7c9e599350">



<!--ONMERGE {"backportTargets":["8.12","8.13","8.14"]} ONMERGE-->