### PR TITLE
[Stateful sidenav] Add cloud yml setting for onboarding default solution

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -256,6 +256,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cloud.serverless.project_id (string)',
         'xpack.cloud.serverless.project_name (string)',
         'xpack.cloud.serverless.project_type (string)',
+        'xpack.cloud.onboarding.default_solution (string)',
         'xpack.discoverEnhanced.actions.exploreDataInChart.enabled (boolean)',
         'xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled (boolean)',
         'xpack.fleet.agents.enabled (boolean)',

--- a/x-pack/plugins/cloud/common/index.ts
+++ b/x-pack/plugins/cloud/common/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type { OnBoardingDefaultSolution } from './types';

--- a/x-pack/plugins/cloud/common/parse_onboarding_default_solution.test.ts
+++ b/x-pack/plugins/cloud/common/parse_onboarding_default_solution.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { parseOnboardingSolution } from './parse_onboarding_default_solution';
+
+describe('parseDeploymentIdFromDeploymentUrl', () => {
+  it('should return undefined if there is no default solution defined', () => {
+    expect(parseOnboardingSolution()).toBeUndefined();
+  });
+
+  it('should map correctly the cloud values to the Kibana values, regardless of case', () => {
+    [
+      ['elasticsearch', 'es'],
+      ['Elasticsearch', 'es'],
+      ['observability', 'oblt'],
+      ['Observability', 'oblt'],
+      ['security', 'security'],
+      ['Security', 'security'],
+    ].forEach(([cloudValue, kibanaValue]) => {
+      expect(parseOnboardingSolution(cloudValue)).toBe(kibanaValue);
+      expect(parseOnboardingSolution(cloudValue.toUpperCase())).toBe(kibanaValue);
+      expect(parseOnboardingSolution(cloudValue.toLowerCase())).toBe(kibanaValue);
+    });
+  });
+
+  it('should return undefined for unknown values', () => {
+    expect(parseOnboardingSolution('unknown')).toBeUndefined();
+  });
+});

--- a/x-pack/plugins/cloud/common/parse_onboarding_default_solution.test.ts
+++ b/x-pack/plugins/cloud/common/parse_onboarding_default_solution.test.ts
@@ -7,7 +7,7 @@
 
 import { parseOnboardingSolution } from './parse_onboarding_default_solution';
 
-describe('parseDeploymentIdFromDeploymentUrl', () => {
+describe('parseOnboardingSolution', () => {
   it('should return undefined if there is no default solution defined', () => {
     expect(parseOnboardingSolution()).toBeUndefined();
   });

--- a/x-pack/plugins/cloud/common/parse_onboarding_default_solution.ts
+++ b/x-pack/plugins/cloud/common/parse_onboarding_default_solution.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { OnBoardingDefaultSolution } from './types';
+
+/**
+ * Cloud does not type the value of the "use case" that is set during onboarding for a deployment. Any string can
+ * be passed. This function maps the known values to the Kibana values.
+ *
+ * @param value The solution value set by Cloud.
+ * @returns The default solution value for onboarding that matches Kibana naming.
+ */
+export function parseOnboardingSolution(value?: string): OnBoardingDefaultSolution | undefined {
+  if (!value) return;
+
+  const solutions: Array<{
+    /** The known value passed by cloud. */
+    cloudValue: 'elasticsearch' | 'observability' | 'security';
+    /**  */
+    kibanaValue: OnBoardingDefaultSolution;
+  }> = [
+    {
+      cloudValue: 'elasticsearch',
+      kibanaValue: 'es',
+    },
+    {
+      cloudValue: 'observability',
+      kibanaValue: 'oblt',
+    },
+    {
+      cloudValue: 'security',
+      kibanaValue: 'security',
+    },
+  ];
+
+  return solutions.find(({ cloudValue }) => value.toLowerCase() === cloudValue)?.kibanaValue;
+}

--- a/x-pack/plugins/cloud/common/parse_onboarding_default_solution.ts
+++ b/x-pack/plugins/cloud/common/parse_onboarding_default_solution.ts
@@ -18,9 +18,7 @@ export function parseOnboardingSolution(value?: string): OnBoardingDefaultSoluti
   if (!value) return;
 
   const solutions: Array<{
-    /** The known value passed by cloud. */
     cloudValue: 'elasticsearch' | 'observability' | 'security';
-    /**  */
     kibanaValue: OnBoardingDefaultSolution;
   }> = [
     {

--- a/x-pack/plugins/cloud/common/types.ts
+++ b/x-pack/plugins/cloud/common/types.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type OnBoardingDefaultSolution = 'es' | 'oblt' | 'security';

--- a/x-pack/plugins/cloud/public/mocks.tsx
+++ b/x-pack/plugins/cloud/public/mocks.tsx
@@ -26,6 +26,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
     isElasticStaffOwned: true,
     trialEndDate: new Date('2020-10-01T14:13:12Z'),
     registerCloudService: jest.fn(),
+    onboarding: {},
     isServerlessEnabled: false,
     serverless: {
       projectId: undefined,

--- a/x-pack/plugins/cloud/public/plugin.test.ts
+++ b/x-pack/plugins/cloud/public/plugin.test.ts
@@ -122,6 +122,15 @@ describe('Cloud Plugin', () => {
         expect(decodeCloudIdMock).toHaveBeenCalledWith('cloudId', expect.any(Object));
       });
 
+      it('exposes `onboarding.default_solution`', () => {
+        const { setup } = setupPlugin({
+          onboarding: {
+            default_solution: 'oblt',
+          },
+        });
+        expect(setup.onboarding.defaultSolution).toBe('oblt');
+      });
+
       describe('isServerlessEnabled', () => {
         it('is `true` when `serverless.projectId` is set', () => {
           const { setup } = setupPlugin({

--- a/x-pack/plugins/cloud/public/plugin.test.ts
+++ b/x-pack/plugins/cloud/public/plugin.test.ts
@@ -125,10 +125,10 @@ describe('Cloud Plugin', () => {
       it('exposes `onboarding.default_solution`', () => {
         const { setup } = setupPlugin({
           onboarding: {
-            default_solution: 'oblt',
+            default_solution: 'Elasticsearch',
           },
         });
-        expect(setup.onboarding.defaultSolution).toBe('oblt');
+        expect(setup.onboarding.defaultSolution).toBe('es');
       });
 
       describe('isServerlessEnabled', () => {

--- a/x-pack/plugins/cloud/public/plugin.tsx
+++ b/x-pack/plugins/cloud/public/plugin.tsx
@@ -11,6 +11,7 @@ import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kb
 import { registerCloudDeploymentMetadataAnalyticsContext } from '../common/register_cloud_deployment_id_analytics_context';
 import { getIsCloudEnabled } from '../common/is_cloud_enabled';
 import { parseDeploymentIdFromDeploymentUrl } from '../common/parse_deployment_id_from_deployment_url';
+import type { OnBoardingDefaultSolution } from '../common/types';
 import { CLOUD_SNAPSHOTS_PATH } from '../common/constants';
 import { decodeCloudId, type DecodedCloudId } from '../common/decode_cloud_id';
 import type { CloudSetup, CloudStart } from './types';
@@ -31,6 +32,9 @@ export interface CloudConfigType {
   performance_url?: string;
   trial_end_date?: string;
   is_elastic_staff_owned?: boolean;
+  onboarding?: {
+    default_solution?: OnBoardingDefaultSolution;
+  };
   serverless?: {
     project_id: string;
     project_name?: string;
@@ -95,6 +99,9 @@ export class CloudPlugin implements Plugin<CloudSetup> {
       trialEndDate: trialEndDate ? new Date(trialEndDate) : undefined,
       isElasticStaffOwned,
       isCloudEnabled: this.isCloudEnabled,
+      onboarding: {
+        defaultSolution: this.config.onboarding?.default_solution,
+      },
       isServerlessEnabled: this.isServerlessEnabled,
       serverless: {
         projectId: this.config.serverless?.project_id,

--- a/x-pack/plugins/cloud/public/plugin.tsx
+++ b/x-pack/plugins/cloud/public/plugin.tsx
@@ -8,14 +8,15 @@
 import React, { FC, PropsWithChildren } from 'react';
 import type { Logger } from '@kbn/logging';
 import type { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
+
 import { registerCloudDeploymentMetadataAnalyticsContext } from '../common/register_cloud_deployment_id_analytics_context';
 import { getIsCloudEnabled } from '../common/is_cloud_enabled';
 import { parseDeploymentIdFromDeploymentUrl } from '../common/parse_deployment_id_from_deployment_url';
-import type { OnBoardingDefaultSolution } from '../common/types';
 import { CLOUD_SNAPSHOTS_PATH } from '../common/constants';
 import { decodeCloudId, type DecodedCloudId } from '../common/decode_cloud_id';
-import type { CloudSetup, CloudStart } from './types';
 import { getFullCloudUrl } from '../common/utils';
+import { parseOnboardingSolution } from '../common/parse_onboarding_default_solution';
+import type { CloudSetup, CloudStart } from './types';
 import { getSupportUrl } from './utils';
 
 export interface CloudConfigType {
@@ -33,7 +34,7 @@ export interface CloudConfigType {
   trial_end_date?: string;
   is_elastic_staff_owned?: boolean;
   onboarding?: {
-    default_solution?: OnBoardingDefaultSolution;
+    default_solution?: string;
   };
   serverless?: {
     project_id: string;
@@ -100,7 +101,7 @@ export class CloudPlugin implements Plugin<CloudSetup> {
       isElasticStaffOwned,
       isCloudEnabled: this.isCloudEnabled,
       onboarding: {
-        defaultSolution: this.config.onboarding?.default_solution,
+        defaultSolution: parseOnboardingSolution(this.config.onboarding?.default_solution),
       },
       isServerlessEnabled: this.isServerlessEnabled,
       serverless: {

--- a/x-pack/plugins/cloud/public/types.ts
+++ b/x-pack/plugins/cloud/public/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { FC, PropsWithChildren } from 'react';
+import type { OnBoardingDefaultSolution } from '../common';
 
 export interface CloudStart {
   /**
@@ -174,6 +175,15 @@ export interface CloudSetup {
    * @param contextProvider The React component from the Service Provider.
    */
   registerCloudService: (contextProvider: FC) => void;
+  /**
+   * Onboarding configuration
+   */
+  onboarding: {
+    /**
+     * The default solution selected during onboarding.
+     */
+    defaultSolution?: OnBoardingDefaultSolution;
+  };
   /**
    * `true` when running on Serverless Elastic Cloud
    * Note that `isCloudEnabled` will always be true when `isServerlessEnabled` is.

--- a/x-pack/plugins/cloud/server/__snapshots__/plugin.test.ts.snap
+++ b/x-pack/plugins/cloud/server/__snapshots__/plugin.test.ts.snap
@@ -17,6 +17,9 @@ Object {
   "isElasticStaffOwned": undefined,
   "isServerlessEnabled": false,
   "kibanaUrl": undefined,
+  "onboarding": Object {
+    "defaultSolution": undefined,
+  },
   "projectsUrl": "https://cloud.elastic.co/projects/",
   "serverless": Object {
     "projectId": undefined,

--- a/x-pack/plugins/cloud/server/config.ts
+++ b/x-pack/plugins/cloud/server/config.ts
@@ -33,6 +33,13 @@ const configSchema = schema.object({
   projects_url: offeringBasedSchema({ serverless: schema.string({ defaultValue: '/projects/' }) }),
   trial_end_date: schema.maybe(schema.string()),
   is_elastic_staff_owned: schema.maybe(schema.boolean()),
+  onboarding: schema.maybe(
+    schema.object({
+      default_solution: schema.maybe(
+        schema.oneOf([schema.literal('es'), schema.literal('oblt'), schema.literal('security')])
+      ),
+    })
+  ),
   serverless: schema.maybe(
     schema.object(
       {
@@ -67,6 +74,9 @@ export const config: PluginConfigDescriptor<CloudConfigType> = {
       project_id: true,
       project_name: true,
       project_type: true,
+    },
+    onboarding: {
+      default_solution: true,
     },
   },
   schema: configSchema,

--- a/x-pack/plugins/cloud/server/config.ts
+++ b/x-pack/plugins/cloud/server/config.ts
@@ -35,9 +35,7 @@ const configSchema = schema.object({
   is_elastic_staff_owned: schema.maybe(schema.boolean()),
   onboarding: schema.maybe(
     schema.object({
-      default_solution: schema.maybe(
-        schema.oneOf([schema.literal('es'), schema.literal('oblt'), schema.literal('security')])
-      ),
+      default_solution: schema.maybe(schema.string()),
     })
   ),
   serverless: schema.maybe(

--- a/x-pack/plugins/cloud/server/mocks.ts
+++ b/x-pack/plugins/cloud/server/mocks.ts
@@ -25,6 +25,7 @@ function createSetupMock(): jest.Mocked<CloudSetup> {
       url: undefined,
       secretToken: undefined,
     },
+    onboarding: {},
     isServerlessEnabled: false,
     serverless: {
       projectId: undefined,

--- a/x-pack/plugins/cloud/server/plugin.test.ts
+++ b/x-pack/plugins/cloud/server/plugin.test.ts
@@ -98,6 +98,15 @@ describe('Cloud Plugin', () => {
         expect(decodeCloudIdMock).toHaveBeenCalledWith('cloudId', expect.any(Object));
       });
 
+      it('exposes `onboarding.default_solution`', () => {
+        const { setup } = setupPlugin({
+          onboarding: {
+            default_solution: 'oblt',
+          },
+        });
+        expect(setup.onboarding.defaultSolution).toBe('oblt');
+      });
+
       describe('isServerlessEnabled', () => {
         it('is `true` when `serverless.projectId` is set', () => {
           const { setup } = setupPlugin({

--- a/x-pack/plugins/cloud/server/plugin.test.ts
+++ b/x-pack/plugins/cloud/server/plugin.test.ts
@@ -101,10 +101,10 @@ describe('Cloud Plugin', () => {
       it('exposes `onboarding.default_solution`', () => {
         const { setup } = setupPlugin({
           onboarding: {
-            default_solution: 'oblt',
+            default_solution: 'Elasticsearch',
           },
         });
-        expect(setup.onboarding.defaultSolution).toBe('oblt');
+        expect(setup.onboarding.defaultSolution).toBe('es');
       });
 
       describe('isServerlessEnabled', () => {

--- a/x-pack/plugins/cloud/server/plugin.ts
+++ b/x-pack/plugins/cloud/server/plugin.ts
@@ -11,6 +11,7 @@ import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { registerCloudDeploymentMetadataAnalyticsContext } from '../common/register_cloud_deployment_id_analytics_context';
 import type { CloudConfigType } from './config';
 import { registerCloudUsageCollector } from './collectors';
+import type { OnBoardingDefaultSolution } from '../common';
 import { getIsCloudEnabled } from '../common/is_cloud_enabled';
 import { parseDeploymentIdFromDeploymentUrl } from '../common/parse_deployment_id_from_deployment_url';
 import { decodeCloudId, DecodedCloudId } from '../common/decode_cloud_id';
@@ -87,6 +88,15 @@ export interface CloudSetup {
   apm: {
     url?: string;
     secretToken?: string;
+  };
+  /**
+   * Onboarding configuration.
+   */
+  onboarding: {
+    /**
+     * The default solution selected during onboarding.
+     */
+    defaultSolution?: OnBoardingDefaultSolution;
   };
   /**
    * `true` when running on Serverless Elastic Cloud
@@ -187,6 +197,9 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       apm: {
         url: this.config.apm?.url,
         secretToken: this.config.apm?.secret_token,
+      },
+      onboarding: {
+        defaultSolution: this.config.onboarding?.default_solution,
       },
       isServerlessEnabled,
       serverless: {

--- a/x-pack/plugins/cloud/server/plugin.ts
+++ b/x-pack/plugins/cloud/server/plugin.ts
@@ -15,6 +15,7 @@ import type { OnBoardingDefaultSolution } from '../common';
 import { getIsCloudEnabled } from '../common/is_cloud_enabled';
 import { parseDeploymentIdFromDeploymentUrl } from '../common/parse_deployment_id_from_deployment_url';
 import { decodeCloudId, DecodedCloudId } from '../common/decode_cloud_id';
+import { parseOnboardingSolution } from '../common/parse_onboarding_default_solution';
 import { getFullCloudUrl } from '../common/utils';
 import { readInstanceSizeMb } from './env';
 
@@ -199,7 +200,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
         secretToken: this.config.apm?.secret_token,
       },
       onboarding: {
-        defaultSolution: this.config.onboarding?.default_solution,
+        defaultSolution: parseOnboardingSolution(this.config.onboarding?.default_solution),
       },
       isServerlessEnabled,
       serverless: {

--- a/x-pack/plugins/enterprise_search/public/applications/shared/get_cloud_enterprise_search_host/get_cloud_enterprise_search_host.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/get_cloud_enterprise_search_host/get_cloud_enterprise_search_host.test.ts
@@ -15,6 +15,7 @@ const defaultPortCloud = {
   cloudHost: 'us-central1.gcp.cloud.es.io',
   cloudDefaultPort: '443',
   registerCloudService: jest.fn(),
+  onboarding: {},
   isServerlessEnabled: false,
   serverless: {
     projectId: undefined,
@@ -29,6 +30,7 @@ const customPortCloud = {
   cloudHost: 'us-central1.gcp.cloud.es.io',
   cloudDefaultPort: '9243',
   registerCloudService: jest.fn(),
+  onboarding: {},
   isServerlessEnabled: false,
   serverless: {
     projectId: undefined,
@@ -39,6 +41,7 @@ const missingDeploymentIdCloud = {
     'dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA=',
   isCloudEnabled: true,
   registerCloudService: jest.fn(),
+  onboarding: {},
   isServerlessEnabled: false,
   serverless: {
     projectId: undefined,
@@ -48,6 +51,7 @@ const noCloud = {
   cloudId: undefined,
   isCloudEnabled: false,
   registerCloudService: jest.fn(),
+  onboarding: {},
   isServerlessEnabled: false,
   serverless: {
     projectId: undefined,

--- a/x-pack/plugins/fleet/.storybook/context/cloud.ts
+++ b/x-pack/plugins/fleet/.storybook/context/cloud.ts
@@ -18,6 +18,7 @@ export const getCloud = ({ isCloudEnabled }: { isCloudEnabled: boolean }) => {
     profileUrl: 'https://profile.url',
     snapshotsUrl: 'https://snapshots.url',
     registerCloudService: () => {},
+    onboarding: {},
     isServerlessEnabled: false,
     serverless: {
       projectId: undefined,

--- a/x-pack/plugins/fleet/server/services/preconfiguration/fleet_server_host.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration/fleet_server_host.test.ts
@@ -159,6 +159,7 @@ describe('getCloudFleetServersHosts', () => {
       deploymentId: 'deployment-id-1',
       cloudHost: 'us-east-1.aws.found.io',
       apm: {},
+      onboarding: {},
       isServerlessEnabled: true,
       serverless: {
         projectId: undefined,
@@ -176,6 +177,7 @@ describe('getCloudFleetServersHosts', () => {
       deploymentId: 'deployment-id-1',
       cloudHost: 'us-east-1.aws.found.io',
       apm: {},
+      onboarding: {},
       isServerlessEnabled: false,
       serverless: {
         projectId: undefined,
@@ -198,6 +200,7 @@ describe('getCloudFleetServersHosts', () => {
       cloudHost: 'test.fr',
       cloudDefaultPort: '9243',
       apm: {},
+      onboarding: {},
       isServerlessEnabled: false,
       serverless: {
         projectId: undefined,
@@ -233,6 +236,7 @@ describe('createCloudFleetServerHostIfNeeded', () => {
       isCloudEnabled: true,
       deploymentId: 'deployment-id-1',
       apm: {},
+      onboarding: {},
       isServerlessEnabled: false,
       serverless: {
         projectId: undefined,
@@ -256,6 +260,7 @@ describe('createCloudFleetServerHostIfNeeded', () => {
       deploymentId: 'deployment-id-1',
       cloudHost: 'us-east-1.aws.found.io',
       apm: {},
+      onboarding: {},
       isServerlessEnabled: false,
       serverless: {
         projectId: undefined,


### PR DESCRIPTION
In this PR I've exposed a new `yml` setting from the `cloud` plugin to forward the use case (solution) selected by the user during deployment onboarding creation.

The use case in Cloud is not typed and any string can be provided. From what @AlexP-Elastic found out, the current values passed are: "elasticsearch", "observability", "security", "Security" (uppercase).

I handled the case and ignored any string that does not match one of the known values.
For consistency I mapped the value to the Kibana naming: "es", "oblt" and "security".

## New `yml` setting

```yaml
# Allowed values: elasticsearch | observability | security
xpack.cloud.onboarding.default_solution: elasticsearch
```

## Update `cloud` API

The `defaultSolution` value is exposed by the `cloud` plugin setup contract (both server and public) under `onboarding`.

```ts
{
  ...,
  onboarding: {
    defaultSolution: 'es', // es, oblt, security
  }
}
```

This value will have to be read by the security team when creating the default space on new deployment. cc @legrego 