### PR TITLE
Revert "[Response Ops][Task Manager] Emitting metrics when metrics ar…

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/create_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/create_aggregator.test.ts
@@ -7,7 +7,7 @@
 
 import sinon from 'sinon';
 import { Subject } from 'rxjs';
-import { take, bufferCount } from 'rxjs';
+import { take, bufferCount, skip } from 'rxjs';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import {
   isTaskManagerMetricEvent,
@@ -109,7 +109,13 @@ describe('createAggregator', () => {
 
       return new Promise<void>((resolve) => {
         taskClaimAggregator
-          .pipe(take(events.length), bufferCount(events.length))
+          .pipe(
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(events.length),
+            bufferCount(events.length)
+          )
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
             expect(metrics[0]).toEqual({
               key: 'task_claim',
@@ -262,8 +268,11 @@ describe('createAggregator', () => {
       return new Promise<void>((resolve) => {
         taskClaimAggregator
           .pipe(
-            take(events1.length + events2.length + 1),
-            bufferCount(events1.length + events2.length + 1)
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(events1.length + events2.length),
+            bufferCount(events1.length + events2.length)
           )
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
             expect(metrics[0]).toEqual({
@@ -330,16 +339,6 @@ describe('createAggregator', () => {
             expect(metrics[6]).toEqual({
               key: 'task_claim',
               value: {
-                success: 0,
-                total: 0,
-                total_errors: 0,
-                duration: { counts: [], values: [] },
-                duration_values: [],
-              },
-            });
-            expect(metrics[7]).toEqual({
-              key: 'task_claim',
-              value: {
                 success: 1,
                 total: 1,
                 total_errors: 0,
@@ -347,7 +346,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[8]).toEqual({
+            expect(metrics[7]).toEqual({
               key: 'task_claim',
               value: {
                 success: 1,
@@ -357,7 +356,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[9]).toEqual({
+            expect(metrics[8]).toEqual({
               key: 'task_claim',
               value: {
                 success: 1,
@@ -367,7 +366,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[10]).toEqual({
+            expect(metrics[9]).toEqual({
               key: 'task_claim',
               value: {
                 success: 2,
@@ -377,7 +376,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10],
               },
             });
-            expect(metrics[11]).toEqual({
+            expect(metrics[10]).toEqual({
               key: 'task_claim',
               value: {
                 success: 3,
@@ -436,8 +435,11 @@ describe('createAggregator', () => {
       return new Promise<void>((resolve) => {
         taskClaimAggregator
           .pipe(
-            take(events1.length + events2.length + 1),
-            bufferCount(events1.length + events2.length + 1)
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(events1.length + events2.length),
+            bufferCount(events1.length + events2.length)
           )
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
             expect(metrics[0]).toEqual({
@@ -504,16 +506,6 @@ describe('createAggregator', () => {
             expect(metrics[6]).toEqual({
               key: 'task_claim',
               value: {
-                success: 0,
-                total: 0,
-                total_errors: 0,
-                duration: { counts: [], values: [] },
-                duration_values: [],
-              },
-            });
-            expect(metrics[7]).toEqual({
-              key: 'task_claim',
-              value: {
                 success: 1,
                 total: 1,
                 total_errors: 0,
@@ -521,7 +513,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[8]).toEqual({
+            expect(metrics[7]).toEqual({
               key: 'task_claim',
               value: {
                 success: 1,
@@ -531,7 +523,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[9]).toEqual({
+            expect(metrics[8]).toEqual({
               key: 'task_claim',
               value: {
                 success: 1,
@@ -541,7 +533,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[10]).toEqual({
+            expect(metrics[9]).toEqual({
               key: 'task_claim',
               value: {
                 success: 2,
@@ -551,7 +543,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10],
               },
             });
-            expect(metrics[11]).toEqual({
+            expect(metrics[10]).toEqual({
               key: 'task_claim',
               value: {
                 success: 3,
@@ -613,22 +605,14 @@ describe('createAggregator', () => {
       return new Promise<void>((resolve) => {
         taskClaimAggregator
           .pipe(
-            take(events1.length + events2.length + 3),
-            bufferCount(events1.length + events2.length + 3)
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(events1.length + events2.length + 1),
+            bufferCount(events1.length + events2.length + 1)
           )
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
-            // reset event
             expect(metrics[0]).toEqual({
-              key: 'task_claim',
-              value: {
-                success: 0,
-                total: 0,
-                total_errors: 0,
-                duration: { counts: [], values: [] },
-                duration_values: [],
-              },
-            });
-            expect(metrics[1]).toEqual({
               key: 'task_claim',
               value: {
                 success: 1,
@@ -638,7 +622,7 @@ describe('createAggregator', () => {
                 duration_values: [10],
               },
             });
-            expect(metrics[2]).toEqual({
+            expect(metrics[1]).toEqual({
               key: 'task_claim',
               value: {
                 success: 2,
@@ -648,7 +632,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10],
               },
             });
-            expect(metrics[3]).toEqual({
+            expect(metrics[2]).toEqual({
               key: 'task_claim',
               value: {
                 success: 3,
@@ -658,7 +642,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10],
               },
             });
-            expect(metrics[4]).toEqual({
+            expect(metrics[3]).toEqual({
               key: 'task_claim',
               value: {
                 success: 4,
@@ -668,7 +652,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10, 10],
               },
             });
-            expect(metrics[5]).toEqual({
+            expect(metrics[4]).toEqual({
               key: 'task_claim',
               value: {
                 success: 4,
@@ -678,7 +662,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10, 10],
               },
             });
-            expect(metrics[6]).toEqual({
+            expect(metrics[5]).toEqual({
               key: 'task_claim',
               value: {
                 success: 5,
@@ -689,7 +673,7 @@ describe('createAggregator', () => {
               },
             });
             // reset interval fired here but stats should not clear
-            expect(metrics[7]).toEqual({
+            expect(metrics[6]).toEqual({
               key: 'task_claim',
               value: {
                 success: 6,
@@ -699,7 +683,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10, 10, 10, 10],
               },
             });
-            expect(metrics[8]).toEqual({
+            expect(metrics[7]).toEqual({
               key: 'task_claim',
               value: {
                 success: 6,
@@ -709,7 +693,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10, 10, 10, 10],
               },
             });
-            expect(metrics[9]).toEqual({
+            expect(metrics[8]).toEqual({
               key: 'task_claim',
               value: {
                 success: 6,
@@ -719,7 +703,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10, 10, 10, 10],
               },
             });
-            expect(metrics[10]).toEqual({
+            expect(metrics[9]).toEqual({
               key: 'task_claim',
               value: {
                 success: 7,
@@ -729,7 +713,7 @@ describe('createAggregator', () => {
                 duration_values: [10, 10, 10, 10, 10, 10, 10],
               },
             });
-            expect(metrics[11]).toEqual({
+            expect(metrics[10]).toEqual({
               key: 'task_claim',
               value: {
                 success: 8,
@@ -740,17 +724,7 @@ describe('createAggregator', () => {
               },
             });
             // reset interval fired here and stats should have cleared
-            expect(metrics[12]).toEqual({
-              key: 'task_claim',
-              value: {
-                success: 0,
-                total: 0,
-                total_errors: 0,
-                duration: { counts: [], values: [] },
-                duration_values: [],
-              },
-            });
-            expect(metrics[13]).toEqual({
+            expect(metrics[11]).toEqual({
               key: 'task_claim',
               value: {
                 success: 1,
@@ -821,7 +795,13 @@ describe('createAggregator', () => {
 
       return new Promise<void>((resolve) => {
         taskRunAggregator
-          .pipe(take(taskRunEvents.length), bufferCount(taskRunEvents.length))
+          .pipe(
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(taskRunEvents.length),
+            bufferCount(taskRunEvents.length)
+          )
           .subscribe((metrics: Array<AggregatedStat<TaskRunMetric>>) => {
             expect(metrics[0]).toEqual({
               key: 'task_run',
@@ -1844,8 +1824,11 @@ describe('createAggregator', () => {
       return new Promise<void>((resolve) => {
         taskRunAggregator
           .pipe(
-            take(taskRunEvents1.length + taskRunEvents2.length + 1),
-            bufferCount(taskRunEvents1.length + taskRunEvents2.length + 1)
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(taskRunEvents1.length + taskRunEvents2.length),
+            bufferCount(taskRunEvents1.length + taskRunEvents2.length)
           )
           .subscribe((metrics: Array<AggregatedStat<TaskRunMetric>>) => {
             expect(metrics[0]).toEqual({
@@ -2248,55 +2231,6 @@ describe('createAggregator', () => {
                   success: 0,
                   not_timed_out: 0,
                   total: 0,
-                  delay: { counts: [], values: [] },
-                  delay_values: [],
-                  framework_errors: 0,
-                  user_errors: 0,
-                  total_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[11]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 0,
-                  not_timed_out: 0,
-                  total: 0,
                   delay: { counts: [1], values: [10] },
                   delay_values: [5],
                   framework_errors: 0,
@@ -2339,7 +2273,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[12]).toEqual({
+            expect(metrics[11]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2388,7 +2322,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[13]).toEqual({
+            expect(metrics[12]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2437,7 +2371,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[14]).toEqual({
+            expect(metrics[13]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2486,7 +2420,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[15]).toEqual({
+            expect(metrics[14]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2535,7 +2469,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[16]).toEqual({
+            expect(metrics[15]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2584,7 +2518,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[17]).toEqual({
+            expect(metrics[16]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2633,7 +2567,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[18]).toEqual({
+            expect(metrics[17]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2682,7 +2616,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[19]).toEqual({
+            expect(metrics[18]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2731,7 +2665,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[20]).toEqual({
+            expect(metrics[19]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -2855,8 +2789,11 @@ describe('createAggregator', () => {
       return new Promise<void>((resolve) => {
         taskRunAggregator
           .pipe(
-            take(taskRunEvents1.length + taskRunEvents2.length + 1),
-            bufferCount(taskRunEvents1.length + taskRunEvents2.length + 1)
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(taskRunEvents1.length + taskRunEvents2.length),
+            bufferCount(taskRunEvents1.length + taskRunEvents2.length)
           )
           .subscribe((metrics: Array<AggregatedStat<TaskRunMetric>>) => {
             expect(metrics[0]).toEqual({
@@ -3259,55 +3196,6 @@ describe('createAggregator', () => {
                   success: 0,
                   not_timed_out: 0,
                   total: 0,
-                  delay: { counts: [], values: [] },
-                  delay_values: [],
-                  framework_errors: 0,
-                  user_errors: 0,
-                  total_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                    total_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[11]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 0,
-                  not_timed_out: 0,
-                  total: 0,
                   delay: { counts: [1], values: [10] },
                   delay_values: [5],
                   framework_errors: 0,
@@ -3350,7 +3238,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[12]).toEqual({
+            expect(metrics[11]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3399,7 +3287,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[13]).toEqual({
+            expect(metrics[12]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3448,7 +3336,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[14]).toEqual({
+            expect(metrics[13]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3497,7 +3385,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[15]).toEqual({
+            expect(metrics[14]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3546,7 +3434,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[16]).toEqual({
+            expect(metrics[15]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3595,7 +3483,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[17]).toEqual({
+            expect(metrics[16]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3644,7 +3532,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[18]).toEqual({
+            expect(metrics[17]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3693,7 +3581,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[19]).toEqual({
+            expect(metrics[18]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3742,7 +3630,7 @@ describe('createAggregator', () => {
                 },
               },
             });
-            expect(metrics[20]).toEqual({
+            expect(metrics[19]).toEqual({
               key: 'task_run',
               value: {
                 overall: {
@@ -3883,7 +3771,13 @@ describe('createAggregator', () => {
 
       return new Promise<void>((resolve) => {
         taskOverdueAggregator
-          .pipe(take(events.length), bufferCount(events.length))
+          .pipe(
+            // skip initial metric which is just initialized data which
+            // ensures we don't stall on combineLatest
+            skip(1),
+            take(events.length),
+            bufferCount(events.length)
+          )
           .subscribe((metrics: Array<AggregatedStat<TaskOverdueMetric>>) => {
             expect(metrics[0]).toEqual({
               key: 'task_overdue',
@@ -4039,9 +3933,17 @@ describe('createAggregator', () => {
     });
 
     return new Promise<void>((resolve) => {
-      aggregator.pipe(take(events.length), bufferCount(events.length)).subscribe(() => {
-        resolve();
-      });
+      aggregator
+        .pipe(
+          // skip initial metric which is just initialized data which
+          // ensures we don't stall on combineLatest
+          skip(1),
+          take(events.length),
+          bufferCount(events.length)
+        )
+        .subscribe(() => {
+          resolve();
+        });
 
       for (const event of events) {
         events$.next(event);
@@ -4082,9 +3984,17 @@ describe('createAggregator', () => {
     });
 
     return new Promise<void>((resolve) => {
-      aggregator.pipe(take(events.length), bufferCount(events.length)).subscribe(() => {
-        resolve();
-      });
+      aggregator
+        .pipe(
+          // skip initial metric which is just initialized data which
+          // ensures we don't stall on combineLatest
+          skip(1),
+          take(events.length),
+          bufferCount(events.length)
+        )
+        .subscribe(() => {
+          resolve();
+        });
 
       for (const event of events) {
         events$.next(event);
@@ -4130,9 +4040,17 @@ describe('createAggregator', () => {
     });
 
     return new Promise<void>((resolve) => {
-      aggregator.pipe(take(events.length + 1), bufferCount(events.length + 1)).subscribe(() => {
-        resolve();
-      });
+      aggregator
+        .pipe(
+          // skip initial metric which is just initialized data which
+          // ensures we don't stall on combineLatest
+          skip(1),
+          take(events.length),
+          bufferCount(events.length)
+        )
+        .subscribe(() => {
+          resolve();
+        });
 
       for (const event of events) {
         events$.next(event);

--- a/x-pack/plugins/task_manager/server/metrics/create_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/create_aggregator.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { filter, interval, map, merge, Observable } from 'rxjs';
+import { combineLatest, filter, interval, map, merge, Observable, startWith } from 'rxjs';
 import { JsonValue } from '@kbn/utility-types';
 import { Logger } from '@kbn/core/server';
 import { AggregatedStat, AggregatedStatProvider } from '../lib/runtime_statistics_aggregator';
@@ -32,12 +32,11 @@ export function createAggregator<T extends JsonValue>({
   eventFilter,
   metricsAggregator,
 }: CreateMetricsAggregatorOpts<T>): AggregatedStatProvider<T> {
-  let taskResetEvent$: Observable<T> | undefined;
   if (reset$) {
     let lastResetTime: Date = new Date();
     // Resets the aggregators either when the reset interval has passed or
     // a reset$ event is received
-    taskResetEvent$ = merge(
+    merge(
       interval(config.metrics_reset_interval).pipe(
         map(() => {
           if (intervalHasPassedSince(lastResetTime, config.metrics_reset_interval)) {
@@ -63,13 +62,11 @@ export function createAggregator<T extends JsonValue>({
           return true;
         })
       )
-    ).pipe(
-      filter((shouldReset: boolean) => shouldReset),
-      map(() => {
+    ).subscribe((shouldReset: boolean) => {
+      if (shouldReset) {
         metricsAggregator.reset();
-        return metricsAggregator.collect();
-      })
-    );
+      }
+    });
   }
 
   const taskEvents$: Observable<T> = events$.pipe(
@@ -80,13 +77,8 @@ export function createAggregator<T extends JsonValue>({
     })
   );
 
-  const observablesToMerge: Array<Observable<T>> = [taskEvents$];
-  if (taskResetEvent$) {
-    observablesToMerge.push(taskResetEvent$);
-  }
-
-  return merge(...observablesToMerge).pipe(
-    map((value: T) => {
+  return combineLatest([taskEvents$.pipe(startWith(metricsAggregator.initialMetric()))]).pipe(
+    map(([value]: [T]) => {
       return {
         key,
         value,

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/metrics_route.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/metrics_route.ts
@@ -133,8 +133,8 @@ export default function ({ getService }: FtrProviderContext) {
           expect(metrics?.task_claim).not.to.be(null);
           expect(metrics?.task_claim?.value).not.to.be(null);
 
-          expect(metrics?.task_claim?.value.success).to.equal(0);
-          expect(metrics?.task_claim?.value.total).to.equal(0);
+          expect(metrics?.task_claim?.value.success).to.equal(1);
+          expect(metrics?.task_claim?.value.total).to.equal(1);
 
           previousTaskClaimTimestamp = metrics?.task_claim?.timestamp!;
 
@@ -264,10 +264,7 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
 
         const metrics = (
-          await getMetrics(
-            false,
-            (m) => m?.metrics?.task_run?.value.overall.framework_errors! === 1
-          )
+          await getMetrics(true, (m) => m?.metrics?.task_run?.value.overall.framework_errors! === 1)
         ).metrics;
 
         const total = metrics?.task_run?.value.overall.total || 0;
@@ -305,13 +302,13 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
 
         const metrics = (
-          await getMetrics(false, (m) => m?.metrics?.task_run?.value.overall.user_errors! === 1)
+          await getMetrics(true, (m) => m?.metrics?.task_run?.value.overall.user_errors! === 1)
         ).metrics;
 
         const total = metrics?.task_run?.value.overall.total || 0;
         const success = metrics?.task_run?.value.overall.success || 0;
 
-        expect(total - success).to.be(2);
+        expect(total - success).to.be(1);
       });
     });
 


### PR DESCRIPTION
…e reset (#184592)"

This reverts commit 557633456ce89757b2c472bdcd0ccf2bfa601ce7.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
