### PR TITLE
Update the docs to clarify the ID of the private location created

### DIFF
--- a/docs/api/synthetics/private-locations/create-private-location.asciidoc
+++ b/docs/api/synthetics/private-locations/create-private-location.asciidoc
@@ -61,7 +61,7 @@ The API returns the created private location as follows:
 [source,json]
 --------------------------------------------------
 {
-  "id": "unique-location-id",
+  "id": "abcd1234",
   "label": "Private Location 1",
   "agentPolicyId": "abcd1234",
   "tags": ["private", "testing"],


### PR DESCRIPTION
Update the docs to clarify that the `id` of the Private Location created via the API will be the same `id` as the agent policy

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->