### PR TITLE
[Security Solution] Toggle new sourcerer implementation with local storage switch

### DIFF
--- a/x-pack/plugins/security_solution/public/sourcerer/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/sourcerer/containers/index.tsx
@@ -15,6 +15,7 @@ import { getDataViewStateFromIndexFields } from '../../common/containers/source/
 import { useFetchIndex } from '../../common/containers/source';
 import type { State } from '../../common/store/types';
 import { sortWithExcludesAtEnd } from '../../../common/utils/sourcerer';
+import { useUnstableSecuritySolutionDataView } from '../experimental/use_unstable_security_solution_data_view';
 
 export const useSourcererDataView = (
   scopeId: SourcererScopeName = SourcererScopeName.default
@@ -114,7 +115,7 @@ export const useSourcererDataView = (
     return dataViewBrowserFields;
   }, [sourcererDataView.fields, sourcererDataView.patternList]);
 
-  return useMemo(
+  const stableSourcererValues = useMemo(
     () => ({
       browserFields: browserFields(),
       dataViewId: sourcererDataView.id,
@@ -142,5 +143,11 @@ export const useSourcererDataView = (
       loading,
       legacyPatterns.length,
     ]
+  );
+
+  return useUnstableSecuritySolutionDataView(
+    scopeId,
+    // NOTE: data view derived from current implementation is used as a fallback
+    stableSourcererValues
   );
 };

--- a/x-pack/plugins/security_solution/public/sourcerer/experimental/is_enabled.ts
+++ b/x-pack/plugins/security_solution/public/sourcerer/experimental/is_enabled.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Allows toggling between sourcerer implementations in runtime. Simply set the value in local storage
+ * to:
+ * - display the experimental component instead of the stable one
+ * - use experimental data views hook instead of the stable one
+ */
+export const IS_EXPERIMENTAL_SOURCERER_ENABLED = !!window.localStorage.getItem(
+  'EXPERIMENTAL_SOURCERER_ENABLED'
+);

--- a/x-pack/plugins/security_solution/public/sourcerer/experimental/readme.md
+++ b/x-pack/plugins/security_solution/public/sourcerer/experimental/readme.md
@@ -1,0 +1,18 @@
+# Experimental Sourcerer Replacement
+
+## Introduction
+
+This directory is a home for Discovery Components based re-implementation of the Sourcerer.
+
+Currently, it can be enabled and used only by setting the localStorage value, like this:
+
+```
+window.localStorage.setItem('EXPERIMENTAL_SOURCERER_ENABLED', true)
+```
+
+The reason for having this feature toggle like this is we want to be able to inspect both implementations side by side,
+using the same Kibana instance deployed locally (for now).
+
+## Architecture
+
+TODO

--- a/x-pack/plugins/security_solution/public/sourcerer/experimental/use_unstable_security_solution_data_view.ts
+++ b/x-pack/plugins/security_solution/public/sourcerer/experimental/use_unstable_security_solution_data_view.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type SourcererScopeName, type SelectedDataView } from '../store/model';
+
+import { IS_EXPERIMENTAL_SOURCERER_ENABLED } from './is_enabled';
+
+/**
+ * FOR INTERNAL USE ONLY
+ * This hook provides data for experimental Sourcerer replacement in Security Solution.
+ * Do not use in client code as the API will change frequently.
+ * It will be extended in the future, covering more and more functionality from the current sourcerer.
+ */
+export const useUnstableSecuritySolutionDataView = (
+  _scopeId: SourcererScopeName,
+  fallbackDataView: SelectedDataView
+): SelectedDataView => {
+  // TODO: extend the fallback state with values computed using new logic
+  return IS_EXPERIMENTAL_SOURCERER_ENABLED ? fallbackDataView : fallbackDataView;
+};


### PR DESCRIPTION
## Summary

Add `localStorage` based mechanism to toggle between the future experiemental sourcerer implementation and the stable one in **runtime**.

Also moved the hook for pulling in the data from the sourcerer to appropriately named file.