### PR TITLE
[security-in-core] flag APIs as deprecated

### DIFF
--- a/x-pack/packages/security/plugin_types_public/src/plugin.ts
+++ b/x-pack/packages/security/plugin_types_public/src/plugin.ts
@@ -14,6 +14,8 @@ import type { UserProfileAPIClient } from './user_profile';
 export interface SecurityPluginSetup {
   /**
    * Exposes authentication information about the currently logged in user.
+   *
+   * @deprecated in favor of Core's `security` service
    */
   authc: AuthenticationServiceSetup;
   /**
@@ -33,6 +35,8 @@ export interface SecurityPluginStart {
   navControlService: SecurityNavControlServiceStart;
   /**
    * Exposes authentication information about the currently logged in user.
+   *
+   * @deprecated in favor of Core's `security` service
    */
   authc: AuthenticationServiceStart;
   /**
@@ -41,6 +45,8 @@ export interface SecurityPluginStart {
   authz: AuthorizationServiceStart;
   /**
    * A set of methods to work with Kibana user profiles.
+   *
+   * @deprecated in favor of Core's `userProfile` service.
    */
   userProfiles: UserProfileAPIClient;
 }

--- a/x-pack/packages/security/plugin_types_server/src/plugin.ts
+++ b/x-pack/packages/security/plugin_types_server/src/plugin.ts
@@ -21,6 +21,8 @@ export interface SecurityPluginSetup {
   license: SecurityLicense;
   /**
    * Exposes services for audit logging.
+   *
+   * @deprecated in favor of Core's `security` service
    */
   audit: AuditServiceSetup;
   /**
@@ -35,6 +37,8 @@ export interface SecurityPluginSetup {
 export interface SecurityPluginStart {
   /**
    * Authentication services to confirm the user is who they say they are.
+   *
+   * @deprecated in favor of Core's `security` service
    */
   authc: AuthenticationServiceStart;
   /**
@@ -43,6 +47,8 @@ export interface SecurityPluginStart {
   authz: AuthorizationServiceSetup;
   /**
    * User profiles services to retrieve user profiles.
+   *
+   * @deprecated in favor of Core's `userProfile` service
    */
   userProfiles: UserProfileServiceStart;
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/174578

Flag as deprecated the APIs from the security plugin that are now re-exposed from Core