### PR TITLE
[IUI] Add unprivilieged agent install instruction

### DIFF
--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/install_section.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/install_section.tsx
@@ -15,6 +15,7 @@ import type { K8sMode, CloudSecurityIntegration } from '../agent_enrollment_flyo
 import { PlatformSelector } from '../platform_selector';
 
 import { RootPrivilegesCallout } from './root_privileges_callout';
+import { UnprivilegedInfo } from './unprivileged_info';
 
 interface Props {
   installCommand: CommandsByPlatform;
@@ -43,6 +44,7 @@ export const InstallSection: React.FunctionComponent<Props> = ({
     <>
       <InstallationMessage isK8s={isK8s} isManaged={isManaged} />
       <RootPrivilegesCallout rootIntegrations={rootIntegrations} />
+      <UnprivilegedInfo />
       <PlatformSelector
         fullCopyButton={fullCopyButton}
         onCopy={onCopy}

--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/unprivileged_info.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/unprivileged_info.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCode, EuiSpacer, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const UnprivilegedInfo: React.FC = () => {
+  return (
+    <>
+      <EuiText>
+        <p>
+          <FormattedMessage
+            id="xpack.fleet.agentEnrollmentFlyout.unprivilegedMessage"
+            defaultMessage="To install Elastic Agent without root privileges, add the {flag} flag to the {command} install command below."
+            values={{
+              flag: <EuiCode>--unprivileged</EuiCode>,
+              command: <EuiCode>sudo ./elastic-agent</EuiCode>,
+            }}
+          />
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/3356

This PR adds a sentence to the `Add agent` flyout to instruct how to install an unprivileged Elastic Agent.

<img width="957" alt="Screenshot 2024-06-05 at 16 53 13" src="https://github.com/elastic/kibana/assets/23701614/48475ec8-f392-4128-971e-ef2d1e40eb8b">
