### PR TITLE
[Spaces] Support for query params in next route when entering space

### DIFF
--- a/x-pack/plugins/spaces/server/routes/views/index.test.ts
+++ b/x-pack/plugins/spaces/server/routes/views/index.test.ts
@@ -198,6 +198,13 @@ describe('Enter Space view routes', () => {
         },
         expectedLocation: '/mock-server-basepath/app/management/kibana/home',
       },
+      {
+        query: {
+          next: '/app/management/kibana/objects?initialQuery=type:(visualization)',
+        },
+        expectedLocation:
+          '/mock-server-basepath/app/management/kibana/objects?initialQuery=type:(visualization)',
+      },
     ]) {
       const request = httpServerMock.createKibanaRequest({
         query,

--- a/x-pack/plugins/spaces/server/routes/views/index.ts
+++ b/x-pack/plugins/spaces/server/routes/views/index.ts
@@ -42,11 +42,11 @@ export function initSpacesViewsRoutes(deps: ViewRouteDeps) {
 
         const route = nextCandidateRoute === '/' ? defaultRoute : nextCandidateRoute;
         // need to get reed of ../../ to make sure we will not be out of space basePath
-        const normalizedRoute = new URL(route, 'https://localhost').pathname;
+        const normalizedRoute = new URL(route, 'https://localhost');
 
         return response.redirected({
           headers: {
-            location: `${basePath}${normalizedRoute}`,
+            location: `${basePath}${normalizedRoute.pathname}${normalizedRoute.search}`,
           },
         });
       } catch (e) {


### PR DESCRIPTION
## Summary

Added support for query params in next route when entering space.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

__Fixes: https://github.com/elastic/kibana/issues/184857__
