### PR TITLE
[Data grid] Allow consumer to set initial columns

### DIFF
--- a/src/plugins/esql_datagrid/public/create_datagrid.tsx
+++ b/src/plugins/esql_datagrid/public/create_datagrid.tsx
@@ -24,6 +24,7 @@ interface ESQLDataGridProps {
   query: AggregateQuery;
   flyoutType?: 'overlay' | 'push';
   isTableView?: boolean;
+  initialColumns?: DatatableColumn[];
 }
 
 const DataGridLazy = withSuspense(lazy(() => import('./data_grid')));

--- a/src/plugins/esql_datagrid/public/data_grid.tsx
+++ b/src/plugins/esql_datagrid/public/data_grid.tsx
@@ -30,6 +30,7 @@ interface ESQLDataGridProps {
   query: AggregateQuery;
   flyoutType?: 'overlay' | 'push';
   isTableView?: boolean;
+  initialColumns?: DatatableColumn[];
 }
 type DataTableColumnsMeta = Record<
   string,
@@ -44,7 +45,7 @@ const sortOrder: SortOrder[] = [];
 const DataGrid: React.FC<ESQLDataGridProps> = (props) => {
   const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>(undefined);
   const [activeColumns, setActiveColumns] = useState<string[]>(
-    props.isTableView ? props.columns.map((c) => c.name) : []
+    (props.initialColumns || (props.isTableView ? props.columns : [])).map((c) => c.name)
   );
   const [rowHeight, setRowHeight] = useState<number>(5);
 


### PR DESCRIPTION
Allow the consumer of `ESQLDataGrid` to set the initial columns to be displayed.