### PR TITLE
[EuiCheckbox] Remove `inList` type checkboxes

### DIFF
--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/index_table/index_table.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/index_table/index_table.js
@@ -429,7 +429,6 @@ export class IndexTable extends Component {
         >
           <EuiTableRowCellCheckbox key={`checkbox-${name}`}>
             <EuiCheckbox
-              type="inList"
               id={`checkboxSelectIndex-${name}`}
               checked={this.isItemSelected(name)}
               onChange={() => {
@@ -696,7 +695,6 @@ export class IndexTable extends Component {
                         id="selectAllIndexes"
                         checked={this.areAllItemsSelected()}
                         onChange={this.toggleAll}
-                        type="inList"
                         aria-label={i18n.translate(
                           'xpack.idxMgmt.indexTable.selectAllIndicesAriaLabel',
                           {

--- a/x-pack/plugins/ml/public/application/components/custom_selection_table/custom_selection_table.js
+++ b/x-pack/plugins/ml/public/application/components/custom_selection_table/custom_selection_table.js
@@ -197,7 +197,6 @@ export function CustomSelectionTable({
         label={mobile ? selectAll : null}
         checked={areAllItemsSelected()}
         onChange={toggleAll}
-        type={mobile ? null : 'inList'}
       />
     );
   }
@@ -283,7 +282,6 @@ export function CustomSelectionTable({
                   data-test-subj={`${item[tableItemId]}-checkbox`}
                   checked={isItemSelected(item[tableItemId])}
                   onChange={() => toggleItem(item[tableItemId])}
-                  type="inList"
                 />
               )}
               {singleSelection && (

--- a/x-pack/plugins/rollup/public/crud_app/sections/job_list/job_table/job_table.js
+++ b/x-pack/plugins/rollup/public/crud_app/sections/job_list/job_table/job_table.js
@@ -305,7 +305,6 @@ export class JobTable extends Component {
         <EuiTableRow key={`${id}-row`} data-test-subj="jobTableRow">
           <EuiTableRowCellCheckbox key={`checkbox-${id}`}>
             <EuiCheckbox
-              type="inList"
               id={`checkboxSelectIndex-${id}`}
               checked={this.isItemSelected(id)}
               onChange={() => {
@@ -393,7 +392,6 @@ export class JobTable extends Component {
                   id="selectAllJobsCheckbox"
                   checked={this.areAllItemsSelected()}
                   onChange={this.toggleAll}
-                  type="inList"
                   aria-label={i18n.translate('xpack.rollupJobs.jobTable.selectAllRows', {
                     defaultMessage: 'Select all rows',
                   })}


### PR DESCRIPTION
## Summary

The `type="inList"` prop is about to be deprecated shortly by EUI (https://github.com/elastic/eui/pull/7814), so this is being removed ahead of time. The same style already gets applied when no `label` prop is passed, so no visual regressions should occur (hence the removal of an unnecessary prop).

That being said, we would appreciate a quick smoke check of the affected tables by CODEOWNERs to ensure your selection checkboxes look the same as before/unbroken. Thank you!