### PR TITLE
[Roles] Reordered sections in role management page

### DIFF
--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/elasticsearch_privileges.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/elasticsearch_privileges.tsx
@@ -120,8 +120,8 @@ export class ElasticsearchPrivileges extends Component<Props, {}> {
             <EuiText size="s" color="subdued">
               <p>
                 <FormattedMessage
-                  id="xpack.security.management.editRole.elasticSearchPrivileges.controlAccessToRemoteClusterDataDescription"
-                  defaultMessage="Control access to the data in remote clusters. "
+                  id="xpack.security.management.editRole.elasticSearchPrivileges.controlAccessToRemoteClusterActionsDescription"
+                  defaultMessage="Manage the actions this role can perform against your remote cluster. "
                 />
                 {this.learnMore(docLinks.links.security.clusterPrivileges)}
               </p>

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/elasticsearch_privileges.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/elasticsearch_privileges.tsx
@@ -106,6 +106,39 @@ export class ElasticsearchPrivileges extends Component<Props, {}> {
           </EuiFormRow>
         </EuiDescribedFormGroup>
         <EuiSpacer />
+        {buildFlavor === 'traditional' && canUseRemoteClusters && (
+          <>
+            <EuiTitle size="xs">
+              <h3>
+                <FormattedMessage
+                  id="xpack.security.management.editRole.elasticSearchPrivileges.remoteClusterPrivilegesTitle"
+                  defaultMessage="Remote cluster privileges"
+                />
+              </h3>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            <EuiText size="s" color="subdued">
+              <p>
+                <FormattedMessage
+                  id="xpack.security.management.editRole.elasticSearchPrivileges.controlAccessToRemoteClusterDataDescription"
+                  defaultMessage="Control access to the data in remote clusters. "
+                />
+                {this.learnMore(docLinks.links.security.clusterPrivileges)}
+              </p>
+            </EuiText>
+            <RemoteClusterPrivileges
+              remoteClusters={remoteClusters}
+              role={role}
+              validator={validator}
+              license={license}
+              onChange={onChange}
+              availableRemoteClusterPrivileges={builtinESPrivileges.remote_cluster ?? []}
+              editable={editable}
+            />
+            <EuiSpacer />
+            <EuiSpacer />
+          </>
+        )}
 
         {buildFlavor === 'traditional' && (
           <>
@@ -219,40 +252,6 @@ export class ElasticsearchPrivileges extends Component<Props, {}> {
               availableIndexPrivileges={builtinESPrivileges.index}
               editable={editable}
               isDarkMode={this.props.isDarkMode}
-            />
-          </>
-        )}
-        {buildFlavor === 'traditional' && canUseRemoteClusters && (
-          <>
-            <EuiSpacer />
-            <EuiSpacer />
-
-            <EuiTitle size="xs">
-              <h3>
-                <FormattedMessage
-                  id="xpack.security.management.editRole.elasticSearchPrivileges.remoteClusterPrivilegesTitle"
-                  defaultMessage="Remote cluster privileges"
-                />
-              </h3>
-            </EuiTitle>
-            <EuiSpacer size="s" />
-            <EuiText size="s" color="subdued">
-              <p>
-                <FormattedMessage
-                  id="xpack.security.management.editRole.elasticSearchPrivileges.controlAccessToRemoteClusterDataDescription"
-                  defaultMessage="Control access to the data in remote clusters. "
-                />
-                {this.learnMore(docLinks.links.security.clusterPrivileges)}
-              </p>
-            </EuiText>
-            <RemoteClusterPrivileges
-              remoteClusters={remoteClusters}
-              role={role}
-              validator={validator}
-              license={license}
-              onChange={onChange}
-              availableRemoteClusterPrivileges={builtinESPrivileges.remote_cluster ?? []}
-              editable={editable}
             />
           </>
         )}


### PR DESCRIPTION
## Summary

Reordered sections in role management page. [As agreed](https://github.com/elastic/kibana/issues/182984#issuecomment-2149886052) the order is the following:

- Cluster
- Remote Cluster
- Run As
- Index
- Remote Index

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

__Fixes: https://github.com/elastic/kibana/issues/182984__


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->