### PR TITLE
[Security Solution][Alert details] - fix timeline osquery flyout shown behind

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/osquery/osquery_flyout.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/osquery/osquery_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import {
   EuiFlyout,
@@ -13,6 +13,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiTitle,
+  useEuiTheme,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -46,6 +47,14 @@ const OsqueryFlyoutComponent: React.FC<OsqueryFlyoutProps> = ({
   onClose,
   ecsData,
 }) => {
+  const { euiTheme } = useEuiTheme();
+
+  // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
+  const maskProps = useMemo(
+    () => ({ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }),
+    [euiTheme.levels.flyout]
+  );
+
   const {
     services: { osquery },
   } = useKibana();
@@ -63,7 +72,13 @@ const OsqueryFlyoutComponent: React.FC<OsqueryFlyoutProps> = ({
 
   if (osquery?.OsqueryAction) {
     return (
-      <EuiFlyout size="m" onClose={onClose} aria-labelledby={osqueryFlyoutTitleId}>
+      <EuiFlyout
+        size="m"
+        onClose={onClose}
+        aria-labelledby={osqueryFlyoutTitleId}
+        // EUI TODO: This z-index override of EuiOverlayMask is a workaround, and ideally should be resolved with a cleaner UI/UX flow long-term
+        maskProps={maskProps}
+      >
         <EuiFlyoutHeader hasBorder data-test-subj="flyout-header-osquery">
           <EuiTitle>
             <h2 id={osqueryFlyoutTitleId}>{ACTION_OSQUERY}</h2>


### PR DESCRIPTION
## Summary

This PR addresses an issue where the flyout for the unified data table used in the ES|QL tab of Timeline is shown behind timeline. This was most likely introduced when we merged [this PR](https://github.com/elastic/kibana/pull/177087) that introduced the expandable flyout to timeline, where we had to modify the `z-index`of timeline from `1000` to `1001`. Therefore all flyouts opened from timeline should have their `z-index` set to higher or equal to `1002`.

This fix's solution follows previous implementations:
- https://github.com/elastic/kibana/pull/182296
- https://github.com/elastic/kibana/pull/182031
- https://github.com/elastic/kibana/pull/180077

Before fix (flyout is open but hidden behind timeline modal)
![Screenshot 2024-06-06 at 11 15 46 AM](https://github.com/elastic/kibana/assets/17276605/099a180c-0be7-45e3-8a0f-7f6f1d023109)

After fix
![Screenshot 2024-06-06 at 11 16 59 AM](https://github.com/elastic/kibana/assets/17276605/a73f9676-449b-4a01-abe4-171554eb3589)

https://github.com/elastic/kibana/issues/184704

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->