### PR TITLE
[8.14] [Response Ops][Task Manager] TM status affected by capacity estimation which is based on a best estimate of number of Kibana instances (#179982)

### DIFF
--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
@@ -12,7 +12,7 @@ import { mockLogger } from '../test_utils';
 describe('estimateCapacity', () => {
   const logger = mockLogger();
 
-  beforeAll(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
   });
 
@@ -568,6 +568,9 @@ describe('estimateCapacity', () => {
       timestamp: expect.any(String),
       value: expect.any(Object),
     });
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Task Manager is healthy, the assumedRequiredThroughputPerMinutePerKibana (190) < capacityPerMinutePerKibana (200)'
+    );
   });
 
   test('marks estimated capacity as Warning state when capacity is insufficient for recent spikes of non-recurring workload, but sufficient for the recurring workload', async () => {
@@ -626,10 +629,13 @@ describe('estimateCapacity', () => {
         )
       )
     ).toMatchObject({
-      status: 'warn',
+      status: 'OK',
       timestamp: expect.any(String),
       value: expect.any(Object),
     });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Task Manager is unhealthy, the assumedAverageRecurringRequiredThroughputPerMinutePerKibana (175) < capacityPerMinutePerKibana (200)'
+    );
   });
 
   test('marks estimated capacity as Error state when workload and load suggest capacity is insufficient', async () => {
@@ -688,10 +694,13 @@ describe('estimateCapacity', () => {
         )
       )
     ).toMatchObject({
-      status: 'error',
+      status: 'OK',
       timestamp: expect.any(String),
       value: expect.any(Object),
     });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Task Manager is unhealthy, the assumedRequiredThroughputPerMinutePerKibana (250) >= capacityPerMinutePerKibana (200) AND assumedAverageRecurringRequiredThroughputPerMinutePerKibana (210) >= capacityPerMinutePerKibana (200)'
+    );
   });
 
   test('recommmends a 20% increase in kibana when a spike in non-recurring tasks forces recurring task capacity to zero', async () => {
@@ -749,7 +758,7 @@ describe('estimateCapacity', () => {
         )
       )
     ).toMatchObject({
-      status: 'warn',
+      status: 'OK',
       timestamp: expect.any(String),
       value: {
         observed: {
@@ -825,7 +834,7 @@ describe('estimateCapacity', () => {
         )
       )
     ).toMatchObject({
-      status: 'error',
+      status: 'OK',
       timestamp: expect.any(String),
       value: {
         observed: {

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
@@ -242,18 +242,20 @@ function getHealthStatus(
     capacityPerMinutePerKibana,
   } = params;
   if (assumedRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana) {
-    return { status: HealthStatus.OK };
+    const reason = `Task Manager is healthy, the assumedRequiredThroughputPerMinutePerKibana (${assumedRequiredThroughputPerMinutePerKibana}) < capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
+    logger.debug(reason);
+    return { status: HealthStatus.OK, reason };
   }
 
   if (assumedAverageRecurringRequiredThroughputPerMinutePerKibana < capacityPerMinutePerKibana) {
-    const reason = `setting HealthStatus.Warning because assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) < capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
-    logger.debug(reason);
-    return { status: HealthStatus.Warning, reason };
+    const reason = `Task Manager is unhealthy, the assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) < capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
+    logger.warn(reason);
+    return { status: HealthStatus.OK, reason };
   }
 
-  const reason = `setting HealthStatus.Error because assumedRequiredThroughputPerMinutePerKibana (${assumedRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana}) AND assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
-  logger.debug(reason);
-  return { status: HealthStatus.Error, reason };
+  const reason = `Task Manager is unhealthy, the assumedRequiredThroughputPerMinutePerKibana (${assumedRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana}) AND assumedAverageRecurringRequiredThroughputPerMinutePerKibana (${assumedAverageRecurringRequiredThroughputPerMinutePerKibana}) >= capacityPerMinutePerKibana (${capacityPerMinutePerKibana})`;
+  logger.warn(reason);
+  return { status: HealthStatus.OK, reason };
 }
 
 export function withCapacityEstimate(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Response Ops][Task Manager] TM status affected by capacity estimation which is based on a best estimate of number of Kibana instances (#179982)](https://github.com/elastic/kibana/pull/179982)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-18T17:48:46Z","message":"[Response Ops][Task Manager] TM status affected by capacity estimation which is based on a best estimate of number of Kibana instances (#179982)\n\nResolves https://github.com/elastic/kibana/issues/176152\r\n\r\n## Summary\r\n\r\nThis PR sets task manager status to `OK` if the required throughput is\r\ngreater than the capacity, but logs a warning to help indicate that Task\r\nManager can not keep up with the workload.\r\nWe decided to do this bc the `assumedKibanaInstances` metric is a best\r\nestimate that could potentially set the task manager status to degraded\r\n.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d61b53fea522c648f4e023e643b52cf6ae6e930d","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","Team:obs-ux-infra_services","v8.15.0"],"number":179982,"url":"https://github.com/elastic/kibana/pull/179982","mergeCommit":{"message":"[Response Ops][Task Manager] TM status affected by capacity estimation which is based on a best estimate of number of Kibana instances (#179982)\n\nResolves https://github.com/elastic/kibana/issues/176152\r\n\r\n## Summary\r\n\r\nThis PR sets task manager status to `OK` if the required throughput is\r\ngreater than the capacity, but logs a warning to help indicate that Task\r\nManager can not keep up with the workload.\r\nWe decided to do this bc the `assumedKibanaInstances` metric is a best\r\nestimate that could potentially set the task manager status to degraded\r\n.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d61b53fea522c648f4e023e643b52cf6ae6e930d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179982","number":179982,"mergeCommit":{"message":"[Response Ops][Task Manager] TM status affected by capacity estimation which is based on a best estimate of number of Kibana instances (#179982)\n\nResolves https://github.com/elastic/kibana/issues/176152\r\n\r\n## Summary\r\n\r\nThis PR sets task manager status to `OK` if the required throughput is\r\ngreater than the capacity, but logs a warning to help indicate that Task\r\nManager can not keep up with the workload.\r\nWe decided to do this bc the `assumedKibanaInstances` metric is a best\r\nestimate that could potentially set the task manager status to degraded\r\n.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d61b53fea522c648f4e023e643b52cf6ae6e930d"}}]}] BACKPORT-->