### PR TITLE
[8.14] [ResponseOps] Fix for flaky task state validation jest integration test (#181206)

### DIFF
--- a/x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts
@@ -326,9 +326,11 @@ describe('task state validation', () => {
       taskIdsToRemove.push(id);
 
       await retry(async () => {
-        expect(logSpy.mock.calls[0][0]).toBe(
-          `Task (fooType/${id}) has a validation error: [foo]: expected value of type [string] but got [boolean]`
-        );
+        const calls = logSpy.mock.calls as string[][];
+        const expected =
+          /^Task \(fooType\/.*\) has a validation error: \[foo\]: expected value of type \[string\] but got \[boolean\]/;
+        const found = calls.map((arr) => arr[0]).find((message) => message.match(expected) != null);
+        expect(found).toMatch(expected);
         expect(updateSpy).toHaveBeenCalledWith(
           expect.arrayContaining([expect.objectContaining({ id, taskType: 'fooType' })]),
           { validate: false }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/164032

# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ResponseOps] Fix for flaky task state validation jest integration test (#181206)](https://github.com/elastic/kibana/pull/181206)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-04-18T22:40:59Z","message":"[ResponseOps] Fix for flaky task state validation jest integration test (#181206)\n\nResolves https://github.com/elastic/kibana/issues/164032#\r\n\r\n## Summary\r\n\r\nThis PR unskips a flaky test caused by a race condition with a TM health\r\nstatus log. We use a regex to find the log we care about instead of just\r\ncomparing the first log to the expected message.\r\n\r\n\r\n### To verify\r\n\r\n- Run the following command to run the test, and verify that it passes\r\n```\r\nnode scripts/jest_integration.js x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts\r\n```","sha":"8f23f23f4d3263d2879df70446010f15359f8ebe","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","v8.15.0"],"number":181206,"url":"https://github.com/elastic/kibana/pull/181206","mergeCommit":{"message":"[ResponseOps] Fix for flaky task state validation jest integration test (#181206)\n\nResolves https://github.com/elastic/kibana/issues/164032#\r\n\r\n## Summary\r\n\r\nThis PR unskips a flaky test caused by a race condition with a TM health\r\nstatus log. We use a regex to find the log we care about instead of just\r\ncomparing the first log to the expected message.\r\n\r\n\r\n### To verify\r\n\r\n- Run the following command to run the test, and verify that it passes\r\n```\r\nnode scripts/jest_integration.js x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts\r\n```","sha":"8f23f23f4d3263d2879df70446010f15359f8ebe"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181206","number":181206,"mergeCommit":{"message":"[ResponseOps] Fix for flaky task state validation jest integration test (#181206)\n\nResolves https://github.com/elastic/kibana/issues/164032#\r\n\r\n## Summary\r\n\r\nThis PR unskips a flaky test caused by a race condition with a TM health\r\nstatus log. We use a regex to find the log we care about instead of just\r\ncomparing the first log to the expected message.\r\n\r\n\r\n### To verify\r\n\r\n- Run the following command to run the test, and verify that it passes\r\n```\r\nnode scripts/jest_integration.js x-pack/plugins/task_manager/server/integration_tests/task_state_validation.test.ts\r\n```","sha":"8f23f23f4d3263d2879df70446010f15359f8ebe"}}]}] BACKPORT-->