### PR TITLE
[EDR Workflows][MKI test] Skip Policy Details cy test on MKI due to feature flags

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/policy/policy_details.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/policy/policy_details.cy.ts
@@ -19,7 +19,12 @@ import { loadPage } from '../../tasks/common';
 describe(
   'Policy Details',
   {
-    tags: ['@ess', '@serverless'],
+    tags: [
+      '@ess',
+      '@serverless',
+      // skipped on MKI since feature flags are not supported there
+      '@skipInServerlessMKI',
+    ],
     env: {
       ftrConfig: {
         kbnServerArgs: [


### PR DESCRIPTION
## Summary

Skip Policy Details cy test on MKI due to feature flags are not supported.