### PR TITLE
[8.14] [Inventory/Metric/Custom threshold] Specify fields instead of '*' in fieldCaps request (#184968)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/common/utils.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/common/utils.ts
@@ -195,7 +195,7 @@ export const doFieldsExist = async (
   // Get all supported fields
   const respMapping = await esClient.fieldCaps({
     index,
-    fields: '*',
+    fields,
   });
 
   const fieldsExisted: Record<string, boolean> = {};

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/utils.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/utils.ts
@@ -130,7 +130,7 @@ export const doFieldsExist = async (
   // Get all supported fields
   const respMapping = await esClient.fieldCaps({
     index,
-    fields: '*',
+    fields,
   });
 
   const fieldsExisted: Record<string, boolean> = {};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Inventory/Metric/Custom threshold] Specify fields instead of '*' in fieldCaps request (#184968)](https://github.com/elastic/kibana/pull/184968)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-06-07T13:39:37Z","message":"[Inventory/Metric/Custom threshold] Specify fields instead of '*' in fieldCaps request (#184968)\n\nResolves https://github.com/elastic/kibana/issues/184909","sha":"00153fd70fbc927f9f8eb5920a0590c8e5116f18","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","Team:obs-ux-management","v8.15.0","v8.14.1"],"number":184968,"url":"https://github.com/elastic/kibana/pull/184968","mergeCommit":{"message":"[Inventory/Metric/Custom threshold] Specify fields instead of '*' in fieldCaps request (#184968)\n\nResolves https://github.com/elastic/kibana/issues/184909","sha":"00153fd70fbc927f9f8eb5920a0590c8e5116f18"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/184968","number":184968,"mergeCommit":{"message":"[Inventory/Metric/Custom threshold] Specify fields instead of '*' in fieldCaps request (#184968)\n\nResolves https://github.com/elastic/kibana/issues/184909","sha":"00153fd70fbc927f9f8eb5920a0590c8e5116f18"}},{"branch":"8.14","label":"v8.14.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->