### PR TITLE
[Security Solution] Fix Entity Analytics OpenAPI schemas

### DIFF
--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/create_asset_criticality.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/create_asset_criticality.schema.yaml
@@ -12,6 +12,8 @@ servers:
 paths:
   /internal/asset_criticality:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       operationId: AssetCriticalityCreateRecord
       summary: Create Criticality Record
       requestBody:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/delete_asset_criticality.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/delete_asset_criticality.schema.yaml
@@ -12,6 +12,8 @@ servers:
 paths:
   /internal/asset_criticality:
     delete:
+      x-labels: [ess, serverless]
+      x-internal: true
       operationId: AssetCriticalityDeleteRecord
       summary: Delete Criticality Record
       parameters:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/get_asset_criticality.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/get_asset_criticality.schema.yaml
@@ -12,6 +12,8 @@ servers:
 paths:
   /internal/asset_criticality:
     get:
+      x-labels: [ess, serverless]
+      x-internal: true
       operationId: AssetCriticalityGetRecord
       summary: Get Criticality Record
       parameters:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/get_asset_criticality_privileges.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/get_asset_criticality_privileges.schema.yaml
@@ -12,6 +12,8 @@ servers:
 paths:
   /internal/asset_criticality/privileges:
     get:
+      x-labels: [ess, serverless]
+      x-internal: true
       operationId: AssetCriticalityGetPrivileges
       summary: Get Asset Criticality Privileges
       responses:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/get_asset_criticality_status.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/get_asset_criticality_status.schema.yaml
@@ -12,6 +12,8 @@ servers:
 paths:
   /internal/asset_criticality/status:
     get:
+      x-labels: [ess, serverless]
+      x-internal: true
       operationId: AssetCriticalityGetStatus
       summary: Get Asset Criticality Status
       responses:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/upload_asset_criticality_csv.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/upload_asset_criticality_csv.schema.yaml
@@ -12,6 +12,8 @@ servers:
 paths:
   /internal/asset_criticality/upload_csv:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Uploads a CSV file containing asset criticality data
       requestBody:
         content:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/calculation_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/calculation_route.schema.yaml
@@ -16,6 +16,8 @@ servers:
 paths:
   /api/risk_scores/calculation:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Trigger calculation of Risk Scores
       description: Calculates and persists a segment of Risk Scores, returning details about the calculation.
       requestBody:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_disable_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_disable_route.schema.yaml
@@ -16,6 +16,8 @@ servers:
 paths:
   /internal/risk_score/engine/disable:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Disable the Risk Engine
       requestBody:
         content:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_enable_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_enable_route.schema.yaml
@@ -16,6 +16,8 @@ servers:
 paths:
   /internal/risk_score/engine/enable:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Enable the Risk Engine
       requestBody:
         content:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_init_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_init_route.schema.yaml
@@ -14,6 +14,8 @@ servers:
 paths:
   /internal/risk_score/engine/init:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Initialize the Risk Engine
       description: Initializes the Risk Engine by creating the necessary indices and mappings, removing old transforms, and starting the new risk engine
       responses:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_settings_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_settings_route.schema.yaml
@@ -12,7 +12,7 @@ servers:
         default: '5601'
 
 paths:
-  /engine/settings:
+  /internal/risk_score/engine/settings:
     get:
       x-labels: [ess, serverless]
       x-internal: true

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_settings_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_settings_route.schema.yaml
@@ -13,8 +13,9 @@ servers:
 
 paths:
   /engine/settings:
-    x-internal: true
     get:
+      x-labels: [ess, serverless]
+      x-internal: true
       operationId: RiskEngineSettingsGet
       summary: Get the settings of the Risk Engine
       responses:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_status_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_status_route.schema.yaml
@@ -12,7 +12,7 @@ servers:
         default: '5601'
 
 paths:
-  /engine/status:
+  /internal/risk_score/engine/status:
     get:
       x-labels: [ess, serverless]
       x-internal: true

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_status_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/engine_status_route.schema.yaml
@@ -14,6 +14,8 @@ servers:
 paths:
   /engine/status:
     get:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Get the status of the Risk Engine
       description: Returns the status of both the legacy transform-based risk engine, as well as the new risk engine
       responses:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/entity_calculation_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/entity_calculation_route.schema.yaml
@@ -15,8 +15,9 @@ servers:
 
 paths:
   /api/risk_scores/calculation/entity:
-    x-internal: true
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Trigger calculation of Risk Scores for an entity
       description: Calculates and persists Risk Scores for an entity, returning the calculated risk score.
       requestBody:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/preview_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/preview_route.schema.yaml
@@ -14,6 +14,8 @@ servers:
 paths:
   /internal/risk_score/preview:
     post:
+      x-labels: [ess, serverless]
+      x-internal: true
       summary: Preview the calculation of Risk Scores
       description: Calculates and returns a list of Risk Scores, sorted by identifier_type and risk score.
       requestBody:

--- a/x-pack/plugins/security_solution/common/entity_analytics/asset_criticality/constants.ts
+++ b/x-pack/plugins/security_solution/common/entity_analytics/asset_criticality/constants.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-export const ASSET_CRITICALITY_URL = `/internal/asset_criticality`;
-export const ASSET_CRITICALITY_PRIVILEGES_URL = `/internal/asset_criticality/privileges`;
-export const ASSET_CRITICALITY_STATUS_URL = `${ASSET_CRITICALITY_URL}/status`;
-export const ASSET_CRITICALITY_CSV_UPLOAD_URL = `${ASSET_CRITICALITY_URL}/upload_csv`;
+export const ASSET_CRITICALITY_URL = `/internal/asset_criticality` as const;
+export const ASSET_CRITICALITY_PRIVILEGES_URL = `${ASSET_CRITICALITY_URL}/privileges` as const;
+export const ASSET_CRITICALITY_STATUS_URL = `${ASSET_CRITICALITY_URL}/status` as const;
+export const ASSET_CRITICALITY_CSV_UPLOAD_URL = `${ASSET_CRITICALITY_URL}/upload_csv` as const;
 
 export const ASSET_CRITICALITY_INDEX_PATTERN = '.asset-criticality.asset-criticality-*';
 

--- a/x-pack/plugins/security_solution/common/entity_analytics/risk_engine/constants.ts
+++ b/x-pack/plugins/security_solution/common/entity_analytics/risk_engine/constants.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 import { INTERNAL_RISK_SCORE_URL } from '../risk_score/constants';
-export const RISK_ENGINE_URL = `${INTERNAL_RISK_SCORE_URL}/engine`;
-export const RISK_ENGINE_STATUS_URL = `${RISK_ENGINE_URL}/status`;
-export const RISK_ENGINE_INIT_URL = `${RISK_ENGINE_URL}/init`;
-export const RISK_ENGINE_ENABLE_URL = `${RISK_ENGINE_URL}/enable`;
-export const RISK_ENGINE_DISABLE_URL = `${RISK_ENGINE_URL}/disable`;
-export const RISK_ENGINE_PRIVILEGES_URL = `${RISK_ENGINE_URL}/privileges`;
-export const RISK_ENGINE_SETTINGS_URL = `${RISK_ENGINE_URL}/settings`;
+export const RISK_ENGINE_URL = `${INTERNAL_RISK_SCORE_URL}/engine` as const;
+export const RISK_ENGINE_STATUS_URL = `${RISK_ENGINE_URL}/status` as const;
+export const RISK_ENGINE_INIT_URL = `${RISK_ENGINE_URL}/init` as const;
+export const RISK_ENGINE_ENABLE_URL = `${RISK_ENGINE_URL}/enable` as const;
+export const RISK_ENGINE_DISABLE_URL = `${RISK_ENGINE_URL}/disable` as const;
+export const RISK_ENGINE_PRIVILEGES_URL = `${RISK_ENGINE_URL}/privileges` as const;
+export const RISK_ENGINE_SETTINGS_URL = `${RISK_ENGINE_URL}/settings` as const;
 
 export const MAX_SPACES_COUNT = 1;
 

--- a/x-pack/plugins/security_solution/common/entity_analytics/risk_score/constants.ts
+++ b/x-pack/plugins/security_solution/common/entity_analytics/risk_score/constants.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 /**
  * Public Risk Score routes
  */
@@ -20,14 +21,18 @@ export const DEV_TOOL_PREBUILT_CONTENT =
   `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/dev_tool/{console_id}` as const;
 export const devToolPrebuiltContentUrl = (spaceId: string, consoleId: string) =>
   `/s/${spaceId}${INTERNAL_RISK_SCORE_URL}/prebuilt_content/dev_tool/${consoleId}` as const;
-export const PREBUILT_SAVED_OBJECTS_BULK_CREATE = `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/saved_objects/_bulk_create/{template_name}`;
+export const PREBUILT_SAVED_OBJECTS_BULK_CREATE =
+  `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/saved_objects/_bulk_create/{template_name}` as const;
 export const prebuiltSavedObjectsBulkCreateUrl = (templateName: string) =>
   `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/saved_objects/_bulk_create/${templateName}` as const;
-export const PREBUILT_SAVED_OBJECTS_BULK_DELETE = `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/saved_objects/_bulk_delete/{template_name}`;
+export const PREBUILT_SAVED_OBJECTS_BULK_DELETE =
+  `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/saved_objects/_bulk_delete/{template_name}` as const;
 export const prebuiltSavedObjectsBulkDeleteUrl = (templateName: string) =>
   `${INTERNAL_RISK_SCORE_URL}/prebuilt_content/saved_objects/_bulk_delete/${templateName}` as const;
-export const RISK_SCORE_CREATE_INDEX = `${INTERNAL_RISK_SCORE_URL}/indices/create`;
-export const RISK_SCORE_DELETE_INDICES = `${INTERNAL_RISK_SCORE_URL}/indices/delete`;
-export const RISK_SCORE_CREATE_STORED_SCRIPT = `${INTERNAL_RISK_SCORE_URL}/stored_scripts/create`;
-export const RISK_SCORE_DELETE_STORED_SCRIPT = `${INTERNAL_RISK_SCORE_URL}/stored_scripts/delete`;
-export const RISK_SCORE_PREVIEW_URL = `${INTERNAL_RISK_SCORE_URL}/preview`;
+export const RISK_SCORE_CREATE_INDEX = `${INTERNAL_RISK_SCORE_URL}/indices/create` as const;
+export const RISK_SCORE_DELETE_INDICES = `${INTERNAL_RISK_SCORE_URL}/indices/delete` as const;
+export const RISK_SCORE_CREATE_STORED_SCRIPT =
+  `${INTERNAL_RISK_SCORE_URL}/stored_scripts/create` as const;
+export const RISK_SCORE_DELETE_STORED_SCRIPT =
+  `${INTERNAL_RISK_SCORE_URL}/stored_scripts/delete` as const;
+export const RISK_SCORE_PREVIEW_URL = `${INTERNAL_RISK_SCORE_URL}/preview` as const;


### PR DESCRIPTION
**Epic:** https://github.com/elastic/security-team/issues/9693 (internal)
**Partially addresses:** https://github.com/elastic/entity-analytics/issues/60 (internal)

## Summary

This PR fixes a few issues with the existing OpenAPI schemas for the Entity Analytics API based on findings described in https://github.com/elastic/entity-analytics/issues/60 and the recent developments of the [OpenAPI specs bundler](https://github.com/elastic/security-team/issues/9401):

- [x] Thanks to https://github.com/elastic/kibana/pull/184348, now we can mark endpoints as being available in ESS, Serverless, or both offerings by marking them with `x-labels`.
- [x] We can also explicitly mark internal endpoints with `x-internal: true`. While this is not required when the endpoint's path starts with `/internal`, I think it's still good to mark them explicitly, according to `access` modifier in the route registration. This fixed an issue where a couple of endpoints, while being in fact internal, were included in the OAS bundle because their paths do not start with `/internal`: `/api/risk_scores/calculation`, `/api/risk_scores/calculation/entity`, `/engine/settings`, `/engine/status`.
- [x] Specified correct paths for `/internal/risk_score/engine/settings` and `/internal/risk_score/engine/status` endpoints.

## How to test

Run the bundler:

```sh
cd x-pack/plugins/security_solution
yarn openapi:bundle
```

Check that the OpenAPI bundles located under the `x-pack/plugins/security_solution/target/openapi` folder don't contain any Entity Analytics endpoints or components.