### PR TITLE
[ES|QL] Allow to comment multiple lines

### DIFF
--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -238,24 +238,28 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
   }, [language, onTextLangQuerySubmit, abortController, isQueryLoading, allowQueryCancellation]);
 
   const onCommentLine = useCallback(() => {
-    const currentPosition = editor1.current?.getPosition();
-    const lineNumber = currentPosition?.lineNumber;
-    if (lineNumber) {
-      const lineContent = editorModel.current?.getLineContent(lineNumber) ?? '';
-      const hasComment = lineContent?.startsWith('//');
-      const commentedLine = hasComment ? lineContent?.replace('//', '') : `//${lineContent}`;
-      // executeEdits allows to keep edit in history
-      editor1.current?.executeEdits('comment', [
-        {
-          range: {
-            startLineNumber: lineNumber,
-            startColumn: 0,
-            endLineNumber: lineNumber,
-            endColumn: (lineContent?.length ?? 0) + 1,
+    const currentSelection = editor1?.current?.getSelection();
+    const startLineNumber = currentSelection?.startLineNumber;
+    const endLineNumber = currentSelection?.endLineNumber;
+    if (startLineNumber && endLineNumber) {
+      for (let lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++) {
+        const lineContent = editorModel.current?.getLineContent(lineNumber) ?? '';
+        const hasComment = lineContent?.startsWith('//');
+        const commentedLine = hasComment ? lineContent?.replace('//', '') : `//${lineContent}`;
+
+        // executeEdits allows to keep edit in history
+        editor1.current?.executeEdits('comment', [
+          {
+            range: {
+              startLineNumber: lineNumber,
+              startColumn: 0,
+              endLineNumber: lineNumber,
+              endColumn: (lineContent?.length ?? 0) + 1,
+            },
+            text: commentedLine,
           },
-          text: commentedLine,
-        },
-      ]);
+        ]);
+      }
     }
   }, []);
 
@@ -466,7 +470,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
 
   useEffect(() => {
     const validateQuery = async () => {
-      if (editorModel?.current) {
+      if (editor1?.current) {
         const parserMessages = await parseMessages();
         setClientParserMessages({
           errors: parserMessages?.errors ?? [],


### PR DESCRIPTION
## Summary

Follow up of https://github.com/elastic/kibana/pull/184637. Allow to comment multiline selections.

![meow](https://github.com/elastic/kibana/assets/17003240/fb7a2c28-8556-46bd-baa1-be52f3f4fa35)
