### PR TITLE
[8.14] [EDR Workflows] fix hidden saved query flyout and unskip test (#185004)

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_linked_apps.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_linked_apps.cy.ts
@@ -22,8 +22,7 @@ import {
 } from '../../tasks/integrations';
 import { RESULTS_TABLE, RESULTS_TABLE_BUTTON } from '../../screens/live_query';
 
-// FLAKY: https://github.com/elastic/kibana/issues/180852
-describe.skip(
+describe(
   'Alert Event Details',
   {
     tags: ['@ess', '@serverless'],

--- a/x-pack/plugins/osquery/public/saved_queries/saved_query_flyout.tsx
+++ b/x-pack/plugins/osquery/public/saved_queries/saved_query_flyout.tsx
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import {
   EuiFlyout,
   EuiTitle,
@@ -16,10 +15,11 @@ import {
   EuiFlexItem,
   EuiButtonEmpty,
   EuiButton,
+  useEuiTheme,
 } from '@elastic/eui';
 import { FormProvider } from 'react-hook-form';
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { SavedQuerySOFormData, SavedQueryFormData } from './form/use_saved_query_form';
@@ -51,6 +51,13 @@ const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({ defaultValue
     },
     [createSavedQueryMutation, onClose, serializer]
   );
+  const { euiTheme } = useEuiTheme();
+
+  // we need this flyout to be above the timeline flyout (which has a z-index of 1002)
+  const maskProps = useMemo(
+    () => ({ style: `z-index: ${(euiTheme.levels.flyout as number) + 3}` }),
+    [euiTheme.levels.flyout]
+  );
 
   return (
     <EuiPortal>
@@ -60,6 +67,7 @@ const SavedQueryFlyoutComponent: React.FC<AddQueryFlyoutProps> = ({ defaultValue
         ownFocus
         onClose={onClose}
         aria-labelledby="flyoutTitle"
+        maskProps={maskProps}
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="s">


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[EDR Workflows] fix hidden saved query flyout and unskip test (#185004)](https://github.com/elastic/kibana/pull/185004)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2024-06-10T10:37:43Z","message":"[EDR Workflows] fix hidden saved query flyout and unskip test (#185004)","sha":"8119aac0fe98020acd2cf9e7ad21be2aa4603851","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","v8.15.0","v8.14.1"],"number":185004,"url":"https://github.com/elastic/kibana/pull/185004","mergeCommit":{"message":"[EDR Workflows] fix hidden saved query flyout and unskip test (#185004)","sha":"8119aac0fe98020acd2cf9e7ad21be2aa4603851"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/185004","number":185004,"mergeCommit":{"message":"[EDR Workflows] fix hidden saved query flyout and unskip test (#185004)","sha":"8119aac0fe98020acd2cf9e7ad21be2aa4603851"}},{"branch":"8.14","label":"v8.14.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->