### PR TITLE
[flaky on mki] Increase timeout for kibanaReportCompletion

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/generate_csv_discover.ts
@@ -68,10 +68,10 @@ export default function ({ getService }: FtrProviderContext) {
    * Tests
    */
   describe('Generate CSV from SearchSource', function () {
-    // 7 minutes timeout for each test in serverless
-    // This is because it may take up to 5 minutes to generate the CSV
+    // 12 minutes timeout for each test in serverless
+    // This is because it may take up to 10 minutes to generate the CSV
     // see kibanaReportCompletion config
-    this.timeout(7 * 60 * 1000);
+    this.timeout(12 * 60 * 1000);
 
     beforeEach(async () => {
       await kibanaServer.uiSettings.update({

--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -159,7 +159,7 @@ export default async () => {
       try: 120 * 1000,
       waitFor: 20 * 1000,
       esRequestTimeout: 30 * 1000,
-      kibanaReportCompletion: 300 * 1000,
+      kibanaReportCompletion: 600 * 1000,
       kibanaStabilize: 15 * 1000,
       navigateStatusPageCheck: 250,
       waitForExists: 2500,


### PR DESCRIPTION
## Summary

Follow up https://github.com/elastic/kibana/pull/184508
close https://github.com/elastic/kibana/issues/184987

Increase kibanaReportCompletion to 10m: this should help with recent failures like
> Reporting Generate CSV from SearchSource validation Searches a large amount of data, stops at Max Size Reached
https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/1827

A report might take longer time to complete if the report is started when nodes are migrating [slack](https://elastic.slack.com/archives/C0574PUV998/p1717063959120689?thread_ts=1717018651.895229&cid=C0574PUV998)



Also see https://github.com/elastic/kibana/issues/160329#issuecomment-2158578112


