### PR TITLE
[ResponseOps][Fix] Update the overdue metrics collector to filter to only claimable task types

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
@@ -110,6 +110,9 @@ describe('TaskManagerMetricsCollector', () => {
       logger,
       pollInterval,
       store: mockTaskStore,
+      taskTypes: new Set(['taskType1', 'taskType2', 'taskType3', 'taskType4']),
+      removedTypes: new Set(['taskType5']),
+      excludedTypes: new Set(['taskType4', 'taskType5']),
     });
     const handler = jest.fn();
     taskManagerMetricsCollector.events.subscribe(handler);
@@ -182,6 +185,17 @@ describe('TaskManagerMetricsCollector', () => {
                           },
                         },
                         { range: { 'task.retryAt': { lte: 'now' } } },
+                      ],
+                    },
+                  },
+                  {
+                    bool: {
+                      must: [
+                        {
+                          terms: {
+                            'task.taskType': ['taskType1', 'taskType2', 'taskType3'],
+                          },
+                        },
                       ],
                     },
                   },
@@ -299,10 +313,14 @@ describe('TaskManagerMetricsCollector', () => {
     const pollInterval = 100;
     const halfInterval = Math.floor(pollInterval / 2);
 
+    const taskTypes = new Set([]);
     const taskManagerMetricsCollector = new TaskManagerMetricsCollector({
       logger,
       pollInterval,
       store: mockTaskStore,
+      taskTypes,
+      removedTypes: taskTypes,
+      excludedTypes: taskTypes,
     });
     const handler = jest.fn();
     taskManagerMetricsCollector.events.subscribe(handler);
@@ -365,10 +383,14 @@ describe('TaskManagerMetricsCollector', () => {
     const pollInterval = 100;
     const halfInterval = Math.floor(pollInterval / 2);
 
+    const taskTypes = new Set([]);
     const taskManagerMetricsCollector = new TaskManagerMetricsCollector({
       logger,
       pollInterval,
       store: mockTaskStore,
+      taskTypes,
+      removedTypes: taskTypes,
+      excludedTypes: taskTypes,
     });
     const handler = jest.fn();
     taskManagerMetricsCollector.events.subscribe(handler);

--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
@@ -188,6 +188,9 @@ describe('TaskManagerMetricsCollector', () => {
                       ],
                     },
                   },
+                ],
+                minimum_should_match: 1,
+                must: [
                   {
                     bool: {
                       must: [

--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.ts
@@ -99,11 +99,9 @@ export class TaskManagerMetricsCollector implements ITaskEventEmitter<TaskLifecy
             filter: [
               {
                 bool: {
-                  should: [
-                    IdleTaskWithExpiredRunAt,
-                    RunningOrClaimingTaskWithExpiredRetryAt,
-                    OneOfTaskTypes('task.taskType', searchedTypes),
-                  ],
+                  must: [OneOfTaskTypes('task.taskType', searchedTypes)],
+                  should: [IdleTaskWithExpiredRunAt, RunningOrClaimingTaskWithExpiredRetryAt],
+                  minimum_should_match: 1,
                 },
               },
             ],

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -257,6 +257,9 @@ export class TaskManagerPlugin
       this.taskManagerMetricsCollector = new TaskManagerMetricsCollector({
         logger: this.logger,
         store: taskStore,
+        taskTypes: new Set(this.definitions.getAllTypes()),
+        removedTypes: new Set(REMOVED_TYPES),
+        excludedTypes: new Set(this.config.unsafe.exclude_task_types),
       });
       this.taskPollingLifecycle = new TaskPollingLifecycle({
         config: this.config!,

--- a/x-pack/plugins/task_manager/server/queries/mark_available_tasks_as_claimed.test.ts
+++ b/x-pack/plugins/task_manager/server/queries/mark_available_tasks_as_claimed.test.ts
@@ -14,6 +14,7 @@ import {
   RunningOrClaimingTaskWithExpiredRetryAt,
   SortByRunAtAndRetryAt,
   EnabledTask,
+  OneOfTaskTypes,
 } from './mark_available_tasks_as_claimed';
 
 import { TaskTypeDictionary } from '../task_type_dictionary';
@@ -192,5 +193,24 @@ if (doc['task.runAt'].size()!=0) {
         }).source
       ).toMatch(/ctx.op = "noop"/);
     });
+  });
+
+  test('generates OneOfTaskTypes clause as expected', () => {
+    expect(OneOfTaskTypes('field-name', ['type-a', 'type-b'])).toMatchInlineSnapshot(`
+      Object {
+        "bool": Object {
+          "must": Array [
+            Object {
+              "terms": Object {
+                "field-name": Array [
+                  "type-a",
+                  "type-b",
+                ],
+              },
+            },
+          ],
+        },
+      }
+    `);
   });
 });

--- a/x-pack/plugins/task_manager/server/queries/mark_available_tasks_as_claimed.ts
+++ b/x-pack/plugins/task_manager/server/queries/mark_available_tasks_as_claimed.ts
@@ -163,3 +163,17 @@ export const updateFieldsAndMarkAsFailed = ({
     },
   };
 };
+
+export const OneOfTaskTypes = (field: string, types: string[]): MustCondition => {
+  return {
+    bool: {
+      must: [
+        {
+          terms: {
+            [field]: types,
+          },
+        },
+      ],
+    },
+  };
+};


### PR DESCRIPTION
## Summary

This PR updates the overdue metrics collector to filter to only claimable task types.
I borrowed the `OneOfTaskTypes` clause from https://github.com/elastic/kibana/pull/180485
 ```
// a task type that's not excluded (may be removed or not)
    OneOfTaskTypes('task.taskType', searchedTypes),
```


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios