### PR TITLE
[8.14] [Security Solution][Alert KPI] Fix leading wildcard in KPI visualizations (#182875)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/alerts_treemap_panel/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/alerts_treemap_panel/index.tsx
@@ -10,6 +10,7 @@ import type { EuiComboBox } from '@elastic/eui';
 import { EuiProgress } from '@elastic/eui';
 import type { Filter, Query } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import React, { useEffect, useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -24,6 +25,7 @@ import { HeaderSection } from '../header_section';
 import { InspectButtonContainer } from '../inspect';
 import { DEFAULT_STACK_BY_FIELD0_SIZE, getAlertsRiskQuery } from '../alerts_treemap/query';
 import type { AlertsTreeMapAggregation } from '../alerts_treemap/types';
+import { useKibana } from '../../lib/kibana';
 
 const DEFAULT_HEIGHT = DEFAULT_MIN_CHART_HEIGHT + 134; // px
 
@@ -81,23 +83,26 @@ const AlertsTreemapPanelComponent: React.FC<Props> = ({
   title,
 }: Props) => {
   const { to, from, deleteQuery, setQuery } = useGlobalTime();
+  const { uiSettings } = useKibana().services;
 
   // create a unique, but stable (across re-renders) query id
   const uniqueQueryId = useMemo(() => `${ALERTS_TREEMAP_ID}-${uuidv4()}`, []);
 
   const additionalFilters = useMemo(() => {
     try {
+      const config = getEsQueryConfig(uiSettings);
       return [
         buildEsQuery(
           undefined,
           query != null ? [query] : [],
-          filters?.filter((f) => f.meta.disabled === false) ?? []
+          filters?.filter((f) => f.meta.disabled === false) ?? [],
+          config
         ),
       ];
     } catch (e) {
       return [];
     }
-  }, [query, filters]);
+  }, [query, filters, uiSettings]);
 
   const {
     data: alertsData,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data.test.tsx
@@ -25,6 +25,8 @@ const dateNow = new Date(to).valueOf();
 const mockDateNow = jest.fn().mockReturnValue(dateNow);
 Date.now = jest.fn(() => mockDateNow()) as unknown as DateConstructor['now'];
 
+jest.mock('../../../../common/lib/kibana');
+
 const defaultUseQueryAlertsReturn = {
   loading: false,
   data: null,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data.tsx
@@ -9,7 +9,9 @@ import { useEffect, useState, useMemo, useCallback } from 'react';
 import { buildEsQuery } from '@kbn/es-query';
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { Filter, Query } from '@kbn/es-query';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { SummaryChartsAgg, SummaryChartsData } from './types';
+import { useKibana } from '../../../../common/lib/kibana';
 import type { EntityFilter } from '../../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
 import type { ESBoolQuery } from '../../../../../common/typed_json';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -86,19 +88,22 @@ export const useSummaryChartData: UseAlerts = ({
   const [updatedAt, setUpdatedAt] = useState(Date.now());
   const [items, setItems] = useState<SummaryChartsData[]>([]);
 
+  const { uiSettings } = useKibana().services;
   const additionalFilters = useMemo(() => {
     try {
+      const config = getEsQueryConfig(uiSettings);
       return [
         buildEsQuery(
           undefined,
           query != null ? [query] : [],
-          filters?.filter((f) => f.meta.disabled === false) ?? []
+          filters?.filter((f) => f.meta.disabled === false) ?? [],
+          config
         ),
       ];
     } catch (e) {
       return [];
     }
-  }, [query, filters]);
+  }, [query, filters, uiSettings]);
 
   const {
     data,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.test.tsx
@@ -112,9 +112,6 @@ jest.mock('../../../common/lib/kibana', () => {
         cases: {
           ui: { getCasesContext: mockCasesContext },
         },
-        uiSettings: {
-          get: jest.fn(),
-        },
         timelines: { ...mockTimelines },
         data: {
           query: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Security Solution][Alert KPI] Fix leading wildcard in KPI visualizations (#182875)](https://github.com/elastic/kibana/pull/182875)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-06-03T20:27:17Z","message":"[Security Solution][Alert KPI] Fix leading wildcard in KPI visualizations (#182875)\n\n## Summary\r\n\r\nSummary charts and tree map were not handling leading wildcards. This PR\r\nupdated the query to reflect advanced settings. If leading wildcard is\r\nnot selected, an error toast should appear.\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/c05c9ca4-2f33-4d84-9479-c09a6a81a6d5)\r\n\r\nRelated: https://github.com/elastic/kibana/issues/182757\r\n\r\nAfter: when leading wildcard is set to true: \r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/38a57cbb-a818-410e-b73b-08b545be4725)\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/66d6647b-ef77-42c0-b431-fd99c4705b7e)","sha":"f2a8306734f2616944aced87d822b974dc57012d","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:Threat Hunting","Team:Threat Hunting:Investigations","v8.15.0"],"number":182875,"url":"https://github.com/elastic/kibana/pull/182875","mergeCommit":{"message":"[Security Solution][Alert KPI] Fix leading wildcard in KPI visualizations (#182875)\n\n## Summary\r\n\r\nSummary charts and tree map were not handling leading wildcards. This PR\r\nupdated the query to reflect advanced settings. If leading wildcard is\r\nnot selected, an error toast should appear.\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/c05c9ca4-2f33-4d84-9479-c09a6a81a6d5)\r\n\r\nRelated: https://github.com/elastic/kibana/issues/182757\r\n\r\nAfter: when leading wildcard is set to true: \r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/38a57cbb-a818-410e-b73b-08b545be4725)\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/66d6647b-ef77-42c0-b431-fd99c4705b7e)","sha":"f2a8306734f2616944aced87d822b974dc57012d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/182875","number":182875,"mergeCommit":{"message":"[Security Solution][Alert KPI] Fix leading wildcard in KPI visualizations (#182875)\n\n## Summary\r\n\r\nSummary charts and tree map were not handling leading wildcards. This PR\r\nupdated the query to reflect advanced settings. If leading wildcard is\r\nnot selected, an error toast should appear.\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/c05c9ca4-2f33-4d84-9479-c09a6a81a6d5)\r\n\r\nRelated: https://github.com/elastic/kibana/issues/182757\r\n\r\nAfter: when leading wildcard is set to true: \r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/38a57cbb-a818-410e-b73b-08b545be4725)\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/18648970/66d6647b-ef77-42c0-b431-fd99c4705b7e)","sha":"f2a8306734f2616944aced87d822b974dc57012d"}}]}] BACKPORT-->