### PR TITLE
[Embeddable Rebuild] Better error handling

### DIFF
--- a/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
+++ b/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
@@ -98,26 +98,26 @@ export const ReactEmbeddableRenderer = <
         const factory = await getReactEmbeddableFactory<SerializedState, Api, RuntimeState>(type);
         const subscriptions = new Subscription();
 
+        const setApi = (
+          apiRegistration: SetReactEmbeddableApiRegistration<SerializedState, Api>
+        ) => {
+          const fullApi = {
+            ...apiRegistration,
+            uuid,
+            phase$,
+            parentApi,
+            type: factory.type,
+          } as unknown as Api;
+          onApiAvailable?.(fullApi);
+          return fullApi;
+        };
+
         const buildEmbeddable = async () => {
           const { initialState, startStateDiffing } = await initializeReactEmbeddableState<
             SerializedState,
             Api,
             RuntimeState
           >(uuid, factory, parentApi);
-
-          const setApi = (
-            apiRegistration: SetReactEmbeddableApiRegistration<SerializedState, Api>
-          ) => {
-            const fullApi = {
-              ...apiRegistration,
-              uuid,
-              phase$,
-              parentApi,
-              type: factory.type,
-            } as unknown as Api;
-            onApiAvailable?.(fullApi);
-            return fullApi;
-          };
 
           const buildApi = (
             apiRegistration: BuildReactEmbeddableApiRegistration<SerializedState, Api>,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/184962

## Summary

This PR adds error handling to the `ReactEmbeddableRenderer` component so that, if any error is thrown when trying to build the API / embeddable (i.e. when the state is deserialized, when the embeddable is being built, etc.), the resulting panel will be deletable. The previous error handling assumed that the API would always exist, which isn't necessarily true - this handles this scenario by providing a dummy API (which provides a blocking error **and** access to the parent API to allow for panel deletion) to the presentation panel when an error is thrown in `ReactEmbeddableRenderer` 

| Before | After |
|--------|--------|
| ![image](https://github.com/elastic/kibana/assets/8698078/e3ed043e-5ab6-49a2-b5ce-d5ee7a5f394f) | ![image](https://github.com/elastic/kibana/assets/8698078/406cf098-88b6-4387-ac25-43f711505c2b) |
| No panel actions available, since no API is provided to the presentation panel | ![image](https://github.com/elastic/kibana/assets/8698078/45010401-63dc-4259-8b1b-3914d791f2cf) | 
| ![image](https://github.com/elastic/kibana/assets/8698078/f3973864-a1cb-4f2d-ab80-9630a9d620c8) | ![image](https://github.com/elastic/kibana/assets/8698078/e36bd761-b932-401a-85e3-5d9059b63392) | 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
