### PR TITLE
[Fleet] Create shared package policy

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -31,6 +31,7 @@ export const allowedExperimentalValues = Object.freeze<Record<string, boolean>>(
   enablePackagesStateMachine: true,
   advancedPolicySettings: true,
   useSpaceAwareness: false,
+  enableReusableIntegrationPolicies: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/confirm_deploy_modal.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/confirm_deploy_modal.tsx
@@ -16,7 +16,7 @@ export const ConfirmDeployAgentPolicyModal: React.FunctionComponent<{
   onConfirm: () => void;
   onCancel: () => void;
   agentCount: number;
-  agentPolicy: AgentPolicy;
+  agentPolicies: AgentPolicy[];
   showUnprivilegedAgentsCallout?: boolean;
   unprivilegedAgentsCount?: number;
   dataStreams?: Array<{ name: string; title: string }>;
@@ -24,7 +24,7 @@ export const ConfirmDeployAgentPolicyModal: React.FunctionComponent<{
   onConfirm,
   onCancel,
   agentCount,
-  agentPolicy,
+  agentPolicies,
   showUnprivilegedAgentsCallout = false,
   unprivilegedAgentsCount = 0,
   dataStreams,
@@ -66,11 +66,11 @@ export const ConfirmDeployAgentPolicyModal: React.FunctionComponent<{
         <div className="eui-textBreakWord">
           <FormattedMessage
             id="xpack.fleet.agentPolicy.confirmModalCalloutDescription"
-            defaultMessage="Fleet has detected that the selected agent policy, {policyName}, is already in use by
+            defaultMessage="Fleet has detected that the selected agent policies, {policyNames}, are already in use by
             some of your agents. As a result of this action, Fleet will deploy updates to all agents
-            that use this policy."
+            that use these policies."
             values={{
-              policyName: <b>{agentPolicy.name}</b>,
+              policyNames: <b>{agentPolicies.map((policy) => policy.name).join(', ')}</b>,
             }}
           />
         </div>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import { EuiComboBox } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
+import React, { useEffect } from 'react';
+
+import type { PackageInfo } from '../../../../../../../../../common';
+
+export interface Props {
+  isLoading: boolean;
+  agentPolicyMultiOptions: Array<EuiComboBoxOptionOption<string>>;
+  selectedPolicyIds: string[];
+  setSelectedPolicyIds: (policyIds: string[]) => void;
+  packageInfo?: PackageInfo;
+}
+
+export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
+  isLoading,
+  agentPolicyMultiOptions,
+  selectedPolicyIds,
+  setSelectedPolicyIds,
+}) => {
+  const [selectedOptions, setSelected] = React.useState<any>([]);
+
+  useEffect(() => {
+    setSelected(
+      agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!))
+    );
+  }, [agentPolicyMultiOptions, selectedPolicyIds]);
+
+  return (
+    <EuiComboBox
+      aria-label="Select Multiple Agent Policies"
+      data-test-subj="agentPolicyMultiSelect"
+      placeholder={i18n.translate(
+        'xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyMultiPlaceholderText',
+        {
+          defaultMessage: 'Select agent policies to add this integration to',
+        }
+      )}
+      options={agentPolicyMultiOptions}
+      selectedOptions={selectedOptions}
+      onChange={(newOptions) => {
+        setSelected(newOptions);
+        setSelectedPolicyIds(newOptions.map((option: any) => option.key));
+      }}
+      isClearable={true}
+      isLoading={isLoading}
+    />
+  );
+};

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
@@ -10,7 +10,7 @@ import { EuiComboBox } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
-import React, { useMemo } from 'react';
+import React, { useEffect } from 'react';
 
 import type { PackageInfo } from '../../../../../../../../../common';
 
@@ -28,11 +28,13 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
   selectedPolicyIds,
   setSelectedPolicyIds,
 }) => {
-  const selectedOptions = useMemo(() => {
-    return agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!));
-  }, [agentPolicyMultiOptions, selectedPolicyIds]);
+  const [selectedOptions, setSelected] = React.useState<any>([]);
 
-  const [selected, setSelected] = React.useState<any>(selectedOptions);
+  useEffect(() => {
+    setSelected(
+      agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!))
+    );
+  }, [agentPolicyMultiOptions, selectedPolicyIds]);
 
   return (
     <EuiComboBox
@@ -45,7 +47,7 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
         }
       )}
       options={agentPolicyMultiOptions}
-      selectedOptions={selected}
+      selectedOptions={selectedOptions}
       onChange={(newOptions) => {
         setSelected(newOptions);
         setSelectedPolicyIds(newOptions.map((option: any) => option.key));

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
@@ -10,7 +10,7 @@ import { EuiComboBox } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
-import React, { useEffect } from 'react';
+import React, { useMemo } from 'react';
 
 import type { PackageInfo } from '../../../../../../../../../common';
 
@@ -28,13 +28,11 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
   selectedPolicyIds,
   setSelectedPolicyIds,
 }) => {
-  const [selectedOptions, setSelected] = React.useState<any>([]);
-
-  useEffect(() => {
-    setSelected(
-      agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!))
-    );
+  const selectedOptions = useMemo(() => {
+    return agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!));
   }, [agentPolicyMultiOptions, selectedPolicyIds]);
+
+  const [selected, setSelected] = React.useState<any>(selectedOptions);
 
   return (
     <EuiComboBox
@@ -47,7 +45,7 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
         }
       )}
       options={agentPolicyMultiOptions}
-      selectedOptions={selectedOptions}
+      selectedOptions={selected}
       onChange={(newOptions) => {
         setSelected(newOptions);
         setSelectedPolicyIds(newOptions.map((option: any) => option.key));

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/agent_policy_multi_select.tsx
@@ -10,7 +10,7 @@ import { EuiComboBox } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
-import React, { useEffect } from 'react';
+import React, { useMemo } from 'react';
 
 import type { PackageInfo } from '../../../../../../../../../common';
 
@@ -28,12 +28,8 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
   selectedPolicyIds,
   setSelectedPolicyIds,
 }) => {
-  const [selectedOptions, setSelected] = React.useState<any>([]);
-
-  useEffect(() => {
-    setSelected(
-      agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!))
-    );
+  const selectedOptions = useMemo(() => {
+    return agentPolicyMultiOptions.filter((option) => selectedPolicyIds.includes(option.key!));
   }, [agentPolicyMultiOptions, selectedPolicyIds]);
 
   return (
@@ -49,7 +45,6 @@ export const AgentPolicyMultiSelect: React.FunctionComponent<Props> = ({
       options={agentPolicyMultiOptions}
       selectedOptions={selectedOptions}
       onChange={(newOptions) => {
-        setSelected(newOptions);
         setSelectedPolicyIds(newOptions.map((option: any) => option.key));
       }}
       isClearable={true}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.test.tsx
@@ -12,25 +12,7 @@ import type { TestRenderer } from '../../../../../../../mock';
 import { createFleetTestRendererMock } from '../../../../../../../mock';
 import type { AgentPolicy, NewPackagePolicy, PackageInfo } from '../../../../../types';
 
-import { useGetPackagePolicies } from '../../../../../hooks';
-
 import { StepDefinePackagePolicy } from './step_define_package_policy';
-
-jest.mock('../../../../../hooks', () => {
-  return {
-    ...jest.requireActual('../../../../../hooks'),
-    useGetPackagePolicies: jest.fn().mockReturnValue({
-      data: {
-        items: [{ name: 'nginx-1' }, { name: 'other-policy' }],
-      },
-      isLoading: false,
-    }),
-    useFleetStatus: jest.fn().mockReturnValue({ isReady: true } as any),
-    sendGetStatus: jest
-      .fn()
-      .mockResolvedValue({ data: { isReady: true, missing_requirements: [] } }),
-  };
-});
 
 describe('StepDefinePackagePolicy', () => {
   const packageInfo: PackageInfo = {
@@ -63,18 +45,32 @@ describe('StepDefinePackagePolicy', () => {
       },
     ],
   };
-  const agentPolicy: AgentPolicy = {
-    id: 'agent-policy-1',
-    namespace: 'ns',
-    name: 'Agent policy 1',
-    is_managed: false,
-    status: 'active',
-    updated_at: '',
-    updated_by: '',
-    revision: 1,
-    package_policies: [],
-    is_protected: false,
-  };
+  const agentPolicies: AgentPolicy[] = [
+    {
+      id: 'agent-policy-1',
+      namespace: 'ns',
+      name: 'Agent policy 1',
+      is_managed: false,
+      status: 'active',
+      updated_at: '',
+      updated_by: '',
+      revision: 1,
+      package_policies: [],
+      is_protected: false,
+    },
+    {
+      id: 'agent-policy-2',
+      namespace: 'default',
+      name: 'Agent policy 2',
+      is_managed: false,
+      status: 'active',
+      updated_at: '',
+      updated_by: '',
+      revision: 1,
+      package_policies: [],
+      is_protected: false,
+    },
+  ];
   let packagePolicy: NewPackagePolicy;
   const mockUpdatePackagePolicy = jest.fn().mockImplementation((val: any) => {
     packagePolicy = {
@@ -96,7 +92,7 @@ describe('StepDefinePackagePolicy', () => {
   const render = () =>
     (renderResult = testRenderer.render(
       <StepDefinePackagePolicy
-        agentPolicies={[agentPolicy]}
+        agentPolicies={agentPolicies}
         packageInfo={packageInfo}
         packagePolicy={packagePolicy}
         updatePackagePolicy={mockUpdatePackagePolicy}
@@ -139,27 +135,11 @@ describe('StepDefinePackagePolicy', () => {
 
       waitFor(() => {
         expect(renderResult.getByRole('switch')).toHaveAttribute('aria-label', 'Advanced var');
+        expect(renderResult.getByTestId('packagePolicyNamespaceInput')).toHaveAttribute(
+          'placeholder',
+          'ns'
+        );
       });
-    });
-  });
-
-  it('should set incremented name if other package policies exist', () => {
-    (useGetPackagePolicies as jest.MockedFunction<any>).mockReturnValueOnce({
-      data: {
-        items: [
-          { name: 'apache-1' },
-          { name: 'apache-2' },
-          { name: 'apache-9' },
-          { name: 'apache-10' },
-        ],
-      },
-      isLoading: false,
-    });
-
-    render();
-
-    waitFor(() => {
-      expect(renderResult.getByDisplayValue('apache-11')).toBeInTheDocument();
     });
   });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.test.tsx
@@ -96,7 +96,7 @@ describe('StepDefinePackagePolicy', () => {
   const render = () =>
     (renderResult = testRenderer.render(
       <StepDefinePackagePolicy
-        agentPolicy={agentPolicy}
+        agentPolicies={[agentPolicy]}
         packageInfo={packageInfo}
         packagePolicy={packagePolicy}
         updatePackagePolicy={mockUpdatePackagePolicy}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
@@ -283,6 +283,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                       }
                     >
                       <EuiComboBox
+                        data-test-subj="packagePolicyNamespaceInput"
                         noSuggestions
                         placeholder={agentPolicies?.[0]?.namespace}
                         isDisabled={isEditPage && packageInfo.type === 'input'}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
@@ -48,7 +48,7 @@ const FormGroupResponsiveFields = styled(EuiDescribedFormGroup)`
 `;
 
 export const StepDefinePackagePolicy: React.FunctionComponent<{
-  agentPolicy?: AgentPolicy;
+  agentPolicies?: AgentPolicy[];
   packageInfo: PackageInfo;
   packagePolicy: NewPackagePolicy;
   updatePackagePolicy: (fields: Partial<NewPackagePolicy>) => void;
@@ -58,7 +58,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
   noAdvancedToggle?: boolean;
 }> = memo(
   ({
-    agentPolicy,
+    agentPolicies,
     packageInfo,
     packagePolicy,
     updatePackagePolicy,
@@ -284,7 +284,7 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                     >
                       <EuiComboBox
                         noSuggestions
-                        placeholder={agentPolicy?.namespace}
+                        placeholder={agentPolicies?.[0]?.namespace}
                         isDisabled={isEditPage && packageInfo.type === 'input'}
                         singleSelection={true}
                         selectedOptions={

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
@@ -41,13 +41,13 @@ describe('step select agent policy', () => {
   let testRenderer: TestRenderer;
   let renderResult: ReturnType<typeof testRenderer.render>;
   const mockSetHasAgentPolicyError = jest.fn();
-  const updateAgentPolicyMock = jest.fn();
+  const updateAgentPoliciesMock = jest.fn();
   const render = () =>
     (renderResult = testRenderer.render(
       <StepSelectAgentPolicy
         packageInfo={{ name: 'apache' } as any}
-        agentPolicy={undefined}
-        updateAgentPolicy={updateAgentPolicyMock}
+        agentPolicies={[]}
+        updateAgentPolicies={updateAgentPoliciesMock}
         setHasAgentPolicyError={mockSetHasAgentPolicyError}
         selectedAgentPolicyId={undefined}
       />
@@ -55,7 +55,7 @@ describe('step select agent policy', () => {
 
   beforeEach(() => {
     testRenderer = createFleetTestRendererMock();
-    updateAgentPolicyMock.mockReset();
+    updateAgentPoliciesMock.mockReset();
   });
 
   test('should not select agent policy by default if multiple exists', async () => {
@@ -92,8 +92,8 @@ describe('step select agent policy', () => {
     render();
     await act(async () => {}); // Needed as updateAgentPolicy is called after multiple useEffect
     await act(async () => {
-      expect(updateAgentPolicyMock).toBeCalled();
-      expect(updateAgentPolicyMock).toBeCalledWith({ id: 'policy-1' });
+      expect(updateAgentPoliciesMock).toBeCalled();
+      expect(updateAgentPoliciesMock).toBeCalledWith([{ id: 'policy-1' }]);
     });
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
@@ -8,6 +8,10 @@
 import React from 'react';
 import { act } from '@testing-library/react';
 
+import type { PackageInfo } from '../../../../../../../../common';
+
+import { ExperimentalFeaturesService } from '../../../../../../../services';
+
 import type { TestRenderer } from '../../../../../../../mock';
 import { createFleetTestRendererMock } from '../../../../../../../mock';
 
@@ -23,13 +27,23 @@ jest.mock('../../../../../hooks', () => {
       data: [],
       isLoading: false,
     }),
-    sendGetOneAgentPolicy: jest.fn().mockResolvedValue({
-      data: { item: { id: 'policy-1' } },
-    }),
+    sendBulkGetAgentPolicies: jest.fn().mockImplementation((ids) =>
+      Promise.resolve({
+        data: { items: ids.map((id: string) => ({ id, package_policies: [] })) },
+      })
+    ),
     useFleetStatus: jest.fn().mockReturnValue({ isReady: true } as any),
     sendGetFleetStatus: jest
       .fn()
       .mockResolvedValue({ data: { isReady: true, missing_requirements: [] } }),
+    useGetPackagePolicies: jest.fn().mockImplementation((query) => ({
+      data: {
+        items: query.kuery.includes('osquery_manager') ? [{ policy_ids: ['policy-1'] }] : [],
+      },
+      error: undefined,
+      isLoading: false,
+      resendRequest: jest.fn(),
+    })),
   };
 });
 
@@ -42,10 +56,10 @@ describe('step select agent policy', () => {
   let renderResult: ReturnType<typeof testRenderer.render>;
   const mockSetHasAgentPolicyError = jest.fn();
   const updateAgentPoliciesMock = jest.fn();
-  const render = () =>
+  const render = (packageInfo?: PackageInfo) =>
     (renderResult = testRenderer.render(
       <StepSelectAgentPolicy
-        packageInfo={{ name: 'apache' } as any}
+        packageInfo={packageInfo ?? ({ name: 'apache' } as any)}
         agentPolicies={[]}
         updateAgentPolicies={updateAgentPoliciesMock}
         setHasAgentPolicyError={mockSetHasAgentPolicyError}
@@ -90,10 +104,63 @@ describe('step select agent policy', () => {
     } as any);
 
     render();
-    await act(async () => {}); // Needed as updateAgentPolicy is called after multiple useEffect
+    await act(async () => {}); // Needed as updateAgentPolicies is called after multiple useEffect
     await act(async () => {
       expect(updateAgentPoliciesMock).toBeCalled();
-      expect(updateAgentPoliciesMock).toBeCalledWith([{ id: 'policy-1' }]);
+      expect(updateAgentPoliciesMock).toBeCalledWith([{ id: 'policy-1', package_policies: [] }]);
+    });
+  });
+
+  describe('multiple agent policies', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(ExperimentalFeaturesService, 'get')
+        .mockReturnValue({ enableReusableIntegrationPolicies: true });
+
+      useGetAgentPoliciesMock.mockReturnValue({
+        data: {
+          items: [
+            { id: 'policy-1', name: 'Policy 1' },
+            { id: 'policy-2', name: 'Policy 2' },
+          ],
+        },
+        error: undefined,
+        isLoading: false,
+        resendRequest: jest.fn(),
+      } as any);
+    });
+
+    test('should select multiple agent policies', async () => {
+      const result = render();
+      expect(result.getByTestId('agentPolicyMultiSelect')).toBeInTheDocument();
+      await act(async () => {
+        result.getByTestId('comboBoxToggleListButton').click();
+      });
+      expect(result.getAllByTestId('agentPolicyMultiItem').length).toBe(2);
+      await act(async () => {
+        result.getByText('Policy 1').click();
+      });
+      await act(async () => {
+        result.getByText('Policy 2').click();
+      });
+      expect(updateAgentPoliciesMock).toBeCalledWith([
+        { id: 'policy-1', package_policies: [] },
+        { id: 'policy-2', package_policies: [] },
+      ]);
+    });
+
+    // TODO: Fix this test
+    test('should disable option if agent policy has limited package', async () => {
+      const result = render({
+        name: 'osquery_manager',
+        policy_templates: [{ multiple: false }],
+      } as any);
+      expect(result.getByTestId('agentPolicyMultiSelect')).toBeInTheDocument();
+      await act(async () => {
+        result.getByTestId('comboBoxToggleListButton').click();
+      });
+      // expect(result.getByText('Policy 1')).toBeDisabled();
+      // expect(result.getAllByTestId('agentPolicyMultiItem')[0]).toBeDisabled();
     });
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -172,7 +172,7 @@ function useAgentPoliciesOptions(packageInfo?: PackageInfo) {
                   content={
                     <FormattedMessage
                       id="xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyDisabledAPMLogstashOuputText"
-                      defaultMessage="Logstash output for agent integration is not supported with APM"
+                      defaultMessage="Logstash output for integrations is not supported with APM"
                     />
                   }
                 >

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -133,7 +133,7 @@ function useAgentPoliciesOptions(packageInfo?: PackageInfo) {
                       <EuiText size="s">
                         <FormattedMessage
                           id="xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyDisabledAPMLogstashOuputText"
-                          defaultMessage="Logstash output for agent integration is not supported with APM"
+                          defaultMessage="Logstash output for integrations is not supported with APM"
                         />
                       </EuiText>
                     </>
@@ -156,7 +156,7 @@ function useAgentPoliciesOptions(packageInfo?: PackageInfo) {
 
   const agentPolicyMultiOptions: Array<EuiComboBoxOptionOption<string>> = useMemo(
     () =>
-      packageInfo
+      packageInfo && !isOutputLoading && !isAgentPoliciesLoading && !isLoadingPackagePolicies
         ? agentPolicies.map((policy) => {
             const isLimitedPackageAlreadyInPolicy =
               isPackageLimited(packageInfo) &&
@@ -191,6 +191,9 @@ function useAgentPoliciesOptions(packageInfo?: PackageInfo) {
       agentPolicies,
       packagePoliciesForThisPackageByAgentPolicyId,
       getDataOutputForPolicy,
+      isOutputLoading,
+      isAgentPoliciesLoading,
+      isLoadingPackagePolicies,
     ]
   );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -230,7 +230,6 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
   const [selectedAgentPolicyError, setSelectedAgentPolicyError] = useState<Error>();
 
   const { enableReusableIntegrationPolicies } = ExperimentalFeaturesService.get();
-  // enableReusableIntegrationPolicies = false;
 
   const {
     isLoading,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -384,7 +384,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 isFleetReady && selectedPolicyIds.length > 0 && !isLoadingSelectedAgentPolicy ? (
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyAgentsDescriptionText"
-                    defaultMessage="{count, plural, one {# agent is} other {# agents are}} enrolled with the selected agent policy."
+                    defaultMessage="{count, plural, one {# agent is} other {# agents are}} enrolled with the selected agent policies."
                     values={{
                       count: selectedAgentPolicies.reduce(
                         (acc, curr) => acc + (curr.agents ?? 0),

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
@@ -24,9 +24,11 @@ jest.mock('../../../../../hooks', () => {
       data: [],
       isLoading: false,
     }),
-    sendGetOneAgentPolicy: jest.fn().mockResolvedValue({
-      data: { item: { id: 'policy-1', name: 'Agent policy 1' } },
-    }),
+    sendGetOneAgentPolicy: jest.fn().mockImplementation((id) =>
+      Promise.resolve({
+        data: { item: { id, name: `Agent policy ${id}` } },
+      })
+    ),
   };
 });
 
@@ -44,18 +46,32 @@ describe('StepSelectHosts', () => {
     status: 'not_installed',
     vars: [],
   };
-  const agentPolicy: AgentPolicy = {
-    id: 'agent-policy-1',
-    namespace: 'default',
-    name: 'Agent policy 1',
-    is_managed: false,
-    status: 'active',
-    updated_at: '',
-    updated_by: '',
-    revision: 1,
-    package_policies: [],
-    is_protected: false,
-  };
+  const agentPolicies: AgentPolicy[] = [
+    {
+      id: '1',
+      namespace: 'default',
+      name: 'Agent policy 1',
+      is_managed: false,
+      status: 'active',
+      updated_at: '',
+      updated_by: '',
+      revision: 1,
+      package_policies: [],
+      is_protected: false,
+    },
+    {
+      id: '2',
+      namespace: 'default',
+      name: 'Agent policy 2',
+      is_managed: false,
+      status: 'active',
+      updated_at: '',
+      updated_by: '',
+      revision: 1,
+      package_policies: [],
+      is_protected: false,
+    },
+  ];
   const newAgentPolicy = {
     name: '',
     namespace: 'default',
@@ -67,7 +83,7 @@ describe('StepSelectHosts', () => {
   const render = () =>
     (renderResult = testRenderer.render(
       <StepSelectHosts
-        agentPolicies={[agentPolicy]}
+        agentPolicies={agentPolicies}
         updateAgentPolicies={jest.fn()}
         newAgentPolicy={newAgentPolicy}
         updateNewAgentPolicy={jest.fn()}
@@ -102,7 +118,7 @@ describe('StepSelectHosts', () => {
   it('should display tabs with New hosts selected when agent policies exist', () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
-        items: [{ id: 'agent-policy-1', name: 'Agent policy 1', namespace: 'default' }],
+        items: [{ id: '1', name: 'Agent policy 1', namespace: 'default' }],
       },
     });
 
@@ -110,7 +126,7 @@ describe('StepSelectHosts', () => {
 
     waitFor(() => {
       expect(renderResult.getByRole('tablist')).toBeInTheDocument();
-      expect(renderResult.getByText('Agent policy 2')).toBeInTheDocument();
+      expect(renderResult.getByText('Agent policy 3')).toBeInTheDocument();
     });
     expect(renderResult.getByText('New hosts').closest('button')).toHaveAttribute(
       'aria-selected',
@@ -121,7 +137,7 @@ describe('StepSelectHosts', () => {
   it('should display dropdown with agent policy selected when Existing hosts selected', async () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
-        items: [{ id: 'agent-policy-1', name: 'Agent policy 1', namespace: 'default' }],
+        items: [{ id: '1', name: 'Agent policy 1', namespace: 'default' }],
       },
     });
 
@@ -143,8 +159,8 @@ describe('StepSelectHosts', () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
         items: [
-          { id: 'agent-policy-1', name: 'Agent policy 1', namespace: 'default' },
-          { id: 'agent-policy-2', name: 'Agent policy 2', namespace: 'default' },
+          { id: '1', name: 'Agent policy 1', namespace: 'default' },
+          { id: '2', name: 'Agent policy 2', namespace: 'default' },
         ],
       },
     });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
@@ -67,8 +67,8 @@ describe('StepSelectHosts', () => {
   const render = () =>
     (renderResult = testRenderer.render(
       <StepSelectHosts
-        agentPolicy={agentPolicy}
-        updateAgentPolicy={jest.fn()}
+        agentPolicies={[agentPolicy]}
+        updateAgentPolicies={jest.fn()}
         newAgentPolicy={newAgentPolicy}
         updateNewAgentPolicy={jest.fn()}
         withSysMonitoring={false}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.tsx
@@ -32,8 +32,8 @@ const StyledEuiTabbedContent = styled(EuiTabbedContent)`
 `;
 
 interface Props {
-  agentPolicy: AgentPolicy | undefined;
-  updateAgentPolicy: (u: AgentPolicy | undefined) => void;
+  agentPolicies: AgentPolicy[];
+  updateAgentPolicies: (u: AgentPolicy[]) => void;
   newAgentPolicy: Partial<NewAgentPolicy>;
   updateNewAgentPolicy: (u: Partial<NewAgentPolicy>) => void;
   withSysMonitoring: boolean;
@@ -46,8 +46,8 @@ interface Props {
 }
 
 export const StepSelectHosts: React.FunctionComponent<Props> = ({
-  agentPolicy,
-  updateAgentPolicy,
+  agentPolicies,
+  updateAgentPolicies,
   newAgentPolicy,
   updateNewAgentPolicy,
   withSysMonitoring,
@@ -58,7 +58,7 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
   updateSelectedTab,
   selectedAgentPolicyId,
 }) => {
-  let agentPolicies: AgentPolicy[] = [];
+  let existingAgentPolicies: AgentPolicy[] = [];
   const { data: agentPoliciesData, error: err } = useGetAgentPolicies({
     page: 1,
     perPage: SO_SEARCH_LIMIT,
@@ -71,19 +71,19 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
     // eslint-disable-next-line no-console
     console.debug('Could not retrieve agent policies');
   }
-  agentPolicies = useMemo(
+  existingAgentPolicies = useMemo(
     () => agentPoliciesData?.items.filter((policy) => !policy.is_managed) || [],
     [agentPoliciesData?.items]
   );
 
   useEffect(() => {
-    if (agentPolicies.length > 0) {
+    if (existingAgentPolicies.length > 0) {
       updateNewAgentPolicy({
         ...newAgentPolicy,
-        name: incrementPolicyName(agentPolicies),
+        name: incrementPolicyName(existingAgentPolicies),
       });
     }
-  }, [agentPolicies.length]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [existingAgentPolicies.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const tabs = [
     {
@@ -107,8 +107,8 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
       content: (
         <StepSelectAgentPolicy
           packageInfo={packageInfo}
-          agentPolicy={agentPolicy}
-          updateAgentPolicy={updateAgentPolicy}
+          agentPolicies={agentPolicies}
+          updateAgentPolicies={updateAgentPolicies}
           setHasAgentPolicyError={setHasAgentPolicyError}
           selectedAgentPolicyId={selectedAgentPolicyId}
         />
@@ -119,7 +119,7 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
   const handleOnTabClick = (tab: EuiTabbedContentTab) =>
     updateSelectedTab(tab.id as SelectedPolicyTab);
 
-  return agentPolicies.length > 0 ? (
+  return existingAgentPolicies.length > 0 ? (
     <StyledEuiTabbedContent
       initialSelectedTab={selectedAgentPolicyId ? tabs[1] : tabs[0]}
       tabs={tabs}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.test.tsx
@@ -106,8 +106,7 @@ describe('useOnSubmit', () => {
 
       expect(renderResult.result.current.packagePolicy).toEqual({
         id: 'new-id',
-        policy_id: '',
-        policy_ids: [''],
+        policy_ids: [],
         namespace: 'newspace',
         description: '',
         enabled: true,
@@ -147,8 +146,7 @@ describe('useOnSubmit', () => {
         inputs: [],
         name: 'apache-1',
         namespace: '',
-        policy_id: '',
-        policy_ids: [''],
+        policy_ids: [],
         package: {
           name: 'apache',
           title: 'Apache',
@@ -193,8 +191,7 @@ describe('useOnSubmit', () => {
       inputs: [],
       name: 'apache-11',
       namespace: '',
-      policy_id: '',
-      policy_ids: [''],
+      policy_ids: [],
       package: {
         name: 'apache',
         title: 'Apache',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -241,7 +241,10 @@ export function useOnSubmit({
   useEffect(() => {
     if (
       agentPolicies.length > 0 &&
-      !agentPolicies.every((agentPolicy) => packagePolicy.policy_ids.includes(agentPolicy.id))
+      !isEqual(
+        agentPolicies.map((policy) => policy.id),
+        packagePolicy.policy_ids
+      )
     ) {
       updatePackagePolicy({
         policy_ids: agentPolicies.map((policy) => policy.id),

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -25,7 +25,7 @@ type MockFn = jest.MockedFunction<any>;
 
 describe('useSetupTechnology', () => {
   const updateNewAgentPolicyMock = jest.fn();
-  const updateAgentPolicyMock = jest.fn();
+  const updateAgentPoliciesMock = jest.fn();
   const setSelectedPolicyTabMock = jest.fn();
   const newAgentPolicyMock = {
     name: 'mock_new_agent_policy',
@@ -59,7 +59,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );
@@ -74,7 +74,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );
@@ -95,7 +95,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );
@@ -110,7 +110,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );
@@ -121,7 +121,7 @@ describe('useSetupTechnology', () => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 
-    expect(updateAgentPolicyMock).toHaveBeenCalledWith({ id: 'agentless-policy-id' });
+    expect(updateAgentPoliciesMock).toHaveBeenCalledWith([{ id: 'agentless-policy-id' }]);
     expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.EXISTING);
   });
 
@@ -130,7 +130,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );
@@ -164,7 +164,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );
@@ -183,7 +183,7 @@ describe('useSetupTechnology', () => {
       useSetupTechnology({
         updateNewAgentPolicy: updateNewAgentPolicyMock,
         newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicy: updateAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
         setSelectedPolicyTab: setSelectedPolicyTabMock,
       })
     );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -64,13 +64,13 @@ export const useAgentless = () => {
 export function useSetupTechnology({
   updateNewAgentPolicy,
   newAgentPolicy,
-  updateAgentPolicy,
+  updateAgentPolicies,
   setSelectedPolicyTab,
   packageInfo,
 }: {
   updateNewAgentPolicy: (policy: NewAgentPolicy) => void;
   newAgentPolicy: NewAgentPolicy;
-  updateAgentPolicy: (policy: AgentPolicy | undefined) => void;
+  updateAgentPolicies: (policies: AgentPolicy[]) => void;
   setSelectedPolicyTab: (tab: SelectedPolicyTab) => void;
   packageInfo?: PackageInfo;
 }) {
@@ -109,13 +109,13 @@ export function useSetupTechnology({
 
       if (setupTechnology === SetupTechnology.AGENTLESS) {
         if (agentlessPolicy) {
-          updateAgentPolicy(agentlessPolicy);
+          updateAgentPolicies([agentlessPolicy]);
           setSelectedPolicyTab(SelectedPolicyTab.EXISTING);
         }
       } else if (setupTechnology === SetupTechnology.AGENT_BASED) {
         updateNewAgentPolicy(newAgentPolicy);
         setSelectedPolicyTab(SelectedPolicyTab.NEW);
-        updateAgentPolicy(undefined);
+        updateAgentPolicies([]);
       }
       setSelectedSetupTechnology(setupTechnology);
     },
@@ -123,7 +123,7 @@ export function useSetupTechnology({
       isAgentlessEnabled,
       selectedSetupTechnology,
       agentlessPolicy,
-      updateAgentPolicy,
+      updateAgentPolicies,
       setSelectedPolicyTab,
       updateNewAgentPolicy,
       newAgentPolicy,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -308,7 +308,6 @@ describe('When on the package policy create page', () => {
         title: 'Nginx',
         version: '1.3.0',
       },
-      policy_id: '',
       policy_ids: ['agent-policy-1'],
       vars: undefined,
     };
@@ -371,6 +370,7 @@ describe('When on the package policy create page', () => {
       expect(sendCreatePackagePolicy as jest.MockedFunction<any>).toHaveBeenCalledWith({
         ...newPackagePolicy,
         policy_id: 'agent-policy-1',
+        policy_ids: ['agent-policy-1'],
         force: false,
       });
       expect(sendCreateAgentPolicy as jest.MockedFunction<any>).not.toHaveBeenCalled();
@@ -498,6 +498,9 @@ describe('When on the package policy create page', () => {
 
         (sendCreateAgentPolicy as jest.MockedFunction<any>).mockClear();
         (sendCreatePackagePolicy as jest.MockedFunction<any>).mockClear();
+        (sendGetAgentStatus as jest.MockedFunction<any>).mockResolvedValue({
+          data: { results: { total: 0 } },
+        });
       });
 
       test('should create agent policy before creating package policy on submit when new hosts is selected', async () => {
@@ -545,7 +548,7 @@ describe('When on the package policy create page', () => {
       });
 
       test('should show modal if agent policy has agents', async () => {
-        (sendGetAgentStatus as jest.MockedFunction<any>).mockResolvedValueOnce({
+        (sendGetAgentStatus as jest.MockedFunction<any>).mockResolvedValue({
           data: { results: { total: 1 } },
         });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -60,6 +60,11 @@ jest.mock('../../../../hooks', () => {
         },
       },
     }),
+    sendBulkGetAgentPolicies: jest.fn().mockImplementation((ids) =>
+      Promise.resolve({
+        data: { items: ids.map((id: string) => ({ id, package_policies: [] })) },
+      })
+    ),
     useGetPackageInfoByKeyQuery: jest.fn(),
     sendGetSettings: jest.fn().mockResolvedValue({
       data: { item: {} },

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -155,8 +155,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     onSubmit,
     updatePackagePolicy,
     packagePolicy,
-    agentPolicy,
-    updateAgentPolicy,
+    agentPolicies,
+    updateAgentPolicies,
     savedPackagePolicy,
     formState,
     setFormState,
@@ -216,19 +216,23 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   );
 
   // Retrieve agent count
-  const agentPolicyId = agentPolicy?.id;
+  const agentPolicyIds = agentPolicies.map((policy) => policy.id);
 
   const { cancelClickHandler, cancelUrl } = useCancelAddPackagePolicy({
     from,
     pkgkey: params.pkgkey,
-    agentPolicyId,
+    agentPolicyId: agentPolicyIds[0],
   });
   useEffect(() => {
     const getAgentCount = async () => {
-      const { data } = await sendGetAgentStatus({ policyId: agentPolicyId });
-      if (data?.results.total !== undefined) {
-        setAgentCount(data.results.total);
+      let count = 0;
+      for (const policyId of agentPolicyIds) {
+        const { data } = await sendGetAgentStatus({ policyId });
+        if (data?.results.total) {
+          count += data.results.total;
+        }
       }
+      setAgentCount(count);
     };
 
     if (selectedPolicyTab === SelectedPolicyTab.NEW) {
@@ -236,10 +240,10 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       return;
     }
 
-    if (isFleetEnabled && agentPolicyId) {
+    if (isFleetEnabled && agentPolicyIds.length > 0) {
       getAgentCount();
     }
-  }, [agentPolicyId, selectedPolicyTab, isFleetEnabled]);
+  }, [agentPolicyIds, selectedPolicyTab, isFleetEnabled]);
 
   const handleExtensionViewOnChange = useCallback<
     PackagePolicyEditExtensionComponentProps['onChange']
@@ -269,18 +273,18 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       from,
       cancelUrl,
       onCancel: cancelClickHandler,
-      agentPolicy,
+      agentPolicies,
       packageInfo,
       integrationInfo,
     }),
-    [agentPolicy, cancelClickHandler, cancelUrl, from, integrationInfo, packageInfo]
+    [agentPolicies, cancelClickHandler, cancelUrl, from, integrationInfo, packageInfo]
   );
 
   const stepSelectAgentPolicy = useMemo(
     () => (
       <StepSelectHosts
-        agentPolicy={agentPolicy}
-        updateAgentPolicy={updateAgentPolicy}
+        agentPolicies={agentPolicies}
+        updateAgentPolicies={updateAgentPolicies}
         newAgentPolicy={newAgentPolicy}
         updateNewAgentPolicy={updateNewAgentPolicy}
         withSysMonitoring={withSysMonitoring}
@@ -294,8 +298,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     ),
     [
       packageInfo,
-      agentPolicy,
-      updateAgentPolicy,
+      agentPolicies,
+      updateAgentPolicies,
       newAgentPolicy,
       updateNewAgentPolicy,
       validation,
@@ -327,7 +331,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     useSetupTechnology({
       newAgentPolicy,
       updateNewAgentPolicy,
-      updateAgentPolicy,
+      updateAgentPolicies,
       setSelectedPolicyTab,
       packageInfo,
     });
@@ -339,7 +343,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       ) : (
         <ExtensionWrapper>
           <replaceDefineStepView.Component
-            agentPolicy={agentPolicy}
+            agentPolicy={agentPolicies[0]}
             packageInfo={packageInfo}
             newPolicy={packagePolicy}
             onChange={handleExtensionViewOnChange}
@@ -359,7 +363,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       ) : packageInfo ? (
         <>
           <StepDefinePackagePolicy
-            agentPolicy={agentPolicy}
+            agentPolicies={agentPolicies}
             packageInfo={packageInfo}
             packagePolicy={packagePolicy}
             updatePackagePolicy={updatePackagePolicy}
@@ -395,7 +399,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
     [
       isInitialized,
       isPackageInfoLoading,
-      agentPolicy,
+      agentPolicies,
       packageInfo,
       packagePolicy,
       updatePackagePolicy,
@@ -444,27 +448,29 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
   }
 
   const rootPrivilegedDataStreams = packageInfo ? getRootPrivilegedDataStreams(packageInfo) : [];
+  const unprivilegedAgentsCount = agentPolicies.reduce(
+    (acc, curr) => acc + (curr.unprivileged_agents ?? 0),
+    0
+  );
 
   return (
     <CreatePackagePolicySinglePageLayout {...layoutProps} data-test-subj="createPackagePolicy">
       <EuiErrorBoundary>
-        {formState === 'CONFIRM' && agentPolicy && (
+        {formState === 'CONFIRM' && agentPolicies.length > 0 && (
           <ConfirmDeployAgentPolicyModal
             agentCount={agentCount}
-            agentPolicy={agentPolicy}
+            agentPolicies={agentPolicies}
             onConfirm={onSubmit}
             onCancel={() => setFormState('VALID')}
             showUnprivilegedAgentsCallout={Boolean(
-              packageInfo &&
-                isRootPrivilegesRequired(packageInfo) &&
-                (agentPolicy?.unprivileged_agents ?? 0) > 0
+              packageInfo && isRootPrivilegesRequired(packageInfo) && unprivilegedAgentsCount > 0
             )}
-            unprivilegedAgentsCount={agentPolicy?.unprivileged_agents ?? 0}
+            unprivilegedAgentsCount={unprivilegedAgentsCount}
             dataStreams={rootPrivilegedDataStreams}
           />
         )}
         {formState === 'SUBMITTED_NO_AGENTS' &&
-          agentPolicy &&
+          agentPolicies.length > 0 &&
           packageInfo &&
           savedPackagePolicy && (
             <PostInstallAddAgentModal
@@ -473,30 +479,36 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
               onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
             />
           )}
-        {formState === 'SUBMITTED_AZURE_ARM_TEMPLATE' && agentPolicy && savedPackagePolicy && (
-          <PostInstallAzureArmTemplateModal
-            agentPolicy={agentPolicy}
-            packagePolicy={savedPackagePolicy}
-            onConfirm={() => navigateAddAgent(savedPackagePolicy)}
-            onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
-          />
-        )}
-        {formState === 'SUBMITTED_CLOUD_FORMATION' && agentPolicy && savedPackagePolicy && (
-          <PostInstallCloudFormationModal
-            agentPolicy={agentPolicy}
-            packagePolicy={savedPackagePolicy}
-            onConfirm={() => navigateAddAgent(savedPackagePolicy)}
-            onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
-          />
-        )}
-        {formState === 'SUBMITTED_GOOGLE_CLOUD_SHELL' && agentPolicy && savedPackagePolicy && (
-          <PostInstallGoogleCloudShellModal
-            agentPolicy={agentPolicy}
-            packagePolicy={savedPackagePolicy}
-            onConfirm={() => navigateAddAgent(savedPackagePolicy)}
-            onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
-          />
-        )}
+        {formState === 'SUBMITTED_AZURE_ARM_TEMPLATE' &&
+          agentPolicies.length > 0 &&
+          savedPackagePolicy && (
+            <PostInstallAzureArmTemplateModal
+              agentPolicy={agentPolicies[0]}
+              packagePolicy={savedPackagePolicy}
+              onConfirm={() => navigateAddAgent(savedPackagePolicy)}
+              onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
+            />
+          )}
+        {formState === 'SUBMITTED_CLOUD_FORMATION' &&
+          agentPolicies.length > 0 &&
+          savedPackagePolicy && (
+            <PostInstallCloudFormationModal
+              agentPolicy={agentPolicies[0]}
+              packagePolicy={savedPackagePolicy}
+              onConfirm={() => navigateAddAgent(savedPackagePolicy)}
+              onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
+            />
+          )}
+        {formState === 'SUBMITTED_GOOGLE_CLOUD_SHELL' &&
+          agentPolicies.length > 0 &&
+          savedPackagePolicy && (
+            <PostInstallGoogleCloudShellModal
+              agentPolicy={agentPolicies[0]}
+              packagePolicy={savedPackagePolicy}
+              onConfirm={() => navigateAddAgent(savedPackagePolicy)}
+              onCancel={() => navigateAddAgentHelp(savedPackagePolicy)}
+            />
+          )}
         {packageInfo && (
           <IntegrationBreadcrumb
             pkgTitle={integrationInfo?.title || packageInfo.title}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
@@ -153,7 +153,7 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
         {agentCount ? (
           <ConfirmDeployAgentPolicyModal
             agentCount={agentCount}
-            agentPolicy={agentPolicy}
+            agentPolicies={[agentPolicy]}
             onConfirm={() => {
               setAgentCount(0);
               submitUpdateAgentPolicy();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -81,7 +81,7 @@ export function usePackagePolicyWithRelatedData(
   });
   const [originalPackagePolicy, setOriginalPackagePolicy] =
     useState<GetOnePackagePolicyResponse['item']>();
-  const [agentPolicy, setAgentPolicy] = useState<AgentPolicy>();
+  const [agentPolicies, setAgentPolicies] = useState<AgentPolicy[]>([]);
   const [isLoadingData, setIsLoadingData] = useState<boolean>(true);
   const [dryRunData, setDryRunData] = useState<UpgradePackagePolicyDryRunResponse>();
   const [loadingError, setLoadingError] = useState<Error>();
@@ -171,17 +171,21 @@ export function usePackagePolicyWithRelatedData(
           throw packagePolicyError;
         }
 
-        const { data: agentPolicyData, error: agentPolicyError } = await sendGetOneAgentPolicy(
-          packagePolicyData!.item.policy_ids[0] // TODO multiple
-        );
+        const newAgentPolicies = [];
+        for (const policyId of packagePolicyData!.item.policy_ids) {
+          const { data: agentPolicyData, error: agentPolicyError } = await sendGetOneAgentPolicy(
+            policyId
+          );
 
-        if (agentPolicyError) {
-          throw agentPolicyError;
-        }
+          if (agentPolicyError) {
+            throw agentPolicyError;
+          }
 
-        if (agentPolicyData?.item) {
-          setAgentPolicy(agentPolicyData.item);
+          if (agentPolicyData?.item) {
+            newAgentPolicies.push(agentPolicyData.item);
+          }
         }
+        setAgentPolicies(newAgentPolicies);
 
         const { data: upgradePackagePolicyDryRunData, error: upgradePackagePolicyDryRunError } =
           await sendUpgradePackagePolicyDryRun([packagePolicyId]);
@@ -353,7 +357,7 @@ export function usePackagePolicyWithRelatedData(
     isUpgrade,
     savePackagePolicy,
     isLoadingData,
-    agentPolicy,
+    agentPolicies,
     loadingError,
     packagePolicy,
     originalPackagePolicy,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useMemo, memo } from 'react';
-import { omit } from 'lodash';
+import { isEmpty, omit } from 'lodash';
 import { useRouteMatch } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -103,7 +103,7 @@ export const EditPackagePolicyForm = memo<{
 
   const {
     // data
-    agentPolicy,
+    agentPolicies,
     isLoadingData,
     loadingError,
     packagePolicy,
@@ -134,22 +134,26 @@ export const EditPackagePolicyForm = memo<{
     return getNewSecrets({ packageInfo, packagePolicy });
   }, [packageInfo, packagePolicy]);
 
-  const policyId = agentPolicy?.id ?? '';
+  const policyIds = agentPolicies.map((policy) => policy.id);
 
   // Retrieve agent count
   const [agentCount, setAgentCount] = useState<number>(0);
   useEffect(() => {
     const getAgentCount = async () => {
-      const { data } = await sendGetAgentStatus({ policyId });
-      if (data?.results.total) {
-        setAgentCount(data.results.total);
+      let count = 0;
+      for (const policyId of policyIds) {
+        const { data } = await sendGetAgentStatus({ policyId });
+        if (data?.results.total) {
+          count += data.results.total;
+        }
       }
+      setAgentCount(count);
     };
 
-    if (isFleetEnabled && policyId) {
+    if (isFleetEnabled && policyIds.length > 0) {
       getAgentCount();
     }
-  }, [policyId, isFleetEnabled]);
+  }, [policyIds, isFleetEnabled]);
 
   const handleExtensionViewOnChange = useCallback<
     PackagePolicyEditExtensionComponentProps['onChange']
@@ -170,25 +174,25 @@ export const EditPackagePolicyForm = memo<{
   //  if `from === 'edit'` then it links back to Policy Details
   //  if `from === 'package-edit'`, or `upgrade-from-integrations-policy-list` then it links back to the Integration Policy List
   const cancelUrl = useMemo((): string => {
-    if (packageInfo && policyId) {
+    if (packageInfo && policyIds.length > 0) {
       return from === 'package-edit'
         ? getHref('integration_details_policies', {
             pkgkey: pkgKeyFromPackageInfo(packageInfo!),
           })
-        : getHref('policy_details', { policyId });
+        : getHref('policy_details', { policyId: policyIds[0] });
     }
     return '/';
-  }, [from, getHref, packageInfo, policyId]);
+  }, [from, getHref, packageInfo, policyIds]);
   const successRedirectPath = useMemo(() => {
-    if (packageInfo && policyId) {
+    if (packageInfo && policyIds.length > 0) {
       return from === 'package-edit' || from === 'upgrade-from-integrations-policy-list'
         ? getHref('integration_details_policies', {
             pkgkey: pkgKeyFromPackageInfo(packageInfo!),
           })
-        : getHref('policy_details', { policyId });
+        : getHref('policy_details', { policyId: policyIds[0] });
     }
     return '/';
-  }, [from, getHref, packageInfo, policyId]);
+  }, [from, getHref, packageInfo, policyIds]);
 
   useHistoryBlock(isEdited);
 
@@ -197,7 +201,7 @@ export const EditPackagePolicyForm = memo<{
       setFormState('INVALID');
       return;
     }
-    if (agentCount !== 0 && policyId !== AGENTLESS_POLICY_ID && formState !== 'CONFIRM') {
+    if (agentCount !== 0 && !policyIds.includes(AGENTLESS_POLICY_ID) && formState !== 'CONFIRM') {
       setFormState('CONFIRM');
       return;
     }
@@ -215,11 +219,11 @@ export const EditPackagePolicyForm = memo<{
         }),
         'data-test-subj': 'policyUpdateSuccessToast',
         text:
-          agentCount && agentPolicy
+          agentCount && agentPolicies.length > 0
             ? i18n.translate('xpack.fleet.editPackagePolicy.updatedNotificationMessage', {
-                defaultMessage: `Fleet will deploy updates to all agents that use the ''{agentPolicyName}'' policy`,
+                defaultMessage: `Fleet will deploy updates to all agents that use the ''{agentPolicyNames}'' policy`,
                 values: {
-                  agentPolicyName: agentPolicy.name,
+                  agentPolicyNames: agentPolicies.map((policy) => policy.name).join(', '),
                 },
               })
             : undefined,
@@ -276,7 +280,7 @@ export const EditPackagePolicyForm = memo<{
   const layoutProps = {
     from: extensionView?.useLatestPackageVersion && isUpgrade ? 'upgrade-from-extension' : from,
     cancelUrl,
-    agentPolicy,
+    agentPolicies,
     packageInfo,
     tabs: tabsViews?.length
       ? [
@@ -302,11 +306,11 @@ export const EditPackagePolicyForm = memo<{
 
   const configurePackage = useMemo(
     () =>
-      agentPolicy && packageInfo ? (
+      agentPolicies && packageInfo ? (
         <>
           {selectedTab === 0 && (
             <StepDefinePackagePolicy
-              agentPolicy={agentPolicy}
+              agentPolicies={agentPolicies}
               packageInfo={packageInfo}
               packagePolicy={packagePolicy}
               updatePackagePolicy={updatePackagePolicy}
@@ -351,7 +355,7 @@ export const EditPackagePolicyForm = memo<{
         </>
       ) : null,
     [
-      agentPolicy,
+      agentPolicies,
       packageInfo,
       packagePolicy,
       updatePackagePolicy,
@@ -368,7 +372,7 @@ export const EditPackagePolicyForm = memo<{
   const replaceConfigurePackage = replaceDefineStepView && originalPackagePolicy && packageInfo && (
     <ExtensionWrapper>
       <replaceDefineStepView.Component
-        agentPolicy={agentPolicy}
+        agentPolicy={agentPolicies[0]}
         packageInfo={packageInfo}
         policy={originalPackagePolicy}
         newPolicy={packagePolicy}
@@ -401,7 +405,7 @@ export const EditPackagePolicyForm = memo<{
       <EuiErrorBoundary>
         {isLoadingData ? (
           <Loading />
-        ) : loadingError || !agentPolicy || !packageInfo ? (
+        ) : loadingError || isEmpty(agentPolicies) || !packageInfo ? (
           <ErrorComponent
             title={
               <FormattedMessage
@@ -419,17 +423,17 @@ export const EditPackagePolicyForm = memo<{
         ) : (
           <>
             <Breadcrumb
-              agentPolicyName={agentPolicy.name}
+              agentPolicyName={agentPolicies[0].name}
               from={from}
               packagePolicyName={packagePolicy.name}
               pkgkey={pkgKeyFromPackageInfo(packageInfo)}
               pkgTitle={packageInfo.title}
-              policyId={policyId}
+              policyId={policyIds[0]}
             />
             {formState === 'CONFIRM' && (
               <ConfirmDeployAgentPolicyModal
                 agentCount={agentCount}
-                agentPolicy={agentPolicy}
+                agentPolicies={agentPolicies}
                 onConfirm={onSubmit}
                 onCancel={() => setFormState('VALID')}
               />
@@ -453,7 +457,7 @@ export const EditPackagePolicyForm = memo<{
             <EuiBottomBar>
               <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
                 <EuiFlexItem grow={false}>
-                  {agentPolicy && packageInfo && formState === 'INVALID' ? (
+                  {agentPolicies && packageInfo && formState === 'INVALID' ? (
                     <FormattedMessage
                       id="xpack.fleet.createPackagePolicy.errorOnSaveText"
                       defaultMessage="Your integration policy has errors. Please fix them before saving."

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_first_time_agent_user.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_first_time_agent_user.ts
@@ -31,7 +31,7 @@ export const useIsFirstTimeAgentUserQuery = (): UseIsFirstTimeAgentUserResponse 
   // now get all agents that are NOT part of a fleet server policy
   const serverPolicyIdsQuery = (agentPolicies?.items || [])
     .filter((item) => policyHasFleetServer(item))
-    .map((p) => `policy_ids:${p.id}`)
+    .map((p) => `policy_id:${p.id}`)
     .join(' or ');
 
   // get agents that are not unenrolled and not fleet server

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_first_time_agent_user.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/hooks/use_is_first_time_agent_user.ts
@@ -31,7 +31,7 @@ export const useIsFirstTimeAgentUserQuery = (): UseIsFirstTimeAgentUserResponse 
   // now get all agents that are NOT part of a fleet server policy
   const serverPolicyIdsQuery = (agentPolicies?.items || [])
     .filter((item) => policyHasFleetServer(item))
-    .map((p) => `policy_id:${p.id}`)
+    .map((p) => `policy_ids:${p.id}`)
     .join(' or ');
 
   // get agents that are not unenrolled and not fleet server

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -50,7 +50,7 @@ interface PackagePoliciesPanelProps {
 
 interface InMemoryPackagePolicyAndAgentPolicy {
   packagePolicy: InMemoryPackagePolicy;
-  agentPolicy?: GetAgentPoliciesResponseItem;
+  agentPolicies: GetAgentPoliciesResponseItem[];
 }
 
 const IntegrationDetailsLink = memo<{
@@ -118,18 +118,18 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
   const canAddFleetServers = useAuthz().fleet.addFleetServers;
 
   const packageAndAgentPolicies = useMemo((): Array<{
-    agentPolicy?: GetAgentPoliciesResponseItem;
+    agentPolicies: GetAgentPoliciesResponseItem[];
     packagePolicy: InMemoryPackagePolicy;
   }> => {
     if (!data?.items) {
       return [];
     }
 
-    const newPolicies = data.items.map(({ agentPolicy, packagePolicy }) => {
+    const newPolicies = data.items.map(({ agentPolicies, packagePolicy }) => {
       const hasUpgrade = isPackagePolicyUpgradable(packagePolicy);
 
       return {
-        agentPolicy,
+        agentPolicies,
         packagePolicy: {
           ...packagePolicy,
           hasUpgrade,
@@ -140,8 +140,8 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
     return newPolicies;
   }, [data?.items, isPackagePolicyUpgradable]);
 
-  const showAddAgentHelpForPackagePolicyId = packageAndAgentPolicies.find(
-    ({ agentPolicy }) => agentPolicy?.id === showAddAgentHelpForPolicyId
+  const showAddAgentHelpForPackagePolicyId = packageAndAgentPolicies.find(({ agentPolicies }) =>
+    agentPolicies.find((agentPolicy) => agentPolicy.id === showAddAgentHelpForPolicyId)
   )?.packagePolicy?.id;
   // Handle the "add agent" link displayed in post-installation toast notifications in the case
   // where a user is clicking the link while on the package policies listing page
@@ -184,7 +184,7 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
         name: i18n.translate('xpack.fleet.epm.packageDetails.integrationList.version', {
           defaultMessage: 'Version',
         }),
-        render(_version, { agentPolicy, packagePolicy }) {
+        render(_version, { agentPolicies, packagePolicy }) {
           return (
             <EuiFlexGroup gutterSize="s" alignItems="center" wrap={true}>
               <EuiFlexItem grow={false}>
@@ -197,13 +197,13 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
                 </EuiText>
               </EuiFlexItem>
 
-              {agentPolicy && packagePolicy.hasUpgrade && (
+              {agentPolicies.length > 0 && packagePolicy.hasUpgrade && (
                 <EuiFlexItem grow={false}>
                   <EuiButton
                     size="s"
                     minWidth="0"
                     href={`${getHref('upgrade_package_policy', {
-                      policyId: agentPolicy.id,
+                      policyId: agentPolicies[0].id,
                       packagePolicyId: packagePolicy.id,
                     })}?from=integrations-policy-list`}
                     data-test-subj="integrationPolicyUpgradeBtn"
@@ -221,14 +221,15 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
         },
       },
       {
-        field: 'packagePolicy.policy_id',
+        field: 'packagePolicy.policy_ids',
         name: i18n.translate('xpack.fleet.epm.packageDetails.integrationList.agentPolicy', {
           defaultMessage: 'Agent policy',
         }),
         truncateText: true,
-        render(id, { agentPolicy }) {
-          return agentPolicy ? (
-            <AgentPolicySummaryLine policy={agentPolicy} />
+        render(id, { agentPolicies }) {
+          return agentPolicies.length > 0 ? (
+            // TODO: handle multiple agent policies
+            <AgentPolicySummaryLine policy={agentPolicies[0]} />
           ) : (
             <AgentPolicyNotFound />
           );
@@ -263,10 +264,11 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
         name: i18n.translate('xpack.fleet.epm.packageDetails.integrationList.agentCount', {
           defaultMessage: 'Agents',
         }),
-        render({ agentPolicy, packagePolicy }: InMemoryPackagePolicyAndAgentPolicy) {
-          if (!agentPolicy) {
+        render({ agentPolicies, packagePolicy }: InMemoryPackagePolicyAndAgentPolicy) {
+          if (agentPolicies.length === 0) {
             return null;
           }
+          const agentPolicy = agentPolicies[0]; // TODO: handle multiple agent policies
           const canAddAgentsForPolicy = policyHasFleetServer(agentPolicy)
             ? canAddFleetServers
             : canAddAgents;
@@ -288,7 +290,8 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
         }),
         width: '8ch',
         align: 'right',
-        render({ agentPolicy, packagePolicy }) {
+        render({ agentPolicies, packagePolicy }) {
+          const agentPolicy = agentPolicies[0]; // TODO: handle multiple agent policies
           return (
             <PackagePolicyActionsMenu
               agentPolicy={agentPolicy}
@@ -342,10 +345,10 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
       <Redirect to={getPath('integration_details_overview', { pkgkey: `${name}-${version}` })} />
     );
   }
-  const selectedPolicies = packageAndAgentPolicies.find(
-    ({ agentPolicy: policy }) => policy?.id === flyoutOpenForPolicyId
+  const selectedPolicies = packageAndAgentPolicies.find(({ agentPolicies: policies }) =>
+    policies.find((policy) => policy.id === flyoutOpenForPolicyId)
   );
-  const agentPolicy = selectedPolicies?.agentPolicy;
+  const agentPolicies = selectedPolicies?.agentPolicies;
   const packagePolicy = selectedPolicies?.packagePolicy;
 
   return (
@@ -364,14 +367,14 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-      {flyoutOpenForPolicyId && agentPolicy && !isLoading && (
+      {flyoutOpenForPolicyId && agentPolicies && !isLoading && (
         <AgentEnrollmentFlyout
           onClose={() => {
             setFlyoutOpenForPolicyId(null);
             const { addAgentToPolicyId, ...rest } = parse(search);
             history.replace({ search: stringify(rest) });
           }}
-          agentPolicy={agentPolicy}
+          agentPolicy={agentPolicies[0]}
           isIntegrationFlow={true}
           installedPackagePolicy={{
             name: packagePolicy?.package?.name || '',

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_package_policies_with_agent_policy.ts
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/use_package_policies_with_agent_policy.ts
@@ -19,13 +19,9 @@ import { agentPolicyRouteService } from '../../../../../services';
 import { useGetPackagePolicies, useConditionalRequest } from '../../../../../hooks';
 import type { SendConditionalRequestConfig } from '../../../../../hooks';
 
-export interface PackagePolicyEnriched extends PackagePolicy {
-  _agentPolicy: GetAgentPoliciesResponseItem | undefined;
-}
-
 export interface PackagePolicyAndAgentPolicy {
   packagePolicy: PackagePolicy;
-  agentPolicy: GetAgentPoliciesResponseItem;
+  agentPolicies: GetAgentPoliciesResponseItem[];
 }
 
 type GetPackagePoliciesWithAgentPolicy = Omit<GetPackagePoliciesResponse, 'items'> & {
@@ -34,7 +30,7 @@ type GetPackagePoliciesWithAgentPolicy = Omit<GetPackagePoliciesResponse, 'items
 
 /**
  * Works similar to `useGetAgentPolicies()`, except that it will add an additional property to
- * each package policy named `_agentPolicy` which may hold the Agent Policy associated with the
+ * each package policy named `agentPolicies` which may hold the Agent Policies associated with the
  * given package policy.
  * @param query
  */
@@ -105,7 +101,9 @@ export const usePackagePoliciesWithAgentPolicy = (
       (packagePolicy) => {
         return {
           packagePolicy,
-          agentPolicy: agentPoliciesById[packagePolicy.policy_ids[0]], // TODO multiple agent policies
+          agentPolicies: packagePolicy.policy_ids
+            .map((policyId: string) => agentPoliciesById[policyId])
+            .filter((policy) => !!policy),
         };
       }
     );

--- a/x-pack/plugins/fleet/public/hooks/use_request/agent_policy.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/agent_policy.ts
@@ -65,6 +65,15 @@ export const useBulkGetAgentPoliciesQuery = (ids: string[], options?: { full?: b
   );
 };
 
+export const sendBulkGetAgentPolicies = (ids: string[], options?: { full?: boolean }) => {
+  return sendRequest<BulkGetAgentPoliciesResponse>({
+    path: agentPolicyRouteService.getBulkGetPath(),
+    method: 'post',
+    body: JSON.stringify({ ids, full: options?.full }),
+    version: API_VERSIONS.public.v1,
+  });
+};
+
 export const sendGetAgentPolicies = (query?: GetAgentPoliciesRequest['query']) => {
   return sendRequest<GetAgentPoliciesResponse>({
     path: agentPolicyRouteService.getListPath(),


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/3263

Added multi-select agent policy component to Add integration policy page.

## Steps to verify

To verify:
- Enable feature flag by adding `xpack.fleet.enableExperimental: ['enableReusableIntegrationPolicies']` to `kibana.dev.yml` locally
- Create a few agent policies
- Open Integrations UI, click on Add integration
- Go to Existing hosts tab at the bottom
- Verify that the agent policy selector support multiple selection
- Verify that all selected agent policy ids are included in the API request (check with `Preview API Request` button)

<img width="870" alt="image" src="https://github.com/elastic/kibana/assets/90178898/57649305-6be1-424d-a5be-08fabbfc475b">

## Logstash output restriction

There are a few scenarios where agent policy selection is restricted.
- Add logstash output to one of the agent policies
- Try to add APM integration policy
- Verify that agent policy with logstash output is disabled
- The new `EuiComboBox` component doesn't support a multiline custom option rendering, so added a warning icon with a tooltip instead.

<img width="889" alt="image" src="https://github.com/elastic/kibana/assets/90178898/259463fa-9831-4bdc-a8b7-edfd8efbd18d">

Existing UI with `EuiSuperSelect`:

<img width="781" alt="image" src="https://github.com/elastic/kibana/assets/90178898/67633284-9c89-4509-b80b-5710c7b22a63">

## Limited packages restriction

The other restrictions don't allow limited packages to be added twice to an agent policy: endpoint, osquery.
Test by adding osquery_manager to one agent policy, and then try to add another integration policy to the same agent policy. It should be disabled.

<img width="871" alt="image" src="https://github.com/elastic/kibana/assets/90178898/50035517-cbe5-439b-bd10-ca5a8f600ba8">

## Agent policies used by agents

The UI shows the sum of agents enrolled to the selected agent policies

<img width="874" alt="image" src="https://github.com/elastic/kibana/assets/90178898/53cc760a-896a-4ae3-a588-86debff3af23">

The `Preview API Request` feature should keep the `policy_ids` list in sync when adding/removing agent policies.

<img width="731" alt="image" src="https://github.com/elastic/kibana/assets/90178898/131bca40-70e3-44eb-9bbd-3563646bb597">

The confirmation modal should also show a sum of enrolled agents and list of selected agent policies.

<img width="779" alt="image" src="https://github.com/elastic/kibana/assets/90178898/d6453006-18fd-463f-8ce4-cc18c142e265">



### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

