### PR TITLE
[SecuritySolution] Disable enrichments cypress test on MKI env

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/enrichments.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/enrichments.cy.ts
@@ -36,7 +36,7 @@ const ORIGINAL_HOST_RISK_LEVEL = 'Original host risk level';
 describe(
   'Enrichment',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess'],
     env: {
       ftrConfig: {
         kbnServerArgs: [


### PR DESCRIPTION
## Summary

MKI environment does not support feature flags.
The test needs the old flyout to work, but the new flyout is now rendered by default.

PR Athat introduced the issue: https://github.com/elastic/kibana/pull/184169

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


