### PR TITLE
[CI] Remove caching of api-docs

### DIFF
--- a/.buildkite/scripts/packer_cache.sh
+++ b/.buildkite/scripts/packer_cache.sh
@@ -17,6 +17,3 @@ done
 for version in $(cat versions.json | jq -r '.versions[].version'); do
   node x-pack/plugins/security_solution/scripts/endpoint/agent_downloader --version "$version"
 done
-
-echo "--- Cloning repos for docs build"
-node scripts/validate_next_docs --clone-only


### PR DESCRIPTION
## Summary
When building the VM image, especially concerning the cache-warmup step (https://github.com/elastic/ci-agent-images/pull/736) this step will fail, because it's running on agents that won't have access to this repository ([see this build](https://buildkite.com/elastic/ci-vm-images/builds/5275#01900893-db68-4242-b73e-cda24df6e20c)).

We're probably not losing much by not having this repo cached, or if we need it, we can always build the VM image with this repo cloned, and use it through the git-mirrors.