### PR TITLE
[KibanaEuiProvider] Fix missing `modify` prop not being passed down to `EuiProvider`

### DIFF
--- a/packages/react/kibana_context/root/eui_provider.test.tsx
+++ b/packages/react/kibana_context/root/eui_provider.test.tsx
@@ -56,7 +56,7 @@ describe('KibanaEuiProvider', () => {
     const coreTheme: KibanaTheme = { darkMode: true };
 
     const wrapper = mountWithIntl(
-      <KibanaEuiProvider theme={{ theme$: of(coreTheme) }}>
+      <KibanaEuiProvider theme={{ theme$: of(coreTheme) }} modify={{ breakpoint: { xxl: 1600 } }}>
         <InnerComponent />
       </KibanaEuiProvider>
     );
@@ -64,6 +64,7 @@ describe('KibanaEuiProvider', () => {
     await refresh(wrapper);
 
     expect(euiTheme!.colorMode).toEqual('DARK');
+    expect(euiTheme!.euiTheme.breakpoint.xxl).toEqual(1600);
     expect(consoleWarnMock).not.toBeCalled();
   });
 

--- a/packages/react/kibana_context/root/eui_provider.tsx
+++ b/packages/react/kibana_context/root/eui_provider.tsx
@@ -60,6 +60,7 @@ export const KibanaEuiProvider: FC<PropsWithChildren<KibanaEuiProviderProps>> = 
   theme: { theme$ },
   globalStyles: globalStylesProp,
   colorMode: colorModeProp,
+  modify,
   children,
 }) => {
   const theme = useObservable(theme$, defaultTheme);
@@ -74,7 +75,7 @@ export const KibanaEuiProvider: FC<PropsWithChildren<KibanaEuiProviderProps>> = 
   const globalStyles = globalStylesProp === false ? false : undefined;
 
   return (
-    <EuiProvider {...{ cache, colorMode, globalStyles, utilityClasses: globalStyles }}>
+    <EuiProvider {...{ cache, modify, colorMode, globalStyles, utilityClasses: globalStyles }}>
       {children}
     </EuiProvider>
   );


### PR DESCRIPTION
## Summary

`KibanaEuiProvider` is typed to accept `modify` here: https://github.com/elastic/kibana/blob/0780c1932253942fb5b61d0ec37dcddcf2d369d6/packages/react/kibana_context/root/eui_provider.tsx#L21

Which should allow Kibana plugins to set custom plugin-wide EUI theme tokens, e.g. custom breakpoints and so forth.

Unfortunately it looks like the `modify` prop was missed during prop destructuring, allowing devs to set it in Kibana but resulting it in not being actually passed down to the underlying `EuiProvider`. This PR fixes that.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
