### PR TITLE
Disable pointer-compression by default on serverless

### DIFF
--- a/src/dev/build/tasks/bin/scripts/kibana
+++ b/src/dev/build/tasks/bin/scripts/kibana
@@ -34,7 +34,7 @@ NODE="${DIR}/node/default/bin/node"
 {{#linux}}
 NODE="${DIR}/node/glibc-217/bin/node"
 {{#serverless}}
-if [ "$KBN_DISABLE_POINTER_COMPRESSION" != 'true' ]; then
+if [ "$KBN_ENABLE_POINTER_COMPRESSION" = 'true' ]; then
   NODE="${DIR}/node/pointer-compression/bin/node"
 fi
 {{/serverless}}


### PR DESCRIPTION
## Summary
Disables pointer compression by default. Supposed to fix incident 490.

Was introduced in https://github.com/elastic/kibana/pull/184675