### PR TITLE
[Embeddable Rebuild] Add tooltip support to `PresentationPanel` header badges

### DIFF
--- a/src/plugins/presentation_panel/public/panel_component/panel_header/use_presentation_panel_header_actions.tsx
+++ b/src/plugins/presentation_panel/public/panel_component/panel_header/use_presentation_panel_header_actions.tsx
@@ -115,7 +115,11 @@ export const usePresentationPanelHeaderActions = <
   const badgeElements = useMemo(() => {
     if (!showBadges) return [];
     return badges?.map((badge) => {
-      return (
+      const tooltipText = badge.getDisplayNameTooltip?.({
+        embeddable: api,
+        trigger: panelBadgeTrigger,
+      });
+      const badgeElement = (
         <EuiBadge
           key={badge.id}
           className="embPanel__headerBadge"
@@ -123,6 +127,7 @@ export const usePresentationPanelHeaderActions = <
           onClick={() => badge.execute({ embeddable: api, trigger: panelBadgeTrigger })}
           onClickAriaLabel={badge.getDisplayName({ embeddable: api, trigger: panelBadgeTrigger })}
           data-test-subj={`embeddablePanelBadge-${badge.id}`}
+          {...(tooltipText ? { 'aria-label': tooltipText } : {})}
         >
           {badge.MenuItem
             ? React.createElement(badge.MenuItem, {
@@ -133,6 +138,12 @@ export const usePresentationPanelHeaderActions = <
               })
             : badge.getDisplayName({ embeddable: api, trigger: panelBadgeTrigger })}
         </EuiBadge>
+      );
+
+      return tooltipText ? (
+        <EuiToolTip content={tooltipText}>{badgeElement}</EuiToolTip>
+      ) : (
+        badgeElement
       );
     });
   }, [api, badges, showBadges]);


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/185914

## Summary

The linked regression is a result of https://github.com/elastic/kibana/issues/172017, which accidentally removed tooltip support from badges - this PR adds it back so that the controls deprecation badge now shows the tooltip as expected on both hover and focus:

<p align="center">
<img src="https://github.com/elastic/kibana/assets/8698078/aca8075b-bce5-4fa6-b4b9-e38e00aefad8" alt="Gif showcasing the deprecation tooltip"/>
</p>

I also ensured that the tooltip contents are available for screen readers by adding a conditional `aria-label` - if a tooltip is not provided, then the screen reader will read the badge's contents instead.

**How to Test**
1. Create a legacy input control embeddable by adding the following to your URL: `/app/visualize#/create?type=input_control_vis`
2. Add that panel to a dashboard
3. You should see the deprecation badge and its corresponding tooltip :+1: 

### Checklist

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
