### PR TITLE
[ML] Removes use of re2 library

### DIFF
--- a/x-pack/plugins/ml/server/saved_objects/initialization/space_overrides/logs.ts
+++ b/x-pack/plugins/ml/server/saved_objects/initialization/space_overrides/logs.ts
@@ -6,7 +6,6 @@
  */
 
 import type { IScopedClusterClient } from '@kbn/core/server';
-import RE2 from 're2';
 import { mlLog } from '../../../lib/log';
 
 const GROUP = 'logs-ui';
@@ -42,7 +41,7 @@ export async function logJobsSpaces({
 }
 
 function findLogJobSpaceFactory() {
-  const reg = new RE2(`${MODULE_PREFIX}-(.+)-(${SOURCES.join('|')})-(${JOB_IDS.join('|')})`);
+  const reg = new RegExp(`${MODULE_PREFIX}-(.+)-(${SOURCES.join('|')})-(${JOB_IDS.join('|')})`);
 
   return (jobId: string) => {
     const result = reg.exec(jobId);

--- a/x-pack/plugins/ml/server/saved_objects/initialization/space_overrides/metrics.ts
+++ b/x-pack/plugins/ml/server/saved_objects/initialization/space_overrides/metrics.ts
@@ -6,7 +6,6 @@
  */
 
 import type { IScopedClusterClient } from '@kbn/core/server';
-import RE2 from 're2';
 import { mlLog } from '../../../lib/log';
 
 const GROUP = 'metrics';
@@ -49,7 +48,7 @@ export async function metricsJobsSpaces({
 }
 
 function findMetricsJobSpaceFactory() {
-  const reg = new RE2(`${MODULE_PREFIX}-(.+)-(${SOURCES.join('|')})-(${JOB_IDS.join('|')})`);
+  const reg = new RegExp(`${MODULE_PREFIX}-(.+)-(${SOURCES.join('|')})-(${JOB_IDS.join('|')})`);
 
   return (jobId: string) => {
     const result = reg.exec(jobId);

--- a/x-pack/plugins/ml/server/saved_objects/service.ts
+++ b/x-pack/plugins/ml/server/saved_objects/service.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import RE2 from 're2';
 import { memoize } from 'lodash';
 import type {
   KibanaRequest,
@@ -329,7 +328,7 @@ export function mlSavedObjectServiceFactory(
       if (id.match('\\*') === null) {
         return jobIds.includes(id);
       }
-      const regex = new RE2(id.replace('*', '.*'));
+      const regex = new RegExp(id.replace('*', '.*'));
       return jobIds.some((jId) => typeof jId === 'string' && regex.exec(jId));
     });
   }
@@ -641,7 +640,7 @@ export function mlSavedObjectServiceFactory(
       if (id.match('\\*') === null) {
         return modelIds.includes(id);
       }
-      const regex = new RE2(id.replace('*', '.*'));
+      const regex = new RegExp(id.replace('*', '.*'));
       return modelIds.some((jId) => typeof jId === 'string' && regex.exec(jId));
     });
   }


### PR DESCRIPTION
We no longer need to use `re2` over the standard regex library.