### PR TITLE
[UII] Maintain log level order by verbosity

### DIFF
--- a/x-pack/plugins/fleet/common/constants/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/constants/agent_policy.ts
@@ -38,11 +38,5 @@ export const DEFAULT_MAX_AGENT_POLICIES_WITH_INACTIVITY_TIMEOUT = 750;
 
 export const AGENTLESS_POLICY_ID = 'agentless'; // the policy id defined here: https://github.com/elastic/project-controller/blob/main/internal/project/security/security_kibana_config.go#L86
 
-export const AGENT_LOG_LEVELS = {
-  info: 'info',
-  debug: 'debug',
-  warning: 'warning',
-  error: 'error',
-};
-
-export const DEFAULT_LOG_LEVEL = AGENT_LOG_LEVELS.info;
+export const AGENT_LOG_LEVELS = ['error', 'warning', 'info', 'debug'] as const;
+export const DEFAULT_LOG_LEVEL = 'info' as const;

--- a/x-pack/plugins/fleet/common/settings/agent_policy_settings.tsx
+++ b/x-pack/plugins/fleet/common/settings/agent_policy_settings.tsx
@@ -148,6 +148,6 @@ export const AGENT_POLICY_ADVANCED_SETTINGS: SettingsConfig[] = [
     },
     learnMoreLink:
       'https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-log-level',
-    schema: z.nativeEnum(AGENT_LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
+    schema: z.enum(AGENT_LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
   },
 ];

--- a/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/form_settings/index.tsx
@@ -63,33 +63,28 @@ settingComponentRegistry.set(ZodFirstPartyTypeKind.ZodString, ({ disabled, ...se
   );
 });
 
-settingComponentRegistry.set(
-  ZodFirstPartyTypeKind.ZodNativeEnum,
-  ({ disabled, ...settingsConfig }) => {
-    return (
-      <SettingsFieldWrapper
-        disabled={disabled}
-        settingsConfig={settingsConfig}
-        typeName={ZodFirstPartyTypeKind.ZodString}
-        renderItem={({ fieldKey, fieldValue, handleChange }: any) => (
-          <EuiSelect
-            data-test-subj={fieldKey}
-            value={fieldValue}
-            fullWidth
-            disabled={disabled}
-            onChange={handleChange}
-            options={Object.entries(settingsConfig.schema._def.innerType._def.values).map(
-              ([key, value]) => ({
-                text: key,
-                value: value as string,
-              })
-            )}
-          />
-        )}
-      />
-    );
-  }
-);
+settingComponentRegistry.set(ZodFirstPartyTypeKind.ZodEnum, ({ disabled, ...settingsConfig }) => {
+  return (
+    <SettingsFieldWrapper
+      disabled={disabled}
+      settingsConfig={settingsConfig}
+      typeName={ZodFirstPartyTypeKind.ZodString}
+      renderItem={({ fieldKey, fieldValue, handleChange }: any) => (
+        <EuiSelect
+          data-test-subj={fieldKey}
+          value={fieldValue}
+          fullWidth
+          disabled={disabled}
+          onChange={handleChange}
+          options={settingsConfig.schema._def.innerType._def.values.map((value: string) => ({
+            text: value,
+            value,
+          }))}
+        />
+      )}
+    />
+  );
+});
 
 export function ConfiguredSettings({
   configuredSettings,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_log_level.tsx
@@ -12,8 +12,6 @@ import { i18n } from '@kbn/i18n';
 
 import { AGENT_LOG_LEVELS } from '../../../../../../../../common/constants';
 
-const LEVEL_VALUES = Object.values(AGENT_LOG_LEVELS);
-
 export const LogLevelFilter: React.FunctionComponent<{
   selectedLevels: string[];
   onToggleLevel: (level: string) => void;
@@ -24,7 +22,7 @@ export const LogLevelFilter: React.FunctionComponent<{
   const closePopover = useCallback(() => setIsOpen(false), []);
 
   const [options, setOptions] = useState<EuiSelectableOption[]>(
-    LEVEL_VALUES.map((level) => ({
+    AGENT_LOG_LEVELS.map((level) => ({
       label: level,
       checked: selectedLevels.includes(level) ? 'on' : undefined,
       key: level,
@@ -39,7 +37,7 @@ export const LogLevelFilter: React.FunctionComponent<{
           iconType="arrowDown"
           onClick={togglePopover}
           isSelected={isOpen}
-          numFilters={LEVEL_VALUES.length}
+          numFilters={options.length}
           hasActiveFilters={selectedLevels.length > 0}
           numActiveFilters={selectedLevels.length}
         >

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/select_log_level.tsx
@@ -129,9 +129,9 @@ export const SelectLogLevel: React.FC<{ agent: Agent; agentPolicyLogLevel?: stri
               onChange={(event) => {
                 setSelectedLogLevel(event.target.value);
               }}
-              options={Object.entries(AGENT_LOG_LEVELS).map(([key, value]) => ({
-                value,
-                text: key,
+              options={AGENT_LOG_LEVELS.map((level) => ({
+                value: level,
+                text: level,
               }))}
             />
           </EuiFlexItem>


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/184994.

This PR makes the list of log levels have the same order (by verbosity) where ever they are used:

- In Agent details > Logs filter dropdown
- In Agent details > Logs > Agent logging level setting
- In Agent policy > Settings > Agent logging level setting

<img width="770" alt="image" src="https://github.com/elastic/kibana/assets/1965714/eab3d91f-4ce3-4a04-a6fe-f673210337a1">

<img width="559" alt="image" src="https://github.com/elastic/kibana/assets/1965714/3f88e2a1-74e6-4001-b46b-6934bf364f55">

<img width="862" alt="image" src="https://github.com/elastic/kibana/assets/1965714/d6880691-e1ea-4bc2-8df2-26dd3a951e8c">
