### PR TITLE
[ES|QL] Supports counter fields in Discover sidebar

### DIFF
--- a/packages/kbn-field-types/src/kbn_field_types.ts
+++ b/packages/kbn-field-types/src/kbn_field_types.ts
@@ -55,6 +55,10 @@ export function esFieldTypeToKibanaFieldType(type: string) {
       return KBN_FIELD_TYPES.STRING;
     case '_version':
       return KBN_FIELD_TYPES.NUMBER;
+    case 'counter_integer':
+    case 'counter_long':
+    case 'counter_double':
+      return KBN_FIELD_TYPES.COUNTER;
     case 'datetime':
       return KBN_FIELD_TYPES.DATE;
     default:

--- a/packages/kbn-field-types/src/kbn_field_types.ts
+++ b/packages/kbn-field-types/src/kbn_field_types.ts
@@ -49,7 +49,7 @@ export const castEsToKbnFieldTypeName = (esType: ES_FIELD_TYPES | string): KBN_F
 export const getFilterableKbnTypeNames = (): string[] =>
   registeredKbnTypes.filter((type) => type.filterable).map((type) => type.name);
 
-function categorize(type: string) {
+function categorizeFieldType(type: string) {
   // We can have  'counter_integer', 'counter_long', 'counter_double'...
   if (type.includes('counter')) {
     return 'counter';
@@ -58,7 +58,7 @@ function categorize(type: string) {
 }
 
 export function esFieldTypeToKibanaFieldType(type: string) {
-  const fieldTypeCategory = categorize(type);
+  const fieldTypeCategory = categorizeFieldType(type);
   switch (fieldTypeCategory) {
     case ES_FIELD_TYPES._INDEX:
       return KBN_FIELD_TYPES.STRING;

--- a/packages/kbn-field-types/src/kbn_field_types.ts
+++ b/packages/kbn-field-types/src/kbn_field_types.ts
@@ -50,6 +50,7 @@ export const getFilterableKbnTypeNames = (): string[] =>
   registeredKbnTypes.filter((type) => type.filterable).map((type) => type.name);
 
 function categorize(type: string) {
+  // We can have  'counter_integer', 'counter_long', 'counter_double'...
   if (type.includes('counter')) {
     return 'counter';
   }

--- a/packages/kbn-field-types/src/kbn_field_types.ts
+++ b/packages/kbn-field-types/src/kbn_field_types.ts
@@ -49,19 +49,25 @@ export const castEsToKbnFieldTypeName = (esType: ES_FIELD_TYPES | string): KBN_F
 export const getFilterableKbnTypeNames = (): string[] =>
   registeredKbnTypes.filter((type) => type.filterable).map((type) => type.name);
 
+function categorize(type: string) {
+  if (type.includes('counter')) {
+    return 'counter';
+  }
+  return type;
+}
+
 export function esFieldTypeToKibanaFieldType(type: string) {
-  switch (type) {
+  const fieldTypeCategory = categorize(type);
+  switch (fieldTypeCategory) {
     case ES_FIELD_TYPES._INDEX:
       return KBN_FIELD_TYPES.STRING;
     case '_version':
       return KBN_FIELD_TYPES.NUMBER;
-    case 'counter_integer':
-    case 'counter_long':
-    case 'counter_double':
+    case 'counter':
       return KBN_FIELD_TYPES.COUNTER;
     case 'datetime':
       return KBN_FIELD_TYPES.DATE;
     default:
-      return castEsToKbnFieldTypeName(type);
+      return castEsToKbnFieldTypeName(fieldTypeCategory);
   }
 }

--- a/packages/kbn-field-types/src/types.ts
+++ b/packages/kbn-field-types/src/types.ts
@@ -85,4 +85,5 @@ export enum KBN_FIELD_TYPES {
   NESTED = 'nested',
   HISTOGRAM = 'histogram',
   MISSING = 'missing',
+  COUNTER = 'counter',
 }


### PR DESCRIPTION
## Summary

In 8.14 we added partial support of counter fields (you have to convert them to long first to use) but in the sidebar they were reported as unknown.

This PR asserts the correct kibana type for these fields. 

<img width="1679" alt="image" src="https://github.com/elastic/kibana/assets/17003240/eb9ab664-c577-459b-bd8e-7ee44a38020b">

<img width="556" alt="image" src="https://github.com/elastic/kibana/assets/17003240/60464b78-b5bc-4b1b-9e56-e168352054ed">

The fields statistics still dont work for this field but I am tracking this work here https://github.com/elastic/kibana/issues/186077