### PR TITLE
Skip flaky tests #186089 #186086

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/endpoint/index.ts
@@ -17,7 +17,7 @@ export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
   // Flaky: https://github.com/elastic/kibana/issues/186089
-  describe.skip('endpoint', function () {
+  describe('@skipInServerless endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/endpoint/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/endpoint/index.ts
@@ -16,7 +16,8 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
-  describe('endpoint', function () {
+  // Flaky: https://github.com/elastic/kibana/issues/186089
+  describe.skip('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/integrations/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/integrations/index.ts
@@ -16,7 +16,8 @@ import {
 export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
-  describe('endpoint', function () {
+  // Flaky: https://github.com/elastic/kibana/issues/186086
+  describe.skip('endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');

--- a/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/integrations/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint/apps/integrations/index.ts
@@ -17,7 +17,7 @@ export default function (providerContext: FtrProviderContext) {
   const { loadTestFile, getService, getPageObjects } = providerContext;
 
   // Flaky: https://github.com/elastic/kibana/issues/186086
-  describe.skip('endpoint', function () {
+  describe('@skipInServerless endpoint', function () {
     const ingestManager = getService('ingestManager');
     const log = getService('log');
     const endpointTestResources = getService('endpointTestResources');


### PR DESCRIPTION
## Summary
In both cases, it looks like the force-logout mechanism is not working:
https://github.com/elastic/kibana/issues/186089
https://github.com/elastic/kibana/issues/186086

Skipping these to unblock builds and allow an ES snapshot build.