### PR TITLE
[CI] Prevent duplicate serverless image build

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -145,15 +145,14 @@ const getPipeline = (filename: string, removeSteps = true) => {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/fips.yml'));
     }
 
-    if (GITHUB_PR_LABELS.includes('ci:build-serverless-image')) {
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/build_project.yml'));
-    }
     if (
       GITHUB_PR_LABELS.includes('ci:project-deploy-elasticsearch') ||
       GITHUB_PR_LABELS.includes('ci:project-deploy-observability') ||
       GITHUB_PR_LABELS.includes('ci:project-deploy-security')
     ) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/deploy_project.yml'));
+    } else if (GITHUB_PR_LABELS.includes('ci:build-serverless-image')) {
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/build_project.yml'));
     }
 
     if (


### PR DESCRIPTION
## Summary
Only adds build_project.yml if there's not already a deploy_project.yml added through labels

## Context
Based on the labeling logic, if we had `ci:build-serverless-image` and `ci:project-deploy-*`, the steps for building the docker image would be added twice.

See: https://elastic.slack.com/archives/C0D8P2XK5/p1718268306523329

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->