### PR TITLE
[Infra] Add tests for alerts section in the container views overview tab

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/alerts/alerts.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/alerts/alerts.tsx
@@ -77,7 +77,7 @@ export const AlertsSummaryContent = ({
               <LinkToAlertsPage
                 kuery={`${assetIdField}:"${assetId}"`}
                 dateRange={dateRange}
-                data-test-subj="nfraAssetDetailsAlertsTabAlertsShowAllButton"
+                data-test-subj="infraAssetDetailsAlertsTabAlertsShowAllButton"
               />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -316,6 +316,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
               expect(containers.length).to.equal(chartsCount);
             });
           });
+
+          it('should show alerts', async () => {
+            await pageObjects.header.waitUntilLoadingHasFinished();
+            await pageObjects.assetDetails.overviewAlertsTitleExists();
+            await pageObjects.assetDetails.overviewLinkToAlertsExist();
+            await pageObjects.assetDetails.overviewOpenAlertsFlyoutExist();
+          });
         });
 
         describe('Metadata Tab', () => {

--- a/x-pack/test/functional/apps/infra/node_details.ts
+++ b/x-pack/test/functional/apps/infra/node_details.ts
@@ -680,6 +680,18 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             });
           });
 
+          it('should show / hide alerts section with no alerts and show / hide closed section content', async () => {
+            await pageObjects.assetDetails.alertsSectionCollapsibleExist();
+            // Collapsed by default
+            await pageObjects.assetDetails.alertsSectionClosedContentNoAlertsExist();
+            // Expand
+            await pageObjects.assetDetails.alertsSectionCollapsibleClick();
+            await pageObjects.assetDetails.alertsSectionClosedContentNoAlertsMissing();
+            // Check if buttons exist
+            await pageObjects.assetDetails.overviewLinkToAlertsExist();
+            await pageObjects.assetDetails.overviewOpenAlertsFlyoutExist();
+          });
+
           describe('Metadata Tab', () => {
             before(async () => {
               await pageObjects.assetDetails.clickMetadataTab();

--- a/x-pack/test/functional/page_objects/asset_details.ts
+++ b/x-pack/test/functional/page_objects/asset_details.ts
@@ -71,12 +71,12 @@ export function AssetDetailsProvider({ getService }: FtrProviderContext) {
       return servicesWithIconsAndNames;
     },
 
-    async clickOverviewLinkToAlerts() {
-      return testSubjects.click('infraAssetDetailsAlertsShowAllButton');
+    async overviewLinkToAlertsExist() {
+      return testSubjects.existOrFail('infraAssetDetailsAlertsTabAlertsShowAllButton');
     },
 
-    async clickOverviewOpenAlertsFlyout() {
-      return testSubjects.click('infraAssetDetailsCreateAlertsRuleButton');
+    async overviewOpenAlertsFlyoutExist() {
+      return testSubjects.existOrFail('infraAssetDetailsAlertsTabCreateAlertsRuleButton');
     },
 
     async clickShowAllMetadataOverviewTab() {


### PR DESCRIPTION
Closes #186124 

## Summary

This PR adds tests for alerts section in the container views overview tab