### PR TITLE
[ML] Functional tests: fix anomaly detection results forecast flaky test

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/forecasts.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/forecasts.ts
@@ -39,8 +39,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  // Failing: See https://github.com/elastic/kibana/issues/164381
-  describe.skip('forecasts', function () {
+  describe('forecasts', function () {
     this.tags(['ml']);
 
     describe('with single metric job', function () {
@@ -100,7 +99,9 @@ export default function ({ getService }: FtrProviderContext) {
           'should display the forecast in the single metric chart'
         );
         await ml.forecast.assertForecastChartElementsExists();
+      });
 
+      it('should allow interaction with the forecast', async () => {
         await ml.testExecution.logTestStep('should hide the forecast in the single metric chart');
         await ml.forecast.clickForecastCheckbox();
         await ml.forecast.assertForecastChartElementsHidden();


### PR DESCRIPTION
## Summary

Fixes skipped test due to flakiness: https://github.com/elastic/kibana/issues/164381
Moves the forecast checkbox uncheck to a separate test to ensure it doesn't happen before the forecast chart check passes.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6324


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


