### PR TITLE
[TEST] [ML] Revert  `#185012 Do not retry model deployment`

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/plugin.ts
+++ b/x-pack/plugins/elastic_assistant/server/plugin.ts
@@ -52,6 +52,8 @@ export class ElasticAssistantPlugin
   ) {
     this.logger.debug('elasticAssistant: Setup');
 
+    // TODO: Remove before merge, this is so the suite will be triggered
+
     this.assistantService = new AIAssistantService({
       logger: this.logger.get('service'),
       ml: plugins.ml,

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -579,15 +579,10 @@ export function trainedModelsRoutes(
       routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
         try {
           const { modelId } = request.params;
-          const body = await mlClient.startTrainedModelDeployment(
-            {
-              model_id: modelId,
-              ...(request.query ? request.query : {}),
-            },
-            {
-              maxRetries: 0,
-            }
-          );
+          const body = await mlClient.startTrainedModelDeployment({
+            model_id: modelId,
+            ...(request.query ? request.query : {}),
+          });
           return response.ok({
             body,
           });

--- a/x-pack/test/security_solution_api_integration/test_suites/genai/nlp_cleanup_task/basic_license_essentials_tier/task_execution.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/genai/nlp_cleanup_task/basic_license_essentials_tier/task_execution.ts
@@ -40,7 +40,6 @@ export default ({ getService }: FtrProviderContext): void => {
           // Make sure the .ml-stats index is created in advance, see https://github.com/elastic/elasticsearch/issues/65846
           await ml.api.assureMlStatsIndexExists();
           // Create a light-weight model that has a `model_type` of `pytorch`
-          // TODO: Remove before merge, this is so the suite will be triggered
           await ml.api.importTrainedModel(TINY_ELSER.name, TINY_ELSER.id);
         });
 

--- a/x-pack/test/security_solution_api_integration/test_suites/genai/nlp_cleanup_task/basic_license_essentials_tier/task_execution.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/genai/nlp_cleanup_task/basic_license_essentials_tier/task_execution.ts
@@ -40,6 +40,7 @@ export default ({ getService }: FtrProviderContext): void => {
           // Make sure the .ml-stats index is created in advance, see https://github.com/elastic/elasticsearch/issues/65846
           await ml.api.assureMlStatsIndexExists();
           // Create a light-weight model that has a `model_type` of `pytorch`
+          // TODO: Remove before merge, this is so the suite will be triggered
           await ml.api.importTrainedModel(TINY_ELSER.name, TINY_ELSER.id);
         });
 


### PR DESCRIPTION
## Summary

Reverts https://github.com/elastic/kibana/pull/185012 to see if it was the cause of [this pt_tiny_elser](https://buildkite.com/elastic/kibana-pull-request/builds/215831) failure.

---

Looks like it passed with the revert: https://buildkite.com/elastic/kibana-pull-request/builds/215924

Now let's do a flakey test run with it reverted here: 
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6325

<img width="1222" alt="image" src="https://github.com/elastic/kibana/assets/2946766/bb23ebae-6f53-4fac-990d-24ef9d59d224">

1 failure: same error:

> Error: Expected status code 200, got 404 with body '{"error":{"root_cause":[{"type":"resource_not_found_exception","reason":"Could not find trained model [pt_tiny_elser]"}],"type":"resource_not_found_exception","reason":"Could not find trained model [pt_tiny_elser]"},"status":404}'


And of another PR now updated w/ `main` that was green before: 
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6327

<img width="1212" alt="image" src="https://github.com/elastic/kibana/assets/2946766/7c5dfbe9-3bd8-487b-b59a-af943fdb2527">

1 failure: same error:

> Error: Expected status code 200, got 404 with body '{"error":{"root_cause":[{"type":"resource_not_found_exception","reason":"Could not find trained model [pt_tiny_elser]"}],"type":"resource_not_found_exception","reason":"Could not find trained model [pt_tiny_elser]"},"status":404}'

---


This does not appear to be caused by this change, so going to close this PR. Will skip test for now and continue investigation w/ ML folks.