### PR TITLE
[Security Solution] Support local OpenAPI circular references by code generation

### DIFF
--- a/packages/kbn-openapi-generator/src/openapi_generator.ts
+++ b/packages/kbn-openapi-generator/src/openapi_generator.ts
@@ -100,7 +100,7 @@ export const generate = async (config: GeneratorConfig) => {
         version: 'Bundle (no version)',
       },
       imports: {},
-      recursiveRefs: new Set<string>(),
+      circularRefs: new Set<string>(),
     });
 
     await fs.writeFile(bundle.outFile, result);

--- a/packages/kbn-openapi-generator/src/openapi_generator.ts
+++ b/packages/kbn-openapi-generator/src/openapi_generator.ts
@@ -100,6 +100,7 @@ export const generate = async (config: GeneratorConfig) => {
         version: 'Bundle (no version)',
       },
       imports: {},
+      recursiveRefs: new Set<string>(),
     });
 
     await fs.writeFile(bundle.outFile, result);

--- a/packages/kbn-openapi-generator/src/parser/get_generation_context.ts
+++ b/packages/kbn-openapi-generator/src/parser/get_generation_context.ts
@@ -13,14 +13,14 @@ import { getImportsMap, ImportsMap } from './lib/get_imports_map';
 import { normalizeSchema } from './lib/normalize_schema';
 import { NormalizedOperation, OpenApiDocument } from './openapi_types';
 import { getInfo } from './lib/get_info';
-import { getRecursiveRefs } from './lib/get_recursive_refs';
+import { getCircularRefs } from './lib/get_circular_refs';
 
 export interface GenerationContext {
   components: OpenAPIV3.ComponentsObject | undefined;
   operations: NormalizedOperation[];
   info: OpenAPIV3.InfoObject;
   imports: ImportsMap;
-  recursiveRefs: Set<string>;
+  circularRefs: Set<string>;
 }
 
 export function getGenerationContext(document: OpenApiDocument): GenerationContext {
@@ -30,13 +30,13 @@ export function getGenerationContext(document: OpenApiDocument): GenerationConte
   const operations = getApiOperationsList(normalizedDocument);
   const info = getInfo(normalizedDocument);
   const imports = getImportsMap(normalizedDocument);
-  const recursiveRefs = getRecursiveRefs(normalizedDocument);
+  const circularRefs = getCircularRefs(normalizedDocument);
 
   return {
     components,
     operations,
     info,
     imports,
-    recursiveRefs,
+    circularRefs,
   };
 }

--- a/packages/kbn-openapi-generator/src/parser/get_generation_context.ts
+++ b/packages/kbn-openapi-generator/src/parser/get_generation_context.ts
@@ -13,12 +13,14 @@ import { getImportsMap, ImportsMap } from './lib/get_imports_map';
 import { normalizeSchema } from './lib/normalize_schema';
 import { NormalizedOperation, OpenApiDocument } from './openapi_types';
 import { getInfo } from './lib/get_info';
+import { getRecursiveRefs } from './lib/get_recursive_refs';
 
 export interface GenerationContext {
   components: OpenAPIV3.ComponentsObject | undefined;
   operations: NormalizedOperation[];
   info: OpenAPIV3.InfoObject;
   imports: ImportsMap;
+  recursiveRefs: Set<string>;
 }
 
 export function getGenerationContext(document: OpenApiDocument): GenerationContext {
@@ -28,11 +30,13 @@ export function getGenerationContext(document: OpenApiDocument): GenerationConte
   const operations = getApiOperationsList(normalizedDocument);
   const info = getInfo(normalizedDocument);
   const imports = getImportsMap(normalizedDocument);
+  const recursiveRefs = getRecursiveRefs(normalizedDocument);
 
   return {
     components,
     operations,
     info,
     imports,
+    recursiveRefs,
   };
 }

--- a/packages/kbn-openapi-generator/src/parser/lib/find_refs.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/find_refs.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { hasRef } from './helpers/has_ref';
+import { traverseObject } from './helpers/traverse_object';
+
+/**
+ * Traverse the OpenAPI document recursively and find all references
+ *
+ * @param obj Any object
+ * @returns A list of external references
+ */
+export function findRefs(obj: unknown): string[] {
+  const refs: string[] = [];
+
+  traverseObject(obj, (element) => {
+    if (hasRef(element)) {
+      refs.push(element.$ref);
+    }
+  });
+
+  return refs;
+}

--- a/packages/kbn-openapi-generator/src/parser/lib/get_circular_refs.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/get_circular_refs.ts
@@ -7,52 +7,83 @@
  */
 
 import type { OpenApiDocument } from '../openapi_types';
+import type { PlainObject } from './helpers/plain_object';
 import { extractByJsonPointer } from './helpers/extract_by_json_pointer';
 import { findRefs } from './find_refs';
-import { hasRef } from './helpers/has_ref';
-import { traverseObject } from './helpers/traverse_object';
 
 /**
  * Extracts circular references from a provided document.
  * Currently only local references are supported.
  */
 export function getCircularRefs(document: OpenApiDocument): Set<string> {
-  // Process only local references
-  // Local references start with `#/`
-  const refs = findRefs(document).filter((ref) => ref.startsWith('#/'));
+  const localRefs = findLocalRefs(document);
   const circularRefs = new Set<string>();
+  const resolveLocalRef = (localRef: string): PlainObject =>
+    extractByJsonPointer(document, extractJsonPointer(localRef));
 
-  // We need to start traversal from each reference to make sure we caught
-  // all circular cycles. Use BFS algorithm on top of traverseObject function.
-  for (const ref of new Set(refs)) {
-    const refsToVisit = [[ref, new Set<string>()] as const];
+  // In general references represent a disconnected graph. To find
+  // all references cycles we need to check each reference.
+  for (const startRef of new Set(localRefs)) {
+    if (circularRefs.has(startRef)) {
+      // We already found a cycle with the current startRef
+      // continue to the next one
+      continue;
+    }
 
-    while (refsToVisit.length > 0) {
-      for (let i = refsToVisit.length - 1; i >= 0; --i) {
-        const [currentRef, visitedRefsSet] = refsToVisit.shift()!;
-        const currentRefNode = extractByJsonPointer(document, extractJsonPointer(currentRef));
-
-        visitedRefsSet.add(currentRef);
-
-        traverseObject(currentRefNode, (node) => {
-          // Only local references are supported
-          // Local references start with `#/`
-          if (!hasRef(node) || !node.$ref.startsWith('#/')) {
-            return;
-          }
-
-          if (visitedRefsSet.has(node.$ref)) {
-            circularRefs.add(node.$ref);
-            return;
-          }
-
-          refsToVisit.push([node.$ref, new Set(visitedRefsSet)]);
-        });
-      }
+    for (const circularRef of findCycle(startRef, resolveLocalRef)) {
+      circularRefs.add(circularRef);
     }
   }
 
   return circularRefs;
+}
+
+/**
+ * Searches for a reference cycle starting from `startRef` reference.
+ *
+ * @param startRef A starting point to find a cycle
+ * @param resolveRef A callback function to resolve an encountered reference.
+ *                   It should return a document node the provided ref resolves to.
+ * @returns a Set representing a cycle or an empty set if a cycle is not found
+ */
+function findCycle(startRef: string, resolveRef: (ref: string) => PlainObject): Set<string> {
+  let result = new Set<string>();
+
+  const visitedRefs = new Set<string>();
+  const search = (ref: string): void => {
+    if (visitedRefs.has(ref)) {
+      // Need to make a copy due to deletion of the current ref
+      // in the recursion chain via `visitedRefs.delete(ref);`
+      result = new Set(visitedRefs);
+      return;
+    }
+
+    const refNode = resolveRef(ref);
+    const nextRefs = findLocalRefs(refNode);
+
+    visitedRefs.add(ref);
+    nextRefs.forEach(search);
+    visitedRefs.delete(ref);
+  };
+
+  search(startRef);
+
+  return result;
+}
+
+/**
+ * Finds local references
+ */
+function findLocalRefs(obj: unknown): string[] {
+  return findRefs(obj).filter((ref) => isLocalRef(ref));
+}
+
+/**
+ * Checks whether the provided ref is local.
+ * Local references start with `#/`
+ */
+function isLocalRef(ref: string): boolean {
+  return ref.startsWith('#/');
 }
 
 /**

--- a/packages/kbn-openapi-generator/src/parser/lib/get_circular_refs.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/get_circular_refs.ts
@@ -13,17 +13,17 @@ import { hasRef } from './helpers/has_ref';
 import { traverseObject } from './helpers/traverse_object';
 
 /**
- * Extracts recursive references from a provided document.
+ * Extracts circular references from a provided document.
  * Currently only local references are supported.
  */
-export function getRecursiveRefs(document: OpenApiDocument): Set<string> {
+export function getCircularRefs(document: OpenApiDocument): Set<string> {
   // Process only local references
   // Local references start with `#/`
   const refs = findRefs(document).filter((ref) => ref.startsWith('#/'));
-  const recursiveRefs = new Set<string>();
+  const circularRefs = new Set<string>();
 
   // We need to start traversal from each reference to make sure we caught
-  // all recursive cycles. Use BFS algorithm on top of traverseObject function.
+  // all circular cycles. Use BFS algorithm on top of traverseObject function.
   for (const ref of new Set(refs)) {
     const refsToVisit = [[ref, new Set<string>()] as const];
 
@@ -42,7 +42,7 @@ export function getRecursiveRefs(document: OpenApiDocument): Set<string> {
           }
 
           if (visitedRefsSet.has(node.$ref)) {
-            recursiveRefs.add(node.$ref);
+            circularRefs.add(node.$ref);
             return;
           }
 
@@ -52,7 +52,7 @@ export function getRecursiveRefs(document: OpenApiDocument): Set<string> {
     }
   }
 
-  return recursiveRefs;
+  return circularRefs;
 }
 
 /**

--- a/packages/kbn-openapi-generator/src/parser/lib/get_imports_map.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/get_imports_map.ts
@@ -8,7 +8,7 @@
 
 import { uniq } from 'lodash';
 import type { OpenApiDocument } from '../openapi_types';
-import { traverseObject } from './traverse_object';
+import { findRefs } from './find_refs';
 
 export interface ImportsMap {
   [importPath: string]: string[];
@@ -37,31 +37,3 @@ export const getImportsMap = (parsedSchema: OpenApiDocument): ImportsMap => {
 
   return importMap;
 };
-
-/**
- * Check if an object has a $ref property
- *
- * @param obj Any object
- * @returns True if the object has a $ref property
- */
-const hasRef = (obj: unknown): obj is { $ref: string } => {
-  return typeof obj === 'object' && obj !== null && '$ref' in obj;
-};
-
-/**
- * Traverse the OpenAPI document recursively and find all references
- *
- * @param obj Any object
- * @returns A list of external references
- */
-function findRefs(obj: unknown): string[] {
-  const refs: string[] = [];
-
-  traverseObject(obj, (element) => {
-    if (hasRef(element)) {
-      refs.push(element.$ref);
-    }
-  });
-
-  return refs;
-}

--- a/packages/kbn-openapi-generator/src/parser/lib/get_recursive_refs.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/get_recursive_refs.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { OpenApiDocument } from '../openapi_types';
+import { extractByJsonPointer } from './helpers/extract_by_json_pointer';
+import { findRefs } from './find_refs';
+import { hasRef } from './helpers/has_ref';
+import { traverseObject } from './helpers/traverse_object';
+
+/**
+ * Extracts recursive references from a provided document.
+ * Currently only local references are supported.
+ */
+export function getRecursiveRefs(document: OpenApiDocument): Set<string> {
+  // Process only local references
+  // Local references start with `#/`
+  const refs = findRefs(document).filter((ref) => ref.startsWith('#/'));
+  const recursiveRefs = new Set<string>();
+
+  // We need to start traversal from each reference to make sure we caught
+  // all recursive cycles. Starting from document root will require BFS.
+  // Current implementation uses DFS implemented by `traverseObject`.
+  for (const ref of refs) {
+    const refsSet = new Set(ref);
+    const refNode = extractByJsonPointer(document, extractJsonPointer(ref));
+
+    traverseObject(refNode, (node) => {
+      // Only local references are supported
+      // Local references start with `#/`
+      if (!hasRef(node) || !node.$ref.startsWith('#/')) {
+        return;
+      }
+
+      if (refsSet.has(node.$ref)) {
+        recursiveRefs.add(ref);
+        return;
+      }
+
+      refsSet.add(node.$ref);
+
+      return extractByJsonPointer(document, extractJsonPointer(node.$ref));
+    });
+  }
+
+  return recursiveRefs;
+}
+
+/**
+ * Extracts a JSON Pointer from a local reference
+ * by getting rid of the leading slash
+ */
+function extractJsonPointer(ref: string): string {
+  return ref.substring(1);
+}

--- a/packages/kbn-openapi-generator/src/parser/lib/get_recursive_refs.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/get_recursive_refs.ts
@@ -23,28 +23,33 @@ export function getRecursiveRefs(document: OpenApiDocument): Set<string> {
   const recursiveRefs = new Set<string>();
 
   // We need to start traversal from each reference to make sure we caught
-  // all recursive cycles. Starting from document root will require BFS.
-  // Current implementation uses DFS implemented by `traverseObject`.
-  for (const ref of refs) {
-    const refsSet = new Set(ref);
-    const refNode = extractByJsonPointer(document, extractJsonPointer(ref));
+  // all recursive cycles. Use BFS algorithm on top of traverseObject function.
+  for (const ref of new Set(refs)) {
+    const refsToVisit = [[ref, new Set<string>()] as const];
 
-    traverseObject(refNode, (node) => {
-      // Only local references are supported
-      // Local references start with `#/`
-      if (!hasRef(node) || !node.$ref.startsWith('#/')) {
-        return;
+    while (refsToVisit.length > 0) {
+      for (let i = refsToVisit.length - 1; i >= 0; --i) {
+        const [currentRef, visitedRefsSet] = refsToVisit.shift()!;
+        const currentRefNode = extractByJsonPointer(document, extractJsonPointer(currentRef));
+
+        visitedRefsSet.add(currentRef);
+
+        traverseObject(currentRefNode, (node) => {
+          // Only local references are supported
+          // Local references start with `#/`
+          if (!hasRef(node) || !node.$ref.startsWith('#/')) {
+            return;
+          }
+
+          if (visitedRefsSet.has(node.$ref)) {
+            recursiveRefs.add(node.$ref);
+            return;
+          }
+
+          refsToVisit.push([node.$ref, new Set(visitedRefsSet)]);
+        });
       }
-
-      if (refsSet.has(node.$ref)) {
-        recursiveRefs.add(ref);
-        return;
-      }
-
-      refsSet.add(node.$ref);
-
-      return extractByJsonPointer(document, extractJsonPointer(node.$ref));
-    });
+    }
   }
 
   return recursiveRefs;

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/extract_by_json_pointer.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/extract_by_json_pointer.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isPlainObjectType } from './is_plain_object_type';
+
+/**
+ * Extract a node from a document using a provided [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901).
+ *
+ * JSON Pointer is the second part in [JSON Reference](https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03).
+ * For example an object `{ $ref: "./some-file.yaml#/components/schemas/MySchema"}` is a reference node.
+ * Where `/components/schemas/MySchema` is a JSON pointer. `./some-file.yaml` is a document reference.
+ * Yaml shares the same JSON reference standard and basically can be considered just as a different
+ * JS Object serialization format. See OpenAPI [Using $ref](https://swagger.io/docs/specification/using-ref/) for more information.
+ *
+ * @param document a document containing node to resolve by using the pointer
+ * @param pointer a JSON Pointer
+ * @returns resolved document node
+ */
+export function extractByJsonPointer(document: unknown, pointer: string): Record<string, unknown> {
+  if (!pointer.startsWith('/')) {
+    throw new Error('$ref pointer must start with a leading slash');
+  }
+
+  if (!isPlainObjectType(document)) {
+    throw new Error('document must be an object');
+  }
+
+  let target = document;
+
+  for (const segment of pointer.slice(1).split('/')) {
+    const nextTarget = target[segment];
+
+    if (!isPlainObjectType(nextTarget)) {
+      throw new Error(`JSON Pointer "${pointer}" is not found in "${JSON.stringify(document)}"`);
+    }
+
+    target = nextTarget;
+  }
+
+  return target;
+}

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/extract_by_json_pointer.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/extract_by_json_pointer.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import type { PlainObject } from './plain_object';
 import { isPlainObjectType } from './is_plain_object_type';
 
 /**
@@ -19,9 +20,9 @@ import { isPlainObjectType } from './is_plain_object_type';
  *
  * @param document a document containing node to resolve by using the pointer
  * @param pointer a JSON Pointer
- * @returns resolved document node
+ * @returns resolved document node (it's always a JS object)
  */
-export function extractByJsonPointer(document: unknown, pointer: string): Record<string, unknown> {
+export function extractByJsonPointer(document: unknown, pointer: string): PlainObject {
   if (!pointer.startsWith('/')) {
     throw new Error('$ref pointer must start with a leading slash');
   }

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/has_ref.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/has_ref.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { NormalizedReferenceObject } from '../../openapi_types';
+
+/**
+ * Check if an object has a $ref property
+ *
+ * @param obj Any object
+ * @returns True if the object has a $ref property
+ */
+export function hasRef(obj: unknown): obj is NormalizedReferenceObject {
+  return typeof obj === 'object' && obj !== null && '$ref' in obj;
+}

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/is_plain_object_type.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/is_plain_object_type.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isPlainObject } from 'lodash';
+
+export function isPlainObjectType(maybeObj: unknown): maybeObj is Record<string, unknown> {
+  return isPlainObject(maybeObj);
+}

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/plain_object.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/plain_object.ts
@@ -6,9 +6,4 @@
  * Side Public License, v 1.
  */
 
-import { isPlainObject } from 'lodash';
-import type { PlainObject } from './plain_object';
-
-export function isPlainObjectType(maybeObj: unknown): maybeObj is PlainObject {
-  return isPlainObject(maybeObj);
-}
+export type PlainObject = Record<string, unknown>;

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/traverse_object.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/traverse_object.ts
@@ -11,15 +11,13 @@
  *
  * @param obj The object to traverse
  * @param onVisit A function that will be called for each traversed node in the object
- *                Optionally it can return an object to be used for further traversal
- *                as a child node. It helps to "expand" OpenAPI references.
  */
-export function traverseObject(obj: unknown, onVisit: (element: object) => object | void) {
+export function traverseObject(obj: unknown, onVisit: (element: object) => void) {
   function search(element: unknown) {
     if (typeof element === 'object' && element !== null) {
-      const nextNode = onVisit(element);
+      onVisit(element);
 
-      Object.values(nextNode ?? element).forEach((value) => {
+      Object.values(element).forEach((value) => {
         if (Array.isArray(value)) {
           value.forEach(search);
         } else {

--- a/packages/kbn-openapi-generator/src/parser/lib/helpers/traverse_object.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/helpers/traverse_object.ts
@@ -11,13 +11,15 @@
  *
  * @param obj The object to traverse
  * @param onVisit A function that will be called for each traversed node in the object
+ *                Optionally it can return an object to be used for further traversal
+ *                as a child node. It helps to "expand" OpenAPI references.
  */
-export function traverseObject(obj: unknown, onVisit: (element: object) => void) {
+export function traverseObject(obj: unknown, onVisit: (element: object) => object | void) {
   function search(element: unknown) {
     if (typeof element === 'object' && element !== null) {
-      onVisit(element);
+      const nextNode = onVisit(element);
 
-      Object.values(element).forEach((value) => {
+      Object.values(nextNode ?? element).forEach((value) => {
         if (Array.isArray(value)) {
           value.forEach(search);
         } else {

--- a/packages/kbn-openapi-generator/src/template_service/register_helpers.ts
+++ b/packages/kbn-openapi-generator/src/template_service/register_helpers.ts
@@ -48,9 +48,6 @@ export function registerHelpers(handlebarsInstance: typeof Handlebars) {
   handlebarsInstance.registerHelper('isUnknown', (val: object) => {
     return !('type' in val || '$ref' in val || 'anyOf' in val || 'oneOf' in val || 'allOf' in val);
   });
-  handlebarsInstance.registerHelper('startsWithSpecialChar', (val: string) => {
-    return /^[^a-zA-Z0-9]/.test(val);
-  });
   handlebarsInstance.registerHelper(
     'replace',
     (val: string, searchValue: string, replaceValue: string) => {

--- a/packages/kbn-openapi-generator/src/template_service/register_helpers.ts
+++ b/packages/kbn-openapi-generator/src/template_service/register_helpers.ts
@@ -59,30 +59,35 @@ export function registerHelpers(handlebarsInstance: typeof Handlebars) {
   );
 
   /**
-   * Checks whether provided reference is a known recursive reference or a part of recursive chain
+   * Checks whether provided reference is a known circular reference or a part of circular chain.
    *
    * It's expected that `context.recursiveRefs` has been filled by the parser.
    */
-  handlebarsInstance.registerHelper('isRecursiveRef', (ref: string, options: HelperOptions) => {
-    if (!options.data?.root?.recursiveRefs) {
+  handlebarsInstance.registerHelper('isCircularRef', (ref: string, options: HelperOptions) => {
+    if (!options.data?.root?.circularRefs) {
       return false;
     }
 
-    const recursiveRefs: Set<string> = options.data.root.recursiveRefs;
+    const circularRefs: Set<string> = options.data.root.circularRefs;
 
-    return recursiveRefs.has(ref);
+    return circularRefs.has(ref);
   });
 
+  /**
+   * Checks whether provided schema is circular or a part of the circular chain.
+   *
+   * It's expected that `context.circularRefs` has been filled by the parser.
+   */
   handlebarsInstance.registerHelper(
-    'isRecursiveSchema',
+    'isCircularSchema',
     (schemaName: string, options: HelperOptions) => {
-      if (!options.data?.root?.recursiveRefs) {
+      if (!options.data?.root?.circularRefs) {
         return false;
       }
 
-      const recursiveRefs: Set<string> = options.data.root.recursiveRefs;
+      const circularRefs: Set<string> = options.data.root.circularRefs;
 
-      return recursiveRefs.has(`#/components/schemas/${schemaName}`);
+      return circularRefs.has(`#/components/schemas/${schemaName}`);
     }
   );
 }

--- a/packages/kbn-openapi-generator/src/template_service/register_helpers.ts
+++ b/packages/kbn-openapi-generator/src/template_service/register_helpers.ts
@@ -7,6 +7,7 @@
  */
 
 import type Handlebars from '@kbn/handlebars';
+import { HelperOptions } from 'handlebars';
 import { snakeCase, camelCase } from 'lodash';
 
 export function registerHelpers(handlebarsInstance: typeof Handlebars) {
@@ -54,6 +55,34 @@ export function registerHelpers(handlebarsInstance: typeof Handlebars) {
     'replace',
     (val: string, searchValue: string, replaceValue: string) => {
       return val.replace(searchValue, replaceValue);
+    }
+  );
+
+  /**
+   * Checks whether provided reference is a known recursive reference or a part of recursive chain
+   *
+   * It's expected that `context.recursiveRefs` has been filled by the parser.
+   */
+  handlebarsInstance.registerHelper('isRecursiveRef', (ref: string, options: HelperOptions) => {
+    if (!options.data?.root?.recursiveRefs) {
+      return false;
+    }
+
+    const recursiveRefs: Set<string> = options.data.root.recursiveRefs;
+
+    return recursiveRefs.has(ref);
+  });
+
+  handlebarsInstance.registerHelper(
+    'isRecursiveSchema',
+    (schemaName: string, options: HelperOptions) => {
+      if (!options.data?.root?.recursiveRefs) {
+        return false;
+      }
+
+      const recursiveRefs: Set<string> = options.data.root.recursiveRefs;
+
+      return recursiveRefs.has(`#/components/schemas/${schemaName}`);
     }
   );
 }

--- a/packages/kbn-openapi-generator/src/template_service/templates/ts_input_type.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/ts_input_type.handlebars
@@ -3,27 +3,27 @@
 {{~/if~}}
 
 {{~#if $ref~}}
-  {{referenceName}}
+  {{referenceName}}Input
   {{~#if nullable}} | null {{/if~}}
 {{~/if~}}
 
 {{~#if allOf~}}
   {{~#each allOf~}}
-    {{~> typescript_item ~}}
+    {{~> ts_input_type ~}}
     {{~#unless @last~}}&{{~/unless~}} 
   {{~/each~}}
 {{~/if~}}
 
 {{~#if anyOf~}}
   {{~#each anyOf~}}
-    {{~> typescript_item ~}}
+    {{~> ts_input_type ~}}
     {{~#unless @last~}}|{{~/unless~}} 
   {{~/each~}}
 {{~/if~}}
 
 {{~#if oneOf~}}
   {{~#each oneOf~}}
-    {{~> typescript_item ~}}
+    {{~> ts_input_type ~}}
     {{~#unless @last~}}|{{~/unless~}} 
   {{~/each~}}
 {{~/if~}}
@@ -33,7 +33,7 @@ unknown
 {{/if}}
 
 {{~#*inline "type_array"~}}
-  ({{~> typescript_item items ~}})[]
+  ({{~> ts_input_type items ~}})[]
 {{~/inline~}}
 
 {{~#*inline "type_boolean"~}}
@@ -59,13 +59,13 @@ unknown
       */
       {{/if}}
       {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}
-      {{~#unless (or (includes ../required @key) (defined default))}}?{{/unless~}}: {{> typescript_item }};
+      {{~#unless (includes ../required @key)}}?{{/unless~}}: {{> ts_input_type }};
     {{/each}}
     {{~#if additionalProperties}}
       {{~#if (eq additionalProperties true)~}}
         [key: string]: unknown;
       {{~else~}}
-        [key: string]: {{> typescript_item additionalProperties}};
+        [key: string]: {{> ts_input_type additionalProperties}};
       {{~/if~}}
     {{~/if~}}
   }

--- a/packages/kbn-openapi-generator/src/template_service/templates/ts_input_type.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/ts_input_type.handlebars
@@ -58,8 +58,7 @@ unknown
       * {{{description}}} 
       */
       {{/if}}
-      {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}
-      {{~#unless (includes ../required @key)}}?{{/unless~}}: {{> ts_input_type }};
+      '{{@key}}'{{~#unless (includes ../required @key)}}?{{/unless~}}: {{> ts_input_type }};
     {{/each}}
     {{~#if additionalProperties}}
       {{~#if (eq additionalProperties true)~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/ts_type.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/ts_type.handlebars
@@ -58,8 +58,7 @@ unknown
       * {{{description}}} 
       */
       {{/if}}
-      {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}
-      {{~#unless (or (includes ../required @key) (defined default))}}?{{/unless~}}: {{> ts_type }};
+      '{{@key}}'{{~#unless (or (includes ../required @key) (defined default))}}?{{/unless~}}: {{> ts_type }};
     {{/each}}
     {{~#if additionalProperties}}
       {{~#if (eq additionalProperties true)~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/ts_type.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/ts_type.handlebars
@@ -1,0 +1,85 @@
+{{~#if type~}}
+  {{~> (concat "type_" type)~}}
+{{~/if~}}
+
+{{~#if $ref~}}
+  {{referenceName}}
+  {{~#if nullable}} | null {{/if~}}
+{{~/if~}}
+
+{{~#if allOf~}}
+  {{~#each allOf~}}
+    {{~> ts_type ~}}
+    {{~#unless @last~}}&{{~/unless~}} 
+  {{~/each~}}
+{{~/if~}}
+
+{{~#if anyOf~}}
+  {{~#each anyOf~}}
+    {{~> ts_type ~}}
+    {{~#unless @last~}}|{{~/unless~}} 
+  {{~/each~}}
+{{~/if~}}
+
+{{~#if oneOf~}}
+  {{~#each oneOf~}}
+    {{~> ts_type ~}}
+    {{~#unless @last~}}|{{~/unless~}} 
+  {{~/each~}}
+{{~/if~}}
+
+{{#if (isUnknown .)}}
+unknown
+{{/if}}
+
+{{~#*inline "type_array"~}}
+  ({{~> ts_type items ~}})[]
+{{~/inline~}}
+
+{{~#*inline "type_boolean"~}}
+  boolean
+{{~/inline~}}
+
+{{~#*inline "type_integer"~}}
+  number
+{{~/inline~}}
+
+{{~#*inline "type_number"~}}
+  number
+{{~/inline~}}
+
+{{~#*inline "type_object"~}}
+  {{~#if (eq x-modify "required")}} Required< {{/if~}}
+  {{~#if (eq x-modify "partial")}} Partial< {{/if~}}
+  {
+    {{#each properties}}
+      {{#if description}}
+      /** 
+      * {{{description}}} 
+      */
+      {{/if}}
+      {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}
+      {{~#unless (or (includes ../required @key) (defined default))}}?{{/unless~}}: {{> ts_type }};
+    {{/each}}
+    {{~#if additionalProperties}}
+      {{~#if (eq additionalProperties true)~}}
+        [key: string]: unknown;
+      {{~else~}}
+        [key: string]: {{> ts_type additionalProperties}};
+      {{~/if~}}
+    {{~/if~}}
+  }
+  {{~#if (eq x-modify "partial")}} > {{/if~}}
+  {{~#if (eq x-modify "required")}} > {{/if~}}
+{{~/inline~}}
+
+{{~#*inline "type_string"~}}
+  {{~#if enum~}}
+    {{~#each enum~}}
+      '{{.}}'
+      {{~#unless @last~}}|{{~/unless~}} 
+    {{~/each~}}
+  {{~else~}}
+  string
+  {{~/if~}}
+{{~/inline~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/typescript_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/typescript_item.handlebars
@@ -49,6 +49,7 @@ unknown
 {{~/inline~}}
 
 {{~#*inline "type_object"~}}
+  {{~#if (eq x-modify "required")}} Required< {{/if~}}
   {{~#if (eq x-modify "partial")}} Partial< {{/if~}}
   {
     {{#each properties}}
@@ -72,6 +73,7 @@ unknown
     {{~/if~}}
   }
   {{~#if (eq x-modify "partial")}} > {{/if~}}
+  {{~#if (eq x-modify "required")}} > {{/if~}}
 {{~/inline~}}
 
 {{~#*inline "type_string"~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/typescript_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/typescript_item.handlebars
@@ -58,11 +58,8 @@ unknown
       * {{{description}}} 
       */
       {{/if}}
-      {{#if (startsWithSpecialChar @key)}}
-        '{{@key}}'{{#unless (includes ../required @key)}}?{{/unless}}: {{> typescript_item }};
-      {{else}}
-        {{@key}}{{#unless (includes ../required @key)}}?{{/unless}}: {{> typescript_item }};
-      {{/if}}
+      {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}
+      {{~#unless (or (includes ../required @key) (defined default))}}?{{/unless~}}: {{> typescript_item }};
     {{/each}}
     {{~#if additionalProperties}}
       {{~#if (eq additionalProperties true)~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/typescript_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/typescript_item.handlebars
@@ -1,0 +1,86 @@
+{{~#if type~}}
+  {{~> (concat "type_" type)~}}
+{{~/if~}}
+
+{{~#if $ref~}}
+  {{referenceName}}
+  {{~#if nullable}} | null {{/if~}}
+{{~/if~}}
+
+{{~#if allOf~}}
+  {{~#each allOf~}}
+    {{~> typescript_item ~}}
+    {{~#unless @last~}}&{{~/unless~}} 
+  {{~/each~}}
+{{~/if~}}
+
+{{~#if anyOf~}}
+  {{~#each anyOf~}}
+    {{~> typescript_item ~}}
+    {{~#unless @last~}}|{{~/unless~}} 
+  {{~/each~}}
+{{~/if~}}
+
+{{~#if oneOf~}}
+  {{~#each oneOf~}}
+    {{~> typescript_item ~}}
+    {{~#unless @last~}}|{{~/unless~}} 
+  {{~/each~}}
+{{~/if~}}
+
+{{#if (isUnknown .)}}
+unknown
+{{/if}}
+
+{{~#*inline "type_array"~}}
+  ({{~> typescript_item items ~}})[]
+{{~/inline~}}
+
+{{~#*inline "type_boolean"~}}
+  boolean
+{{~/inline~}}
+
+{{~#*inline "type_integer"~}}
+  number
+{{~/inline~}}
+
+{{~#*inline "type_number"~}}
+  number
+{{~/inline~}}
+
+{{~#*inline "type_object"~}}
+  {{~#if (eq x-modify "partial")}} Partial< {{/if~}}
+  {
+    {{#each properties}}
+      {{#if description}}
+      /** 
+      * {{{description}}} 
+      */
+      {{/if}}
+      {{#if (startsWithSpecialChar @key)}}
+        '{{@key}}'{{#unless (includes ../required @key)}}?{{/unless}}: {{> typescript_item }};
+      {{else}}
+        {{@key}}{{#unless (includes ../required @key)}}?{{/unless}}: {{> typescript_item }};
+      {{/if}}
+    {{/each}}
+    {{~#if additionalProperties}}
+      {{~#if (eq additionalProperties true)~}}
+        [key: string]: unknown;
+      {{~else~}}
+        [key: string]: {{> typescript_item additionalProperties}};
+      {{~/if~}}
+    {{~/if~}}
+  }
+  {{~#if (eq x-modify "partial")}} > {{/if~}}
+{{~/inline~}}
+
+{{~#*inline "type_string"~}}
+  {{~#if enum~}}
+    {{~#each enum~}}
+      '{{.}}'
+      {{~#unless @last~}}|{{~/unless~}} 
+    {{~/each~}}
+  {{~else~}}
+  string
+  {{~/if~}}
+{{~/inline~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
@@ -25,8 +25,14 @@ import {
   {{/if}}
   */
 {{/if}}
+{{#if (isRecursiveSchema @key)}}
+export type {{@key}} = {{> typescript_item}};
+export const {{@key}}: z.ZodType<{{@key}}> = {{> zod_schema_item }};
+{{else}}
 export type {{@key}} = z.infer<typeof {{@key}}>;
 export const {{@key}} = {{> zod_schema_item}};
+{{/if}}
+
 {{#if enum}}
 {{#unless (isSingle enum)}}
 export type {{@key}}Enum = typeof {{@key}}.enum;

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
@@ -7,8 +7,9 @@
 
  {{> disclaimer}}
 
-import { z } from "zod";
-import { requiredOptional, isValidDateMath, ArrayFromString, BooleanFromString } from "@kbn/zod-helpers"
+import type { ZodTypeDef } from 'zod';
+import { z } from 'zod';
+import { requiredOptional, isValidDateMath, ArrayFromString, BooleanFromString } from '@kbn/zod-helpers';
 
 {{#each imports}}
 import { 
@@ -26,8 +27,9 @@ import {
   */
 {{/if}}
 {{#if (isCircularSchema @key)}}
-export type {{@key}} = {{> typescript_item}};
-export const {{@key}}: z.ZodType<{{@key}}> = {{> zod_schema_item }};
+export type {{@key}} = {{> ts_type}};
+export type {{@key}}Input = {{> ts_input_type }};
+export const {{@key}}: z.ZodType<{{@key}}, ZodTypeDef, {{@key}}Input> = {{> zod_schema_item }};
 {{else}}
 export type {{@key}} = z.infer<typeof {{@key}}>;
 export const {{@key}} = {{> zod_schema_item}};

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
@@ -25,7 +25,7 @@ import {
   {{/if}}
   */
 {{/if}}
-{{#if (isRecursiveSchema @key)}}
+{{#if (isCircularSchema @key)}}
 export type {{@key}} = {{> typescript_item}};
 export const {{@key}}: z.ZodType<{{@key}}> = {{> zod_schema_item }};
 {{else}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_operation_schema.handlebars
@@ -32,7 +32,6 @@ export const {{@key}}: z.ZodType<{{@key}}> = {{> zod_schema_item }};
 export type {{@key}} = z.infer<typeof {{@key}}>;
 export const {{@key}} = {{> zod_schema_item}};
 {{/if}}
-
 {{#if enum}}
 {{#unless (isSingle enum)}}
 export type {{@key}}Enum = typeof {{@key}}.enum;

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
@@ -6,7 +6,11 @@
 {{~/if~}}
 
 {{~#if $ref~}}
-  {{referenceName}}
+  {{~#if (isRecursiveRef $ref)~}}
+    z.lazy(() => {{referenceName}})
+  {{~else~}}
+    {{referenceName}}
+  {{~/if~}}
   {{~#if nullable}}.nullable(){{/if~}}
   {{~#if (eq requiredBool false)}}.optional(){{/if~}}
   {{~#if (defined default)}}.default({{{toJSON default}}}){{/if~}}
@@ -127,4 +131,3 @@ z.unknown()
   {{~#if pattern}}.regex(/{{pattern}}/){{/if~}}
   {{~/if~}}
 {{~/inline~}}
-

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
@@ -91,11 +91,8 @@ z.unknown()
       * {{{description}}} 
       */
       {{/if}}
-      {{#if (startsWithSpecialChar @key)}}
-        '{{@key}}': {{> zod_schema_item requiredBool=(includes ../required @key)}},
-      {{else}}
-        {{@key}}: {{> zod_schema_item requiredBool=(includes ../required @key)}},
-      {{/if}}
+      {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}:
+      {{~> zod_schema_item requiredBool=(includes ../required @key)~}},
     {{/each}}
   })
   {{~#if (eq additionalProperties false)}}.strict(){{/if~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
@@ -91,8 +91,7 @@ z.unknown()
       * {{{description}}} 
       */
       {{/if}}
-      {{#if (startsWithSpecialChar @key)}}'{{@key}}'{{else}}{{@key}}{{/if}}:
-      {{~> zod_schema_item requiredBool=(includes ../required @key)~}},
+      '{{@key}}':{{~> zod_schema_item requiredBool=(includes ../required @key)~}},
     {{/each}}
   })
   {{~#if (eq additionalProperties false)}}.strict(){{/if~}}

--- a/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
+++ b/packages/kbn-openapi-generator/src/template_service/templates/zod_schema_item.handlebars
@@ -6,7 +6,7 @@
 {{~/if~}}
 
 {{~#if $ref~}}
-  {{~#if (isRecursiveRef $ref)~}}
+  {{~#if (isCircularRef $ref)~}}
     z.lazy(() => {{referenceName}})
   {{~else~}}
     {{referenceName}}


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/186066

## Summary

This PR adds `kbn-openapi-generator` support for local OpenAPI circular references.

## Details

Circular references represent a problem for OpenAPI adoption since lack of support forces engineers to disable code generation and manually define Zod schemas and related TS types. This PR brings `kbn-openapi-generator` support for local OpenAPI circular references. Local references means references to schemas inside one document which looks like `#/components/schemas/MySchema`. It should cover the majority of cases when circular references support id required.

The feature is implemented by detecting local circular references and applying a different generation template for involved in cycles inspired by [Zod recursive types docs section](https://github.com/colinhacks/zod?tab=readme-ov-file#recursive-types) for schemas. It involves TS types generation since TS isn't able to properly infer types in this case and hinting circular Zod schemas via `z.ZodType<>`. On top of that circular schema usages are wrapped in `z.lazy()`.

## What's not implemented?

- Multi-file circular references aren't supported

## How to test

Security Solution doesn't have OpenAPI circular schemas yet. But generator's behavior has been verified on the following specs

- Self-recursive

Spec:
```yaml
components:
  x-codegen-enabled: true
  schemas:
    SelfRecursive:
      type: object
      properties:
        fieldA:
          $ref: '#/components/schemas/SelfRecursive'
```

Generated output:
```ts
import type { ZodTypeDef } from 'zod';
import { z } from 'zod';

export interface SchemaA {
  fieldA?: SchemaA;
}
export interface SchemaAInput {
  fieldA?: SchemaAInput;
}
export const SchemaA: z.ZodType<SchemaA, ZodTypeDef, SchemaAInput> = z.object({
  fieldA: z.lazy(() => SchemaA).optional(),
});
```

- Two circular schemas

Spec:
```yaml
components:
  x-codegen-enabled: true
  schemas:
    SchemaA:
      type: object
      properties:
        recursiveFieldB:
          $ref: '#/components/schemas/SchemaB'

    SchemaB:
      type: object
      properties:
        recursiveFieldA:
          $ref: '#/components/schemas/SchemaA'
```

Generated output:
```ts
import type { ZodTypeDef } from 'zod';
import { z } from 'zod';

export interface SchemaA {
  recursiveFieldB?: SchemaB;
}
export interface SchemaAInput {
  recursiveFieldB?: SchemaBInput;
}
export const SchemaA: z.ZodType<SchemaA, ZodTypeDef, SchemaAInput> = z.object({
  recursiveFieldB: z.lazy(() => SchemaB).optional(),
});

export interface SchemaB {
  recursiveFieldA?: SchemaA;
}
export interface SchemaBInput {
  recursiveFieldA?: SchemaAInput;
}
export const SchemaB: z.ZodType<SchemaB, ZodTypeDef, SchemaBInput> = z.object({
  recursiveFieldA: z.lazy(() => SchemaA).optional(),
});
```

- More complex example with circular with `anyOf` and non circular schemas

Spec:
```yaml
components:
  x-codegen-enabled: true
  schemas:
    SchemaA:
      anyOf:
        - $ref: '#/components/schemas/SchemaB'
        - $ref: '#/components/schemas/SchemaC'
        - type: string
          enum: [valueA, valueB]

    SchemaB:
      type: object
      properties:
        fieldB:
          $ref: '#/components/schemas/SchemaC'
        defaultableField:
          type: number
          default: 1
      required: [fieldB]

    SchemaC:
      type: object
      properties:
        fieldC:
          $ref: '#/components/schemas/SchemaA'

    SchemaZ:
      anyOf:
        - type: object
          properties:
            fieldZ:
              type: string
            defField:
              type: number
              default: 1
          required: [fieldZ]
        - type: object
          properties:
            fieldX:
              type: boolean
          required: [fieldX]
```

Generated output:
```ts
import type { ZodTypeDef } from 'zod';
import { z } from 'zod';

export type SchemaA = SchemaB | SchemaC | 'valueA' | 'valueB';
export type SchemaAInput = SchemaBInput | SchemaCInput | 'valueA' | 'valueB';
export const SchemaA: z.ZodType<SchemaA, ZodTypeDef, SchemaAInput> = z.union([
  z.lazy(() => SchemaB),
  z.lazy(() => SchemaC),
  z.enum(['valueA', 'valueB']),
]);

export interface SchemaB {
  fieldB: SchemaC;
  defaultableField: number;
}
export interface SchemaBInput {
  fieldB: SchemaCInput;
  defaultableField?: number;
}
export const SchemaB: z.ZodType<SchemaB, ZodTypeDef, SchemaBInput> = z.object({
  fieldB: z.lazy(() => SchemaC),
  defaultableField: z.number().optional().default(1),
});

export interface SchemaC {
  fieldC?: SchemaA;
}
export interface SchemaCInput {
  fieldC?: SchemaAInput;
}
export const SchemaC: z.ZodType<SchemaC, ZodTypeDef, SchemaCInput> = z.object({
  fieldC: z.lazy(() => SchemaA).optional(),
});

export type SchemaZ = z.infer<typeof SchemaZ>;
export const SchemaZ = z.union([
  z.object({
    fieldZ: z.string(),
    defField: z.number().optional().default(1),
  }),
  z.object({
    fieldX: z.boolean(),
  }),
]);
```

- Real life example provided by @bhapas while working on OpenAPI specs for Integration Assistant APIs

Spec:
```yaml
components:
  x-codegen-enabled: true
  schemas:
    ESProcessorItem:
      type: object
      description: Processor item for the Elasticsearch processor.
      additionalProperties:
        $ref: '#/components/schemas/ESProcessorOptions'

    ESProcessorOptions:
      type: object
      description: Processor options for the Elasticsearch processor.
      properties:
        on_failure:
          type: array
          items:
            $ref: '#/components/schemas/ESProcessorItem'
          description: An array of items to execute if the processor fails.
        ignore_failure:
          type: boolean
          description: If true, the processor continues to the next processor if the current processor fails.
        ignore_missing:
          type: boolean
          description: If true, the processor continues to the next processor if the field is missing.
        if:
          type: string
          description: Conditionally execute the processor.
        tag:
          type: string
          description: A tag to assign to the document after processing.
      additionalProperties: true
```

Generated output:
```ts
import type { ZodTypeDef } from 'zod';
import { z } from 'zod';

/**
 * Processor item for the Elasticsearch processor.
 */
export interface ESProcessorItem {
  [key: string]: ESProcessorOptions;
}
export interface ESProcessorItemInput {
  [key: string]: ESProcessorOptionsInput;
}
export const ESProcessorItem: z.ZodType<ESProcessorItem, ZodTypeDef, ESProcessorItemInput> = z
  .object({})
  .catchall(z.lazy(() => ESProcessorOptions));

/**
 * Processor options for the Elasticsearch processor.
 */
export interface ESProcessorOptions {
  /**
   * An array of items to execute if the processor fails.
   */
  on_failure?: ESProcessorItem[];
  /**
   * If true, the processor continues to the next processor if the current processor fails.
   */
  ignore_failure?: boolean;
  /**
   * If true, the processor continues to the next processor if the field is missing.
   */
  ignore_missing?: boolean;
  /**
   * Conditionally execute the processor.
   */
  if?: string;
  /**
   * A tag to assign to the document after processing.
   */
  tag?: string;
  [key: string]: unknown;
}
export interface ESProcessorOptionsInput {
  /**
   * An array of items to execute if the processor fails.
   */
  on_failure?: ESProcessorItemInput[];
  /**
   * If true, the processor continues to the next processor if the current processor fails.
   */
  ignore_failure?: boolean;
  /**
   * If true, the processor continues to the next processor if the field is missing.
   */
  ignore_missing?: boolean;
  /**
   * Conditionally execute the processor.
   */
  if?: string;
  /**
   * A tag to assign to the document after processing.
   */
  tag?: string;
  [key: string]: unknown;
}
export const ESProcessorOptions: z.ZodType<
  ESProcessorOptions,
  ZodTypeDef,
  ESProcessorOptionsInput
> = z
  .object({
    /**
     * An array of items to execute if the processor fails.
     */
    on_failure: z.array(z.lazy(() => ESProcessorItem)).optional(),
    /**
     * If true, the processor continues to the next processor if the current processor fails.
     */
    ignore_failure: z.boolean().optional(),
    /**
     * If true, the processor continues to the next processor if the field is missing.
     */
    ignore_missing: z.boolean().optional(),
    /**
     * Conditionally execute the processor.
     */
    if: z.string().optional(),
    /**
     * A tag to assign to the document after processing.
     */
    tag: z.string().optional(),
  })
  .catchall(z.unknown());
```