### PR TITLE
[Security Solution][Detection Engine] unskips FTR user roles tests

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/user_roles/trial_license_complete_tier/read_privileges.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/user_roles/trial_license_complete_tier/read_privileges.ts
@@ -19,8 +19,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  // Failing ES Promotion: https://github.com/elastic/kibana/issues/174028
-  describe.skip('@ess @serverless @skipInServerless read_privileges', () => {
+  describe('@ess @serverless @skipInServerless read_privileges', () => {
     it('should return expected privileges for elastic admin', async () => {
       const { body } = await supertest.get(DETECTION_ENGINE_PRIVILEGES_URL).send().expect(200);
       expect(body).to.eql({


### PR DESCRIPTION
## Summary

- addresses https://github.com/elastic/kibana/issues/174028
- checked locally with the [latest main(8.15 snapshot)](https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify/builds/4126)