### PR TITLE
[Space] Solution Badge

### DIFF
--- a/x-pack/plugins/spaces/public/constants.ts
+++ b/x-pack/plugins/spaces/public/constants.ts
@@ -22,5 +22,3 @@ export const getSpacesFeatureDescription = () => {
 export const DEFAULT_OBJECT_NOUN = i18n.translate('xpack.spaces.shareToSpace.objectNoun', {
   defaultMessage: 'object',
 });
-
-export const SOLUTION_NAV_FEATURE_FLAG_NAME = 'solutionNavEnabled';

--- a/x-pack/plugins/spaces/public/experiments/index.ts
+++ b/x-pack/plugins/spaces/public/experiments/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { isSolutionNavEnabled } from './is_solution_nav_enabled';

--- a/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
+++ b/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { from, of, shareReplay } from 'rxjs';
+
+export const SOLUTION_NAV_FEATURE_FLAG_NAME = 'solutionNavEnabled';
+import type { CloudExperimentsPluginStart } from '@kbn/cloud-experiments-plugin/common';
+import type { CloudStart } from '@kbn/cloud-plugin/public';
+
+export const isSolutionNavEnabled = (
+  cloud?: CloudStart,
+  cloudExperiments?: CloudExperimentsPluginStart
+) => {
+  return Boolean(cloud?.isCloudEnabled) && cloudExperiments
+    ? from(
+        cloudExperiments.getVariation(SOLUTION_NAV_FEATURE_FLAG_NAME, false).catch(() => false)
+      ).pipe(shareReplay(1))
+    : of(false);
+};

--- a/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
+++ b/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { from, of, shareReplay } from 'rxjs';
-
 import type { CloudExperimentsPluginStart } from '@kbn/cloud-experiments-plugin/common';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 
@@ -17,8 +15,6 @@ export const isSolutionNavEnabled = (
   cloudExperiments?: CloudExperimentsPluginStart
 ) => {
   return Boolean(cloud?.isCloudEnabled) && cloudExperiments
-    ? from(
-        cloudExperiments.getVariation(SOLUTION_NAV_FEATURE_FLAG_NAME, false).catch(() => false)
-      ).pipe(shareReplay(1))
-    : of(false);
+    ? cloudExperiments.getVariation(SOLUTION_NAV_FEATURE_FLAG_NAME, false).catch(() => false)
+    : Promise.resolve(false);
 };

--- a/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
+++ b/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
@@ -7,9 +7,10 @@
 
 import { from, of, shareReplay } from 'rxjs';
 
-export const SOLUTION_NAV_FEATURE_FLAG_NAME = 'solutionNavEnabled';
 import type { CloudExperimentsPluginStart } from '@kbn/cloud-experiments-plugin/common';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
+
+const SOLUTION_NAV_FEATURE_FLAG_NAME = 'solutionNavEnabled';
 
 export const isSolutionNavEnabled = (
   cloud?: CloudStart,

--- a/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
+++ b/x-pack/plugins/spaces/public/experiments/is_solution_nav_enabled.ts
@@ -15,6 +15,6 @@ export const isSolutionNavEnabled = (
   cloudExperiments?: CloudExperimentsPluginStart
 ) => {
   return Boolean(cloud?.isCloudEnabled) && cloudExperiments
-    ? cloudExperiments.getVariation(SOLUTION_NAV_FEATURE_FLAG_NAME, false).catch(() => false)
+    ? cloudExperiments.getVariation(SOLUTION_NAV_FEATURE_FLAG_NAME, false)
     : Promise.resolve(false);
 };

--- a/x-pack/plugins/spaces/public/management/edit_space/manage_space_page.test.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/manage_space_page.test.tsx
@@ -10,7 +10,6 @@ import { EuiButton } from '@elastic/eui';
 import { waitFor } from '@testing-library/react';
 import type { ReactWrapper } from 'enzyme';
 import React from 'react';
-import { of } from 'rxjs';
 
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import { notificationServiceMock, scopedHistoryMock } from '@kbn/core/public/mocks';
@@ -124,7 +123,7 @@ describe('ManageSpacePage', () => {
           spaces: { manage: true },
         }}
         allowFeatureVisibility
-        isSolutionNavEnabled$={of(true)}
+        solutionNavExperiment={Promise.resolve(true)}
       />
     );
 
@@ -180,7 +179,7 @@ describe('ManageSpacePage', () => {
             spaces: { manage: true },
           }}
           allowFeatureVisibility
-          isSolutionNavEnabled$={of(false)}
+          solutionNavExperiment={Promise.resolve(false)}
         />
       );
 

--- a/x-pack/plugins/spaces/public/management/edit_space/manage_space_page.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/manage_space_page.tsx
@@ -18,7 +18,6 @@ import {
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import React, { Component } from 'react';
-import type { Observable, Subscription } from 'rxjs';
 
 import type { Capabilities, NotificationsStart, ScopedHistory } from '@kbn/core/public';
 import { SectionLoading } from '@kbn/es-ui-shared-plugin/public';
@@ -56,7 +55,7 @@ interface Props {
   capabilities: Capabilities;
   history: ScopedHistory;
   allowFeatureVisibility: boolean;
-  isSolutionNavEnabled$?: Observable<boolean>;
+  solutionNavExperiment?: Promise<boolean>;
 }
 
 interface State {
@@ -76,7 +75,6 @@ interface State {
 export class ManageSpacePage extends Component<Props, State> {
   private readonly validator: SpaceValidator;
   private initialSpaceState: State['space'] | null = null;
-  private subscription: Subscription | null = null;
 
   constructor(props: Props) {
     super(props);
@@ -115,22 +113,14 @@ export class ManageSpacePage extends Component<Props, State> {
       });
     }
 
-    if (this.props.isSolutionNavEnabled$) {
-      this.subscription = this.props.isSolutionNavEnabled$.subscribe((isEnabled) => {
-        this.setState({ isSolutionNavEnabled: isEnabled });
-      });
-    }
+    this.props.solutionNavExperiment?.then((isEnabled) => {
+      this.setState({ isSolutionNavEnabled: isEnabled });
+    });
   }
 
   public async componentDidUpdate(previousProps: Props) {
     if (this.props.spaceId !== previousProps.spaceId && this.props.spaceId) {
       await this.loadSpace(this.props.spaceId, Promise.resolve(this.state.features));
-    }
-  }
-
-  public componentWillUnmount() {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
     }
   }
 

--- a/x-pack/plugins/spaces/public/management/management_service.test.ts
+++ b/x-pack/plugins/spaces/public/management/management_service.test.ts
@@ -38,6 +38,7 @@ describe('ManagementService', () => {
         spacesManager: spacesManagerMock.create(),
         config,
         getRolesAPIClient: getRolesAPIClientMock,
+        solutionNavExperiment: Promise.resolve(false),
       });
 
       expect(mockKibanaSection.registerApp).toHaveBeenCalledTimes(1);
@@ -58,6 +59,7 @@ describe('ManagementService', () => {
         spacesManager: spacesManagerMock.create(),
         config,
         getRolesAPIClient: getRolesAPIClientMock,
+        solutionNavExperiment: Promise.resolve(false),
       });
     });
   });
@@ -79,6 +81,7 @@ describe('ManagementService', () => {
         spacesManager: spacesManagerMock.create(),
         config,
         getRolesAPIClient: jest.fn(),
+        solutionNavExperiment: Promise.resolve(false),
       });
 
       service.stop();

--- a/x-pack/plugins/spaces/public/management/management_service.tsx
+++ b/x-pack/plugins/spaces/public/management/management_service.tsx
@@ -20,6 +20,7 @@ interface SetupDeps {
   spacesManager: SpacesManager;
   config: ConfigType;
   getRolesAPIClient: () => Promise<RolesAPIClient>;
+  solutionNavExperiment: Promise<boolean>;
 }
 
 export class ManagementService {
@@ -31,9 +32,16 @@ export class ManagementService {
     spacesManager,
     config,
     getRolesAPIClient,
+    solutionNavExperiment,
   }: SetupDeps) {
     this.registeredSpacesManagementApp = management.sections.section.kibana.registerApp(
-      spacesManagementApp.create({ getStartServices, spacesManager, config, getRolesAPIClient })
+      spacesManagementApp.create({
+        getStartServices,
+        spacesManager,
+        config,
+        getRolesAPIClient,
+        solutionNavExperiment,
+      })
     );
   }
 

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
@@ -7,7 +7,6 @@
 
 import { act } from '@testing-library/react';
 import React from 'react';
-import { of } from 'rxjs';
 
 import {
   httpServiceMock,

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
@@ -140,7 +140,7 @@ describe('SpacesGridPage', () => {
           spaces: { manage: true },
         }}
         maxSpaces={1000}
-        isSolutionNavEnabled$={of(true)}
+        solutionNavExperiment={Promise.resolve(true)}
       />
     );
 

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
@@ -140,7 +140,7 @@ describe('SpacesGridPage', () => {
           spaces: { manage: true },
         }}
         maxSpaces={1000}
-        isSpaceSolutionEnabled$={of(true)}
+        isSolutionNavEnabled$={of(true)}
       />
     );
 

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
@@ -7,6 +7,7 @@
 
 import { act } from '@testing-library/react';
 import React from 'react';
+import { of } from 'rxjs';
 
 import {
   httpServiceMock,
@@ -88,6 +89,72 @@ describe('SpacesGridPage', () => {
     wrapper.update();
 
     expect(wrapper.find('EuiInMemoryTable').prop('items')).toBe(spaces);
+    expect(wrapper.find('EuiInMemoryTable').prop('columns')).not.toContainEqual({
+      field: 'solution',
+      name: 'Solution View',
+      sortable: true,
+      render: expect.any(Function),
+    });
+  });
+
+  it('renders the list of spaces with solution column', async () => {
+    const httpStart = httpServiceMock.createStartContract();
+    httpStart.get.mockResolvedValue([]);
+    const spacesWithSolution = [
+      {
+        id: 'default',
+        name: 'Default',
+        disabledFeatures: [],
+        _reserved: true,
+      },
+      {
+        id: 'custom-1',
+        name: 'Custom 1',
+        disabledFeatures: [],
+        solution: 'es',
+      },
+      {
+        id: 'custom-2',
+        name: 'Custom 2',
+        initials: 'LG',
+        color: '#ABCDEF',
+        description: 'my description here',
+        disabledFeatures: [],
+        solution: 'security',
+      },
+    ];
+
+    spacesManager.getSpaces = jest.fn().mockResolvedValue(spacesWithSolution);
+
+    const wrapper = shallowWithIntl(
+      <SpacesGridPage
+        spacesManager={spacesManager as unknown as SpacesManager}
+        getFeatures={featuresStart.getFeatures}
+        notifications={notificationServiceMock.createStartContract()}
+        getUrlForApp={getUrlForApp}
+        history={history}
+        capabilities={{
+          navLinks: {},
+          management: {},
+          catalogue: {},
+          spaces: { manage: true },
+        }}
+        maxSpaces={1000}
+        isSpaceSolutionEnabled$={of(true)}
+      />
+    );
+
+    // allow spacesManager to load spaces and lazy-load SpaceAvatar
+    await act(async () => {});
+    wrapper.update();
+
+    expect(wrapper.find('EuiInMemoryTable').prop('items')).toBe(spacesWithSolution);
+    expect(wrapper.find('EuiInMemoryTable').prop('columns')).toContainEqual({
+      field: 'solution',
+      name: 'Solution View',
+      sortable: true,
+      render: expect.any(Function),
+    });
   });
 
   it('renders a create spaces button', async () => {

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -55,7 +55,7 @@ interface Props {
   history: ScopedHistory;
   getUrlForApp: ApplicationStart['getUrlForApp'];
   maxSpaces: number;
-  isSolutionNavEnabled$?: Observable<boolean>;
+  isSpaceSolutionEnabled$?: Observable<boolean>;
 }
 
 interface State {
@@ -68,7 +68,7 @@ interface State {
 }
 
 export class SpacesGridPage extends Component<Props, State> {
-  private spaceSolution$: Subscription | null = null;
+  private spaceSolution$?: Subscription;
 
   constructor(props: Props) {
     super(props);
@@ -87,11 +87,9 @@ export class SpacesGridPage extends Component<Props, State> {
       this.loadGrid();
     }
 
-    if (this.props.isSolutionNavEnabled$) {
-      this.spaceSolution$ = this.props.isSolutionNavEnabled$.subscribe((isEnabled) => {
-        this.setState({ isSpaceSolutionEnabled: isEnabled });
-      });
-    }
+    this.spaceSolution$ = this.props.isSpaceSolutionEnabled$?.subscribe((isEnabled) => {
+      this.setState({ isSpaceSolutionEnabled: isEnabled });
+    });
   }
 
   public componentWillUnmount() {
@@ -347,7 +345,9 @@ export class SpacesGridPage extends Component<Props, State> {
           defaultMessage: 'Solution View',
         }),
         sortable: true,
-        render: (solution?: Space['solution']) => <SpaceSolutionBadge solution={solution} />,
+        render: (solution: Space['solution'], record: Space) => (
+          <SpaceSolutionBadge solution={solution} data-test-subj={`${record.id}-solution`} />
+        ),
       });
     }
 

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import {
   EuiButton,
   EuiButtonIcon,
@@ -35,6 +36,7 @@ import { isReservedSpace } from '../../../common';
 import { DEFAULT_SPACE_ID } from '../../../common/constants';
 import { getSpacesFeatureDescription } from '../../constants';
 import { getSpaceAvatarComponent } from '../../space_avatar';
+import { SpaceSolutionBadge } from '../../space_solution_badge';
 import type { SpacesManager } from '../../spaces_manager';
 import { ConfirmDeleteModal, UnauthorizedPrompt } from '../components';
 import { getEnabledFeatures } from '../lib/feature_utils';
@@ -233,7 +235,10 @@ export class SpacesGridPage extends Component<Props, State> {
   };
 
   public getColumnConfig() {
-    return [
+    // TODO use from https://github.com/elastic/kibana/pull/186178/files#diff-bbd1ade87fa29c63e1504ab5f48924a477882d2bf66e5a656c1b61ea6afb02efR67
+    const isSolutionNavEnabled = true;
+
+    const config: Array<EuiBasicTableColumn<Space>> = [
       {
         field: 'initials',
         name: '',
@@ -320,49 +325,63 @@ export class SpacesGridPage extends Component<Props, State> {
           return id;
         },
       },
-      {
-        name: i18n.translate('xpack.spaces.management.spacesGridPage.actionsColumnName', {
-          defaultMessage: 'Actions',
-        }),
-        actions: [
-          {
-            render: (record: Space) => (
-              <EuiButtonIcon
-                data-test-subj={`${record.name}-editSpace`}
-                aria-label={i18n.translate(
-                  'xpack.spaces.management.spacesGridPage.editSpaceActionName',
-                  {
-                    defaultMessage: `Edit {spaceName}.`,
-                    values: { spaceName: record.name },
-                  }
-                )}
-                color={'primary'}
-                iconType={'pencil'}
-                {...reactRouterNavigate(this.props.history, this.getEditSpacePath(record))}
-              />
-            ),
-          },
-          {
-            available: (record: Space) => !isReservedSpace(record),
-            render: (record: Space) => (
-              <EuiButtonIcon
-                data-test-subj={`${record.name}-deleteSpace`}
-                aria-label={i18n.translate(
-                  'xpack.spaces.management.spacesGridPage.deleteActionName',
-                  {
-                    defaultMessage: `Delete {spaceName}.`,
-                    values: { spaceName: record.name },
-                  }
-                )}
-                color={'danger'}
-                iconType={'trash'}
-                onClick={() => this.onDeleteSpaceClick(record)}
-              />
-            ),
-          },
-        ],
-      },
     ];
+
+    if (isSolutionNavEnabled) {
+      config.push({
+        field: 'solution',
+        name: i18n.translate('xpack.spaces.management.spacesGridPage.solutionColumnName', {
+          defaultMessage: 'Solution View',
+        }),
+        sortable: true,
+        render: (solution?: Space['solution']) => <SpaceSolutionBadge solution={solution} />,
+      });
+    }
+
+    config.push({
+      name: i18n.translate('xpack.spaces.management.spacesGridPage.actionsColumnName', {
+        defaultMessage: 'Actions',
+      }),
+      actions: [
+        {
+          render: (record: Space) => (
+            <EuiButtonIcon
+              data-test-subj={`${record.name}-editSpace`}
+              aria-label={i18n.translate(
+                'xpack.spaces.management.spacesGridPage.editSpaceActionName',
+                {
+                  defaultMessage: `Edit {spaceName}.`,
+                  values: { spaceName: record.name },
+                }
+              )}
+              color={'primary'}
+              iconType={'pencil'}
+              {...reactRouterNavigate(this.props.history, this.getEditSpacePath(record))}
+            />
+          ),
+        },
+        {
+          available: (record: Space) => !isReservedSpace(record),
+          render: (record: Space) => (
+            <EuiButtonIcon
+              data-test-subj={`${record.name}-deleteSpace`}
+              aria-label={i18n.translate(
+                'xpack.spaces.management.spacesGridPage.deleteActionName',
+                {
+                  defaultMessage: `Delete {spaceName}.`,
+                  values: { spaceName: record.name },
+                }
+              )}
+              color={'danger'}
+              iconType={'trash'}
+              onClick={() => this.onDeleteSpaceClick(record)}
+            />
+          ),
+        },
+      ],
+    });
+
+    return config;
   }
 
   private getEditSpacePath = (space: Space) => `edit/${encodeURIComponent(space.id)}`;

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -55,7 +55,7 @@ interface Props {
   history: ScopedHistory;
   getUrlForApp: ApplicationStart['getUrlForApp'];
   maxSpaces: number;
-  isSpaceSolutionEnabled$?: Observable<boolean>;
+  isSolutionNavEnabled$?: Observable<boolean>;
 }
 
 interface State {
@@ -64,7 +64,7 @@ interface State {
   loading: boolean;
   showConfirmDeleteModal: boolean;
   selectedSpace: Space | null;
-  isSpaceSolutionEnabled: boolean;
+  isSolutionNavEnabled: boolean;
 }
 
 export class SpacesGridPage extends Component<Props, State> {
@@ -78,7 +78,7 @@ export class SpacesGridPage extends Component<Props, State> {
       loading: true,
       showConfirmDeleteModal: false,
       selectedSpace: null,
-      isSpaceSolutionEnabled: false,
+      isSolutionNavEnabled: false,
     };
   }
 
@@ -87,8 +87,8 @@ export class SpacesGridPage extends Component<Props, State> {
       this.loadGrid();
     }
 
-    this.spaceSolution$ = this.props.isSpaceSolutionEnabled$?.subscribe((isEnabled) => {
-      this.setState({ isSpaceSolutionEnabled: isEnabled });
+    this.spaceSolution$ = this.props.isSolutionNavEnabled$?.subscribe((isEnabled) => {
+      this.setState({ isSolutionNavEnabled: isEnabled });
     });
   }
 
@@ -338,7 +338,7 @@ export class SpacesGridPage extends Component<Props, State> {
       },
     ];
 
-    if (this.state.isSpaceSolutionEnabled) {
+    if (this.state.isSolutionNavEnabled) {
       config.push({
         field: 'solution',
         name: i18n.translate('xpack.spaces.management.spacesGridPage.solutionColumnName', {

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -19,7 +19,6 @@ import {
   EuiText,
 } from '@elastic/eui';
 import React, { Component, lazy, Suspense } from 'react';
-import type { Observable, Subscription } from 'rxjs';
 
 import type {
   ApplicationStart,
@@ -55,7 +54,7 @@ interface Props {
   history: ScopedHistory;
   getUrlForApp: ApplicationStart['getUrlForApp'];
   maxSpaces: number;
-  isSolutionNavEnabled$?: Observable<boolean>;
+  solutionNavExperiment?: Promise<boolean>;
 }
 
 interface State {
@@ -68,8 +67,6 @@ interface State {
 }
 
 export class SpacesGridPage extends Component<Props, State> {
-  private spaceSolution$?: Subscription;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -87,13 +84,9 @@ export class SpacesGridPage extends Component<Props, State> {
       this.loadGrid();
     }
 
-    this.spaceSolution$ = this.props.isSolutionNavEnabled$?.subscribe((isEnabled) => {
+    this.props.solutionNavExperiment?.then((isEnabled) => {
       this.setState({ isSolutionNavEnabled: isEnabled });
     });
-  }
-
-  public componentWillUnmount() {
-    this.spaceSolution$?.unsubscribe();
   }
 
   public render() {

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.test.tsx
@@ -98,7 +98,7 @@ describe('spacesManagementApp', () => {
           css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"maxSpaces":1000}
+          Spaces Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"maxSpaces":1000,"isSolutionNavEnabled$":{}}
         </div>
       </div>
     `);

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.test.tsx
@@ -53,6 +53,7 @@ async function mountApp(basePath: string, pathname: string, spaceId?: string) {
       getStartServices: async () => [coreStart, pluginsStart as PluginsStart, {}],
       config,
       getRolesAPIClient: jest.fn(),
+      solutionNavExperiment: Promise.resolve(false),
     })
     .mount({
       basePath,
@@ -74,6 +75,7 @@ describe('spacesManagementApp', () => {
         getStartServices: coreMock.createSetup().getStartServices as any,
         config,
         getRolesAPIClient: jest.fn(),
+        solutionNavExperiment: Promise.resolve(false),
       })
     ).toMatchInlineSnapshot(`
       Object {
@@ -98,7 +100,7 @@ describe('spacesManagementApp', () => {
           css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"maxSpaces":1000,"isSolutionNavEnabled$":{}}
+          Spaces Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/","search":"","hash":""}},"maxSpaces":1000,"solutionNavExperiment":{}}
         </div>
       </div>
     `);
@@ -125,7 +127,7 @@ describe('spacesManagementApp', () => {
           css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Edit Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/create","search":"","hash":""}},"allowFeatureVisibility":true,"isSolutionNavEnabled$":{}}
+          Spaces Edit Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"history":{"action":"PUSH","length":1,"location":{"pathname":"/create","search":"","hash":""}},"allowFeatureVisibility":true,"solutionNavExperiment":{}}
         </div>
       </div>
     `);
@@ -158,7 +160,7 @@ describe('spacesManagementApp', () => {
           css="You have tried to stringify object returned from \`css\` function. It isn't supposed to be used directly (e.g. as value of the \`className\` prop), but rather handed to emotion so it can handle it (e.g. as value of \`css\` prop)."
           data-test-subj="kbnRedirectAppLink"
         >
-          Spaces Edit Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"spaceId":"some-space","history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/some-space","search":"","hash":""}},"allowFeatureVisibility":true,"isSolutionNavEnabled$":{}}
+          Spaces Edit Page: {"capabilities":{"catalogue":{},"management":{},"navLinks":{}},"notifications":{"toasts":{}},"spacesManager":{"onActiveSpaceChange$":{}},"spaceId":"some-space","history":{"action":"PUSH","length":1,"location":{"pathname":"/edit/some-space","search":"","hash":""}},"allowFeatureVisibility":true,"solutionNavExperiment":{}}
         </div>
       </div>
     `);

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { useParams } from 'react-router-dom';
-import { from, of, shareReplay } from 'rxjs';
 
 import type { StartServicesAccessor } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
@@ -21,7 +20,7 @@ import { Route, Router, Routes } from '@kbn/shared-ux-router';
 
 import type { Space } from '../../common';
 import type { ConfigType } from '../config';
-import { SOLUTION_NAV_FEATURE_FLAG_NAME } from '../constants';
+import { isSolutionNavEnabled } from '../experiments';
 import type { PluginsStart } from '../plugin';
 import type { SpacesManager } from '../spaces_manager';
 
@@ -63,16 +62,7 @@ export const spacesManagementApp = Object.freeze({
 
         chrome.docTitle.change(title);
 
-        const onCloud = Boolean(cloud?.isCloudEnabled);
-        const isSolutionNavEnabled$ =
-          // Only available on Cloud and if the Launch Darkly flag is turned on
-          onCloud && cloudExperiments
-            ? from(
-                cloudExperiments
-                  .getVariation(SOLUTION_NAV_FEATURE_FLAG_NAME, false)
-                  .catch(() => false)
-              ).pipe(shareReplay(1))
-            : of(false);
+        const isSolutionNavEnabled$ = isSolutionNavEnabled(cloud, cloudExperiments);
 
         const SpacesGridPageWithBreadcrumbs = () => {
           setBreadcrumbs([{ ...spacesFirstBreadcrumb, href: undefined }]);
@@ -85,7 +75,7 @@ export const spacesManagementApp = Object.freeze({
               history={history}
               getUrlForApp={application.getUrlForApp}
               maxSpaces={config.maxSpaces}
-              isSpaceSolutionEnabled$={isSolutionNavEnabled$}
+              isSolutionNavEnabled$={isSolutionNavEnabled$}
             />
           );
         };

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
@@ -85,7 +85,7 @@ export const spacesManagementApp = Object.freeze({
               history={history}
               getUrlForApp={application.getUrlForApp}
               maxSpaces={config.maxSpaces}
-              isSolutionNavEnabled$={isSolutionNavEnabled$}
+              isSpaceSolutionEnabled$={isSolutionNavEnabled$}
             />
           );
         };

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
@@ -20,7 +20,6 @@ import { Route, Router, Routes } from '@kbn/shared-ux-router';
 
 import type { Space } from '../../common';
 import type { ConfigType } from '../config';
-import { isSolutionNavEnabled } from '../experiments';
 import type { PluginsStart } from '../plugin';
 import type { SpacesManager } from '../spaces_manager';
 
@@ -29,11 +28,12 @@ interface CreateParams {
   spacesManager: SpacesManager;
   config: ConfigType;
   getRolesAPIClient: () => Promise<RolesAPIClient>;
+  solutionNavExperiment: Promise<boolean>;
 }
 
 export const spacesManagementApp = Object.freeze({
   id: 'spaces',
-  create({ getStartServices, spacesManager, config }: CreateParams) {
+  create({ getStartServices, spacesManager, config, solutionNavExperiment }: CreateParams) {
     const title = i18n.translate('xpack.spaces.displayName', {
       defaultMessage: 'Spaces',
     });
@@ -44,15 +44,8 @@ export const spacesManagementApp = Object.freeze({
       title,
 
       async mount({ element, setBreadcrumbs, history }) {
-        const [
-          [coreStart, { features, cloud, cloudExperiments }],
-          { SpacesGridPage },
-          { ManageSpacePage },
-        ] = await Promise.all([
-          getStartServices(),
-          import('./spaces_grid'),
-          import('./edit_space'),
-        ]);
+        const [[coreStart, { features }], { SpacesGridPage }, { ManageSpacePage }] =
+          await Promise.all([getStartServices(), import('./spaces_grid'), import('./edit_space')]);
 
         const spacesFirstBreadcrumb = {
           text: title,
@@ -61,8 +54,6 @@ export const spacesManagementApp = Object.freeze({
         const { notifications, application, chrome } = coreStart;
 
         chrome.docTitle.change(title);
-
-        const isSolutionNavEnabled$ = isSolutionNavEnabled(cloud, cloudExperiments);
 
         const SpacesGridPageWithBreadcrumbs = () => {
           setBreadcrumbs([{ ...spacesFirstBreadcrumb, href: undefined }]);
@@ -75,7 +66,7 @@ export const spacesManagementApp = Object.freeze({
               history={history}
               getUrlForApp={application.getUrlForApp}
               maxSpaces={config.maxSpaces}
-              isSolutionNavEnabled$={isSolutionNavEnabled$}
+              solutionNavExperiment={solutionNavExperiment}
             />
           );
         };
@@ -98,7 +89,7 @@ export const spacesManagementApp = Object.freeze({
               spacesManager={spacesManager}
               history={history}
               allowFeatureVisibility={config.allowFeatureVisibility}
-              isSolutionNavEnabled$={isSolutionNavEnabled$}
+              solutionNavExperiment={solutionNavExperiment}
             />
           );
         };
@@ -125,7 +116,7 @@ export const spacesManagementApp = Object.freeze({
               onLoadSpace={onLoadSpace}
               history={history}
               allowFeatureVisibility={config.allowFeatureVisibility}
-              isSolutionNavEnabled$={isSolutionNavEnabled$}
+              solutionNavExperiment={solutionNavExperiment}
             />
           );
         };

--- a/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_management_app.tsx
@@ -85,6 +85,7 @@ export const spacesManagementApp = Object.freeze({
               history={history}
               getUrlForApp={application.getUrlForApp}
               maxSpaces={config.maxSpaces}
+              isSolutionNavEnabled$={isSolutionNavEnabled$}
             />
           );
         };

--- a/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
@@ -126,7 +126,8 @@ class SpacesMenuUI extends Component<Props> {
   }
 
   private getSpaceOptions = (): EuiSelectableOption[] => {
-    const canShowSolution = true;
+    // TODO use from https://github.com/elastic/kibana/pull/186178/files#diff-bbd1ade87fa29c63e1504ab5f48924a477882d2bf66e5a656c1b61ea6afb02efR67
+    const isSolutionNavEnabled = true;
 
     return this.props.spaces.map((space) => {
       return {
@@ -139,7 +140,7 @@ class SpacesMenuUI extends Component<Props> {
             <LazySpaceAvatar space={space} size={'s'} announceSpaceName={false} />
           </Suspense>
         ),
-        ...(canShowSolution && { append: <SpaceSolutionBadge solution={space.solution} /> }),
+        ...(isSolutionNavEnabled && { append: <SpaceSolutionBadge solution={space.solution} /> }),
         checked: this.props.activeSpace?.id === space.id ? 'on' : undefined,
         'data-test-subj': `${space.id}-selectableSpaceItem`,
         className: 'selectableSpaceItem',

--- a/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
@@ -47,6 +47,7 @@ interface Props {
   navigateToApp: ApplicationStart['navigateToApp'];
   navigateToUrl: ApplicationStart['navigateToUrl'];
   readonly activeSpace: Space | null;
+  isSpaceSolutionEnabled: boolean;
 }
 class SpacesMenuUI extends Component<Props> {
   public render() {
@@ -126,9 +127,6 @@ class SpacesMenuUI extends Component<Props> {
   }
 
   private getSpaceOptions = (): EuiSelectableOption[] => {
-    // TODO use from https://github.com/elastic/kibana/pull/186178/files#diff-bbd1ade87fa29c63e1504ab5f48924a477882d2bf66e5a656c1b61ea6afb02efR67
-    const isSolutionNavEnabled = true;
-
     return this.props.spaces.map((space) => {
       return {
         'aria-label': space.name,
@@ -140,7 +138,9 @@ class SpacesMenuUI extends Component<Props> {
             <LazySpaceAvatar space={space} size={'s'} announceSpaceName={false} />
           </Suspense>
         ),
-        ...(isSolutionNavEnabled && { append: <SpaceSolutionBadge solution={space.solution} /> }),
+        ...(this.props.isSpaceSolutionEnabled && {
+          append: <SpaceSolutionBadge solution={space.solution} />,
+        }),
         checked: this.props.activeSpace?.id === space.id ? 'on' : undefined,
         'data-test-subj': `${space.id}-selectableSpaceItem`,
         className: 'selectableSpaceItem',

--- a/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
@@ -31,6 +31,7 @@ import { ManageSpacesButton } from './manage_spaces_button';
 import type { Space } from '../../../common';
 import { addSpaceIdToPath, ENTER_SPACE_PATH, SPACE_SEARCH_COUNT_THRESHOLD } from '../../../common';
 import { getSpaceAvatarComponent } from '../../space_avatar';
+import { SpaceSolutionBadge } from '../../space_solution_badge';
 
 const LazySpaceAvatar = lazy(() =>
   getSpaceAvatarComponent().then((component) => ({ default: component }))
@@ -99,7 +100,7 @@ class SpacesMenuUI extends Component<Props> {
           noMatchesMessage={noSpacesMessage}
           options={spaceOptions}
           singleSelection={'always'}
-          style={{ width: 300 }}
+          style={{ minWidth: 300, maxWidth: 320 }}
           onChange={this.spaceSelectionChange}
           listProps={{
             rowHeight: 40,
@@ -125,6 +126,8 @@ class SpacesMenuUI extends Component<Props> {
   }
 
   private getSpaceOptions = (): EuiSelectableOption[] => {
+    const canShowSolution = true;
+
     return this.props.spaces.map((space) => {
       return {
         'aria-label': space.name,
@@ -136,6 +139,7 @@ class SpacesMenuUI extends Component<Props> {
             <LazySpaceAvatar space={space} size={'s'} announceSpaceName={false} />
           </Suspense>
         ),
+        ...(canShowSolution && { append: <SpaceSolutionBadge solution={space.solution} /> }),
         checked: this.props.activeSpace?.id === space.id ? 'on' : undefined,
         'data-test-subj': `${space.id}-selectableSpaceItem`,
         className: 'selectableSpaceItem',

--- a/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/components/spaces_menu.tsx
@@ -47,7 +47,7 @@ interface Props {
   navigateToApp: ApplicationStart['navigateToApp'];
   navigateToUrl: ApplicationStart['navigateToUrl'];
   readonly activeSpace: Space | null;
-  isSpaceSolutionEnabled: boolean;
+  isSolutionNavEnabled: boolean;
 }
 class SpacesMenuUI extends Component<Props> {
   public render() {
@@ -138,7 +138,7 @@ class SpacesMenuUI extends Component<Props> {
             <LazySpaceAvatar space={space} size={'s'} announceSpaceName={false} />
           </Suspense>
         ),
-        ...(this.props.isSpaceSolutionEnabled && {
+        ...(this.props.isSolutionNavEnabled && {
           append: <SpaceSolutionBadge solution={space.solution} />,
         }),
         checked: this.props.activeSpace?.id === space.id ? 'on' : undefined,

--- a/x-pack/plugins/spaces/public/nav_control/nav_control.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control.tsx
@@ -8,7 +8,6 @@
 import { EuiLoadingSpinner } from '@elastic/eui';
 import React, { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom';
-import type { Observable } from 'rxjs';
 
 import type { CoreStart } from '@kbn/core/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
@@ -18,7 +17,7 @@ import type { SpacesManager } from '../spaces_manager';
 export function initSpacesNavControl(
   spacesManager: SpacesManager,
   core: CoreStart,
-  isSolutionNavEnabled$: Observable<boolean>
+  solutionNavExperiment: Promise<boolean>
 ) {
   core.chrome.navControls.registerLeft({
     order: 1000,
@@ -43,7 +42,7 @@ export function initSpacesNavControl(
               capabilities={core.application.capabilities}
               navigateToApp={core.application.navigateToApp}
               navigateToUrl={core.application.navigateToUrl}
-              isSolutionNavEnabled$={isSolutionNavEnabled$}
+              solutionNavExperiment={solutionNavExperiment}
             />
           </Suspense>
         </KibanaRenderContextProvider>,

--- a/x-pack/plugins/spaces/public/nav_control/nav_control.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control.tsx
@@ -8,13 +8,18 @@
 import { EuiLoadingSpinner } from '@elastic/eui';
 import React, { lazy, Suspense } from 'react';
 import ReactDOM from 'react-dom';
+import type { Observable } from 'rxjs';
 
 import type { CoreStart } from '@kbn/core/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 
 import type { SpacesManager } from '../spaces_manager';
 
-export function initSpacesNavControl(spacesManager: SpacesManager, core: CoreStart) {
+export function initSpacesNavControl(
+  spacesManager: SpacesManager,
+  core: CoreStart,
+  isSpaceSolutionEnabled$: Observable<boolean>
+) {
   core.chrome.navControls.registerLeft({
     order: 1000,
     mount(targetDomElement: HTMLElement) {
@@ -38,6 +43,7 @@ export function initSpacesNavControl(spacesManager: SpacesManager, core: CoreSta
               capabilities={core.application.capabilities}
               navigateToApp={core.application.navigateToApp}
               navigateToUrl={core.application.navigateToUrl}
+              isSpaceSolutionEnabled$={isSpaceSolutionEnabled$}
             />
           </Suspense>
         </KibanaRenderContextProvider>,

--- a/x-pack/plugins/spaces/public/nav_control/nav_control.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control.tsx
@@ -18,7 +18,7 @@ import type { SpacesManager } from '../spaces_manager';
 export function initSpacesNavControl(
   spacesManager: SpacesManager,
   core: CoreStart,
-  isSpaceSolutionEnabled$: Observable<boolean>
+  isSolutionNavEnabled$: Observable<boolean>
 ) {
   core.chrome.navControls.registerLeft({
     order: 1000,
@@ -43,7 +43,7 @@ export function initSpacesNavControl(
               capabilities={core.application.capabilities}
               navigateToApp={core.application.navigateToApp}
               navigateToUrl={core.application.navigateToUrl}
-              isSpaceSolutionEnabled$={isSpaceSolutionEnabled$}
+              isSolutionNavEnabled$={isSolutionNavEnabled$}
             />
           </Suspense>
         </KibanaRenderContextProvider>,

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
@@ -15,6 +15,7 @@ import {
 import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import * as Rx from 'rxjs';
+import { of } from 'rxjs';
 
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 
@@ -45,7 +46,7 @@ const mockSpaces = [
 ];
 
 describe('NavControlPopover', () => {
-  async function setup(spaces: Space[]) {
+  async function setup(spaces: Space[], isSpaceSolutionEnabled = false) {
     const spacesManager = spacesManagerMock.create();
     spacesManager.getSpaces = jest.fn().mockResolvedValue(spaces);
 
@@ -57,6 +58,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
+        isSpaceSolutionEnabled$={of(isSpaceSolutionEnabled)}
       />
     );
 
@@ -78,6 +80,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
+        isSpaceSolutionEnabled$={of(false)}
       />
     );
     expect(baseElement).toMatchSnapshot();
@@ -102,6 +105,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
+        isSpaceSolutionEnabled$={of(false)}
       />
     );
 
@@ -240,7 +244,7 @@ describe('NavControlPopover', () => {
       },
     ];
 
-    const wrapper = await setup(spaces);
+    const wrapper = await setup(spaces, true);
 
     await act(async () => {
       wrapper.find(EuiHeaderSectionItemButton).find('button').simulate('click');

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
@@ -15,7 +15,6 @@ import {
 import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import * as Rx from 'rxjs';
-import { of } from 'rxjs';
 
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 
@@ -58,7 +57,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
-        isSolutionNavEnabled$={of(isSolutionNavEnabled)}
+        solutionNavExperiment={Promise.resolve(isSolutionNavEnabled)}
       />
     );
 
@@ -80,7 +79,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
-        isSolutionNavEnabled$={of(false)}
+        solutionNavExperiment={Promise.resolve(false)}
       />
     );
     expect(baseElement).toMatchSnapshot();
@@ -105,7 +104,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
-        isSolutionNavEnabled$={of(false)}
+        solutionNavExperiment={Promise.resolve(false)}
       />
     );
 

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
@@ -46,7 +46,7 @@ const mockSpaces = [
 ];
 
 describe('NavControlPopover', () => {
-  async function setup(spaces: Space[], isSpaceSolutionEnabled = false) {
+  async function setup(spaces: Space[], isSolutionNavEnabled = false) {
     const spacesManager = spacesManagerMock.create();
     spacesManager.getSpaces = jest.fn().mockResolvedValue(spaces);
 
@@ -58,7 +58,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
-        isSpaceSolutionEnabled$={of(isSpaceSolutionEnabled)}
+        isSolutionNavEnabled$={of(isSolutionNavEnabled)}
       />
     );
 
@@ -80,7 +80,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
-        isSpaceSolutionEnabled$={of(false)}
+        isSolutionNavEnabled$={of(false)}
       />
     );
     expect(baseElement).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe('NavControlPopover', () => {
         capabilities={{ navLinks: {}, management: {}, catalogue: {}, spaces: { manage: true } }}
         navigateToApp={jest.fn()}
         navigateToUrl={jest.fn()}
-        isSpaceSolutionEnabled$={of(false)}
+        isSolutionNavEnabled$={of(false)}
       />
     );
 

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
@@ -244,7 +244,7 @@ describe('NavControlPopover', () => {
       },
     ];
 
-    const wrapper = await setup(spaces, true);
+    const wrapper = await setup(spaces, true /** isSolutionEnabled **/);
 
     await act(async () => {
       wrapper.find(EuiHeaderSectionItemButton).find('button').simulate('click');

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.test.tsx
@@ -21,6 +21,7 @@ import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { NavControlPopover } from './nav_control_popover';
 import type { Space } from '../../common';
 import { SpaceAvatarInternal } from '../space_avatar/space_avatar_internal';
+import { SpaceSolutionBadge } from '../space_solution_badge';
 import type { SpacesManager } from '../spaces_manager';
 import { spacesManagerMock } from '../spaces_manager/mocks';
 
@@ -221,5 +222,32 @@ describe('NavControlPopover', () => {
     wrapper.update();
 
     expect(wrapper.find(EuiPopover).props().isOpen).toEqual(false);
+  });
+
+  it('should render solution for spaces', async () => {
+    const spaces: Space[] = [
+      {
+        id: 'space-1',
+        name: 'Space-1',
+        disabledFeatures: [],
+        solution: 'classic',
+      },
+      {
+        id: 'space-2',
+        name: 'Space 2',
+        disabledFeatures: [],
+        solution: 'security',
+      },
+    ];
+
+    const wrapper = await setup(spaces);
+
+    await act(async () => {
+      wrapper.find(EuiHeaderSectionItemButton).find('button').simulate('click');
+    });
+
+    wrapper.update();
+
+    expect(wrapper.find(SpaceSolutionBadge)).toHaveLength(2);
   });
 });

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.tsx
@@ -13,7 +13,7 @@ import {
   withEuiTheme,
 } from '@elastic/eui';
 import React, { Component, lazy, Suspense } from 'react';
-import type { Observable, Subscription } from 'rxjs';
+import type { Subscription } from 'rxjs';
 
 import type { ApplicationStart, Capabilities } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
@@ -37,7 +37,7 @@ interface Props {
   navigateToUrl: ApplicationStart['navigateToUrl'];
   serverBasePath: string;
   theme: WithEuiThemeProps['theme'];
-  isSolutionNavEnabled$: Observable<boolean>;
+  solutionNavExperiment: Promise<boolean>;
 }
 
 interface State {
@@ -52,7 +52,6 @@ const popoutContentId = 'headerSpacesMenuContent';
 
 class NavControlPopoverUI extends Component<Props, State> {
   private activeSpace$?: Subscription;
-  private spaceSolution$?: Subscription;
 
   constructor(props: Props) {
     super(props);
@@ -74,14 +73,13 @@ class NavControlPopoverUI extends Component<Props, State> {
       },
     });
 
-    this.spaceSolution$ = this.props.isSolutionNavEnabled$.subscribe((isEnabled) => {
+    this.props.solutionNavExperiment.then((isEnabled) => {
       this.setState({ isSolutionNavEnabled: isEnabled });
     });
   }
 
   public componentWillUnmount() {
     this.activeSpace$?.unsubscribe();
-    this.spaceSolution$?.unsubscribe();
   }
 
   public render() {

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.tsx
@@ -13,7 +13,7 @@ import {
   withEuiTheme,
 } from '@elastic/eui';
 import React, { Component, lazy, Suspense } from 'react';
-import type { Subscription } from 'rxjs';
+import type { Observable, Subscription } from 'rxjs';
 
 import type { ApplicationStart, Capabilities } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
@@ -37,6 +37,7 @@ interface Props {
   navigateToUrl: ApplicationStart['navigateToUrl'];
   serverBasePath: string;
   theme: WithEuiThemeProps['theme'];
+  isSpaceSolutionEnabled$: Observable<boolean>;
 }
 
 interface State {
@@ -44,12 +45,14 @@ interface State {
   loading: boolean;
   activeSpace: Space | null;
   spaces: Space[];
+  isSpaceSolutionEnabled: boolean;
 }
 
 const popoutContentId = 'headerSpacesMenuContent';
 
 class NavControlPopoverUI extends Component<Props, State> {
   private activeSpace$?: Subscription;
+  private spaceSolution$?: Subscription;
 
   constructor(props: Props) {
     super(props);
@@ -58,6 +61,7 @@ class NavControlPopoverUI extends Component<Props, State> {
       loading: false,
       activeSpace: null,
       spaces: [],
+      isSpaceSolutionEnabled: false,
     };
   }
 
@@ -69,12 +73,15 @@ class NavControlPopoverUI extends Component<Props, State> {
         });
       },
     });
+
+    this.spaceSolution$ = this.props.isSpaceSolutionEnabled$.subscribe((isEnabled) => {
+      this.setState({ isSpaceSolutionEnabled: isEnabled });
+    });
   }
 
   public componentWillUnmount() {
-    if (this.activeSpace$) {
-      this.activeSpace$.unsubscribe();
-    }
+    this.activeSpace$?.unsubscribe();
+    this.spaceSolution$?.unsubscribe();
   }
 
   public render() {
@@ -103,6 +110,7 @@ class NavControlPopoverUI extends Component<Props, State> {
           navigateToApp={this.props.navigateToApp}
           navigateToUrl={this.props.navigateToUrl}
           activeSpace={this.state.activeSpace}
+          isSpaceSolutionEnabled={this.state.isSpaceSolutionEnabled}
         />
       );
     }

--- a/x-pack/plugins/spaces/public/nav_control/nav_control_popover.tsx
+++ b/x-pack/plugins/spaces/public/nav_control/nav_control_popover.tsx
@@ -37,7 +37,7 @@ interface Props {
   navigateToUrl: ApplicationStart['navigateToUrl'];
   serverBasePath: string;
   theme: WithEuiThemeProps['theme'];
-  isSpaceSolutionEnabled$: Observable<boolean>;
+  isSolutionNavEnabled$: Observable<boolean>;
 }
 
 interface State {
@@ -45,7 +45,7 @@ interface State {
   loading: boolean;
   activeSpace: Space | null;
   spaces: Space[];
-  isSpaceSolutionEnabled: boolean;
+  isSolutionNavEnabled: boolean;
 }
 
 const popoutContentId = 'headerSpacesMenuContent';
@@ -61,7 +61,7 @@ class NavControlPopoverUI extends Component<Props, State> {
       loading: false,
       activeSpace: null,
       spaces: [],
-      isSpaceSolutionEnabled: false,
+      isSolutionNavEnabled: false,
     };
   }
 
@@ -74,8 +74,8 @@ class NavControlPopoverUI extends Component<Props, State> {
       },
     });
 
-    this.spaceSolution$ = this.props.isSpaceSolutionEnabled$.subscribe((isEnabled) => {
-      this.setState({ isSpaceSolutionEnabled: isEnabled });
+    this.spaceSolution$ = this.props.isSolutionNavEnabled$.subscribe((isEnabled) => {
+      this.setState({ isSolutionNavEnabled: isEnabled });
     });
   }
 
@@ -110,7 +110,7 @@ class NavControlPopoverUI extends Component<Props, State> {
           navigateToApp={this.props.navigateToApp}
           navigateToUrl={this.props.navigateToUrl}
           activeSpace={this.state.activeSpace}
-          isSpaceSolutionEnabled={this.state.isSpaceSolutionEnabled}
+          isSolutionNavEnabled={this.state.isSolutionNavEnabled}
         />
       );
     }

--- a/x-pack/plugins/spaces/public/plugin.test.ts
+++ b/x-pack/plugins/spaces/public/plugin.test.ts
@@ -132,7 +132,7 @@ describe('Spaces plugin', () => {
       const plugin = new SpacesPlugin(mockInitializerContext);
       plugin.setup(coreSetup, {});
 
-      plugin.start(coreStart);
+      plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
 
       expect(coreStart.chrome.navControls.registerLeft).toHaveBeenCalled();
     });
@@ -144,7 +144,7 @@ describe('Spaces plugin', () => {
       const plugin = new SpacesPlugin(coreMock.createPluginInitializerContext());
       plugin.setup(coreSetup, {});
 
-      plugin.start(coreStart);
+      plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
 
       expect(coreStart.chrome.navControls.registerLeft).not.toHaveBeenCalled();
     });
@@ -156,7 +156,7 @@ describe('Spaces plugin', () => {
 
     const plugin = new SpacesPlugin(coreMock.createPluginInitializerContext({ maxSpaces: 1 }));
     const spacesSetup = plugin.setup(coreSetup, {});
-    const spacesStart = plugin.start(coreStart);
+    const spacesStart = plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
 
     expect(spacesSetup.hasOnlyDefaultSpace).toBe(true);
     expect(spacesStart.hasOnlyDefaultSpace).toBe(true);
@@ -168,7 +168,7 @@ describe('Spaces plugin', () => {
 
     const plugin = new SpacesPlugin(coreMock.createPluginInitializerContext({ maxSpaces: 1000 }));
     const spacesSetup = plugin.setup(coreSetup, {});
-    const spacesStart = plugin.start(coreStart);
+    const spacesStart = plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
 
     expect(spacesSetup.hasOnlyDefaultSpace).toBe(false);
     expect(spacesStart.hasOnlyDefaultSpace).toBe(false);

--- a/x-pack/plugins/spaces/public/plugin.test.ts
+++ b/x-pack/plugins/spaces/public/plugin.test.ts
@@ -132,7 +132,7 @@ describe('Spaces plugin', () => {
       const plugin = new SpacesPlugin(mockInitializerContext);
       plugin.setup(coreSetup, {});
 
-      plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
+      plugin.start(coreStart);
 
       expect(coreStart.chrome.navControls.registerLeft).toHaveBeenCalled();
     });
@@ -144,7 +144,7 @@ describe('Spaces plugin', () => {
       const plugin = new SpacesPlugin(coreMock.createPluginInitializerContext());
       plugin.setup(coreSetup, {});
 
-      plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
+      plugin.start(coreStart);
 
       expect(coreStart.chrome.navControls.registerLeft).not.toHaveBeenCalled();
     });
@@ -156,7 +156,7 @@ describe('Spaces plugin', () => {
 
     const plugin = new SpacesPlugin(coreMock.createPluginInitializerContext({ maxSpaces: 1 }));
     const spacesSetup = plugin.setup(coreSetup, {});
-    const spacesStart = plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
+    const spacesStart = plugin.start(coreStart);
 
     expect(spacesSetup.hasOnlyDefaultSpace).toBe(true);
     expect(spacesStart.hasOnlyDefaultSpace).toBe(true);
@@ -168,7 +168,7 @@ describe('Spaces plugin', () => {
 
     const plugin = new SpacesPlugin(coreMock.createPluginInitializerContext({ maxSpaces: 1000 }));
     const spacesSetup = plugin.setup(coreSetup, {});
-    const spacesStart = plugin.start(coreStart, { features: { getFeatures: jest.fn() } });
+    const spacesStart = plugin.start(coreStart);
 
     expect(spacesSetup.hasOnlyDefaultSpace).toBe(false);
     expect(spacesStart.hasOnlyDefaultSpace).toBe(false);

--- a/x-pack/plugins/spaces/public/plugin.tsx
+++ b/x-pack/plugins/spaces/public/plugin.tsx
@@ -53,6 +53,7 @@ export class SpacesPlugin implements Plugin<SpacesPluginSetup, SpacesPluginStart
   private managementService?: ManagementService;
   private readonly config: ConfigType;
   private readonly isServerless: boolean;
+  private solutionNavExperiment = Promise.resolve(false);
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.config = this.initializerContext.config.get<ConfigType>();
@@ -71,6 +72,15 @@ export class SpacesPlugin implements Plugin<SpacesPluginSetup, SpacesPluginStart
       getActiveSpace: () => this.spacesManager.getActiveSpace(),
       hasOnlyDefaultSpace,
     };
+
+    this.solutionNavExperiment = core
+      .getStartServices()
+      .then(([, { cloud, cloudExperiments }]) => isSolutionNavEnabled(cloud, cloudExperiments))
+      .catch((err) => {
+        this.initializerContext.logger.get().error(`Failed to retrieve cloud experiment: ${err}`);
+
+        return false;
+      });
 
     if (!this.isServerless) {
       const getRolesAPIClient = async () => {
@@ -97,6 +107,7 @@ export class SpacesPlugin implements Plugin<SpacesPluginSetup, SpacesPluginStart
           spacesManager: this.spacesManager,
           config: this.config,
           getRolesAPIClient,
+          solutionNavExperiment: this.solutionNavExperiment,
         });
       }
 
@@ -110,12 +121,9 @@ export class SpacesPlugin implements Plugin<SpacesPluginSetup, SpacesPluginStart
     return { hasOnlyDefaultSpace };
   }
 
-  public start(core: CoreStart, plugins: PluginsStart) {
+  public start(core: CoreStart) {
     if (!this.isServerless) {
-      const { cloud, cloudExperiments } = plugins;
-      const isSpaceSolutionEnabled$ = isSolutionNavEnabled(cloud, cloudExperiments);
-
-      initSpacesNavControl(this.spacesManager, core, isSpaceSolutionEnabled$);
+      initSpacesNavControl(this.spacesManager, core, this.solutionNavExperiment);
     }
 
     return this.spacesApi;

--- a/x-pack/plugins/spaces/public/space_solution_badge/__snapshots__/badge.test.tsx.snap
+++ b/x-pack/plugins/spaces/public/space_solution_badge/__snapshots__/badge.test.tsx.snap
@@ -1,0 +1,247 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it renders without crashing with solution provided 1`] = `
+<EuiBadge
+  color="hollow"
+  iconType="logoSecurity"
+  intl={
+    Object {
+      "$t": [Function],
+      "defaultFormats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "style": "long",
+          },
+          "hours": Object {
+            "style": "long",
+          },
+          "minutes": Object {
+            "style": "long",
+          },
+          "months": Object {
+            "style": "long",
+          },
+          "seconds": Object {
+            "style": "long",
+          },
+          "years": Object {
+            "style": "long",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "defaultLocale": "en",
+      "fallbackOnEmptyString": true,
+      "formatDate": [Function],
+      "formatDateTimeRange": [Function],
+      "formatDateToParts": [Function],
+      "formatDisplayName": [Function],
+      "formatList": [Function],
+      "formatListToParts": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatNumberToParts": [Function],
+      "formatPlural": [Function],
+      "formatRelativeTime": [Function],
+      "formatTime": [Function],
+      "formatTimeToParts": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getDisplayNames": [Function],
+        "getListFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralRules": [Function],
+        "getRelativeTimeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "onError": [Function],
+      "onWarn": [Function],
+      "timeZone": undefined,
+    }
+  }
+>
+  <MemoizedFormattedMessage
+    defaultMessage="Security"
+    id="xpack.spaces.spaceSolutionBadge.security"
+  />
+</EuiBadge>
+`;
+
+exports[`it renders without crashing without solution 1`] = `
+<EuiBadge
+  color="hollow"
+  iconType="logoElasticStack"
+  intl={
+    Object {
+      "$t": [Function],
+      "defaultFormats": Object {
+        "date": Object {
+          "full": Object {
+            "day": "numeric",
+            "month": "long",
+            "weekday": "long",
+            "year": "numeric",
+          },
+          "long": Object {
+            "day": "numeric",
+            "month": "long",
+            "year": "numeric",
+          },
+          "medium": Object {
+            "day": "numeric",
+            "month": "short",
+            "year": "numeric",
+          },
+          "short": Object {
+            "day": "numeric",
+            "month": "numeric",
+            "year": "2-digit",
+          },
+        },
+        "number": Object {
+          "currency": Object {
+            "style": "currency",
+          },
+          "percent": Object {
+            "style": "percent",
+          },
+        },
+        "relative": Object {
+          "days": Object {
+            "style": "long",
+          },
+          "hours": Object {
+            "style": "long",
+          },
+          "minutes": Object {
+            "style": "long",
+          },
+          "months": Object {
+            "style": "long",
+          },
+          "seconds": Object {
+            "style": "long",
+          },
+          "years": Object {
+            "style": "long",
+          },
+        },
+        "time": Object {
+          "full": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "long": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+            "timeZoneName": "short",
+          },
+          "medium": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+            "second": "numeric",
+          },
+          "short": Object {
+            "hour": "numeric",
+            "minute": "numeric",
+          },
+        },
+      },
+      "defaultLocale": "en",
+      "fallbackOnEmptyString": true,
+      "formatDate": [Function],
+      "formatDateTimeRange": [Function],
+      "formatDateToParts": [Function],
+      "formatDisplayName": [Function],
+      "formatList": [Function],
+      "formatListToParts": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatNumberToParts": [Function],
+      "formatPlural": [Function],
+      "formatRelativeTime": [Function],
+      "formatTime": [Function],
+      "formatTimeToParts": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getDisplayNames": [Function],
+        "getListFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralRules": [Function],
+        "getRelativeTimeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "onError": [Function],
+      "onWarn": [Function],
+      "timeZone": undefined,
+    }
+  }
+>
+  <MemoizedFormattedMessage
+    defaultMessage="Classic"
+    id="xpack.spaces.spaceSolutionBadge.classic"
+  />
+</EuiBadge>
+`;

--- a/x-pack/plugins/spaces/public/space_solution_badge/badge.test.tsx
+++ b/x-pack/plugins/spaces/public/space_solution_badge/badge.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { shallowWithIntl } from '@kbn/test-jest-helpers';
+
+import { SpaceSolutionBadge } from './badge';
+
+test('it renders without crashing with solution provided', () => {
+  const component = shallowWithIntl(<SpaceSolutionBadge solution="security" />);
+  expect(component).toMatchSnapshot();
+});
+
+test('it renders without crashing without solution', () => {
+  const component = shallowWithIntl(<SpaceSolutionBadge />);
+  expect(component).toMatchSnapshot();
+});

--- a/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
+++ b/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
@@ -10,7 +10,12 @@ import React, { useMemo } from 'react';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 
-const SolutionOptions = {
+import type { Space } from '../../common';
+
+const SolutionOptions: Record<
+  NonNullable<Space['solution']>,
+  { iconType: string; label: JSX.Element }
+> = {
   search: {
     iconType: 'logoElasticsearch',
     label: (
@@ -44,14 +49,17 @@ const SolutionOptions = {
 };
 
 export type SpaceSolutionBadgeProps = Omit<EuiBadgeProps, 'iconType'> & {
-  solution?: keyof typeof SolutionOptions;
+  solution?: Space['solution'];
 };
 
 export const SpaceSolutionBadge = ({ solution, ...badgeProps }: SpaceSolutionBadgeProps) => {
-  const { iconType, label } = useMemo(
-    () => SolutionOptions[solution as keyof typeof SolutionOptions] ?? SolutionOptions.classic,
-    [solution]
-  );
+  const { iconType, label } = useMemo(() => {
+    if (!solution || !SolutionOptions[solution]) {
+      return SolutionOptions.classic;
+    }
+
+    return SolutionOptions[solution];
+  }, [solution]);
 
   return (
     <EuiBadge {...(badgeProps as EuiBadgeProps)} iconType={iconType} color="hollow">

--- a/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
+++ b/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { EuiBadgeProps } from '@elastic/eui';
+import { EuiBadge } from '@elastic/eui';
+import React, { useMemo } from 'react';
+
+import { FormattedMessage } from '@kbn/i18n-react';
+
+const SolutionOptions = {
+  search: {
+    iconType: 'logoElasticsearch',
+    label: <FormattedMessage id="spaceSolutionBadge.elasticsearch" defaultMessage="Search" />,
+  },
+  security: {
+    iconType: 'logoSecurity',
+    label: <FormattedMessage id="spaceSolutionBadge.security" defaultMessage="Security" />,
+  },
+  observability: {
+    iconType: 'logoObservability',
+    label: (
+      <FormattedMessage id="spaceSolutionBadge.observability" defaultMessage="Observability" />
+    ),
+  },
+  classic: {
+    iconType: 'logoElasticStack',
+    label: <FormattedMessage id="spaceSolutionBadge.classic" defaultMessage="Classic" />,
+  },
+};
+
+export type SpaceSolutionBadgeProps = Omit<EuiBadgeProps, 'iconType'> & {
+  solution?: keyof typeof SolutionOptions;
+};
+
+export const SpaceSolutionBadge = ({ solution, ...badgeProps }: SpaceSolutionBadgeProps) => {
+  const { iconType, label } = useMemo(
+    () => SolutionOptions[solution as keyof typeof SolutionOptions] ?? SolutionOptions.classic,
+    [solution]
+  );
+
+  return (
+    <EuiBadge {...(badgeProps as EuiBadgeProps)} iconType={iconType} color="hollow">
+      {label}
+    </EuiBadge>
+  );
+};

--- a/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
+++ b/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
@@ -16,7 +16,7 @@ const SolutionOptions: Record<
   NonNullable<Space['solution']>,
   { iconType: string; label: JSX.Element }
 > = {
-  search: {
+  es: {
     iconType: 'logoElasticsearch',
     label: (
       <FormattedMessage
@@ -31,7 +31,7 @@ const SolutionOptions: Record<
       <FormattedMessage id="xpack.spaces.spaceSolutionBadge.security" defaultMessage="Security" />
     ),
   },
-  observability: {
+  oblt: {
     iconType: 'logoObservability',
     label: (
       <FormattedMessage

--- a/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
+++ b/x-pack/plugins/spaces/public/space_solution_badge/badge.tsx
@@ -13,21 +13,33 @@ import { FormattedMessage } from '@kbn/i18n-react';
 const SolutionOptions = {
   search: {
     iconType: 'logoElasticsearch',
-    label: <FormattedMessage id="spaceSolutionBadge.elasticsearch" defaultMessage="Search" />,
+    label: (
+      <FormattedMessage
+        id="xpack.spaces.spaceSolutionBadge.elasticsearch"
+        defaultMessage="Search"
+      />
+    ),
   },
   security: {
     iconType: 'logoSecurity',
-    label: <FormattedMessage id="spaceSolutionBadge.security" defaultMessage="Security" />,
+    label: (
+      <FormattedMessage id="xpack.spaces.spaceSolutionBadge.security" defaultMessage="Security" />
+    ),
   },
   observability: {
     iconType: 'logoObservability',
     label: (
-      <FormattedMessage id="spaceSolutionBadge.observability" defaultMessage="Observability" />
+      <FormattedMessage
+        id="xpack.spaces.spaceSolutionBadge.observability"
+        defaultMessage="Observability"
+      />
     ),
   },
   classic: {
     iconType: 'logoElasticStack',
-    label: <FormattedMessage id="spaceSolutionBadge.classic" defaultMessage="Classic" />,
+    label: (
+      <FormattedMessage id="xpack.spaces.spaceSolutionBadge.classic" defaultMessage="Classic" />
+    ),
   },
 };
 

--- a/x-pack/plugins/spaces/public/space_solution_badge/index.ts
+++ b/x-pack/plugins/spaces/public/space_solution_badge/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+export { SpaceSolutionBadge } from './badge';


### PR DESCRIPTION
## Summary

Added solution badge to Spaces Selector and Spaces Grid components.

### How to test
* Add the following in `kibana.dev.yml`

```yml
xpack.cloud.id: "ftr_fake_cloud_id:aGVsbG8uY29tOjQ0MyRFUzEyM2FiYyRrYm4xMjNhYmM="
xpack.cloud.base_url: "https://cloud.elastic.co/"
xpack.cloud.deployment_url: "/deployments/deploymentId"
xpack.cloud_integrations.experiments.enabled: true
xpack.cloud_integrations.experiments.flag_overrides:
  "solutionNavEnabled": true
```
* Create a couple of spaces with solution.
```
    POST kbn:/api/spaces/space 
    {
      "name": "space with solution",
      "id": "my-space-solution-1",
      "description": "a description",
      "color": "#5c5959",
      "solution": "es",
      "disabledFeatures": []
    }
    
    POST kbn:/api/spaces/space 
    {
      "name": "space with solution",
      "id": "my-space-solution-2",
      "description": "a description",
      "color": "#5c5959",
      "solution": "security",
      "disabledFeatures": []
    }
    
    POST kbn:/api/spaces/space 
    {
      "name": "space with solution",
      "id": "my-space-solution-3",
      "description": "a description",
      "color": "#5c5959",
      "solution": "oblt",
      "disabledFeatures": []
    }
```
* Check that Spaces Selector displays solution badge.
  
    <img width="299" alt="Screenshot 2024-06-17 at 11 52 29" src="https://github.com/elastic/kibana/assets/165678770/9cff68d3-55fb-4804-90d1-7d2171175dd7">


     

* Check that Spaces Grid displays solution column, column is sortable.

    
    <img width="1249" alt="Screenshot 2024-06-17 at 15 01 12" src="https://github.com/elastic/kibana/assets/165678770/194ace27-d386-4b87-92ee-f78ebdb946d0">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


__Fixes: https://github.com/elastic/kibana/issues/186197, https://github.com/elastic/kibana/issues/186198__

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
