### PR TITLE
[skip on mki] skip serverless-api_integration-test_suites-common-telemetry-telemetry_config

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/telemetry/telemetry_config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/telemetry/telemetry_config.ts
@@ -15,6 +15,8 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
   describe('/api/telemetry/v2/config API Telemetry config', function () {
+    // see details: https://github.com/elastic/kibana/issues/186288
+    this.tags(['failsOnMKI']);
     let roleAuthc: RoleCredentials;
 
     before(async () => {


### PR DESCRIPTION
## Summary

see issue: https://github.com/elastic/kibana/issues/186288