### PR TITLE
[8.14] [ResponseOps] rules runs recovered actions without ever running active actions (#183646)

### DIFF
--- a/x-pack/plugins/alerting/server/lib/get_alerts_for_notification.test.ts
+++ b/x-pack/plugins/alerting/server/lib/get_alerts_for_notification.test.ts
@@ -674,6 +674,36 @@ describe('getAlertsForNotification', () => {
     expect(delayedAlertsCount).toBe(2);
   });
 
+  test('should remove the alert from recoveredAlerts and should not return the alert in currentRecoveredAlerts if the activeCount is less than the rule alertDelay', () => {
+    const alert1 = new Alert('1', {
+      meta: { activeCount: 1, uuid: 'uuid-1' },
+    });
+    const alert2 = new Alert('2', { meta: { uuid: 'uuid-2' } });
+
+    const { recoveredAlerts, currentRecoveredAlerts, delayedAlertsCount } =
+      getAlertsForNotification(
+        DEFAULT_FLAPPING_SETTINGS,
+        true,
+        'default',
+        5,
+        {},
+        {},
+        {
+          // recovered alerts
+          '1': alert1,
+          '2': alert2,
+        },
+        {
+          // current recovered alerts
+          '1': alert1,
+          '2': alert2,
+        }
+      );
+    expect(recoveredAlerts).toMatchInlineSnapshot(`Object {}`);
+    expect(currentRecoveredAlerts).toMatchInlineSnapshot(`Object {}`);
+    expect(delayedAlertsCount).toBe(0);
+  });
+
   test('should update active alert to look like a new alert if the activeCount is equal to the rule alertDelay', () => {
     const alert2 = new Alert('2', { meta: { uuid: 'uuid-2' } });
 

--- a/x-pack/plugins/alerting/server/lib/get_alerts_for_notification.ts
+++ b/x-pack/plugins/alerting/server/lib/get_alerts_for_notification.ts
@@ -54,6 +54,12 @@ export function getAlertsForNotification<
 
   for (const id of keys(currentRecoveredAlerts)) {
     const alert = recoveredAlerts[id];
+    // if alert has not reached the alertDelay threshold don't recover the alert
+    if (alert.getActiveCount() < alertDelay) {
+      // remove from recovered alerts
+      delete recoveredAlerts[id];
+      delete currentRecoveredAlerts[id];
+    }
     alert.resetActiveCount();
     if (flappingSettings.enabled) {
       const flapping = alert.getFlapping();

--- a/x-pack/plugins/rule_registry/server/utils/get_alerts_for_notification.test.ts
+++ b/x-pack/plugins/rule_registry/server/utils/get_alerts_for_notification.test.ts
@@ -245,6 +245,13 @@ describe('getAlertsForNotification', () => {
     ).toMatchInlineSnapshot(`Array []`);
   });
 
+  test('should not return recovered alerts if the activeCount is less than the rule alertDelay', () => {
+    const trackedEvents = cloneDeep([alert1]);
+    expect(
+      getAlertsForNotification(DEFAULT_FLAPPING_SETTINGS, 5, trackedEvents, [], newEventParams)
+    ).toMatchInlineSnapshot(`Array []`);
+  });
+
   test('should update active alert to look like a new alert if the activeCount is equal to the rule alertDelay', () => {
     const trackedEvents = cloneDeep([alert5]);
     expect(

--- a/x-pack/plugins/rule_registry/server/utils/get_alerts_for_notification.ts
+++ b/x-pack/plugins/rule_registry/server/utils/get_alerts_for_notification.ts
@@ -56,6 +56,10 @@ export function getAlertsForNotification(
         }
       }
     } else if (trackedEvent.event[ALERT_STATUS] === ALERT_STATUS_RECOVERED) {
+      // if alert has not reached the alertDelay threshold don't recover the alert
+      if (trackedEvent.activeCount < alertDelay) {
+        continue;
+      }
       trackedEvent.activeCount = 0;
       if (flappingSettings.enabled) {
         if (trackedEvent.flapping) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_delay.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_delay.ts
@@ -43,7 +43,7 @@ export default function createAlertDelayTests({ getService }: FtrProviderContext
         instance: [true, true, true, false, true],
       };
 
-      const ruleId = await createRule(actionId, pattern, 20);
+      const ruleId = await createRule(actionId, pattern, 1);
       objectRemover.add(space.id, ruleId, 'rule', 'alerting');
 
       let state = await getAlertState(start, ruleId);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ResponseOps] rules runs recovered actions without ever running active actions (#183646)](https://github.com/elastic/kibana/pull/183646)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-05-20T15:35:51Z","message":"[ResponseOps] rules runs recovered actions without ever running active actions (#183646)\n\nResolves https://github.com/elastic/kibana/issues/182888\r\n\r\n## Summary\r\n\r\nThis PR resolves a bug where rules will run the recovery actions for a\r\ndelayed active alert.\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### To verify\r\n\r\n- Create a rule and set the `alert after x consecutive matches` to be\r\ngreater than 1. It may be helpful for testing to include recovered and\r\nactive actions.\r\n- Make sure the delayed active alert recovers before hitting the\r\nconsecutive matches threshold.\r\n- Verify that the rule does not send a recovery action and does not show\r\na recovered alert in the rule run table.","sha":"0f159b7488d1e1a823f1c49ae155586cbef345f1","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:ResponseOps","v8.15.0"],"number":183646,"url":"https://github.com/elastic/kibana/pull/183646","mergeCommit":{"message":"[ResponseOps] rules runs recovered actions without ever running active actions (#183646)\n\nResolves https://github.com/elastic/kibana/issues/182888\r\n\r\n## Summary\r\n\r\nThis PR resolves a bug where rules will run the recovery actions for a\r\ndelayed active alert.\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### To verify\r\n\r\n- Create a rule and set the `alert after x consecutive matches` to be\r\ngreater than 1. It may be helpful for testing to include recovered and\r\nactive actions.\r\n- Make sure the delayed active alert recovers before hitting the\r\nconsecutive matches threshold.\r\n- Verify that the rule does not send a recovery action and does not show\r\na recovered alert in the rule run table.","sha":"0f159b7488d1e1a823f1c49ae155586cbef345f1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183646","number":183646,"mergeCommit":{"message":"[ResponseOps] rules runs recovered actions without ever running active actions (#183646)\n\nResolves https://github.com/elastic/kibana/issues/182888\r\n\r\n## Summary\r\n\r\nThis PR resolves a bug where rules will run the recovery actions for a\r\ndelayed active alert.\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### To verify\r\n\r\n- Create a rule and set the `alert after x consecutive matches` to be\r\ngreater than 1. It may be helpful for testing to include recovered and\r\nactive actions.\r\n- Make sure the delayed active alert recovers before hitting the\r\nconsecutive matches threshold.\r\n- Verify that the rule does not send a recovery action and does not show\r\na recovered alert in the rule run table.","sha":"0f159b7488d1e1a823f1c49ae155586cbef345f1"}}]}] BACKPORT-->