### PR TITLE
[ci] Prevent alerts for spot preemptions

### DIFF
--- a/.buildkite/pipeline-utils/buildkite/client.ts
+++ b/.buildkite/pipeline-utils/buildkite/client.ts
@@ -282,7 +282,7 @@ export class BuildkiteClient {
         hasRetries = true;
         const isPreemptionFailure =
           job.state === 'failed' &&
-          job.agent?.meta_data?.includes('spot=true') &&
+          job.agent?.meta_data?.some((el) => ['spot=true', 'gcp:preemptible=true'].includes(el)) &&
           job.exit_status === -1;
 
         if (!isPreemptionFailure) {


### PR DESCRIPTION
After migrating to gobld, the string identifying spot instances has changed.  This updates the check to determine if there are retries available by filtering on the metadata for both gobld and buildkite-agent-manager.

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->