### PR TITLE
[Cloud Security] [Fleet] Adding new agentless-api url config for Fleet plugin

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -261,6 +261,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.discoverEnhanced.actions.exploreDataInChart.enabled (boolean)',
         'xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled (boolean)',
         'xpack.fleet.agents.enabled (boolean)',
+        'xpack.fleet.agentless.api.url (string)',
         'xpack.fleet.enableExperimental (array)',
         'xpack.fleet.internal.activeAgentsSoftLimit (number)',
         'xpack.fleet.internal.fleetServerStandalone (boolean)',

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -30,6 +30,11 @@ export interface FleetConfigType {
       hosts?: string[];
     };
   };
+  agentless?: {
+    api: {
+      url: string;
+    };
+  };
   agentPolicies?: PreconfiguredAgentPolicy[];
   packages?: PreconfiguredPackage[];
   outputs?: PreconfiguredOutput[];

--- a/x-pack/plugins/fleet/server/config.test.ts
+++ b/x-pack/plugins/fleet/server/config.test.ts
@@ -102,6 +102,14 @@ describe('Config schema', () => {
       });
     }).not.toThrow();
   });
+  it('should allow to specify a URL in xpack.fleet.agentless.api.url ', () => {
+    expect(() => {
+      config.schema.validate({
+        agentless: { api: { url: 'https://agentless.api.url' } },
+      });
+    }).not.toThrow();
+  });
+
   describe('deprecations', () => {
     it('should add a depreciations when trying to enable a non existing experimental feature', () => {
       const res = applyConfigDeprecations({

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -141,6 +141,15 @@ export const config: PluginConfigDescriptor = {
           })
         ),
       }),
+      agentless: schema.maybe(
+        schema.object({
+          api: schema.object({
+            url: schema.maybe(
+              schema.uri({ scheme: ['http', 'https'], defaultValue: 'http://agentless-api-url' })
+            ),
+          }),
+        })
+      ),
       packages: PreconfiguredPackagesSchema,
       agentPolicies: PreconfiguredAgentPoliciesSchema,
       outputs: PreconfiguredOutputsSchema,

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -33,6 +33,7 @@ export const config: PluginConfigDescriptor = {
     agents: {
       enabled: true,
     },
+    agentless: true,
     enableExperimental: true,
     developer: {
       maxAgentPoliciesWithInactivityTimeout: true,

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -145,9 +145,7 @@ export const config: PluginConfigDescriptor = {
       agentless: schema.maybe(
         schema.object({
           api: schema.object({
-            url: schema.maybe(
-              schema.uri({ scheme: ['http', 'https'], defaultValue: 'http://agentless-api-url' })
-            ),
+            url: schema.maybe(schema.uri({ scheme: ['http', 'https'] })),
           }),
         })
       ),


### PR DESCRIPTION
## Summary

### Resolves
- https://github.com/elastic/security-team/issues/9231

The configuration will be used by Fleet to signal that it should use the Agentless API for creating agentless agents,  if the user has chosen to have an agentless-agent.

Documentation of the new configuration will be completed in a [follow-up issue](https://github.com/elastic/security-team/issues/9688).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
    - Not at this moment, we will be manually configuring this in ESS test regions until [ we configured this when we add this to the ESS deployment scripts](https://github.com/orgs/elastic/projects/705/views/92?sliceBy%5Bvalue%5D=Agentless+-+API+-+ESS&pane=issue&itemId=64502693). 

