### PR TITLE
[Security Solution][Detection Engine] unskips FTR user roles tests 7.17

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/read_privileges.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/read_privileges.ts
@@ -17,8 +17,7 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertest');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  // Failing ES 8.x Compatibility: https://github.com/elastic/kibana/issues/174028
-  describe.skip('read_privileges', () => {
+  describe('read_privileges', () => {
     it('should return expected privileges for elastic admin', async () => {
       const { body } = await supertest.get(DETECTION_ENGINE_PRIVILEGES_URL).send().expect(200);
       expect(body).to.eql({


### PR DESCRIPTION
## Summary

- addresses https://github.com/elastic/kibana/issues/174028 for 7.17
- PR for main: https://github.com/elastic/kibana/pull/186276