### PR TITLE
[ObsUX][Infra] Fix container metrics not showing correct fields for docker

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/components/kpis/container_kpi_charts.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/components/kpis/container_kpi_charts.tsx
@@ -44,24 +44,30 @@ export const ContainerKpiCharts = ({
   if (!isDockerContainer && !isKubernetesContainer) {
     return null;
   }
-  return isKubernetesContainer ? (
-    <KubernetesKpiCharts
-      dateRange={dateRange}
-      dataView={dataView}
-      filters={filters}
-      query={query}
-      searchSessionId={searchSessionId}
-      loading={loading}
-    />
-  ) : (
-    <DockerKpiCharts
-      dateRange={dateRange}
-      dataView={dataView}
-      filters={filters}
-      query={query}
-      searchSessionId={searchSessionId}
-      loading={loading}
-    />
+
+  return (
+    <>
+      {isDockerContainer && (
+        <DockerKpiCharts
+          dateRange={dateRange}
+          dataView={dataView}
+          filters={filters}
+          query={query}
+          searchSessionId={searchSessionId}
+          loading={loading}
+        />
+      )}
+      {!isDockerContainer && isKubernetesContainer && (
+        <KubernetesKpiCharts
+          dateRange={dateRange}
+          dataView={dataView}
+          filters={filters}
+          query={query}
+          searchSessionId={searchSessionId}
+          loading={loading}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/186359

## Summary

Some conditions were not correct on the render of the KPI, this didn’t show in the e2e tests because with synthtrace we just generate data for docker without kubernetes fields so it will be always showing docker fields. Apparently is possible to have both docker and k8s fields (kubernetes.container & docker.container), at least on the test data we have on the oblt-clusters.
What we did is check if docker.container or kubernetes.container exist, in case of none, charts will not display, in case of both we show docker metric charts, otherwise k8s metrics charts

For the metrics section the condition was correct but not for the KPIs


