### PR TITLE
[ES|QL][Visualizations] Keep the chart type when the query reruns

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -15,7 +15,8 @@ import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { TypedLensByValueInput } from '../../../embeddable/embeddable_component';
 import type { LensPluginStartDependencies } from '../../../plugin';
 import type { DatasourceMap, VisualizationMap } from '../../../types';
-import { suggestionsApi } from '../../../lens_suggestions_api';
+import { suggestionsApi, type ChartType } from '../../../lens_suggestions_api';
+import type { VisualizationState } from '../../../state_management';
 
 export const getSuggestions = async (
   query: AggregateQuery,
@@ -24,6 +25,7 @@ export const getSuggestions = async (
   visualizationMap: VisualizationMap,
   adHocDataViews: DataViewSpec[],
   setErrors: (errors: Error[]) => void,
+  visualization: VisualizationState,
   abortController?: AbortController
 ) => {
   try {
@@ -49,7 +51,13 @@ export const getSuggestions = async (
     };
 
     const allSuggestions =
-      suggestionsApi({ context, dataView, datasourceMap, visualizationMap }) ?? [];
+      suggestionsApi({
+        context,
+        dataView,
+        datasourceMap,
+        visualizationMap,
+        preferredChartType: visualization.activeId as ChartType,
+      }) ?? [];
 
     // Lens might not return suggestions for some cases, i.e. in case of errors
     if (!allSuggestions.length) return undefined;

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -297,6 +297,7 @@ export function LensEditConfigurationFlyout({
         visualizationMap,
         adHocDataViews,
         setErrors,
+        visualization,
         abortController
       );
       if (attrs) {
@@ -307,6 +308,7 @@ export function LensEditConfigurationFlyout({
       setIsVisualizationLoading(false);
     },
     [
+      visualization,
       startDependencies,
       datasourceMap,
       visualizationMap,


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

