### PR TITLE
[ML] AIOps: Fix log rate analysis alert details page embedding.

### DIFF
--- a/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_content.tsx
+++ b/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_content.tsx
@@ -8,7 +8,6 @@
 import { isEqual } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import { EuiButton, EuiEmptyPrompt, EuiHorizontalRule, EuiPanel } from '@elastic/eui';
-import type { Moment } from 'moment';
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { BarStyleAccessor } from '@elastic/charts/dist/chart_types/xy_chart/utils/specs';
@@ -37,7 +36,7 @@ import {
   type LogRateAnalysisResultsData,
 } from '../log_rate_analysis_results';
 
-const DEFAULT_SEARCH_QUERY: estypes.QueryDslQueryContainer = { match_all: {} };
+export const DEFAULT_SEARCH_QUERY: estypes.QueryDslQueryContainer = { match_all: {} };
 const DEFAULT_SEARCH_BAR_QUERY: estypes.QueryDslQueryContainer = {
   bool: {
     filter: [],
@@ -51,8 +50,6 @@ const DEFAULT_SEARCH_BAR_QUERY: estypes.QueryDslQueryContainer = {
 };
 
 export interface LogRateAnalysisContentProps {
-  /** Optional time range override */
-  timeRange?: { min: Moment; max: Moment };
   /** Elasticsearch query to pass to analysis endpoint */
   esSearchQuery?: estypes.QueryDslQueryContainer;
   /** Optional color override for the default bar color for charts */
@@ -68,7 +65,6 @@ export interface LogRateAnalysisContentProps {
 }
 
 export const LogRateAnalysisContent: FC<LogRateAnalysisContentProps> = ({
-  timeRange,
   esSearchQuery = DEFAULT_SEARCH_QUERY,
   barColorOverride,
   barHighlightColorOverride,

--- a/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_content_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_content_wrapper.tsx
@@ -27,6 +27,7 @@ import { AIOPS_STORAGE_KEYS } from '../../../types/storage';
 
 import type { LogRateAnalysisResultsData } from '../log_rate_analysis_results';
 
+import { LogRateAnalysisDocumentCountChartData } from './log_rate_analysis_document_count_chart_data';
 import { LogRateAnalysisContent } from './log_rate_analysis_content';
 
 const localStorage = new Storage(window.localStorage);
@@ -93,8 +94,11 @@ export const LogRateAnalysisContentWrapper: FC<LogRateAnalysisContentWrapperProp
           <LogRateAnalysisReduxProvider initialAnalysisStart={initialAnalysisStart}>
             <StorageContextProvider storage={localStorage} storageKeys={AIOPS_STORAGE_KEYS}>
               <DatePickerContextProvider {...datePickerDeps}>
-                <LogRateAnalysisContent
+                <LogRateAnalysisDocumentCountChartData
                   timeRange={timeRange}
+                  esSearchQuery={esSearchQuery}
+                />
+                <LogRateAnalysisContent
                   esSearchQuery={esSearchQuery}
                   barColorOverride={barColorOverride}
                   barHighlightColorOverride={barHighlightColorOverride}

--- a/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_document_count_chart_data.tsx
+++ b/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_document_count_chart_data.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type FC, useEffect } from 'react';
+import type { Moment } from 'moment';
+
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
+import {
+  useAppDispatch,
+  useCurrentSelectedSignificantItem,
+  useCurrentSelectedGroup,
+  setDocumentCountChartData,
+} from '@kbn/aiops-log-rate-analysis/state';
+
+import { DEFAULT_SEARCH_QUERY } from './log_rate_analysis_content';
+
+import { useData } from '../../../hooks/use_data';
+import { useDataSource } from '../../../hooks/use_data_source';
+
+export interface LogRateAnalysisDocumentcountChartDataProps {
+  /** Optional time range */
+  timeRange?: { min: Moment; max: Moment };
+  /** Optional Elasticsearch query to pass to analysis endpoint */
+  esSearchQuery?: estypes.QueryDslQueryContainer;
+}
+
+export const LogRateAnalysisDocumentCountChartData: FC<
+  LogRateAnalysisDocumentcountChartDataProps
+> = ({ timeRange, esSearchQuery }) => {
+  const { dataView } = useDataSource();
+
+  const currentSelectedGroup = useCurrentSelectedGroup();
+  const currentSelectedSignificantItem = useCurrentSelectedSignificantItem();
+  const dispatch = useAppDispatch();
+
+  const { documentStats, earliest, latest, intervalMs } = useData(
+    dataView,
+    'log_rate_analysis',
+    esSearchQuery ?? DEFAULT_SEARCH_QUERY,
+    undefined,
+    currentSelectedSignificantItem,
+    currentSelectedGroup,
+    undefined,
+    true,
+    timeRange
+  );
+
+  // TODO Since `useData` isn't just used within Log Rate Analysis, this is a bit of
+  // a workaround to pass the result on to the redux store. At least this ensures
+  // we now use `useData` only once across Log Rate Analysis! Originally `useData`
+  // was quite general, but over time it got quite some specific features used
+  // across Log Rate Analysis and Pattern Analysis. We discussed that we should
+  // split this up into more specific hooks.
+  useEffect(() => {
+    dispatch(
+      setDocumentCountChartData({
+        earliest,
+        latest,
+        intervalMs,
+        documentStats,
+      })
+    );
+  }, [documentStats, dispatch, earliest, intervalMs, latest]);
+
+  return null;
+};


### PR DESCRIPTION
## Summary

Fixes the log rate analysis embedding in the O11y alert details page, a regression caused by #180969.

The refactor in the linked PR moved the data fetching for the histogram chart higher up in the component tree and it was then missing from the embedded variant. 

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
