### PR TITLE
Open API Generator: Support local references and param references

### DIFF
--- a/packages/kbn-openapi-generator/src/openapi_generator.ts
+++ b/packages/kbn-openapi-generator/src/openapi_generator.ts
@@ -63,10 +63,11 @@ export const generate = async (config: GeneratorConfig) => {
       };
     })
   );
-  // If there are no operations or components to generate, skip this file
+
+  // If there are no operations or component schemas to generate, skip this file
   parsedSources = parsedSources.filter(
     ({ generationContext }) =>
-      generationContext.operations.length > 0 || generationContext.components !== undefined
+      generationContext.operations.length > 0 || generationContext.components?.schemas !== undefined
   );
 
   console.log(`🧹  Cleaning up any previously generated artifacts`);

--- a/packages/kbn-openapi-generator/src/parser/lib/get_imports_map.ts
+++ b/packages/kbn-openapi-generator/src/parser/lib/get_imports_map.ts
@@ -29,8 +29,8 @@ export const getImportsMap = (parsedSchema: OpenApiDocument): ImportsMap => {
   return externalSchemaRefs.reduce<ImportsMap>((importMap, ref) => {
     const { importPath, importedSymbol, genFileImportPath } = parseRef(ref);
     if (importPath) {
-      const symbols = uniq([...importMap[genFileImportPath], importedSymbol]);
-      importMap[genFileImportPath] = symbols;
+      const existingSymbols = importMap[genFileImportPath] || [];
+      importMap[genFileImportPath] = uniq([...existingSymbols, importedSymbol]);
     }
     return importMap;
   }, {});


### PR DESCRIPTION
## Summary

I encountered a bug when using parameter references.

The following simplified schema:
```
openapi: 3.0.0
info:
  version: '1'
  title: Shared parameter bug example
paths:
  /api/route1:
    post:
      summary: Route 1
      parameters:
        - $ref: '#/components/parameters/sort_field'
      responses:
        '200':
          description: success
  /api/route2:
    post:
      summary: Route 2
      parameters:
        - $ref: '#/components/parameters/sort_field'
      responses:
        '200':
          description: success
components:
  parameters:
    sort_field:
      name: sort_field
      in: query
      required: false
      schema:
        type: string
      description: The field to sort by.
```

Produced the following error:

```
  stderr: '[error] common/api/entity_analytics/asset_criticality/example.gen.ts: SyntaxError: Identifier expected. (21:3)\n' +
    '[error]   19 |\n' +
    '[error]   20 | import { \n' +
    '[error] > 21 |   , \n' +
    '[error]      |   ^\n' +
    '[error]   22 | } from "#/components/parameters/sort_field"\n' +
    '[error]   23 |\n' +
    '[error]   24 |',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
```

this is because we detected `#/components/parameters/sort_field` as an external reference needing an import when it doesn't.