### PR TITLE
[Fleet] Add global data tags telemetry

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/agent_policies.ts
+++ b/x-pack/plugins/fleet/server/collectors/agent_policies.ts
@@ -18,6 +18,8 @@ import type { OutputSOAttributes, AgentPolicy } from '../types';
 export interface AgentPoliciesUsage {
   count: number;
   output_types: string[];
+  count_with_global_data_tags: number;
+  avg_number_global_data_tags_per_policy?: number;
 }
 
 export const getAgentPoliciesUsage = async (
@@ -52,8 +54,26 @@ export const getAgentPoliciesUsage = async (
     })
   );
 
+  const [policiesWithGlobalDataTag, totalNumberOfGlobalDataTagFields] = agentPolicies.reduce(
+    ([policiesNumber, fieldsNumber], agentPolicy) => {
+      if (agentPolicy.attributes.global_data_tags?.length ?? 0 > 0) {
+        return [
+          policiesNumber + 1,
+          fieldsNumber + (agentPolicy.attributes.global_data_tags?.length ?? 0),
+        ];
+      }
+      return [policiesNumber, fieldsNumber];
+    },
+    [0, 0]
+  );
+
   return {
     count: totalAgentPolicies,
     output_types: Array.from(uniqueOutputTypes),
+    count_with_global_data_tags: policiesWithGlobalDataTag,
+    avg_number_global_data_tags_per_policy:
+      policiesWithGlobalDataTag > 0
+        ? Math.round(totalNumberOfGlobalDataTagFields / policiesWithGlobalDataTag)
+        : undefined,
   };
 };

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -428,6 +428,10 @@ describe('fleet usage telemetry', () => {
         schema_version: '1.0.0',
         data_output_id: 'output2',
         monitoring_output_id: 'output3',
+        global_data_tags: [
+          { name: 'test', value: 'test1' },
+          { name: 'test2', value: 'test2' },
+        ],
       },
       { id: 'policy2' }
     );
@@ -446,6 +450,10 @@ describe('fleet usage telemetry', () => {
         schema_version: '1.0.0',
         data_output_id: 'output4',
         monitoring_output_id: 'output4',
+        global_data_tags: [
+          { name: 'test', value: 'test1' },
+          { name: 'test2', value: 'test2' },
+        ],
       },
       { id: 'policy3' }
     );
@@ -566,6 +574,8 @@ describe('fleet usage telemetry', () => {
         agent_policies: {
           count: 3,
           output_types: expect.arrayContaining(['elasticsearch', 'logstash', 'third_type']),
+          count_with_global_data_tags: 2,
+          avg_number_global_data_tags_per_policy: 2,
         },
         agent_logs_panics_last_hour: [
           {

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -346,6 +346,19 @@ export const fleetUsagesSchema: RootSchema<any> = {
           _meta: { description: 'Output types of agent policies' },
         },
       },
+      count_with_global_data_tags: {
+        type: 'long',
+        _meta: {
+          description: 'Number of agent policies using global data tags',
+        },
+      },
+      avg_number_global_data_tags_per_policy: {
+        type: 'long',
+        _meta: {
+          description:
+            'Average number of global data tags defined per agent policy (accross policies using global data tags)',
+        },
+      },
     },
   },
   agent_checkin_status: {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/184504

Add  telemetry for the new global data tags feature
```
+   "count_with_global_data_tags": 2, // Count of policies using global data tags
+    "avg_number_global_data_tags_per_policy": 3  // Average number of fields per policy
```

## Tests

That change is covered with an automated tests.

That PR will need a follow up PR in telemetry to had the mappings.