### PR TITLE
[Global Search] Add integration tests to test limited security user and limited space access

### DIFF
--- a/x-pack/test/plugin_functional/test_suites/global_search/global_search_security_spaces.ts
+++ b/x-pack/test/plugin_functional/test_suites/global_search/global_search_security_spaces.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  describe('Global Search Bar', function () {
+    const PageObjects = getPageObjects([
+      'navigationalSearch',
+      'security',
+      'common',
+      'spaceSelector',
+    ]);
+    const kibanaServer = getService('kibanaServer');
+    const security = getService('security');
+    const spaces = getService('spaces');
+    const retry = getService('retry');
+
+    describe('With spaces', () => {
+      before(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await spaces.delete('limited');
+
+        await spaces.create({ id: 'limited', name: 'Limited Space' });
+        await security.role.create('global_search_limited_space_role', {
+          elasticsearch: {
+            indices: [{ names: ['logstash-*'], privileges: ['read', 'view_index_metadata'] }],
+          },
+          kibana: [
+            {
+              feature: {
+                advancedSettings: ['all'],
+                globalSettings: ['all'],
+              },
+              spaces: ['limited'],
+            },
+          ],
+        });
+        await security.user.create('global_search_limited_space_user', {
+          password: 'global_search_read_url_create_user-password',
+          roles: ['global_search_limited_space_role'],
+          full_name: 'test user',
+        });
+
+        await kibanaServer.importExport.load(
+          'x-pack/test/functional/fixtures/kbn_archiver/global_search/search_syntax'
+        );
+        await PageObjects.security.forceLogout();
+
+        await PageObjects.security.login(
+          'global_search_limited_space_user',
+          'global_search_read_url_create_user-password'
+        );
+      });
+      after(async () => {
+        await security.role.delete('global_search_limited_space_role');
+        await security.user.delete('global_search_limited_space_user');
+        await spaces.delete('limited');
+        await kibanaServer.savedObjects.cleanStandardList();
+      });
+
+      it('results displayed should be filtered by spaces', async () => {
+        await retry.try(async () => {
+          await PageObjects.navigationalSearch.searchFor('type:dashboard', { wait: true });
+          expect(await PageObjects.navigationalSearch.isNoResultsPlaceholderDisplayed(1000)).to.eql(
+            true
+          );
+        });
+      });
+    });
+    describe('With security', () => {
+      before(async () => {
+        await kibanaServer.savedObjects.cleanStandardList();
+        await kibanaServer.importExport.load(
+          'x-pack/test/functional/fixtures/kbn_archiver/global_search/search_syntax'
+        );
+
+        await security.role.create('global_search_limited_role', {
+          elasticsearch: {
+            indices: [{ names: ['logstash-*'], privileges: ['read', 'view_index_metadata'] }],
+          },
+          kibana: [
+            {
+              feature: {
+                advancedSettings: ['read'],
+                globalSettings: ['show'],
+              },
+              spaces: ['*'],
+            },
+          ],
+        });
+        await security.user.create('global_search_limited_user', {
+          password: 'global_search_read_url_create_user-password',
+          roles: ['global_search_limited_role'],
+          full_name: 'test user',
+        });
+        await PageObjects.security.forceLogout();
+
+        await PageObjects.security.login(
+          'global_search_limited_user',
+          'global_search_read_url_create_user-password'
+        );
+      });
+
+      after(async () => {
+        await security.role.delete('global_search_limited_role');
+        await security.user.delete('global_search_limited_user');
+        await kibanaServer.savedObjects.cleanStandardList();
+      });
+
+      it('results displayed should be filtered by the user permissions', async () => {
+        await retry.try(async () => {
+          await PageObjects.navigationalSearch.searchFor('type:dashboard', { wait: true });
+          expect(await PageObjects.navigationalSearch.isNoResultsPlaceholderDisplayed(1000)).to.eql(
+            true
+          );
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/plugin_functional/test_suites/global_search/index.ts
+++ b/x-pack/test/plugin_functional/test_suites/global_search/index.ts
@@ -11,5 +11,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('GlobalSearch API', function () {
     loadTestFile(require.resolve('./global_search_providers'));
     loadTestFile(require.resolve('./global_search_bar'));
+    loadTestFile(require.resolve('./global_search_security_spaces'));
   });
 }


### PR DESCRIPTION
## Summary
Closes #78105 

There are existing tests that confirm global search works for type:dashboard when users have the correct permissions, so I'm adapting off that a user with limited permissions or access to a different space. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
