### PR TITLE
Add semantic query autocomplete support

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/js/query/dsl.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/query/dsl.ts
@@ -526,6 +526,14 @@ export const query = (specService: SpecDefinitionsService) => {
         },
       },
     },
+    semantic: {
+      __template: {
+        field: '',
+        query: '',
+      },
+      field: '{field}',
+      query: '',
+    },
     span_first: {
       __template: spanFirstTemplate,
       match: SPAN_QUERIES,


### PR DESCRIPTION
## Summary

Adds [semantic query](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-semantic-query.html) support in dev tools autocomplete.

![Screenshot 2024-06-18 at 18 34 30](https://github.com/elastic/kibana/assets/6339205/54839bac-09b5-49fd-9ca4-0febe204e7b2)

![Screenshot 2024-06-18 at 18 34 37](https://github.com/elastic/kibana/assets/6339205/0d55f29e-d30e-4e18-86ac-57d995bcb72f)
