### PR TITLE
[Cloud Security] Patch fix for Column label on Cloud Security Data table

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -271,7 +271,6 @@ export interface UnifiedDataTableProps {
     toastNotifications: ToastsStart;
     storage: Storage;
     data: DataPublicPluginStart;
-    isCloudSecurity?: boolean;
   };
   /**
    * Callback to render DocumentView when the document is expanded
@@ -459,15 +458,8 @@ export const UnifiedDataTable = ({
   cellContext,
   renderCellPopover,
 }: UnifiedDataTableProps) => {
-  const {
-    fieldFormats,
-    toastNotifications,
-    dataViewFieldEditor,
-    uiSettings,
-    storage,
-    data,
-    isCloudSecurity,
-  } = services;
+  const { fieldFormats, toastNotifications, dataViewFieldEditor, uiSettings, storage, data } =
+    services;
   const { darkMode } = useObservable(services.theme?.theme$ ?? of(themeDefault), themeDefault);
   const dataGridRef = useRef<EuiDataGridRefProps>(null);
   const [selectedDocs, setSelectedDocs] = useState<string[]>([]);
@@ -767,9 +759,7 @@ export const UnifiedDataTable = ({
           toastNotifications,
         },
         hasEditDataViewPermission: () =>
-          Boolean(
-            isCloudSecurity ? false : dataViewFieldEditor?.userPermissions?.editIndexPattern()
-          ),
+          Boolean(dataViewFieldEditor?.userPermissions?.editIndexPattern()),
         valueToStringConverter,
         onFilter,
         editField,
@@ -799,7 +789,6 @@ export const UnifiedDataTable = ({
       valueToStringConverter,
       visibleCellActions,
       visibleColumns,
-      isCloudSecurity,
     ]
   );
 

--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -271,6 +271,7 @@ export interface UnifiedDataTableProps {
     toastNotifications: ToastsStart;
     storage: Storage;
     data: DataPublicPluginStart;
+    isCloudSecurity?: boolean;
   };
   /**
    * Callback to render DocumentView when the document is expanded
@@ -458,8 +459,15 @@ export const UnifiedDataTable = ({
   cellContext,
   renderCellPopover,
 }: UnifiedDataTableProps) => {
-  const { fieldFormats, toastNotifications, dataViewFieldEditor, uiSettings, storage, data } =
-    services;
+  const {
+    fieldFormats,
+    toastNotifications,
+    dataViewFieldEditor,
+    uiSettings,
+    storage,
+    data,
+    isCloudSecurity,
+  } = services;
   const { darkMode } = useObservable(services.theme?.theme$ ?? of(themeDefault), themeDefault);
   const dataGridRef = useRef<EuiDataGridRefProps>(null);
   const [selectedDocs, setSelectedDocs] = useState<string[]>([]);
@@ -759,7 +767,9 @@ export const UnifiedDataTable = ({
           toastNotifications,
         },
         hasEditDataViewPermission: () =>
-          Boolean(dataViewFieldEditor?.userPermissions?.editIndexPattern()),
+          Boolean(
+            isCloudSecurity ? false : dataViewFieldEditor?.userPermissions?.editIndexPattern()
+          ),
         valueToStringConverter,
         onFilter,
         editField,

--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -799,6 +799,7 @@ export const UnifiedDataTable = ({
       valueToStringConverter,
       visibleCellActions,
       visibleColumns,
+      isCloudSecurity,
     ]
   );
 

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -6,7 +6,11 @@
  */
 import React, { useState, useMemo } from 'react';
 import _ from 'lodash';
-import { UnifiedDataTableSettings, UnifiedDataTableSettingsColumn, useColumns } from '@kbn/unified-data-table';
+import {
+  UnifiedDataTableSettings,
+  UnifiedDataTableSettingsColumn,
+  useColumns,
+} from '@kbn/unified-data-table';
 import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import { HttpSetup } from '@kbn/core-http-browser';
@@ -142,16 +146,16 @@ export const CloudSecurityDataTable = ({
     }
   );
 
-    const settings: UnifiedDataTableSettings = {
-        columns: defaultColumns.reduce((prev, curr) => {
-          const newColumn: UnifiedDataTableSettingsColumn = {
-            ..._.pick(localSettings?.columns?.[curr.id], ['width']),
-            display: columnHeaders?.[curr.id]
-          };
-    
-          return { ...prev, ...{ [curr.id]: newColumn }};
-        }, {} as UnifiedDataTableSettings['columns']),
+  const settings: UnifiedDataTableSettings = {
+    columns: defaultColumns.reduce((prev, curr) => {
+      const newColumn: UnifiedDataTableSettingsColumn = {
+        ..._.pick(localSettings?.columns?.[curr.id], ['width']),
+        display: columnHeaders?.[curr.id],
       };
+
+      return { ...prev, ...{ [curr.id]: newColumn } };
+    }, {} as UnifiedDataTableSettings['columns']),
+  };
 
   const { dataView, dataViewIsRefetching, dataViewRefetch } = useDataViewContext();
 

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -162,7 +162,7 @@ export const CloudSecurityDataTable = ({
     };
   }, [persistedSettings, columnHeaders]);
 
-  const { dataView, dataViewIsRefetching, dataViewRefetch } = useDataViewContext();
+  const { dataView, dataViewIsRefetching } = useDataViewContext();
 
   const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>(undefined);
 
@@ -195,6 +195,7 @@ export const CloudSecurityDataTable = ({
     toastNotifications,
     storage,
     data,
+    dataViewFieldEditor
   };
 
   const {
@@ -363,7 +364,6 @@ export const CloudSecurityDataTable = ({
           gridStyleOverride={gridStyle}
           rowLineHeightOverride="24px"
           controlColumnIds={controlColumnIds}
-          onFieldEdited={dataViewRefetch}
         />
       </div>
     </CellActionsProvider>

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -180,7 +180,6 @@ export const CloudSecurityDataTable = ({
     fieldFormats,
     toastNotifications,
     storage,
-    dataViewFieldEditor,
   } = useKibana().services;
 
   const styles = useStyles();
@@ -195,7 +194,6 @@ export const CloudSecurityDataTable = ({
     toastNotifications,
     storage,
     data,
-    dataViewFieldEditor,
   };
 
   const {

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -149,13 +149,13 @@ export const CloudSecurityDataTable = ({
   const settings = useMemo(() => {
     return {
       columns: Object.keys(persistedSettings?.columns as UnifiedDataTableSettings).reduce(
-        (columnSettings, column) => {
+        (columnSettings, columnId) => {
           const newColumn: UnifiedDataTableSettingsColumn = {
-            ..._.pick(persistedSettings?.columns?.[column], ['width']),
-            display: columnHeaders?.[column],
+            ..._.pick(persistedSettings?.columns?.[columnId], ['width']),
+            display: columnHeaders?.[columnId],
           };
 
-          return { ...columnSettings, [column]: newColumn };
+          return { ...columnSettings, [columnId]: newColumn };
         },
         {} as UnifiedDataTableSettings['columns']
       ),

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -195,7 +195,7 @@ export const CloudSecurityDataTable = ({
     toastNotifications,
     storage,
     data,
-    dataViewFieldEditor
+    dataViewFieldEditor,
   };
 
   const {

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -160,7 +160,7 @@ export const CloudSecurityDataTable = ({
         {} as UnifiedDataTableSettings['columns']
       ),
     };
-  }, [defaultColumns, persistedSettings, columnHeaders]);
+  }, [persistedSettings, columnHeaders]);
 
   const { dataView, dataViewIsRefetching, dataViewRefetch } = useDataViewContext();
 
@@ -196,6 +196,7 @@ export const CloudSecurityDataTable = ({
     storage,
     data,
     dataViewFieldEditor,
+    isCloudSecurity : true
   };
 
   const {

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -196,7 +196,7 @@ export const CloudSecurityDataTable = ({
     storage,
     data,
     dataViewFieldEditor,
-    isCloudSecurity : true
+    isCloudSecurity: true,
   };
 
   const {

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -195,8 +195,6 @@ export const CloudSecurityDataTable = ({
     toastNotifications,
     storage,
     data,
-    dataViewFieldEditor,
-    isCloudSecurity: true,
   };
 
   const {

--- a/x-pack/test/cloud_security_posture_functional/pages/findings.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings.ts
@@ -238,14 +238,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    describe('DataTable features', () => {
-      it('Edit data view field option is Enabled', async () => {
-        await latestFindingsTable.toggleEditDataViewFieldsOption('result.evaluation');
-        expect(await testSubjects.find('gridEditFieldButton')).to.be.ok();
-        await latestFindingsTable.toggleEditDataViewFieldsOption('result.evaluation');
-      });
-    });
-
     describe('Findings - Fields selector', () => {
       const CSP_FIELDS_SELECTOR_MODAL = 'cloudSecurityFieldsSelectorModal';
       const CSP_FIELDS_SELECTOR_OPEN_BUTTON = 'cloudSecurityFieldsSelectorOpenButton';

--- a/x-pack/test/cloud_security_posture_functional/pages/vulnerabilities.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/vulnerabilities.ts
@@ -93,14 +93,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    describe('DataTable features', () => {
-      it('Edit data view field option is Enabled', async () => {
-        await latestVulnerabilitiesTable.toggleEditDataViewFieldsOption('vulnerability.id');
-        expect(await testSubjects.find('gridEditFieldButton')).to.be.ok();
-        await latestVulnerabilitiesTable.toggleEditDataViewFieldsOption('vulnerability.id');
-      });
-    });
-
     describe('Vulnerabilities - Fields selector', () => {
       const CSP_FIELDS_SELECTOR_MODAL = 'cloudSecurityFieldsSelectorModal';
       const CSP_FIELDS_SELECTOR_OPEN_BUTTON = 'cloudSecurityFieldsSelectorOpenButton';


### PR DESCRIPTION
## Summary
<img width="1478" alt="Screenshot 2024-06-18 at 6 10 05 PM" src="https://github.com/elastic/kibana/assets/8703149/f095591d-f0ee-41bd-8b7d-07880bcf61d9">


Currently we have an issue where if user already has localStorageKey from previous version where we still use Update for our Column Label and then proceed to upgrading to version where we no longer use that, the column name in Findings table will show field name (it shows resource.id instead of Resource ID) 

also because we changed the logic and not allow users to change the column headers in the data grid, option to **edit data view field** is removed for Cloud Security Table
<img width="741" alt="Screenshot 2024-06-19 at 9 16 06 AM" src="https://github.com/elastic/kibana/assets/8703149/df1ec765-89de-4f43-a723-daf9558af135">


This patch fixes that issues

Related to #184295 



<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->