### PR TITLE
[Response Ops][Alerting] Adding more granular apm spans to alerting task runner for better traceability

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/lib/with_alerting_span.ts
+++ b/x-pack/plugins/alerting/server/task_runner/lib/with_alerting_span.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
-export { partiallyUpdateAdHocRun } from './partially_update_ad_hoc_run';
-export { processRunResults } from './process_run_result';
-export { withAlertingSpan } from './with_alerting_span';
+import { withSpan } from '@kbn/apm-utils';
+
+export async function withAlertingSpan<T>(name: string, cb: () => Promise<T>): Promise<T> {
+  return withSpan({ name, type: 'rule run', labels: { plugin: 'alerting' } }, cb);
+}

--- a/x-pack/plugins/alerting/server/task_runner/rule_type_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/rule_type_runner.ts
@@ -30,6 +30,7 @@ import {
 import { ExecutorServices } from './get_executor_services';
 import { TaskRunnerTimer, TaskRunnerTimerSpan } from './task_runner_timer';
 import { RuleRunnerErrorStackTraceLog, RuleTypeRunnerContext, TaskRunnerContext } from './types';
+import { withAlertingSpan } from './lib';
 
 interface ConstructorOpts<
   Params extends RuleTypeParams,
@@ -211,67 +212,69 @@ export class RuleTypeRunner<
               context.namespace ?? DEFAULT_NAMESPACE_STRING
             }] namespace`,
           };
-          executorResult = await this.options.context.executionContext.withContext(ctx, () =>
-            ruleType.executor({
-              executionId,
-              services: {
-                alertFactory: alertsClient.factory(),
-                alertsClient: alertsClient.client(),
-                dataViews: executorServices.dataViews,
-                ruleMonitoringService: executorServices.ruleMonitoringService,
-                ruleResultService: executorServices.ruleResultService,
-                savedObjectsClient: executorServices.savedObjectsClient,
-                scopedClusterClient: executorServices.wrappedScopedClusterClient.client(),
-                searchSourceClient: executorServices.wrappedSearchSourceClient.searchSourceClient,
-                share: this.options.context.share,
-                shouldStopExecution: () => this.cancelled,
-                shouldWriteAlerts: () =>
-                  this.shouldLogAndScheduleActionsForAlerts(ruleType.cancelAlertsOnRuleTimeout),
-                uiSettingsClient: executorServices.uiSettingsClient,
-              },
-              params: validatedParams,
-              state: ruleTypeState as RuleState,
-              startedAtOverridden,
-              startedAt,
-              previousStartedAt: previousStartedAt ? new Date(previousStartedAt) : null,
-              spaceId: context.spaceId,
-              namespace: context.namespace,
-              rule: {
-                id: context.ruleId,
-                name,
-                tags,
-                consumer,
-                producer: ruleType.producer,
-                revision,
-                ruleTypeId,
-                ruleTypeName: ruleType.name,
-                enabled,
-                schedule,
-                actions,
-                createdBy,
-                updatedBy,
-                createdAt,
-                updatedAt,
-                throttle,
-                notifyWhen,
-                muteAll,
-                snoozeSchedule,
-                alertDelay,
-              },
-              logger: this.options.logger,
-              flappingSettings: context.flappingSettings ?? DEFAULT_FLAPPING_SETTINGS,
-              // passed in so the rule registry knows about maintenance windows
-              ...(maintenanceWindowsWithoutScopedQueryIds.length
-                ? { maintenanceWindowIds: maintenanceWindowsWithoutScopedQueryIds }
-                : {}),
-              getTimeRange: (timeWindow) =>
-                getTimeRange({
-                  logger: this.options.logger,
-                  window: timeWindow,
-                  ...(context.queryDelaySec ? { queryDelay: context.queryDelaySec } : {}),
-                  ...(startedAtOverridden ? { forceNow: startedAt } : {}),
-                }),
-            })
+          executorResult = await withAlertingSpan('rule-type-executor', () =>
+            this.options.context.executionContext.withContext(ctx, () =>
+              ruleType.executor({
+                executionId,
+                services: {
+                  alertFactory: alertsClient.factory(),
+                  alertsClient: alertsClient.client(),
+                  dataViews: executorServices.dataViews,
+                  ruleMonitoringService: executorServices.ruleMonitoringService,
+                  ruleResultService: executorServices.ruleResultService,
+                  savedObjectsClient: executorServices.savedObjectsClient,
+                  scopedClusterClient: executorServices.wrappedScopedClusterClient.client(),
+                  searchSourceClient: executorServices.wrappedSearchSourceClient.searchSourceClient,
+                  share: this.options.context.share,
+                  shouldStopExecution: () => this.cancelled,
+                  shouldWriteAlerts: () =>
+                    this.shouldLogAndScheduleActionsForAlerts(ruleType.cancelAlertsOnRuleTimeout),
+                  uiSettingsClient: executorServices.uiSettingsClient,
+                },
+                params: validatedParams,
+                state: ruleTypeState as RuleState,
+                startedAtOverridden,
+                startedAt,
+                previousStartedAt: previousStartedAt ? new Date(previousStartedAt) : null,
+                spaceId: context.spaceId,
+                namespace: context.namespace,
+                rule: {
+                  id: context.ruleId,
+                  name,
+                  tags,
+                  consumer,
+                  producer: ruleType.producer,
+                  revision,
+                  ruleTypeId,
+                  ruleTypeName: ruleType.name,
+                  enabled,
+                  schedule,
+                  actions,
+                  createdBy,
+                  updatedBy,
+                  createdAt,
+                  updatedAt,
+                  throttle,
+                  notifyWhen,
+                  muteAll,
+                  snoozeSchedule,
+                  alertDelay,
+                },
+                logger: this.options.logger,
+                flappingSettings: context.flappingSettings ?? DEFAULT_FLAPPING_SETTINGS,
+                // passed in so the rule registry knows about maintenance windows
+                ...(maintenanceWindowsWithoutScopedQueryIds.length
+                  ? { maintenanceWindowIds: maintenanceWindowsWithoutScopedQueryIds }
+                  : {}),
+                getTimeRange: (timeWindow) =>
+                  getTimeRange({
+                    logger: this.options.logger,
+                    window: timeWindow,
+                    ...(context.queryDelaySec ? { queryDelay: context.queryDelaySec } : {}),
+                    ...(startedAtOverridden ? { forceNow: startedAt } : {}),
+                  }),
+              })
+            )
           );
           // Rule type execution has successfully completed
           // Check that the rule type either never requested the max alerts limit
@@ -318,31 +321,35 @@ export class RuleTypeRunner<
       return { state: undefined, error, stackTrace };
     }
 
-    await this.options.timer.runWithTimer(TaskRunnerTimerSpan.ProcessAlerts, async () => {
-      alertsClient.processAlerts({
-        flappingSettings: context.flappingSettings ?? DEFAULT_FLAPPING_SETTINGS,
-        maintenanceWindowIds: maintenanceWindowsWithoutScopedQueryIds,
-        alertDelay: alertDelay?.active ?? 0,
-        ruleRunMetricsStore: context.ruleRunMetricsStore,
-      });
-    });
+    await withAlertingSpan('alerting:process-alerts', () =>
+      this.options.timer.runWithTimer(TaskRunnerTimerSpan.ProcessAlerts, async () => {
+        alertsClient.processAlerts({
+          flappingSettings: context.flappingSettings ?? DEFAULT_FLAPPING_SETTINGS,
+          maintenanceWindowIds: maintenanceWindowsWithoutScopedQueryIds,
+          alertDelay: alertDelay?.active ?? 0,
+          ruleRunMetricsStore: context.ruleRunMetricsStore,
+        });
+      })
+    );
 
-    await this.options.timer.runWithTimer(TaskRunnerTimerSpan.PersistAlerts, async () => {
-      const updateAlertsMaintenanceWindowResult = await alertsClient.persistAlerts(
-        maintenanceWindows
-      );
-
-      // Set the event log MW ids again, this time including the ids that matched alerts with
-      // scoped query
-      if (
-        updateAlertsMaintenanceWindowResult?.maintenanceWindowIds &&
-        updateAlertsMaintenanceWindowResult?.maintenanceWindowIds.length > 0
-      ) {
-        context.alertingEventLogger.setMaintenanceWindowIds(
-          updateAlertsMaintenanceWindowResult.maintenanceWindowIds
+    await withAlertingSpan('alerting:index-alerts-as-data', () =>
+      this.options.timer.runWithTimer(TaskRunnerTimerSpan.PersistAlerts, async () => {
+        const updateAlertsMaintenanceWindowResult = await alertsClient.persistAlerts(
+          maintenanceWindows
         );
-      }
-    });
+
+        // Set the event log MW ids again, this time including the ids that matched alerts with
+        // scoped query
+        if (
+          updateAlertsMaintenanceWindowResult?.maintenanceWindowIds &&
+          updateAlertsMaintenanceWindowResult?.maintenanceWindowIds.length > 0
+        ) {
+          context.alertingEventLogger.setMaintenanceWindowIds(
+            updateAlertsMaintenanceWindowResult.maintenanceWindowIds
+          );
+        }
+      })
+    );
 
     alertsClient.logAlerts({
       eventLogger: context.alertingEventLogger,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/185873

## Summary

Added more granular APM spans during rule execution.

## To Verify
Add the following to your kibana config:

```
elastic.apm:
  active: true
  environment: 'ying-test-185873'
  transactionSampleRate: 1.0
  breakdownMetrics: true
  spanStackTraceMinDuration: 10ms
  # Disables Kibana RUM
  servicesOverrides.kibana-frontend.active: false
```

This will push APM transaction information to `https://kibana-cloud-apm.elastic.dev/` where you can see what the new spans look like. Create an alerting rule that will generate alerts and add some actions and summary actions to the rule. Let it run and then check out the transactions in the cloud APM cluster. Make sure the correct environment is selected and then view the transaction for `Execute Alerting Rule ${ruleName}`.

<img width="1380" alt="Screenshot 2024-06-20 at 10 09 30 AM" src="https://github.com/elastic/kibana/assets/13104637/519b06eb-0b5f-4550-9f32-c71559d61757">
<img width="1347" alt="Screenshot 2024-06-20 at 10 09 38 AM" src="https://github.com/elastic/kibana/assets/13104637/c3b7242e-9930-4bbe-b392-82bc3732c0a8">
