### PR TITLE
[CI] Fix missing test failure annotations

### DIFF
--- a/.buildkite/pipeline-utils/test-failures/annotate.ts
+++ b/.buildkite/pipeline-utils/test-failures/annotate.ts
@@ -177,7 +177,7 @@ export const annotateTestFailures = async () => {
     );
   }
 
-  if (process.env.SLACK_NOTIFICATIONS_ENABLED === 'true') {
+  if (process.env.ELASTIC_SLACK_NOTIFICATIONS_ENABLED === 'true') {
     buildkite.setMetadata(
       'slack:test_failures:body',
       getSlackMessage(failures, failureHtmlArtifacts)


### PR DESCRIPTION
## Summary
rename `SLACK_NOTIFICATIONS_ENABLED` => `ELASTIC_SLACK_NOTIFICATIONS_ENABLED` to follow up on elastic-wide buildkite changes.
This should re-enable test failure listing on the slack errors we post.

Solves: https://github.com/elastic/kibana-operations/issues/106

<!--ONMERGE {"backportTargets":["7.17","8.14"]} ONMERGE-->