### PR TITLE
[Fleet] Add retry when retrieving agent version

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -25,8 +25,7 @@ export default function (providerContext: FtrProviderContext) {
   const config = getService('config');
   const log = getService('log');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/184681
-  describe.skip('inputs_with_standalone_docker_agent', () => {
+  describe('inputs_with_standalone_docker_agent', () => {
     skipIfNoDockerRegistry(providerContext);
     let apiKey: string;
     let agent: AgentProcess;

--- a/x-pack/test/fleet_cypress/artifact_manager.ts
+++ b/x-pack/test/fleet_cypress/artifact_manager.ts
@@ -7,8 +7,14 @@
 
 import axios from 'axios';
 import { last } from 'lodash';
+import pRetry from 'p-retry';
+
+const DEFAULT_VERSION = '8.15.0-SNAPSHOT';
 
 export async function getLatestVersion(): Promise<string> {
-  const response: any = await axios('https://artifacts-api.elastic.co/v1/versions');
-  return last(response.data.versions as string[]) || '8.1.0-SNAPSHOT';
+  return pRetry(() => axios('https://artifacts-api.elastic.co/v1/versions'), {
+    maxRetryTime: 60 * 1000, // 1 minute
+  })
+    .then((response) => last(response.data.versions as string[]) || DEFAULT_VERSION)
+    .catch(() => DEFAULT_VERSION);
 }


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/184681

The test to run standalone agents are sometime failing when retrieving the agent version for the artifacts API. 
That PR should fix it, by adding retries and a fallback value.