### PR TITLE
[8.14] [Custom threshold/Metric threshold] Use emotion instead of styled component for auto suggestion (#186422)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/metrics_explorer/components/kuery_bar.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/metrics_explorer/components/kuery_bar.tsx
@@ -10,8 +10,9 @@ import { fromKueryExpression } from '@kbn/es-query';
 import React, { useEffect, useState } from 'react';
 import { DataViewBase } from '@kbn/es-query';
 import { QuerySuggestion } from '@kbn/unified-search-plugin/public';
+import { AutocompleteField } from '@kbn/observability-plugin/public';
+import { useEuiTheme } from '@elastic/eui';
 import { WithKueryAutocompletion } from '../../../../containers/with_kuery_autocompletion';
-import { AutocompleteField } from '../../../../components/autocomplete_field';
 
 type LoadSuggestionsFn = (
   e: string,
@@ -59,6 +60,8 @@ export const MetricsExplorerKueryBar = ({
     }
   }, [value]);
 
+  const { euiTheme } = useEuiTheme();
+
   const handleChange = (query: string) => {
     setValidation(validateQuery(query));
     setDraftQuery(query);
@@ -93,6 +96,7 @@ export const MetricsExplorerKueryBar = ({
           placeholder={placeholder || defaultPlaceholder}
           suggestions={suggestions}
           value={draftQuery}
+          theme={euiTheme}
         />
       )}
     </WithKueryAutocompletion>

--- a/x-pack/plugins/observability_solution/observability/public/components/rule_kql_filter/autocomplete_field/suggestion_item.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/rule_kql_filter/autocomplete_field/suggestion_item.tsx
@@ -6,84 +6,102 @@
  */
 
 import React from 'react';
-import { EuiIcon } from '@elastic/eui';
-import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import { EuiIcon, euiPaletteColorBlind, EuiThemeComputed, useEuiTheme } from '@elastic/eui';
 import { QuerySuggestion, QuerySuggestionTypes } from '@kbn/unified-search-plugin/public';
 import { transparentize } from 'polished';
+import { css } from '@emotion/react';
 
 interface Props {
   isSelected?: boolean;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   suggestion: QuerySuggestion;
 }
 
 export function SuggestionItem(props: Props) {
-  const { isSelected, onClick, onMouseEnter, suggestion } = props;
+  const { isSelected, onClick, onMouseEnter, onKeyDown, suggestion } = props;
+  const { euiTheme } = useEuiTheme();
+
+  const suggestionItemContainerCss = `
+    display: flex;
+    flex-direction: row;
+    font-size: ${euiTheme.font.scale.s};
+    height: ${euiTheme.size.xl};
+    white-space: nowrap;
+    background-color: ${isSelected ? euiTheme.colors.lightestShade : 'transparent'};
+  `;
+
+  const suggestionItemFieldCss = `
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    height: ${euiTheme.size.xl};
+    padding: ${euiTheme.size.xs};
+  `;
+
+  const suggestionItemIconFieldCss = `
+    background-color: ${transparentize(0.9, getEuiIconColor(euiTheme, suggestion.type))};
+    color: ${getEuiIconColor(euiTheme, suggestion.type)};
+    flex: 0 0 auto;
+    justify-content: center;
+    width: ${euiTheme.size.xl};
+  `;
+
+  const suggestionItemTextFieldCss = `
+    flex: 2 0 0;
+    font-family: ${euiTheme.font.familyCode};
+  `;
+
+  const suggestionItemDescriptionFieldCss = `
+    flex: 3 0 0;
+    p {
+      display: inline;
+      span {
+        font-family: ${euiTheme.font.familyCode};
+      }
+    }
+  `;
 
   return (
-    <SuggestionItemContainer isSelected={isSelected} onClick={onClick} onMouseEnter={onMouseEnter}>
-      <SuggestionItemIconField suggestionType={suggestion.type}>
+    <div
+      css={suggestionItemContainerCss}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onKeyDown={onKeyDown}
+    >
+      <div
+        css={css`
+          ${suggestionItemFieldCss}
+          ${suggestionItemIconFieldCss}
+        `}
+      >
         <EuiIcon type={getEuiIconType(suggestion.type)} />
-      </SuggestionItemIconField>
-      <SuggestionItemTextField>{suggestion.text}</SuggestionItemTextField>
-      <SuggestionItemDescriptionField>{suggestion.description}</SuggestionItemDescriptionField>
-    </SuggestionItemContainer>
+      </div>
+      <div
+        css={css`
+          ${suggestionItemFieldCss}
+          ${suggestionItemTextFieldCss}
+        `}
+      >
+        {suggestion.text}
+      </div>
+      <div
+        css={css`
+          ${suggestionItemFieldCss}
+          ${suggestionItemDescriptionFieldCss}
+        `}
+      >
+        {suggestion.description}
+      </div>
+    </div>
   );
 }
 
 SuggestionItem.defaultProps = {
   isSelected: false,
 };
-
-const SuggestionItemContainer = euiStyled.div<{
-  isSelected?: boolean;
-}>`
-  display: flex;
-  flex-direction: row;
-  font-size: ${(props) => props.theme.eui.euiFontSizeS};
-  height: ${(props) => props.theme.eui.euiSizeXL};
-  white-space: nowrap;
-  background-color: ${(props) =>
-    props.isSelected ? props.theme.eui.euiColorLightestShade : 'transparent'};
-`;
-
-const SuggestionItemField = euiStyled.div`
-  align-items: center;
-  cursor: pointer;
-  display: flex;
-  flex-direction: row;
-  height: ${(props) => props.theme.eui.euiSizeXL};
-  padding: ${(props) => props.theme.eui.euiSizeXS};
-`;
-
-const SuggestionItemIconField = euiStyled(SuggestionItemField)<{
-  suggestionType: QuerySuggestionTypes;
-}>`
-  background-color: ${(props) =>
-    transparentize(0.9, getEuiIconColor(props.theme, props.suggestionType))};
-  color: ${(props) => getEuiIconColor(props.theme, props.suggestionType)};
-  flex: 0 0 auto;
-  justify-content: center;
-  width: ${(props) => props.theme.eui.euiSizeXL};
-`;
-
-const SuggestionItemTextField = euiStyled(SuggestionItemField)`
-  flex: 2 0 0;
-  font-family: ${(props) => props.theme.eui.euiCodeFontFamily};
-`;
-
-const SuggestionItemDescriptionField = euiStyled(SuggestionItemField)`
-  flex: 3 0 0;
-
-  p {
-    display: inline;
-
-    span {
-      font-family: ${(props) => props.theme.eui.euiCodeFontFamily};
-    }
-  }
-`;
 
 const getEuiIconType = (suggestionType: QuerySuggestionTypes) => {
   switch (suggestionType) {
@@ -102,18 +120,23 @@ const getEuiIconType = (suggestionType: QuerySuggestionTypes) => {
   }
 };
 
-const getEuiIconColor = (theme: any, suggestionType: QuerySuggestionTypes): string => {
+const getEuiIconColor = (
+  euiTheme: EuiThemeComputed,
+  suggestionType: QuerySuggestionTypes
+): string => {
+  const palette = euiPaletteColorBlind();
+
   switch (suggestionType) {
     case QuerySuggestionTypes.Field:
-      return theme?.eui.euiColorVis7;
+      return palette[7];
     case QuerySuggestionTypes.Value:
-      return theme?.eui.euiColorVis0;
+      return palette[0];
     case QuerySuggestionTypes.Operator:
-      return theme?.eui.euiColorVis1;
+      return palette[1];
     case QuerySuggestionTypes.Conjunction:
-      return theme?.eui.euiColorVis2;
+      return palette[2];
     case QuerySuggestionTypes.RecentSearch:
     default:
-      return theme?.eui.euiColorMediumShade;
+      return euiTheme.colors.mediumShade;
   }
 };

--- a/x-pack/plugins/observability_solution/observability/public/components/rule_kql_filter/kuery_bar.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/rule_kql_filter/kuery_bar.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useState } from 'react';
 import { DataViewBase } from '@kbn/es-query';
 import { QuerySuggestion } from '@kbn/unified-search-plugin/public';
 
+import { useEuiTheme } from '@elastic/eui';
 import { WithKueryAutocompletion } from './with_kuery_autocompletion';
 import { AutocompleteField } from './autocomplete_field';
 
@@ -59,6 +60,8 @@ export function RuleFlyoutKueryBar({
     }
   }, [value]);
 
+  const { euiTheme } = useEuiTheme();
+
   const handleChange = (query: string) => {
     setValidation(validateQuery(query));
     setDraftQuery(query);
@@ -86,6 +89,7 @@ export function RuleFlyoutKueryBar({
           placeholder={placeholder}
           suggestions={suggestions}
           value={draftQuery}
+          theme={euiTheme}
         />
       )}
     </WithKueryAutocompletion>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Custom threshold/Metric threshold] Use emotion instead of styled component for auto suggestion (#186422)](https://github.com/elastic/kibana/pull/186422)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-06-19T11:49:32Z","message":"[Custom threshold/Metric threshold] Use emotion instead of styled component for auto suggestion (#186422)\n\nFixes https://github.com/elastic/kibana/issues/186248 for Custom\r\nthreshold and Metric threshold (custom equation use case) rules\r\n\r\n### Custom threshold rule\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/69037875/dd25a874-4c7b-4cb2-9319-82ac5977e5d9\r\n\r\n### Metric threshold rule (Custom equation)\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/69037875/14cb0394-632c-418c-813e-6c4eef6e44fb\r\n\r\n---------\r\n\r\nCo-authored-by: jennypavlova <jennypavlova94@gmail.com>","sha":"36c2d128a06077f328a81adb3b7ce12b4af3dc15","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","Team:obs-ux-management","v8.14.0","v8.15.0"],"number":186422,"url":"https://github.com/elastic/kibana/pull/186422","mergeCommit":{"message":"[Custom threshold/Metric threshold] Use emotion instead of styled component for auto suggestion (#186422)\n\nFixes https://github.com/elastic/kibana/issues/186248 for Custom\r\nthreshold and Metric threshold (custom equation use case) rules\r\n\r\n### Custom threshold rule\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/69037875/dd25a874-4c7b-4cb2-9319-82ac5977e5d9\r\n\r\n### Metric threshold rule (Custom equation)\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/69037875/14cb0394-632c-418c-813e-6c4eef6e44fb\r\n\r\n---------\r\n\r\nCo-authored-by: jennypavlova <jennypavlova94@gmail.com>","sha":"36c2d128a06077f328a81adb3b7ce12b4af3dc15"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/186422","number":186422,"mergeCommit":{"message":"[Custom threshold/Metric threshold] Use emotion instead of styled component for auto suggestion (#186422)\n\nFixes https://github.com/elastic/kibana/issues/186248 for Custom\r\nthreshold and Metric threshold (custom equation use case) rules\r\n\r\n### Custom threshold rule\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/69037875/dd25a874-4c7b-4cb2-9319-82ac5977e5d9\r\n\r\n### Metric threshold rule (Custom equation)\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/69037875/14cb0394-632c-418c-813e-6c4eef6e44fb\r\n\r\n---------\r\n\r\nCo-authored-by: jennypavlova <jennypavlova94@gmail.com>","sha":"36c2d128a06077f328a81adb3b7ce12b4af3dc15"}}]}] BACKPORT-->