### PR TITLE
[Security Solution] Fix : Resolver script for serverless

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/resolver_generator_script.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/resolver_generator_script.ts
@@ -274,11 +274,13 @@ async function main() {
     },
   }).argv;
 
+  const logger = createToolingLogger();
+
   let ca: Buffer;
   let clientOptions: ClientOptions;
   let url: string;
-  let node: string;
-  const logger = createToolingLogger();
+  let node: string = Array.isArray(argv.node) ? argv.node[argv.node.length - 1] : argv.node;
+
   const toolingLogOptions = { log: logger };
 
   let kbnClientOptions: KbnClientOptions = {
@@ -298,8 +300,11 @@ async function main() {
 
     clientOptions = { node, tls: { ca: [ca] } };
   } else {
-    clientOptions = { node: argv.node };
+    clientOptions = { node };
   }
+
+  logger.info(`ES URL: ${JSON.stringify({ clientOptions })}`);
+
   let client = new Client(clientOptions);
   let kbnClient = new KbnClient({ ...kbnClientOptions });
   let user: UserInfo | undefined;


### PR DESCRIPTION
## Summary

When passing node URL for serverless, resolver script was passing `node` param as the array to ES client with normal ES node URL and custom passed URL from the user.

For example, If I run the script as below:

```sh
node scripts/endpoint/resolver_generator -ne 10 -nd 100 -ape 20 -k http://elastic_serverless:changeme@localhost:5601 -n http://elastic_serverless:changeme@localhost:9200
```

value of `argv.node` will be an array : 
```log
info ES Url :  [
        "http://elastic:changeme@127.0.0.1:9200",
        "http://elastic:changeme@127.0.0.1:9200",
        "http://elastic_serverless:changeme@localhost:9200"
      ]
```
![grafik](https://github.com/elastic/kibana/assets/7485038/395ac128-b4a1-4fde-b07c-398a14462b4d)


This PR takes the last value and passed that to ES client so that script just works for the serverless mode.

Please feel free to let me know if there is an issue with this.