### PR TITLE
[Fleet] Fix package upgrade variable merge

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -111,7 +111,7 @@ jest.mock('../../../../../../hooks/use_request', () => ({
                   },
                 ],
                 vars: {
-                  existing_package_level_var: { value: '/var/log/nginx/access.log*', type: 'text' },
+                  existing_input_level_var: { value: 'existing-value', type: 'text' },
                 },
               },
             ],
@@ -415,8 +415,8 @@ describe('usePackagePolicy', () => {
                   ],
                   vars: {
                     new_input_level_var: { value: 'test', type: 'text' },
-                    existing_package_level_var: {
-                      value: '/var/log/nginx/access.log*',
+                    existing_input_level_var: {
+                      value: 'default_value',
                       type: 'text',
                     },
                   },
@@ -448,6 +448,13 @@ describe('usePackagePolicy', () => {
                   vars: [
                     {
                       name: 'new_input_level_var',
+                      type: 'text',
+                      title: 'Paths',
+                      required: false,
+                      show_user: true,
+                    },
+                    {
+                      name: 'existing_input_level_var',
                       type: 'text',
                       title: 'Paths',
                       required: false,
@@ -501,13 +508,6 @@ describe('usePackagePolicy', () => {
               required: false,
               show_user: true,
             },
-            {
-              name: 'existing_package_level_var',
-              type: 'text',
-              title: 'Existing',
-              required: false,
-              show_user: true,
-            },
           ],
         },
       },
@@ -515,7 +515,7 @@ describe('usePackagePolicy', () => {
     } as any);
     const renderer = createFleetTestRendererMock();
     const { result, waitForNextUpdate } = renderer.renderHook(() =>
-      usePackagePolicyWithRelatedData('package-policy-1', {
+      usePackagePolicyWithRelatedData('package-policy-2', {
         forceUpgrade: true,
       })
     );
@@ -547,9 +547,9 @@ describe('usePackagePolicy', () => {
             ],
             "type": "logfile",
             "vars": Object {
-              "existing_package_level_var": Object {
+              "existing_input_level_var": Object {
                 "type": "text",
-                "value": "/var/log/nginx/access.log*",
+                "value": "existing-value",
               },
               "new_input_level_var": Object {
                 "type": "text",

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.test.tsx
@@ -14,6 +14,7 @@
 
 import { omit } from 'lodash';
 
+import { sendGetPackageInfoByKey, sendUpgradePackagePolicyDryRun } from '../../../../../../hooks';
 import { createFleetTestRendererMock } from '../../../../../../mock';
 
 import { usePackagePolicyWithRelatedData } from './use_package_policy';
@@ -77,6 +78,41 @@ jest.mock('../../../../../../hooks/use_request', () => ({
                   },
                 ],
                 vars: undefined,
+              },
+            ],
+          },
+        },
+      };
+    }
+    if (packagePolicyId === 'package-policy-2') {
+      return {
+        data: {
+          item: {
+            id: 'nginx-1',
+            name: 'nginx-1',
+            namespace: 'default',
+            description: 'Nginx description',
+            package: { name: 'nginx', title: 'Nginx', version: '1.3.0' },
+            enabled: true,
+            policy_id: 'agent-policy-1',
+            policy_ids: ['agent-policy-1'],
+            inputs: [
+              {
+                type: 'logfile',
+                policy_template: 'nginx',
+                enabled: true,
+                streams: [
+                  {
+                    enabled: true,
+                    data_stream: { type: 'logs', dataset: 'nginx.access' },
+                    vars: {
+                      paths: { value: ['/var/log/nginx/access.log*'], type: 'text' },
+                    },
+                  },
+                ],
+                vars: {
+                  existing_package_level_var: { value: '/var/log/nginx/access.log*', type: 'text' },
+                },
               },
             ],
           },
@@ -281,6 +317,240 @@ describe('usePackagePolicy', () => {
             ],
             "type": "logfile",
             "vars": Object {
+              "new_input_level_var": Object {
+                "type": "text",
+                "value": "test",
+              },
+            },
+          },
+        ],
+        "name": "nginx-1",
+        "namespace": "default",
+        "package": Object {
+          "name": "nginx",
+          "title": "Nginx",
+          "version": "1.4.0",
+        },
+        "policy_id": "agent-policy-1",
+        "policy_ids": Array [
+          "agent-policy-1",
+        ],
+        "vars": Object {
+          "new_package_level_var": Object {
+            "type": "text",
+            "value": "test",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should load the package policy if this is an upgrade with new input vars', async () => {
+    jest.mocked(sendUpgradePackagePolicyDryRun).mockResolvedValue({
+      data: [
+        {
+          diff: [
+            {
+              id: 'nginx-1',
+              name: 'nginx-1',
+              namespace: 'default',
+              description: 'Nginx description',
+              package: { name: 'nginx', title: 'Nginx', version: '1.3.0' },
+              enabled: true,
+              policy_id: 'agent-policy-1',
+              policy_ids: ['agent-policy-1'],
+              vars: {},
+              inputs: [
+                {
+                  type: 'logfile',
+                  policy_template: 'nginx',
+                  enabled: true,
+                  streams: [
+                    {
+                      enabled: true,
+                      data_stream: { type: 'logs', dataset: 'nginx.access' },
+                      vars: {
+                        paths: { value: ['/var/log/nginx/access.log*'], type: 'text' },
+                        existing_package_level_var: {
+                          value: '/var/log/nginx/access.log*',
+                          type: 'text',
+                        },
+                      },
+                    },
+                  ],
+                  vars: {
+                    existing_package_level_var: {
+                      value: '/var/log/nginx/access.log*',
+                      type: 'text',
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              id: 'nginx-1',
+              name: 'nginx-1',
+              namespace: 'default',
+              description: 'Nginx description',
+              package: { name: 'nginx', title: 'Nginx', version: '1.4.0' },
+              enabled: true,
+              policy_id: 'agent-policy-1',
+              policy_ids: ['agent-policy-1'],
+              vars: {
+                new_package_level_var: { value: 'test', type: 'text' },
+              },
+              inputs: [
+                {
+                  type: 'logfile',
+                  policy_template: 'nginx',
+                  enabled: true,
+                  streams: [
+                    {
+                      enabled: true,
+                      data_stream: { type: 'logs', dataset: 'nginx.access' },
+                      vars: {
+                        paths: { value: ['/var/log/nginx/access.log*'], type: 'text' },
+                      },
+                    },
+                  ],
+                  vars: {
+                    new_input_level_var: { value: 'test', type: 'text' },
+                    existing_package_level_var: {
+                      value: '/var/log/nginx/access.log*',
+                      type: 'text',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as any);
+    jest.mocked(sendGetPackageInfoByKey).mockResolvedValue({
+      data: {
+        item: {
+          name: 'nginx',
+          title: 'Nginx',
+          version: '1.4.0',
+          release: 'ga',
+          description: 'Collect logs and metrics from Nginx HTTP servers with Elastic Agent.',
+          policy_templates: [
+            {
+              name: 'nginx',
+              title: 'Nginx logs and metrics',
+              description: 'Collect logs and metrics from Nginx instances',
+              inputs: [
+                {
+                  type: 'logfile',
+                  title: 'Collect logs from Nginx instances',
+                  description: 'Collecting Nginx access and error logs',
+                  vars: [
+                    {
+                      name: 'new_input_level_var',
+                      type: 'text',
+                      title: 'Paths',
+                      required: false,
+                      show_user: true,
+                    },
+                  ],
+                },
+              ],
+              multiple: true,
+            },
+          ],
+          data_streams: [
+            {
+              type: 'logs',
+              dataset: 'nginx.access',
+              title: 'Nginx access logs',
+              release: 'experimental',
+              ingest_pipeline: 'default',
+              streams: [
+                {
+                  input: 'logfile',
+                  vars: [
+                    {
+                      name: 'paths',
+                      type: 'text',
+                      title: 'Paths',
+                      multi: true,
+                      required: true,
+                      show_user: true,
+                      default: ['/var/log/nginx/access.log*'],
+                    },
+                  ],
+                  template_path: 'stream.yml.hbs',
+                  title: 'Nginx access logs',
+                  description: 'Collect Nginx access logs',
+                  enabled: true,
+                },
+              ],
+              package: 'nginx',
+              path: 'access',
+            },
+          ],
+          latestVersion: '1.4.0',
+          keepPoliciesUpToDate: false,
+          status: 'not_installed',
+          vars: [
+            {
+              name: 'new_package_level_var',
+              type: 'text',
+              title: 'Paths',
+              required: false,
+              show_user: true,
+            },
+            {
+              name: 'existing_package_level_var',
+              type: 'text',
+              title: 'Existing',
+              required: false,
+              show_user: true,
+            },
+          ],
+        },
+      },
+      isLoading: false,
+    } as any);
+    const renderer = createFleetTestRendererMock();
+    const { result, waitForNextUpdate } = renderer.renderHook(() =>
+      usePackagePolicyWithRelatedData('package-policy-1', {
+        forceUpgrade: true,
+      })
+    );
+    await waitForNextUpdate();
+    expect(result.current.packagePolicy).toMatchInlineSnapshot(`
+      Object {
+        "description": "Nginx description",
+        "enabled": true,
+        "inputs": Array [
+          Object {
+            "enabled": true,
+            "policy_template": "nginx",
+            "streams": Array [
+              Object {
+                "data_stream": Object {
+                  "dataset": "nginx.access",
+                  "type": "logs",
+                },
+                "enabled": true,
+                "vars": Object {
+                  "paths": Object {
+                    "type": "text",
+                    "value": Array [
+                      "/var/log/nginx/access.log*",
+                    ],
+                  },
+                },
+              },
+            ],
+            "type": "logfile",
+            "vars": Object {
+              "existing_package_level_var": Object {
+                "type": "text",
+                "value": "/var/log/nginx/access.log*",
+              },
               "new_input_level_var": Object {
                 "type": "text",
                 "value": "test",

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -264,7 +264,7 @@ export function usePackagePolicyWithRelatedData(
                 ...restOfInput
               } = input;
 
-              let basePolicyInputVars: any =
+              const basePolicyInputVars: any =
                 isUpgradeScenario &&
                 basePolicy.inputs.find(
                   (i) => i.type === input.type && i.policy_template === input.policy_template
@@ -272,14 +272,7 @@ export function usePackagePolicyWithRelatedData(
               let newInputVars = inputVars;
               if (basePolicyInputVars && inputVars) {
                 // merging vars from dry run with updated ones
-                basePolicyInputVars = Object.keys(inputVars).reduce(
-                  (acc, curr) => ({ ...acc, [curr]: basePolicyInputVars[curr] }),
-                  {}
-                );
-                newInputVars = {
-                  ...inputVars,
-                  ...basePolicyInputVars,
-                };
+                newInputVars = mergeVars(inputVars, basePolicyInputVars);
               }
               // Fix duration vars, if it's a migrated setting, and it's a plain old number with no suffix
               if (basePackage.name === 'apm') {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/159001

Fix upgrading a package with new input variables. It seems the logic to merge input variables is not correct that PR attempt to fix it.

Previously when trying to merge variable we were incorrectly doing this with an empty object that PR fix it and avoid the following error
```
Error
Error: Cannot destructure property 'value' of 'n.vars[r]' as it is undefined.
at https://.../70281/bundles/plugin/fleet/1.0.0/fleet.chunk.0.js:3:130917
at Array.map (anonymous>)
at https://.../70281/bundles/plugin/fleet/1.0.0/fleet.chunk.0.js:3:130849
```

## Tests

I added unit test to cover that change.

You can manually test it by trying to upgrade `microsoft_exchange_online_message_trace` from `1.2.0` to `.1.21.0`