### PR TITLE
[Infra] Fix processes chart query time range

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/lib/host_details/process_list_chart.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/host_details/process_list_chart.ts
@@ -19,6 +19,8 @@ export const getProcessListChart = async (
   search: ESSearchClient,
   { hostTerm, indexPattern, to, command }: ProcessListAPIChartRequest
 ) => {
+  const from = to - 60 * 15 * 1000; // 15 minutes
+
   const body = {
     size: 0,
     query: {
@@ -27,7 +29,7 @@ export const getProcessListChart = async (
           {
             range: {
               [TIMESTAMP_FIELD]: {
-                gte: to - 60 * 1000, // 1 minute
+                gte: from,
                 lte: to,
                 format: 'epoch_millis',
               },
@@ -64,7 +66,7 @@ export const getProcessListChart = async (
                   field: TIMESTAMP_FIELD,
                   fixed_interval: '1m',
                   extended_bounds: {
-                    min: to - 60 * 15 * 1000, // 15 minutes,
+                    min: from,
                     max: to,
                   },
                 },


### PR DESCRIPTION
Closes https://github.com/elastic/sdh-kibana/issues/4739

## Summary

Fixes an issue with process chart query where it was fetching only for 1 minute while the chart was expecting data for 15 minites.

The issue was that `query` was filtering the documents by the latest 1 minute while `date_histogram` is using `extended_bounds` to cover the last 15 minutes (relative the to provided `to` date). `extended_bounds` ensures that we return buckets for 15 minutes range even if some buckets are empty, but it does not expand the filter range from the `query` which is set to 1 minute, meaning the first 13 buckets were always empty. 

This change expands the `filter` query for the chart to 15 minutes.

**After the change**
![CleanShot 2024-06-19 at 19 57 33@2x](https://github.com/elastic/kibana/assets/793851/5b828891-1f73-4b27-b73f-c48501bcf69b)
