### PR TITLE
[ML] AIOps: Fix the text field icon margins in the log rate analysis results table.

### DIFF
--- a/x-pack/plugins/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
+++ b/x-pack/plugins/aiops/public/components/log_rate_analysis_results_table/use_columns.tsx
@@ -163,19 +163,26 @@ export const useColumns = (
                 />
               )}
               {type === SIGNIFICANT_ITEM_TYPE.LOG_PATTERN && (
-                <EuiIconTip
-                  type="aggregate"
-                  data-test-subj={'aiopsLogPatternIcon'}
-                  css={{ marginLeft: euiTheme.euiSizeS, marginRight: euiTheme.euiSizeXS }}
-                  size="m"
-                  content={i18n.translate(
-                    'xpack.aiops.fieldContextPopover.descriptionTooltipLogPattern',
-                    {
-                      defaultMessage:
-                        'The field value for this field shows an example of the identified significant text field pattern.',
-                    }
-                  )}
-                />
+                <span
+                  // match the margins of the FieldStatsPopover button
+                  css={{
+                    marginLeft: euiTheme.euiSizeS,
+                    marginRight: euiTheme.euiSizeXS,
+                  }}
+                >
+                  <EuiIconTip
+                    type="aggregate"
+                    data-test-subj={'aiopsLogPatternIcon'}
+                    size="m"
+                    content={i18n.translate(
+                      'xpack.aiops.fieldContextPopover.descriptionTooltipLogPattern',
+                      {
+                        defaultMessage:
+                          'The field value for this field shows an example of the identified significant text field pattern.',
+                      }
+                    )}
+                  />
+                </span>
               )}
 
               <span title={fieldName} className="eui-textTruncate">


### PR DESCRIPTION
## Summary

Part of #181111.

Fixes the regression where the text field icon margins in the log rate analysis results table were not rendered. It turned out the css applied to `EuiIconTip` was not picked up correctly. Wrapping it in a `span` applies it correctly.

Before:

<img width="1094" alt="image" src="https://github.com/elastic/kibana/assets/230104/fd1a3e09-1815-490c-9c6a-ded3af71cf15">


After:

<img width="1098" alt="image" src="https://github.com/elastic/kibana/assets/230104/4522f85a-82b5-4009-9ac5-ad207ac7b3e3">

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
