### PR TITLE
[BK] Migrate emergency-release-branch-testing pipeline to the new infra

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-serverless-emergency-release-branch-testing
+  description: Runs testing for emergency release / hotfix branches
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-serverless-emergency-release-branch-testing'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  owner: 'group:kibana-operations'
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / serverless / emergency release branch testing
+      description: Runs testing for emergency release / hotfix branches
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-mission-control'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+      allow_rebuilds: true
+      branch_configuration: deploy-fix@*
+      default_branch: main
+      repository: elastic/kibana
+      pipeline_file: .buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
+      skip_intermediate_builds: false
+      provider_settings:
+        build_branches: true
+        build_pull_requests: false
+        publish_commit_status: true
+        trigger_mode: code
+        build_tags: false
+        prefix_pull_request_fork_branch_names: false
+        skip_pull_request_builds_for_existing_commits: true
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        appex-qa:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-tech-leads:
+          access_level: MANAGE_BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -27,6 +27,7 @@ spec:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-performance-data-set-extraction-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-pr.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/security-solution-ess/security-solution-ess.yml

--- a/.buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
+++ b/.buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
@@ -3,7 +3,7 @@
 ## Triggers the artifacts container image build for emergency releases
 agents:
   image: family/kibana-ubuntu-2004
-  imageProject: elastic-images-qa
+  imageProject: elastic-images-prod
   provider: gcp
   machineType: n2-standard-2
 

--- a/.buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
+++ b/.buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
@@ -2,7 +2,10 @@
 
 ## Triggers the artifacts container image build for emergency releases
 agents:
-  queue: kibana-default
+  image: family/kibana-ubuntu-2004
+  imageProject: elastic-images-qa
+  provider: gcp
+  machineType: n2-standard-2
 
 notify:
   - slack: "#kibana-mission-control"


### PR DESCRIPTION
## Summary
Migrates (without history preservation) the emergency release branch testing job to the new infra

Verified through:
 - [x] locally tested the pipeline definition file
 - [x] ran the testing pipeline through the migration staging job (https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/125#_)