### PR TITLE
[Security solution] Fix SimpleChatModel arguments

### DIFF
--- a/x-pack/packages/kbn-langchain/server/language_models/constants.ts
+++ b/x-pack/packages/kbn-langchain/server/language_models/constants.ts
@@ -5,11 +5,17 @@
  * 2.0.
  */
 
-export const getDefaultArguments = (llmType?: string, temperature?: number, stop?: string[]) =>
+export const getDefaultArguments = (
+  llmType?: string,
+  temperature?: number,
+  stop?: string[],
+  maxTokens?: number
+) =>
   llmType === 'bedrock'
     ? {
         temperature: temperature ?? DEFAULT_BEDROCK_TEMPERATURE,
         stopSequences: stop ?? DEFAULT_BEDROCK_STOP_SEQUENCES,
+        maxTokens,
       }
     : llmType === 'gemini'
     ? {

--- a/x-pack/packages/kbn-langchain/server/language_models/simple_chat_model.test.ts
+++ b/x-pack/packages/kbn-langchain/server/language_models/simple_chat_model.test.ts
@@ -226,6 +226,7 @@ describe('ActionsClientSimpleChatModel', () => {
         actions: mockStreamActions,
         llmType: 'bedrock',
         streaming: true,
+        maxTokens: 333,
       });
 
       const result = await actionsClientSimpleChatModel._call(
@@ -235,6 +236,14 @@ describe('ActionsClientSimpleChatModel', () => {
       );
       const subAction = mockStreamExecute.mock.calls[0][0].params.subAction;
       expect(subAction).toEqual('invokeStream');
+
+      const { messages, ...rest } = mockStreamExecute.mock.calls[0][0].params.subActionParams;
+
+      expect(rest).toEqual({
+        temperature: 0,
+        stopSequences: ['\n'],
+        maxTokens: 333,
+      });
 
       expect(result).toEqual(mockActionResponse.message);
     });
@@ -244,6 +253,7 @@ describe('ActionsClientSimpleChatModel', () => {
         actions: mockStreamActions,
         llmType: 'gemini',
         streaming: true,
+        maxTokens: 333,
       });
 
       const result = await actionsClientSimpleChatModel._call(
@@ -253,6 +263,11 @@ describe('ActionsClientSimpleChatModel', () => {
       );
       const subAction = mockStreamExecute.mock.calls[0][0].params.subAction;
       expect(subAction).toEqual('invokeStream');
+      const { messages, ...rest } = mockStreamExecute.mock.calls[0][0].params.subActionParams;
+
+      expect(rest).toEqual({
+        temperature: 0,
+      });
 
       expect(result).toEqual(mockActionResponse.message);
     });

--- a/x-pack/packages/kbn-langchain/server/language_models/simple_chat_model.ts
+++ b/x-pack/packages/kbn-langchain/server/language_models/simple_chat_model.ts
@@ -125,8 +125,7 @@ export class ActionsClientSimpleChatModel extends SimpleChatModel {
         subActionParams: {
           model: this.model,
           messages: formattedMessages,
-          maxTokens: this.#maxTokens,
-          ...getDefaultArguments(this.llmType, this.temperature, options.stop),
+          ...getDefaultArguments(this.llmType, this.temperature, options.stop, this.#maxTokens),
         },
       },
     };


### PR DESCRIPTION
## Summary

The `maxTokens` argument was added in the [Integration Assistant pr]([https://github.com/elastic/kibana/pull/184296](https://github.com/elastic/kibana/pull/184296/files#diff-a301f9d49f31c61a030f4899f64e55eaadbc9b5fd21efba458c5c757a7aeaf21R128)). We do not accept this argument in Gemini, so it broke the integration: 

<img width="610" alt="Screenshot 2024-06-20 at 8 37 00 AM" src="https://github.com/elastic/kibana/assets/6935300/06ac1c14-4786-4474-acf5-2ac0466cff63">

I moved `maxTokens` into `getDefaultArguments` which adds arguments per connector type, and ensure it only gets added for Bedrock. Also added some tests to ensure proper arguments.

## To test

Add a Gemini connector ([credentials](https://p.elstc.co/paste/ZPm9DQ6X#PoQTA8BBQYH2mxC6mGJdsm5bQTnChVOL78IfC+XO5FA)) and enable the LangChain integration in the assistant. Send a message and ensure a proper response.