### PR TITLE
fix(serverless/deploy): use `patch` instead of `put`

### DIFF
--- a/.buildkite/scripts/steps/serverless/deploy.sh
+++ b/.buildkite/scripts/steps/serverless/deploy.sh
@@ -99,7 +99,7 @@ deploy() {
       -H "Authorization: ApiKey $PROJECT_API_KEY" \
       -H "Content-Type: application/json" \
       "${PROJECT_API_DOMAIN}/api/v1/serverless/projects/${PROJECT_TYPE}/${PROJECT_ID}" \
-      -XPUT -d "$PROJECT_UPDATE_CONFIGURATION" &> $PROJECT_DEPLOY_LOGS
+      -XPATCH -d "$PROJECT_UPDATE_CONFIGURATION" &> $PROJECT_DEPLOY_LOGS
   fi
 
   echo "Getting project info..."


### PR DESCRIPTION
## Summary

The `PUT` endpoint was deprecated and removed on [February 20](https://groups.google.com/a/elastic.co/g/dev/c/1S0xcVAbmCA/m/Ybkr1H01AQAJ). We should use `PATCH` when updating the existing projects.


