### PR TITLE
Update deploy.sh to fail if curl doesn't get 2xx

### DIFF
--- a/.buildkite/scripts/steps/serverless/deploy.sh
+++ b/.buildkite/scripts/steps/serverless/deploy.sh
@@ -49,7 +49,7 @@ deploy() {
   PROJECT_EXISTS_LOGS=$(mktemp --suffix ".json")
   PROJECT_INFO_LOGS=$(mktemp --suffix ".json")
 
-  curl -s \
+  curl -s --fail \
     -H "Authorization: ApiKey $PROJECT_API_KEY" \
     "${PROJECT_API_DOMAIN}/api/v1/serverless/projects/${PROJECT_TYPE}" \
     -XGET &> $PROJECT_EXISTS_LOGS
@@ -60,7 +60,7 @@ deploy() {
       echo "No project to remove"
     else
       echo "Shutting down previous project..."
-      curl -s \
+      curl -s --fail \
         -H "Authorization: ApiKey $PROJECT_API_KEY" \
         -H "Content-Type: application/json" \
         "${PROJECT_API_DOMAIN}/api/v1/serverless/projects/${PROJECT_TYPE}/${PROJECT_ID}" \
@@ -71,7 +71,7 @@ deploy() {
 
   if [ -z "${PROJECT_ID}" ] || [ "$PROJECT_ID" = 'null' ]; then
     echo "Creating project..."
-    curl -s \
+    curl -s --fail \
       -H "Authorization: ApiKey $PROJECT_API_KEY" \
       -H "Content-Type: application/json" \
       "${PROJECT_API_DOMAIN}/api/v1/serverless/projects/${PROJECT_TYPE}" \
@@ -95,7 +95,7 @@ deploy() {
 
   else
     echo "Updating project..."
-    curl -s \
+    curl -s --fail \
       -H "Authorization: ApiKey $PROJECT_API_KEY" \
       -H "Content-Type: application/json" \
       "${PROJECT_API_DOMAIN}/api/v1/serverless/projects/${PROJECT_TYPE}/${PROJECT_ID}" \
@@ -103,7 +103,7 @@ deploy() {
   fi
 
   echo "Getting project info..."
-  curl -s \
+  curl -s --fail \
     -H "Authorization: ApiKey $PROJECT_API_KEY" \
     "${PROJECT_API_DOMAIN}/api/v1/serverless/projects/${PROJECT_TYPE}/${PROJECT_ID}" \
     -XGET &> $PROJECT_INFO_LOGS


### PR DESCRIPTION
This adds the use of the `-f` flag to `curl` commands so that the `deploy.sh` script will fail if an HTTP response is not 2xx.

This will prevent, for example, us from thinking that an update of a project worked when instead the API responded `405` and nothing happened (related [slack convo](https://elastic.slack.com/archives/C0D8P2XK5/p1718891627827249?thread_ts=1718814664.324879&cid=C0D8P2XK5)).

Related to https://github.com/elastic/kibana/pull/186543.