### PR TITLE
Empty prompt UI tweaks

### DIFF
--- a/x-pack/plugins/search_inference_endpoints/public/components/empty_prompt/add_empty_prompt.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/empty_prompt/add_empty_prompt.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import {
   EuiButton,
-  EuiEmptyPrompt,
+  EuiPageTemplate,
   EuiFlexGroup,
   EuiFlexItem,
   EuiImage,
@@ -19,9 +19,7 @@ import {
 import * as i18n from '../../../common/translations';
 
 import inferenceEndpoint from '../../assets/images/inference_endpoint.svg';
-
-import { ElserPrompt } from './elser_prompt';
-import { MultilingualE5Prompt } from './multilingual_e5_prompt';
+import { EndpointPrompt } from './endpoint_prompt';
 
 import './add_empty_prompt.scss';
 
@@ -31,9 +29,12 @@ interface AddEmptyPromptProps {
 
 export const AddEmptyPrompt: React.FC<AddEmptyPromptProps> = ({ setIsInferenceFlyoutVisible }) => {
   return (
-    <EuiEmptyPrompt
-      className="addEmptyPrompt"
+    <EuiPageTemplate.EmptyPrompt
       layout="horizontal"
+      restrictWidth
+      color="plain"
+      hasShadow
+      icon={<EuiImage size="fullWidth" src={inferenceEndpoint} alt="" />}
       title={<h2>{i18n.INFERENCE_ENDPOINT_LABEL}</h2>}
       body={
         <EuiFlexGroup direction="column">
@@ -60,20 +61,36 @@ export const AddEmptyPrompt: React.FC<AddEmptyPromptProps> = ({ setIsInferenceFl
           <EuiFlexItem>
             <strong>{i18n.START_WITH_PREPARED_ENDPOINTS_LABEL}</strong>
           </EuiFlexItem>
-          <EuiSpacer />
+          <EuiSpacer size='s'/>
           <EuiFlexGroup>
             <EuiFlexItem>
-              <ElserPrompt setIsInferenceFlyoutVisible={setIsInferenceFlyoutVisible} />
+              <EndpointPrompt 
+                setIsInferenceFlyoutVisible={setIsInferenceFlyoutVisible}
+                title={i18n.ELSER_TITLE}
+                description={i18n.ELSER_DESCRIPTION}
+                footer={
+                  <EuiButton iconType="plusInCircle" onClick={() => setIsInferenceFlyoutVisible(true)}>
+                  {i18n.ADD_ENDPOINT_LABEL}
+                </EuiButton>
+                }
+              />
             </EuiFlexItem>
             <EuiFlexItem>
-              <MultilingualE5Prompt setIsInferenceFlyoutVisible={setIsInferenceFlyoutVisible} />
+              <EndpointPrompt 
+                setIsInferenceFlyoutVisible={setIsInferenceFlyoutVisible}
+                title={i18n.E5_TITLE}
+                description={i18n.E5_DESCRIPTION}
+                footer={
+                  <EuiButton iconType="plusInCircle" onClick={() => setIsInferenceFlyoutVisible(true)}>
+                  {i18n.ADD_ENDPOINT_LABEL}
+                </EuiButton>
+                }
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexGroup>
       }
-      color="plain"
-      hasBorder
-      icon={<EuiImage size="fullWidth" src={inferenceEndpoint} alt="" />}
+      
     />
   );
 };

--- a/x-pack/plugins/search_inference_endpoints/public/components/empty_prompt/endpoint_prompt.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/empty_prompt/endpoint_prompt.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCard } from '@elastic/eui';
+
+
+interface EndpointPromptProps {
+  setIsInferenceFlyoutVisible: (value: boolean) => void;
+  title: string,
+  description: string,
+  footer: React.ReactElement
+}
+
+export const EndpointPrompt: React.FC<EndpointPromptProps> = ({
+  setIsInferenceFlyoutVisible,
+  title,
+  description,
+  footer
+}) => (
+  <EuiCard
+    display="plain"
+    textAlign="left"
+    data-test-subj="multilingualE5PromptForEmptyState"
+    title={title}
+    titleSize="xs"
+    description={description}
+    footer={footer}
+  />  
+)

--- a/x-pack/plugins/search_inference_endpoints/public/components/inference_endpoints_header.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/inference_endpoints_header.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiPageTemplate, EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
+import { EuiPageTemplate, EuiButton } from '@elastic/eui';
 import * as i18n from '../../common/translations';
 
 interface InferenceEndpointsHeaderProps {
@@ -21,9 +21,8 @@ export const InferenceEndpointsHeader: React.FC<InferenceEndpointsHeaderProps> =
     data-test-subj="allInferenceEndpointsPage"
     pageTitle={i18n.INFERENCE_ENDPOINT_LABEL}
     description={i18n.MANAGE_INFERENCE_ENDPOINTS_LABEL}
+    bottomBorder={true}
     rightSideItems={[
-      <EuiFlexGroup gutterSize="xs">
-        <EuiFlexItem>
           <EuiButton
             key="newInferenceEndpoint"
             color="primary"
@@ -33,9 +32,7 @@ export const InferenceEndpointsHeader: React.FC<InferenceEndpointsHeaderProps> =
             onClick={() => setIsInferenceFlyoutVisible(true)}
           >
             {i18n.ADD_ENDPOINT_LABEL}
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>,
+          </EuiButton> 
     ]}
   />
 );


### PR DESCRIPTION
## Summary

Makes some slight UI tweaks to the empty page

- Created single card component for the two endpoint prompts
- Changed some borders, backgrounds and shadows

![Screenshot--2024-06-20--Inference Endpoints - Elastic](https://github.com/elastic/kibana/assets/3756330/0993ed0c-dadd-47b1-b6f9-1ea5a2e0f5da)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [ ] ~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


