### PR TITLE
[Controls] Hide empty drag handle for two line layout

### DIFF
--- a/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
@@ -70,6 +70,7 @@ const SortableControlInner = forwardRef<
   ) => {
     const { isOver, isDragging, draggingIndex, index } = dragInfo;
     const panels = controlGroupSelector((state) => state.explicitInput.panels);
+    const controlStyle = controlGroupSelector((state) => state.explicitInput.controlStyle);
 
     const grow = panels[embeddableId].grow;
     const width = panels[embeddableId].width;
@@ -84,9 +85,9 @@ const SortableControlInner = forwardRef<
       >
         <EuiIcon type="grabHorizontal" />
       </button>
-    ) : (
+    ) : controlStyle === 'oneLine' ? (
       <EuiIcon type="empty" size="s" />
-    );
+    ) : null;
 
     return (
       <EuiFlexItem

--- a/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
+++ b/src/plugins/controls/public/control_group/component/control_group_sortable_item.tsx
@@ -87,7 +87,7 @@ const SortableControlInner = forwardRef<
       </button>
     ) : controlStyle === 'oneLine' ? (
       <EuiIcon type="empty" size="s" />
-    ) : null;
+    ) : undefined;
 
     return (
       <EuiFlexItem

--- a/src/plugins/controls/public/control_group/control_group.scss
+++ b/src/plugins/controls/public/control_group/control_group.scss
@@ -84,6 +84,12 @@ $controlMinWidth: $euiSize * 14;
   flex-basis: auto;
   position: relative;
 
+  &:not(.controlFrameWrapper-isEditable) {
+    .controlFrame--twoLine {
+      border-radius: $euiFormControlBorderRadius !important;
+    }
+  }
+
   .controlFrame__labelToolTip {
     max-width: 40%;
   }


### PR DESCRIPTION
## Summary

Follow up to #184532.

This fixes a visual bug introduced in #184532. The empty drag handle should only be visible in view mode when controls are using the `inline` layout, not when the labels are shown above the controls.

#### Before
<img width="319" alt="Screenshot 2024-06-20 at 4 15 08 PM" src="https://github.com/elastic/kibana/assets/1697105/de5e2237-92e8-4dce-ab74-3b5dcfeb5313">

#### After
<img width="319" alt="Screenshot 2024-06-20 at 4 01 26 PM" src="https://github.com/elastic/kibana/assets/1697105/38886a50-9011-43dd-9c21-cbc4dc0ac0c9">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
