### PR TITLE
[Cloud Security][Tech Debt] Removing 'mock' type: password because we change the manifest file

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
@@ -52,7 +52,6 @@ export const AwsInputVarFields = ({
                     varDef={{
                       ...findVariableDef(packageInfo, field.id)!,
                       required: true,
-                      type: 'password',
                     }}
                     value={field.value || ''}
                     onChange={(value) => {

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
@@ -301,7 +301,6 @@ export const AzureInputVarFields = ({
                     varDef={{
                       ...findVariableDef(packageInfo, field.id)!,
                       required: true,
-                      type: 'password',
                     }}
                     value={field.value || ''}
                     onChange={(value) => {


### PR DESCRIPTION
## Summary

Since we updated the type in the manifest file, we no longer need to mock type:password 

In order to test this, make sure you have the at least this version of manifest file https://github.com/elastic/integrations/pull/10208

Merge this after we have the newest version (not preview)


