### PR TITLE
Add saved objects serverless API tests to esGate

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/saved_objects_management/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/saved_objects_management/index.ts
@@ -8,7 +8,9 @@
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('saved objects management apis', () => {
+  describe('saved objects management apis', function () {
+    this.tags(['esGate']);
+
     loadTestFile(require.resolve('./find'));
     loadTestFile(require.resolve('./bulk_get'));
     loadTestFile(require.resolve('./bulk_delete'));


### PR DESCRIPTION
## Summary

This PR tags the saved_object_management API integration test suite with `esGate` to include it in the verification checks that run as part of the Elasticsearch on-merge process.
