### PR TITLE
[OAS] Bump joi-to-json for meta copy fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1055,7 +1055,7 @@
     "ipaddr.js": "2.0.0",
     "isbinaryfile": "4.0.2",
     "joi": "^17.7.1",
-    "joi-to-json": "^4.2.1",
+    "joi-to-json": "^4.3.0",
     "jquery": "^3.5.0",
     "js-levenshtein": "^1.1.6",
     "js-search": "^1.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21238,10 +21238,10 @@ jest@^29.6.1:
     import-local "^3.0.2"
     jest-cli "^29.6.1"
 
-joi-to-json@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/joi-to-json/-/joi-to-json-4.2.1.tgz#be275866fd617c63f1ae81eea428fa5de6e036a4"
-  integrity sha512-HIPyrmT9akm2C4zOZ3qR30GkQs7JBr3LX1/oXXWyC2E1NUnDHjTczqHT0H6l495B99xAyFaJ6LM6KRFTdkKoxQ==
+joi-to-json@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/joi-to-json/-/joi-to-json-4.3.0.tgz#c56131ecf8a772fce89fd98b7f81d7b0fac31dbc"
+  integrity sha512-j6wV/liW2CmPJBJCAsRHegS91JV2QQtg2J/Z/67VfdSvuE65njCx6DrYZY1cw0BXwlxHewpVtiDnY8W0aaNr+A==
   dependencies:
     combinations "^1.0.0"
     lodash "^4.17.21"


### PR DESCRIPTION
## Summary

Bumps `joi-to-json` for new meta copy behaviour. See https://github.com/kenspirit/joi-to-json/pull/52.