### PR TITLE
[Rollups] Add attributes for tracking doc links clicks

### DIFF
--- a/x-pack/plugins/rollup/public/crud_app/sections/components/deprecation_callout/deprecation_callout.tsx
+++ b/x-pack/plugins/rollup/public/crud_app/sections/components/deprecation_callout/deprecation_callout.tsx
@@ -11,10 +11,16 @@ import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { documentationLinks } from '../../../services/documentation_links';
 
+interface DeprecationCalloutProps {
+  /** The prefix to be applied at the test subjects for the doc links.
+   * Used for clicks tracking in Fullstory. */
+  linksTestSubjPrefix: string;
+}
+
 /*
 A component for displaying a deprecation warning.
  */
-export const DeprecationCallout = () => {
+export const DeprecationCallout = ({ linksTestSubjPrefix }: DeprecationCalloutProps) => {
   return (
     <EuiCallOut
       title="Deprecated in 8.11.0"
@@ -30,6 +36,7 @@ export const DeprecationCallout = () => {
             <EuiLink
               href={documentationLinks.elasticsearch.rollupMigratingToDownsampling}
               target="_blank"
+              data-test-subj={`${linksTestSubjPrefix}-rollupDeprecationCalloutMigrationGuideLink`}
             >
               {i18n.translate('xpack.rollupJobs.deprecationCallout.migrationGuideLink', {
                 defaultMessage: 'migration guide',
@@ -37,7 +44,11 @@ export const DeprecationCallout = () => {
             </EuiLink>
           ),
           downsamplingLink: (
-            <EuiLink href={documentationLinks.fleet.datastreamsDownsampling} target="_blank">
+            <EuiLink
+              href={documentationLinks.fleet.datastreamsDownsampling}
+              target="_blank"
+              data-test-subj={`${linksTestSubjPrefix}-rollupDeprecationCalloutDownsamplingDocLink`}
+            >
               {i18n.translate('xpack.rollupJobs.deprecationCallout.downsamplingLink', {
                 defaultMessage: 'downsampling',
               })}

--- a/x-pack/plugins/rollup/public/crud_app/sections/job_create/job_create.js
+++ b/x-pack/plugins/rollup/public/crud_app/sections/job_create/job_create.js
@@ -557,7 +557,7 @@ export class JobCreateUi extends Component {
 
         <EuiSpacer size="l" />
 
-        <DeprecationCallout />
+        <DeprecationCallout linksTestSubjPrefix="createForm" />
 
         <EuiSpacer size="l" />
 

--- a/x-pack/plugins/rollup/public/crud_app/sections/job_list/deprecated_prompt.tsx
+++ b/x-pack/plugins/rollup/public/crud_app/sections/job_list/deprecated_prompt.tsx
@@ -41,6 +41,7 @@ export const DeprecatedPrompt = () => {
             target="_blank"
             fill
             iconType="help"
+            data-test-subj="rollupDeprecatedPromptDocsLink"
           >
             <FormattedMessage
               id="xpack.rollupJobs.deprecatedPrompt.downsamplingDocsButtonLabel"

--- a/x-pack/plugins/rollup/public/crud_app/sections/job_list/job_list.js
+++ b/x-pack/plugins/rollup/public/crud_app/sections/job_list/job_list.js
@@ -173,7 +173,7 @@ export class JobListUi extends Component {
 
         <EuiSpacer size="l" />
 
-        <DeprecationCallout />
+        <DeprecationCallout linksTestSubjPrefix="listView" />
 
         <EuiSpacer size="l" />
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/186610

## Summary

This PR adds `data-test-subj` attributes to the doc links in the Rollup deprecation warning callout and the deprecation empty callout so that clicks on these links can be tracked on Fullstory. The links on the deprecation callout have test subjects with a prefix depending on whether they are on the list view page or the create form page so that we can differentiate the clicks from the different pages.
