### PR TITLE
[Security Solution] Handle Transform Name Changes

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -29,21 +29,6 @@ export const metadataIndexPattern = 'metrics-endpoint.metadata-*';
 /** index that the metadata transform writes to (destination) and that is used by endpoint APIs */
 export const metadataCurrentIndexPattern = 'metrics-endpoint.metadata_current_*';
 
-// endpoint package V2 has an additional prefix in the transform names
-const PACKAGE_V2_PREFIX = 'logs-';
-
-/** The metadata Transform Name prefix with NO (package) version) */
-export const metadataTransformPrefix = 'endpoint.metadata_current-default';
-export const METADATA_CURRENT_TRANSFORM_V2 = `${PACKAGE_V2_PREFIX}${metadataTransformPrefix}`;
-
-// metadata transforms pattern for matching all metadata transform ids
-export const METADATA_TRANSFORMS_PATTERN = 'endpoint.metadata_*';
-export const METADATA_TRANSFORMS_PATTERN_V2 = `${PACKAGE_V2_PREFIX}${METADATA_TRANSFORMS_PATTERN}`;
-
-// united metadata transform id
-export const METADATA_UNITED_TRANSFORM = 'endpoint.metadata_united-default';
-export const METADATA_UNITED_TRANSFORM_V2 = `${PACKAGE_V2_PREFIX}${METADATA_UNITED_TRANSFORM}`;
-
 // united metadata transform destination index
 export const METADATA_UNITED_INDEX = '.metrics-endpoint.metadata_united_default';
 

--- a/x-pack/plugins/security_solution/common/endpoint/index_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/index_data.ts
@@ -112,8 +112,8 @@ export const indexHostsAndAlerts = usageTracker.track(
 
     const shouldWaitForEndpointMetadataDocs = fleet;
     if (shouldWaitForEndpointMetadataDocs) {
-      await waitForMetadataTransformsReady(client, epmEndpointPackage.version);
-      await stopMetadataTransforms(client, epmEndpointPackage.version);
+      await waitForMetadataTransformsReady(client);
+      await stopMetadataTransforms(client);
     }
 
     for (let i = 0; i < numHosts; i++) {
@@ -148,8 +148,7 @@ export const indexHostsAndAlerts = usageTracker.track(
     if (shouldWaitForEndpointMetadataDocs) {
       await startMetadataTransforms(
         client,
-        response.agents.map((agent) => agent.agent?.id ?? ''),
-        epmEndpointPackage.version
+        response.agents.map((agent) => agent.agent?.id ?? '')
       );
     }
 

--- a/x-pack/plugins/security_solution/common/endpoint/utils/package_v2.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/package_v2.ts
@@ -4,11 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { Installation } from '@kbn/fleet-plugin/common';
+import { ElasticsearchAssetType } from '@kbn/fleet-plugin/common';
 
-// import semverLte from 'semver/functions/lte';
-
-// switch to "v2" logic
-// const MIN_ENDPOINT_PACKAGE_V2_VERSION = '8.14.0-prerelease.1';
-export function isEndpointPackageV2(version: string) {
-  return false;
+export function isTransformUnattended(install: Installation) {
+  const unattendedTransforms = install.installed_es.filter(
+    (asset) => asset.type === ElasticsearchAssetType.transform && asset.id.startsWith('logs-')
+  );
+  return unattendedTransforms?.length > 0;
 }

--- a/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
@@ -8,30 +8,20 @@
 import type { Client } from '@elastic/elasticsearch';
 import type { TransformGetTransformStatsTransformStats } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
-import { isEndpointPackageV2 } from './package_v2';
 import { usageTracker } from '../data_loaders/usage_tracker';
-import {
-  metadataCurrentIndexPattern,
-  metadataTransformPrefix,
-  METADATA_CURRENT_TRANSFORM_V2,
-  METADATA_TRANSFORMS_PATTERN,
-  METADATA_TRANSFORMS_PATTERN_V2,
-  METADATA_UNITED_TRANSFORM,
-  METADATA_UNITED_TRANSFORM_V2,
-} from '../constants';
+import { metadataCurrentIndexPattern } from '../constants';
 
 export const waitForMetadataTransformsReady = usageTracker.track(
   'waitForMetadataTransformsReady',
-  async (esClient: Client, version: string): Promise<void> => {
-    await waitFor(() => areMetadataTransformsReady(esClient, version));
+  async (esClient: Client): Promise<void> => {
+    await waitFor(() => areMetadataTransformsReady(esClient));
   }
 );
 
 export const stopMetadataTransforms = usageTracker.track(
   'stopMetadataTransforms',
-  async (esClient: Client, version: string): Promise<void> => {
-    const transformIds = await getMetadataTransformIds(esClient, version);
-
+  async (esClient: Client): Promise<void> => {
+    const transformIds = await getMetadataTransformIds(esClient);
     await Promise.all(
       transformIds.map((transformId) =>
         esClient.transform.stopTransform({
@@ -45,24 +35,49 @@ export const stopMetadataTransforms = usageTracker.track(
   }
 );
 
+/*
+
+For version "9.0":
+
+              {
+                "id": "logs-endpoint.metadata_current-default-0.1.0",
+                "type": "transform",
+                "deferred": false,
+                "version": "0.1.0"
+              },
+              {
+                "id": "logs-endpoint.metadata_united-default-0.1.0",
+                "type": "transform",
+                "deferred": false,
+                "version": "0.1.0"
+              }
+
+
+
+For current:
+
+              {
+                "id": "endpoint.metadata_current-default-8.15.0-prerelease.0",
+                "type": "transform"
+              },
+              {
+                "id": "endpoint.metadata_united-default-8.15.0-prerelease.0",
+                "type": "transform"
+              }
+
+
+*/
+
 export const startMetadataTransforms = usageTracker.track(
   'startMetadataTransforms',
   async (
     esClient: Client,
     // agentIds to wait for
-    agentIds: string[],
-    version: string
+    agentIds: string[]
   ): Promise<void> => {
-    const transformIds = await getMetadataTransformIds(esClient, version);
-    const isV2 = isEndpointPackageV2(version);
-    const currentTransformPrefix = isV2 ? METADATA_CURRENT_TRANSFORM_V2 : metadataTransformPrefix;
-    const currentTransformId = transformIds.find((transformId) =>
-      transformId.startsWith(currentTransformPrefix)
-    );
-    const unitedTransformPrefix = isV2 ? METADATA_UNITED_TRANSFORM_V2 : METADATA_UNITED_TRANSFORM;
-    const unitedTransformId = transformIds.find((transformId) =>
-      transformId.startsWith(unitedTransformPrefix)
-    );
+    const transformIds = await getMetadataTransformIds(esClient);
+    const currentTransformId = transformIds.find((transformId) => transformId.includes('current'));
+    const unitedTransformId = transformIds.find((transformId) => transformId.includes('united'));
     if (!currentTransformId || !unitedTransformId) {
       // eslint-disable-next-line no-console
       console.warn('metadata transforms not found, skipping transform start');
@@ -96,26 +111,22 @@ export const startMetadataTransforms = usageTracker.track(
 );
 
 async function getMetadataTransformStats(
-  esClient: Client,
-  version: string
+  esClient: Client
 ): Promise<TransformGetTransformStatsTransformStats[]> {
-  const transformId = isEndpointPackageV2(version)
-    ? METADATA_TRANSFORMS_PATTERN_V2
-    : METADATA_TRANSFORMS_PATTERN;
   return (
     await esClient.transform.getTransformStats({
-      transform_id: transformId,
+      transform_id: '*endpoint.metadata_*',
       allow_no_match: true,
     })
   ).transforms;
 }
 
-async function getMetadataTransformIds(esClient: Client, version: string): Promise<string[]> {
-  return (await getMetadataTransformStats(esClient, version)).map((transform) => transform.id);
+async function getMetadataTransformIds(esClient: Client): Promise<string[]> {
+  return (await getMetadataTransformStats(esClient)).map((transform) => transform.id);
 }
 
-async function areMetadataTransformsReady(esClient: Client, version: string): Promise<boolean> {
-  const transforms = await getMetadataTransformStats(esClient, version);
+async function areMetadataTransformsReady(esClient: Client): Promise<boolean> {
+  const transforms = await getMetadataTransformStats(esClient);
   return !transforms.some(
     // TODO TransformGetTransformStatsTransformStats type needs to be updated to include health
     (transform: TransformGetTransformStatsTransformStats & { health?: { status: string } }) =>

--- a/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
@@ -35,39 +35,6 @@ export const stopMetadataTransforms = usageTracker.track(
   }
 );
 
-/*
-
-For version "9.0":
-
-              {
-                "id": "logs-endpoint.metadata_current-default-0.1.0",
-                "type": "transform",
-                "deferred": false,
-                "version": "0.1.0"
-              },
-              {
-                "id": "logs-endpoint.metadata_united-default-0.1.0",
-                "type": "transform",
-                "deferred": false,
-                "version": "0.1.0"
-              }
-
-
-
-For current:
-
-              {
-                "id": "endpoint.metadata_current-default-8.15.0-prerelease.0",
-                "type": "transform"
-              },
-              {
-                "id": "endpoint.metadata_united-default-8.15.0-prerelease.0",
-                "type": "transform"
-              }
-
-
-*/
-
 export const startMetadataTransforms = usageTracker.track(
   'startMetadataTransforms',
   async (

--- a/x-pack/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
@@ -79,7 +79,7 @@ export const cyLoadEndpointDataHandler = async (
   });
 
   const endpointPackage = await getEndpointPackageInfo(kbnClient);
-  const transforms = endpointPackage.installationInfo.installed_es
+  const transforms = endpointPackage?.installationInfo?.installed_es
     .filter((asset) => asset.type === ElasticsearchAssetType.transform)
     .map((asset) => asset.id);
   if (!transforms) {

--- a/x-pack/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
@@ -83,7 +83,7 @@ export const cyLoadEndpointDataHandler = async (
     .filter((asset) => asset.type === ElasticsearchAssetType.transform)
     .map((asset) => asset.id);
   if (!transforms) {
-    throw new error('transforms not installed');
+    throw new Error('transforms not installed');
   }
   const currentTransformName = transforms.find((t) => t.includes('current'));
   const unitedTransformName = transforms.find((t) => t.includes('united'));

--- a/x-pack/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/plugin_handlers/endpoint_data_loader.ts
@@ -10,6 +10,7 @@ import type { KbnClient } from '@kbn/test';
 import pRetry from 'p-retry';
 import { kibanaPackageJson } from '@kbn/repo-info';
 import type { ToolingLog } from '@kbn/tooling-log';
+import { getEndpointPackageInfo } from '../../../../../common/endpoint/utils/package';
 import { dump } from '../../../../../scripts/endpoint/common/utils';
 import { STARTED_TRANSFORM_STATES } from '../../../../../common/constants';
 import {
@@ -19,11 +20,7 @@ import {
 import {
   METADATA_DATASTREAM,
   METADATA_UNITED_INDEX,
-  METADATA_UNITED_TRANSFORM,
   metadataCurrentIndexPattern,
-  metadataTransformPrefix,
-  METADATA_CURRENT_TRANSFORM_V2,
-  METADATA_UNITED_TRANSFORM_V2,
   POLICY_RESPONSE_INDEX,
 } from '../../../../../common/endpoint/constants';
 import { EndpointDocGenerator } from '../../../../../common/endpoint/generate_data';
@@ -81,15 +78,23 @@ export const cyLoadEndpointDataHandler = async (
     CustomMetadataGenerator: EndpointMetadataGenerator.custom({ version, os, isolation }),
   });
 
+  const endpointPackage = await getEndpointPackageInfo(kbnClient);
+  const transforms = endpointPackage.installationInfo.installed_es
+    .filter((asset) => asset.type === ElasticsearchAssetType.transform)
+    .map((asset) => asset.id);
+  if (!transforms) {
+    throw new error('transforms not installed');
+  }
+  const currentTransformName = transforms.find((t) => t.includes('current'));
+  const unitedTransformName = transforms.find((t) => t.includes('united'));
+
   if (waitUntilTransformed) {
     log.info(`Stopping transforms...`);
 
     // need this before indexing docs so that the united transform doesn't
     // create a checkpoint with a timestamp after the doc timestamps
-    await stopTransform(esClient, log, metadataTransformPrefix);
-    await stopTransform(esClient, log, METADATA_CURRENT_TRANSFORM_V2);
-    await stopTransform(esClient, log, METADATA_UNITED_TRANSFORM);
-    await stopTransform(esClient, log, METADATA_UNITED_TRANSFORM_V2);
+    await stopTransform(esClient, log, currentTransformName);
+    await stopTransform(esClient, log, unitedTransformName);
   }
 
   log.info(`Calling indexHostAndAlerts() to index [${numHosts}] endpoint hosts...`);
@@ -122,14 +127,12 @@ export const cyLoadEndpointDataHandler = async (
     log.info(`starting transforms...`);
 
     // missing transforms are ignored, start either name
-    await startTransform(esClient, log, metadataTransformPrefix);
-    await startTransform(esClient, log, METADATA_CURRENT_TRANSFORM_V2);
+    await startTransform(esClient, log, currentTransformName);
 
     const metadataIds = Array.from(new Set(indexedData.hosts.map((host) => host.agent.id)));
     await waitForEndpoints(esClient, log, 'endpoint_index', metadataIds);
 
-    await startTransform(esClient, log, METADATA_UNITED_TRANSFORM);
-    await startTransform(esClient, log, METADATA_UNITED_TRANSFORM_V2);
+    await startTransform(esClient, log, unitedTransformName);
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const agentIds = Array.from(new Set(indexedData.agents.map((agent) => agent.agent!.id)));

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/transform_failed_callout.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/components/transform_failed_callout.tsx
@@ -14,7 +14,6 @@ import { useKibana } from '../../../../../common/lib/kibana';
 import type { ImmutableArray } from '../../../../../../common/endpoint/types';
 import type { TransformStats } from '../../types';
 import { WARNING_TRANSFORM_STATES } from '../../../../../../common/constants';
-import { metadataTransformPrefix } from '../../../../../../common/endpoint/constants';
 import { LinkToApp } from '../../../../../common/components/endpoint/link_to_app';
 import { CallOut } from '../../../../../common/components/callouts';
 import type { EndpointAction } from '../../store/action';
@@ -74,7 +73,7 @@ export const TransformFailedCallout = memo<TransformFailedCalloutProps>(
             id="xpack.securitySolution.endpoint.list.transformFailed.message"
             defaultMessage="A required transform, {transformId}, is currently failing. Most of the time this can be fixed by {transformsPage}. For additional help, please visit the {docsPage}"
             values={{
-              transformId: failingTransformIds || metadataTransformPrefix,
+              transformId: failingTransformIds,
               transformsPage: (
                 <LinkToApp
                   data-test-subj="failed-transform-restart-link"

--- a/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/endpoint_hosts/view/index.test.tsx
@@ -41,11 +41,7 @@ import {
   TRANSFORM_STATES,
 } from '../../../../../common/constants';
 import type { TransformStats } from '../types';
-import {
-  HOST_METADATA_LIST_ROUTE,
-  METADATA_UNITED_TRANSFORM,
-  metadataTransformPrefix,
-} from '../../../../../common/endpoint/constants';
+import { HOST_METADATA_LIST_ROUTE } from '../../../../../common/endpoint/constants';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import {
   initialUserPrivilegesState,
@@ -1147,7 +1143,7 @@ describe('when on the endpoint list page', () => {
     it('is not displayed when transform state is not failed', () => {
       const transforms: TransformStats[] = [
         {
-          id: `${metadataTransformPrefix}-0.20.0`,
+          id: `endpoint.metadata_current-default-0.20.0`,
           state: TRANSFORM_STATES.STARTED,
         } as TransformStats,
       ];
@@ -1192,7 +1188,7 @@ describe('when on the endpoint list page', () => {
     it('is displayed when relevant transform state is failed state', async () => {
       const transforms: TransformStats[] = [
         {
-          id: `${metadataTransformPrefix}-0.20.0`,
+          id: `endpoint.metadata_current-default-0.20.0`,
           state: TRANSFORM_STATES.FAILED,
         } as TransformStats,
       ];
@@ -1209,11 +1205,11 @@ describe('when on the endpoint list page', () => {
     it('displays correct transform id when in failed state', async () => {
       const transforms: TransformStats[] = [
         {
-          id: `${metadataTransformPrefix}-0.20.0`,
+          id: `endpoint.metadata_current-default-0.20.0`,
           state: TRANSFORM_STATES.STARTED,
         } as TransformStats,
         {
-          id: `${METADATA_UNITED_TRANSFORM}-1.2.1`,
+          id: `endpoint.metadata_united-default-1.2.1`,
           state: TRANSFORM_STATES.FAILED,
         } as TransformStats,
       ];

--- a/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.test.ts
@@ -22,7 +22,6 @@ import { getDeleteTaskRunResult } from '@kbn/task-manager-plugin/server/task';
 import type { CoreSetup } from '@kbn/core/server';
 import type { ElasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 import { TRANSFORM_STATES } from '../../../../common/constants';
-import { METADATA_TRANSFORMS_PATTERN } from '../../../../common/endpoint/constants';
 import type { RunResult } from '@kbn/task-manager-plugin/server/task';
 import type { EsAssetReference, Installation } from '@kbn/fleet-plugin/common';
 import { ElasticsearchAssetType } from '@kbn/fleet-plugin/common';
@@ -143,7 +142,7 @@ describe('check metadata transforms task', () => {
         await runTask();
         expect(esClient.transform.getTransformStats).toHaveBeenCalledWith(
           {
-            transform_id: METADATA_TRANSFORMS_PATTERN,
+            transform_id: ['', ''],
           },
           { meta: true }
         );
@@ -159,7 +158,7 @@ describe('check metadata transforms task', () => {
 
         expect(esClient.transform.getTransformStats).toHaveBeenCalledWith(
           {
-            transform_id: METADATA_TRANSFORMS_PATTERN,
+            transform_id: ['', ''],
           },
           { meta: true }
         );

--- a/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.test.ts
@@ -43,6 +43,10 @@ const MOCK_TASK_INSTANCE = {
   state: {},
   taskType: TYPE,
 };
+
+const MockCurrentTransformName = 'metadata.endpoint_current-default-8.12.0';
+const MockUnitedTransformName = 'metadata.endpoint_united-default-8.12.0';
+
 const failedTransformId = 'failing-transform';
 const goodTransformId = 'good-transform';
 
@@ -67,8 +71,14 @@ describe('check metadata transforms task', () => {
       .spyOn(mockEndpointAppContext.service.getInternalFleetServices().packages, 'getInstallation')
       .mockResolvedValue({
         installed_es: [
-          { type: ElasticsearchAssetType.transform } as EsAssetReference,
-          { type: ElasticsearchAssetType.transform } as EsAssetReference,
+          {
+            type: ElasticsearchAssetType.transform,
+            id: MockCurrentTransformName,
+          } as EsAssetReference,
+          {
+            type: ElasticsearchAssetType.transform,
+            id: MockUnitedTransformName,
+          } as EsAssetReference,
         ],
         version: '8.11.0',
       } as Installation);
@@ -142,7 +152,7 @@ describe('check metadata transforms task', () => {
         await runTask();
         expect(esClient.transform.getTransformStats).toHaveBeenCalledWith(
           {
-            transform_id: ['', ''],
+            transform_id: [MockCurrentTransformName, MockUnitedTransformName],
           },
           { meta: true }
         );
@@ -158,7 +168,7 @@ describe('check metadata transforms task', () => {
 
         expect(esClient.transform.getTransformStats).toHaveBeenCalledWith(
           {
-            transform_id: ['', ''],
+            transform_id: [MockCurrentTransformName, MockUnitedTransformName],
           },
           { meta: true }
         );

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -7,8 +7,7 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import type { Logger, RequestHandler } from '@kbn/core/server';
-import { FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
-
+import { ElasticsearchAssetType, FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
 import type {
   MetadataListResponse,
   EndpointSortableField,
@@ -111,7 +110,7 @@ export function getMetadataTransformStatsHandler(
       return response.notFound(); // ?
     }
     const transformNames = installation.installed_es
-      .filter((item) => item.type === 'transform')
+      .filter((item) => item.type === ElasticsearchAssetType.transform)
       .map((asset) => asset.id);
 
     try {

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/metadata.test.ts
@@ -60,6 +60,7 @@ import type { TransformGetTransformStatsResponse } from '@elastic/elasticsearch/
 import { getEndpointAuthzInitialStateMock } from '../../../../common/endpoint/service/authz/mocks';
 import type { VersionedRouteConfig } from '@kbn/core-http-server';
 import type { SecuritySolutionPluginRouterMock } from '../../../mocks';
+import { ElasticsearchAssetType } from '@kbn/fleet-plugin/common';
 
 describe('test endpoint routes', () => {
   let routerMock: SecuritySolutionPluginRouterMock;
@@ -81,6 +82,9 @@ describe('test endpoint routes', () => {
     perPage: 1,
   };
   const agentGenerator = new FleetAgentGenerator('seed');
+
+  const MockCurrentTransformName = 'metadata.endpoint_current-default-8.12.0';
+  const MockUnitedTransformName = 'metadata.endpoint_united-default-8.12.0';
 
   beforeEach(() => {
     mockScopedClient = elasticsearchServiceMock.createScopedClusterClient();
@@ -110,6 +114,23 @@ describe('test endpoint routes', () => {
       .agent as jest.Mocked<AgentClient>;
     mockAgentPolicyService = startContract.endpointFleetServicesFactory.asInternalUser()
       .agentPolicy as jest.Mocked<AgentPolicyServiceInterface>;
+
+    const mockEndpointAppContext = createMockEndpointAppContext();
+    jest
+      .spyOn(endpointAppContextService.getInternalFleetServices().packages, 'getInstallation')
+      .mockResolvedValue({
+        installed_es: [
+          {
+            type: ElasticsearchAssetType.transform,
+            id: MockCurrentTransformName,
+          } as EsAssetReference,
+          {
+            type: ElasticsearchAssetType.transform,
+            id: MockUnitedTransformName,
+          } as EsAssetReference,
+        ],
+        version: '8.11.0',
+      } as Installation);
 
     registerEndpointRoutes(routerMock, {
       ...createMockEndpointAppContext(),

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -127,7 +127,7 @@ import {
   latestRiskScoreIndexPattern,
   allRiskScoreIndexPattern,
 } from '../common/entity_analytics/risk_engine';
-import { isEndpointPackageV2 } from '../common/endpoint/utils/package_v2';
+import { isTransformUnattended } from '../common/endpoint/utils/package_v2';
 import { getAssistantTools } from './assistant/tools';
 import { turnOffAgentPolicyFeatures } from './endpoint/migrations/turn_off_agent_policy_features';
 import { getCriblPackagePolicyPostCreateOrUpdateCallback } from './security_integrations';
@@ -699,10 +699,7 @@ export class Plugin implements ISecuritySolutionPlugin {
     Promise.all([endpointPkgInstallationPromise, plugins.fleet?.fleetSetupCompleted()])
       .then(async ([endpointPkgInstallation]) => {
         if (plugins.taskManager) {
-          if (
-            endpointPkgInstallation?.version &&
-            isEndpointPackageV2(endpointPkgInstallation.version)
-          ) {
+          if (endpointPkgInstallation && isTransformUnattended(endpointPkgInstallation)) {
             return;
           }
 

--- a/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint_api_int/apis/metadata.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/security_solution_endpoint_api_int/apis/metadata.ts
@@ -15,10 +15,6 @@ import {
   METADATA_DATASTREAM,
   METADATA_TRANSFORMS_STATUS_ROUTE,
   METADATA_UNITED_INDEX,
-  METADATA_UNITED_TRANSFORM,
-  METADATA_UNITED_TRANSFORM_V2,
-  metadataTransformPrefix,
-  METADATA_CURRENT_TRANSFORM_V2,
 } from '@kbn/security-solution-plugin/common/endpoint/constants';
 import { AGENTS_INDEX } from '@kbn/fleet-plugin/common';
 import { indexFleetEndpointPolicy } from '@kbn/security-solution-plugin/common/endpoint/data_loaders/index_fleet_endpoint_policy';


### PR DESCRIPTION
## Summary

The endpoint package transform names are subject to change outside of this repo, and out-of-band from stack releases. This removes some pattern assumptions of the names, and fetches the names from fleet's known inventory list.

It additionally removes reliance on parsing particular package _version numbers_ to detect when these transforms enable the setting `unattended: true` (another out-of-band change). And instead relies on the name change undergone when that feature occurs


### Checklist

Delete any items that are not applicable to this PR.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
