### PR TITLE
[Security solution] Fix executor for `SimpleChatModel`

### DIFF
--- a/x-pack/packages/kbn-langchain/server/language_models/simple_chat_model.ts
+++ b/x-pack/packages/kbn-langchain/server/language_models/simple_chat_model.ts
@@ -98,20 +98,13 @@ export class ActionsClientSimpleChatModel extends SimpleChatModel {
     if (!messages.length) {
       throw new Error('No messages provided.');
     }
-    const formattedMessages = [];
-    if (messages.length >= 2) {
-      messages.forEach((message, i) => {
-        if (typeof message.content !== 'string') {
-          throw new Error('Multimodal messages are not supported.');
-        }
-        formattedMessages.push(getMessageContentAndRole(message.content, message._getType()));
-      });
-    } else {
-      if (typeof messages[0].content !== 'string') {
+    const formattedMessages: Array<{ content: string; role: string }> = [];
+    messages.forEach((message, i) => {
+      if (typeof message.content !== 'string') {
         throw new Error('Multimodal messages are not supported.');
       }
-      formattedMessages.push(getMessageContentAndRole(messages[0].content));
-    }
+      formattedMessages.push(getMessageContentAndRole(message.content, message._getType()));
+    });
     this.#logger.debug(
       `ActionsClientSimpleChatModel#_call\ntraceId: ${
         this.#traceId
@@ -129,7 +122,6 @@ export class ActionsClientSimpleChatModel extends SimpleChatModel {
         },
       },
     };
-
     // create an actions client from the authenticated request context:
     const actionsClient = await this.#actions.getActionsClientWithRequest(this.#request);
 

--- a/x-pack/packages/kbn-langchain/server/utils/bedrock.ts
+++ b/x-pack/packages/kbn-langchain/server/utils/bedrock.ts
@@ -180,7 +180,7 @@ const prepareBedrockOutput = (responseBody: CompletionChunk, logger?: Logger): s
       return responseBody.delta.text;
     }
   }
-  logger?.warn(`Failed to parse bedrock chunk ${JSON.stringify(responseBody)}`);
+  // ignore any chunks that do not include text output
   return '';
 };
 

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
@@ -17,6 +17,7 @@ import {
   ActionsClientChatOpenAI,
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server';
+import { MessagesPlaceholder } from '@langchain/core/prompts';
 import { AgentExecutor } from '../executors/types';
 import { APMTracer } from '../tracers/apm_tracer';
 import { AssistantToolParams } from '../../../types';
@@ -127,6 +128,7 @@ export const callAgentExecutor: AgentExecutor<true | false> = async ({
         agentArgs: {
           // this is important to help LangChain correctly format tool input
           humanMessageTemplate: `Question: {input}\n\n{agent_scratchpad}`,
+          memoryPrompts: [new MessagesPlaceholder('chat_history')],
         },
       });
 

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
@@ -127,8 +127,10 @@ export const callAgentExecutor: AgentExecutor<true | false> = async ({
         returnIntermediateSteps: false,
         agentArgs: {
           // this is important to help LangChain correctly format tool input
-          humanMessageTemplate: `Question: {input}\n\n{agent_scratchpad}`,
+          humanMessageTemplate: `Remember, when you have enough information, always prefix your final JSON output with "Final Answer:"\n\nQuestion: {input}\n\n{agent_scratchpad}.`,
           memoryPrompts: [new MessagesPlaceholder('chat_history')],
+          suffix:
+            'Begin! Reminder to ALWAYS use the above format, and to use tools if appropriate.',
         },
       });
 


### PR DESCRIPTION
## Summary

Chat history was not being properly passed to the structured chat zero shot react agent. After working with @jacoblee93, determined this argument needed to be added to `agentArgs`:

```
memoryPrompts: [new MessagesPlaceholder('chat_history')],
```

I also cleaned up the function that builds `formattedMessages` in `simple_chat_model` 

Before (not respecting chat history): https://smith.langchain.com/public/a1b2115d-5a14-41d4-b237-70538e89f347/r
After: https://smith.langchain.com/public/693f53d7-5346-40b9-b91f-2ad5abb8c8f5/r

### Bedrock parsing

I was getting parsing issues with Bedrock models. Jacob suggests we move over to `BedrockChat` because tool calling will solve this issue. In the meantime, we tweaked the prompt to coax a better response out of Bedrock. These are the changes it took (under `agentArgs`). The addition to `humanMessageTemplate` is everything before "Question", and `suffix` is a new argument:

```
humanMessageTemplate: `Remember, when you have enough information, always prefix your final JSON output with "Final Answer:"\n\nQuestion: {input}\n\n{agent_scratchpad}.`,
suffix: 'Begin! Reminder to ALWAYS use the above format, and to use tools if appropriate.',
```

Before: https://smith.langchain.com/public/af355371-f029-4614-8c0d-e481185f4678/r
After: https://smith.langchain.com/public/c0d49dc7-6bde-4238-b3cf-af54fbcfc717/r