### PR TITLE
[Security solution][Detection Engine] removes skipped "alerts index does not exist" FTR test

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/ess_specific_index_logic/create_index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/ess_specific_index_logic/create_index.ts
@@ -38,12 +38,6 @@ export default ({ getService }: FtrProviderContext) => {
           await esArchiver.unload('x-pack/test/functional/es_archives/signals/index_alias_clash');
         });
 
-        // Skipped: see https://github.com/elastic/kibana/issues/179208
-        it.skip('should report that alerts index does not exist', async () => {
-          const { body } = await supertest.get(DETECTION_ENGINE_INDEX_URL).send().expect(404);
-          expect(body).to.eql({ message: 'index for this space does not exist', status_code: 404 });
-        });
-
         it('should return 200 for create_index', async () => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_INDEX_URL)


### PR DESCRIPTION

## Summary

- addresses https://github.com/elastic/kibana/issues/179208 by removing skipped test

I tracked skipped test to this PR: https://github.com/elastic/kibana/pull/115290

Test was added already skipped https://github.com/elastic/kibana/pull/115290/files#diff-16cebcbaef99c1aab50640a5bee66351bcbfd7575361d97eee4d2ca6753f5a27R38-R41

In the tested route itself, when index does not exist, it returns 200: https://github.com/elastic/kibana/pull/115290/files#diff-a4e27aaa05560a7737e153e53fe4bdaf839056180347c338e8d0842ab39f1240R79-R84

So, test from the very beginning was not testing valid use case.

After talking to PR author @marshallmain , we agreed to remove that test
