### PR TITLE
[Security Solution][Notes] - add create note to flyout notes tab

### DIFF
--- a/x-pack/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/global_state.ts
@@ -520,11 +520,11 @@ export const mockGlobalState: State = {
     },
     status: {
       fetchNotesByDocumentId: ReqStatus.Idle,
-      createNoteByDocumentId: ReqStatus.Idle,
+      createNote: ReqStatus.Idle,
     },
     error: {
       fetchNotesByDocumentId: null,
-      createNoteByDocumentId: null,
+      createNote: null,
     },
   },
 };

--- a/x-pack/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/global_state.ts
@@ -520,9 +520,11 @@ export const mockGlobalState: State = {
     },
     status: {
       fetchNotesByDocumentId: ReqStatus.Idle,
+      createNoteByDocumentId: ReqStatus.Idle,
     },
     error: {
       fetchNotesByDocumentId: null,
+      createNoteByDocumentId: null,
     },
   },
 };

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
@@ -53,7 +53,7 @@ describe('AddNote', () => {
 
   it('should render the add note button in loading state while creating a new note', () => {
     const state = { ...mockGlobalState };
-    state.notes.status.createNoteByDocumentId = ReqStatus.Loading;
+    state.notes.status.createNote = ReqStatus.Loading;
     const store = createMockStore(state);
 
     const { container } = render(
@@ -67,8 +67,8 @@ describe('AddNote', () => {
 
   it('should render error toast if create a note fails', () => {
     const state = { ...mockGlobalState };
-    state.notes.status.createNoteByDocumentId = ReqStatus.Failed;
-    state.notes.error.createNoteByDocumentId = { type: 'http', status: 500 };
+    state.notes.status.createNote = ReqStatus.Failed;
+    state.notes.error.createNote = { type: 'http', status: 500 };
     const store = createMockStore(state);
 
     render(

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { createMockStore, mockGlobalState, TestProviders } from '../../../../common/mock';
+import { AddNote, CREATE_NOTE_ERROR } from './add_note';
+import { ADD_NOTE_BUTTON_TEST_ID, ADD_NOTE_MARKDOWN_TEST_ID } from './test_ids';
+import { ReqStatus } from '../../../../notes/store/notes.slice';
+
+const mockAddError = jest.fn();
+jest.mock('../../../../common/hooks/use_app_toasts', () => ({
+  useAppToasts: () => ({
+    addError: mockAddError,
+  }),
+}));
+
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+  return {
+    ...original,
+    useDispatch: () => mockDispatch,
+  };
+});
+
+const renderAddNote = () =>
+  render(
+    <TestProviders>
+      <AddNote eventId={'event-id'} />
+    </TestProviders>
+  );
+
+describe('AddNote', () => {
+  it('should render the markdown and add button components', () => {
+    const { getByTestId } = renderAddNote();
+
+    expect(getByTestId(ADD_NOTE_MARKDOWN_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(ADD_NOTE_BUTTON_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should create note', () => {
+    const { getByTestId } = renderAddNote();
+
+    getByTestId(ADD_NOTE_BUTTON_TEST_ID).click();
+
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should render the add note button in loading state while creating a new note', () => {
+    const state = { ...mockGlobalState };
+    state.notes.status.createNoteByDocumentId = ReqStatus.Loading;
+    const store = createMockStore(state);
+
+    const { container } = render(
+      <TestProviders store={store}>
+        <AddNote eventId={'event-id'} />
+      </TestProviders>
+    );
+
+    expect(container.querySelector('.euiLoadingSpinner')).toBeInTheDocument();
+  });
+
+  it('should render error toast if create a note fails', () => {
+    const state = { ...mockGlobalState };
+    state.notes.status.createNoteByDocumentId = ReqStatus.Failed;
+    state.notes.error.createNoteByDocumentId = { type: 'http', status: 500 };
+    const store = createMockStore(state);
+
+    render(
+      <TestProviders store={store}>
+        <AddNote eventId={'event-id'} />
+      </TestProviders>
+    );
+
+    expect(mockAddError).toHaveBeenCalledWith(null, {
+      title: CREATE_NOTE_ERROR,
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -20,10 +20,10 @@ import { ADD_NOTE_BUTTON_TEST_ID, ADD_NOTE_MARKDOWN_TEST_ID } from './test_ids';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import type { State } from '../../../../common/store';
 import {
-  createNoteByDocumentId,
+  createNote,
   ReqStatus,
-  selectCreateNoteByDocumentIdError,
-  selectCreateNoteByDocumentIdStatus,
+  selectCreateNoteError,
+  selectCreateNoteStatus,
 } from '../../../../notes/store/notes.slice';
 import { MarkdownEditor } from '../../../../common/components/markdown_editor';
 
@@ -58,12 +58,12 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
   const { addError: addErrorToast } = useAppToasts();
   const [editorValue, setEditorValue] = useState('');
 
-  const createStatus = useSelector((state: State) => selectCreateNoteByDocumentIdStatus(state));
-  const createError = useSelector((state: State) => selectCreateNoteByDocumentIdError(state));
+  const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));
+  const createError = useSelector((state: State) => selectCreateNoteError(state));
 
   const addNote = useCallback(() => {
     dispatch(
-      createNoteByDocumentId({
+      createNote({
         note: {
           timelineId: '',
           eventId,

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -27,7 +27,13 @@ import {
 } from '../../../../notes/store/notes.slice';
 import { MarkdownEditor } from '../../../../common/components/markdown_editor';
 
-export const ADD_NOTE_BUTTON = i18n.translate('xpack.securitySolution.notes.addNoteButtonLabel', {
+export const MARKDOWN_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.notes.markdownAriaLabel',
+  {
+    defaultMessage: 'Note',
+  }
+);
+export const ADD_NOTE_BUTTON = i18n.translate('xpack.securitySolution.notes.addNoteBtnLabel', {
   defaultMessage: 'Add note',
 });
 export const CREATE_NOTE_ERROR = i18n.translate(
@@ -84,7 +90,7 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
             dataTestSubj={ADD_NOTE_MARKDOWN_TEST_ID}
             value={editorValue}
             onChange={setEditorValue}
-            ariaLabel={'add new note'}
+            ariaLabel={MARKDOWN_ARIA_LABEL}
             setIsMarkdownInvalid={() => {}}
           />
         </EuiComment>

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiComment,
+  EuiCommentList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+} from '@elastic/eui';
+import { useDispatch, useSelector } from 'react-redux';
+import { i18n } from '@kbn/i18n';
+import { ADD_NOTE_BUTTON_TEST_ID, ADD_NOTE_MARKDOWN_TEST_ID } from './test_ids';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import type { State } from '../../../../common/store';
+import {
+  createNoteByDocumentId,
+  ReqStatus,
+  selectCreateNoteByDocumentIdError,
+  selectCreateNoteByDocumentIdStatus,
+} from '../../../../notes/store/notes.slice';
+import { MarkdownEditor } from '../../../../common/components/markdown_editor';
+
+export const ADD_NOTE_BUTTON = i18n.translate('xpack.securitySolution.notes.addNoteButtonLabel', {
+  defaultMessage: 'Add note',
+});
+export const CREATE_NOTE_ERROR = i18n.translate(
+  'xpack.securitySolution.notes.createNoteErrorLabel',
+  {
+    defaultMessage: 'Error create note',
+  }
+);
+
+export interface AddNewNoteProps {
+  /**
+   * Id of the document
+   */
+  eventId: string;
+}
+
+/**
+ * Renders a markdown editor and a add button to create new notes
+ */
+export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
+  const dispatch = useDispatch();
+  const { addError: addErrorToast } = useAppToasts();
+  const [editorValue, setEditorValue] = useState('');
+
+  const createStatus = useSelector((state: State) => selectCreateNoteByDocumentIdStatus(state));
+  const createError = useSelector((state: State) => selectCreateNoteByDocumentIdError(state));
+
+  const addNote = useCallback(() => {
+    dispatch(
+      createNoteByDocumentId({
+        note: {
+          timelineId: '',
+          eventId,
+          note: editorValue,
+        },
+      })
+    );
+    setEditorValue('');
+  }, [dispatch, editorValue, eventId]);
+
+  useEffect(() => {
+    if (createStatus === ReqStatus.Failed && createError) {
+      addErrorToast(null, {
+        title: CREATE_NOTE_ERROR,
+      });
+    }
+  }, [addErrorToast, createError, createStatus]);
+
+  return (
+    <>
+      <EuiCommentList>
+        <EuiComment username="">
+          <MarkdownEditor
+            dataTestSubj={ADD_NOTE_MARKDOWN_TEST_ID}
+            value={editorValue}
+            onChange={setEditorValue}
+            ariaLabel={'add new note'}
+            setIsMarkdownInvalid={() => {}}
+          />
+        </EuiComment>
+      </EuiCommentList>
+      <EuiSpacer />
+      <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            onClick={addNote}
+            isLoading={createStatus === ReqStatus.Loading}
+            data-test-subj={ADD_NOTE_BUTTON_TEST_ID}
+          >
+            {ADD_NOTE_BUTTON}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+});
+
+AddNote.displayName = 'AddNote';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
@@ -7,6 +7,8 @@
 
 import React, { memo, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { EuiSpacer } from '@elastic/eui';
+import { AddNote } from './add_note';
 import { NotesList } from './notes_list';
 import { fetchNotesByDocumentId } from '../../../../notes/store/notes.slice';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -23,7 +25,13 @@ export const NotesDetails = memo(() => {
     dispatch(fetchNotesByDocumentId({ documentId: eventId }));
   }, [dispatch, eventId]);
 
-  return <NotesList eventId={eventId} />;
+  return (
+    <>
+      <NotesList eventId={eventId} />
+      <EuiSpacer />
+      <AddNote eventId={eventId} />
+    </>
+  );
 });
 
 NotesDetails.displayName = 'NotesDetails';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
@@ -7,7 +7,7 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
-import { NOTES_COMMENT_TEST_ID, NOTES_LOADING_TEST_ID } from './test_ids';
+import { ADD_NOTE_LOADING_TEST_ID, NOTES_COMMENT_TEST_ID, NOTES_LOADING_TEST_ID } from './test_ids';
 import { createMockStore, mockGlobalState, TestProviders } from '../../../../common/mock';
 import { FETCH_NOTES_ERROR, NO_NOTES, NotesList } from './notes_list';
 import { ReqStatus } from '../../../../notes/store/notes.slice';
@@ -76,5 +76,19 @@ describe('NotesList', () => {
     expect(mockAddError).toHaveBeenCalledWith(null, {
       title: FETCH_NOTES_ERROR,
     });
+  });
+
+  it('should render create loading when user create a new note', () => {
+    const state = { ...mockGlobalState };
+    state.notes.status.createNoteByDocumentId = ReqStatus.Loading;
+    const store = createMockStore(state);
+
+    const { getByTestId } = render(
+      <TestProviders store={store}>
+        <NotesList eventId={'event-id'} />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ADD_NOTE_LOADING_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
@@ -80,7 +80,7 @@ describe('NotesList', () => {
 
   it('should render create loading when user create a new note', () => {
     const state = { ...mockGlobalState };
-    state.notes.status.createNoteByDocumentId = ReqStatus.Loading;
+    state.notes.status.createNote = ReqStatus.Loading;
     const store = createMockStore(state);
 
     const { getByTestId } = render(

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -77,7 +77,7 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
       {notes.map((note, index) => (
         <EuiComment
           data-test-subj={`${NOTES_COMMENT_TEST_ID}-${index}`}
-          key={`note-${index}`}
+          key={note.noteId}
           username={note.createdBy}
           timestamp={<>{note.created && <FormattedRelative value={new Date(note.created)} />}</>}
           event={ADDED_A_NOTE}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -15,7 +15,7 @@ import type { State } from '../../../../common/store';
 import type { Note } from '../../../../../common/api/timeline';
 import {
   ReqStatus,
-  selectCreateNoteByDocumentIdStatus,
+  selectCreateNoteStatus,
   selectFetchNotesByDocumentIdError,
   selectFetchNotesByDocumentIdStatus,
   selectNotesByDocumentId,
@@ -54,7 +54,7 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
   const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdError(state));
   const notes: Note[] = useSelector((state: State) => selectNotesByDocumentId(state, eventId));
 
-  const createStatus = useSelector((state: State) => selectCreateNoteByDocumentIdStatus(state));
+  const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));
 
   useEffect(() => {
     if (fetchStatus === ReqStatus.Failed && fetchError) {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -10,11 +10,12 @@ import { EuiComment, EuiCommentList, EuiLoadingElastic, EuiMarkdownFormat } from
 import { useSelector } from 'react-redux';
 import { FormattedRelative } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { NOTES_COMMENT_TEST_ID, NOTES_LOADING_TEST_ID } from './test_ids';
+import { ADD_NOTE_LOADING_TEST_ID, NOTES_COMMENT_TEST_ID, NOTES_LOADING_TEST_ID } from './test_ids';
 import type { State } from '../../../../common/store';
 import type { Note } from '../../../../../common/api/timeline';
 import {
   ReqStatus,
+  selectCreateNoteByDocumentIdStatus,
   selectFetchNotesByDocumentIdError,
   selectFetchNotesByDocumentIdStatus,
   selectNotesByDocumentId,
@@ -25,7 +26,7 @@ export const ADDED_A_NOTE = i18n.translate('xpack.securitySolution.notes.addedAN
   defaultMessage: 'added a note',
 });
 export const FETCH_NOTES_ERROR = i18n.translate(
-  'xpack.securitySolution.notes.fetchNoteErrorLabel',
+  'xpack.securitySolution.notes.fetchNotesErrorLabel',
   {
     defaultMessage: 'Error fetching notes',
   }
@@ -44,6 +45,7 @@ export interface NotesListProps {
 /**
  * Renders a list of notes for the document.
  * If a note belongs to a timeline, a timeline icon will be shown the top right corner.
+ * When a note is being created, the component renders a loading spinner when the new note is about to be added.
  */
 export const NotesList = ({ eventId }: NotesListProps) => {
   const { addError: addErrorToast } = useAppToasts();
@@ -51,6 +53,8 @@ export const NotesList = ({ eventId }: NotesListProps) => {
   const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdStatus(state));
   const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdError(state));
   const notes: Note[] = useSelector((state: State) => selectNotesByDocumentId(state, eventId));
+
+  const createStatus = useSelector((state: State) => selectCreateNoteByDocumentIdStatus(state));
 
   useEffect(() => {
     if (fetchStatus === ReqStatus.Failed && fetchError) {
@@ -81,6 +85,9 @@ export const NotesList = ({ eventId }: NotesListProps) => {
           <EuiMarkdownFormat textSize="s">{note.note || ''}</EuiMarkdownFormat>
         </EuiComment>
       ))}
+      {createStatus === ReqStatus.Loading && (
+        <EuiLoadingElastic size="xxl" data-test-subj={ADD_NOTE_LOADING_TEST_ID} />
+      )}
     </EuiCommentList>
   );
 };

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React, { memo, useEffect } from 'react';
 import { EuiComment, EuiCommentList, EuiLoadingElastic, EuiMarkdownFormat } from '@elastic/eui';
 import { useSelector } from 'react-redux';
 import { FormattedRelative } from '@kbn/i18n-react';
@@ -47,7 +47,7 @@ export interface NotesListProps {
  * If a note belongs to a timeline, a timeline icon will be shown the top right corner.
  * When a note is being created, the component renders a loading spinner when the new note is about to be added.
  */
-export const NotesList = ({ eventId }: NotesListProps) => {
+export const NotesList = memo(({ eventId }: NotesListProps) => {
   const { addError: addErrorToast } = useAppToasts();
 
   const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdStatus(state));
@@ -90,6 +90,6 @@ export const NotesList = ({ eventId }: NotesListProps) => {
       )}
     </EuiCommentList>
   );
-};
+});
 
 NotesList.displayName = 'NotesList';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/test_ids.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/test_ids.ts
@@ -94,3 +94,6 @@ export const INVESTIGATION_GUIDE_LOADING_TEST_ID = `${INVESTIGATION_GUIDE_TEST_I
 
 export const NOTES_LOADING_TEST_ID = `${PREFIX}NotesLoading` as const;
 export const NOTES_COMMENT_TEST_ID = `${PREFIX}NotesComment` as const;
+export const ADD_NOTE_LOADING_TEST_ID = `${PREFIX}AddNotesLoading` as const;
+export const ADD_NOTE_MARKDOWN_TEST_ID = `${PREFIX}AddNotesMarkdown` as const;
+export const ADD_NOTE_BUTTON_TEST_ID = `${PREFIX}AddNotesButton` as const;

--- a/x-pack/plugins/security_solution/public/notes/api/api.ts
+++ b/x-pack/plugins/security_solution/public/notes/api/api.ts
@@ -16,21 +16,18 @@ import { NOTE_URL } from '../../../common/constants';
  * // TODO remove the old method when the transition to the new notes system is complete
  */
 export const createNote = async ({ note }: { note: BareNote }) => {
-  let requestBody;
-
   try {
-    requestBody = JSON.stringify({ note });
+    const response = await KibanaServices.get().http.patch<{
+      data: { persistNote: { code: number; message: string; note: Note } };
+    }>(NOTE_URL, {
+      method: 'PATCH',
+      body: JSON.stringify({ note }),
+      version: '2023-10-31',
+    });
+    return response.data.persistNote.note;
   } catch (err) {
-    return Promise.reject(new Error(`Failed to stringify query: ${JSON.stringify(err)}`));
+    throw new Error(`Failed to stringify query: ${JSON.stringify(err)}`);
   }
-  const response = await KibanaServices.get().http.patch<{
-    data: { persistNote: { code: number; message: string; note: Note } };
-  }>(NOTE_URL, {
-    method: 'PATCH',
-    body: requestBody,
-    version: '2023-10-31',
-  });
-  return response.data.persistNote.note;
 };
 
 // TODO point to the correct API when it is available

--- a/x-pack/plugins/security_solution/public/notes/api/api.ts
+++ b/x-pack/plugins/security_solution/public/notes/api/api.ts
@@ -10,21 +10,16 @@ import type { BareNote, Note } from '../../../common/api/timeline';
 import { KibanaServices } from '../../common/lib/kibana';
 import { NOTE_URL } from '../../../common/constants';
 
-export const createNote = async ({
-  note,
-  noteId,
-  version,
-  overrideOwner,
-}: {
-  note: BareNote;
-  noteId?: string | null;
-  version?: string | null;
-  overrideOwner?: boolean;
-}) => {
+/**
+ * Adds a new note.
+ * This code is very close to the persistNote found in x-pack/plugins/security_solution/public/timelines/containers/notes/api.ts.
+ * // TODO remove the old method when the transition to the new notes system is complete
+ */
+export const createNote = async ({ note }: { note: BareNote }) => {
   let requestBody;
 
   try {
-    requestBody = JSON.stringify({ noteId, version, note, overrideOwner });
+    requestBody = JSON.stringify({ note });
   } catch (err) {
     return Promise.reject(new Error(`Failed to stringify query: ${JSON.stringify(err)}`));
   }

--- a/x-pack/plugins/security_solution/public/notes/api/api.ts
+++ b/x-pack/plugins/security_solution/public/notes/api/api.ts
@@ -6,6 +6,37 @@
  */
 
 import * as uuid from 'uuid';
+import type { BareNote, Note } from '../../../common/api/timeline';
+import { KibanaServices } from '../../common/lib/kibana';
+import { NOTE_URL } from '../../../common/constants';
+
+export const createNote = async ({
+  note,
+  noteId,
+  version,
+  overrideOwner,
+}: {
+  note: BareNote;
+  noteId?: string | null;
+  version?: string | null;
+  overrideOwner?: boolean;
+}) => {
+  let requestBody;
+
+  try {
+    requestBody = JSON.stringify({ noteId, version, note, overrideOwner });
+  } catch (err) {
+    return Promise.reject(new Error(`Failed to stringify query: ${JSON.stringify(err)}`));
+  }
+  const response = await KibanaServices.get().http.patch<{
+    data: { persistNote: { code: number; message: string; note: Note } };
+  }>(NOTE_URL, {
+    method: 'PATCH',
+    body: requestBody,
+    version: '2023-10-31',
+  });
+  return response.data.persistNote.note;
+};
 
 // TODO point to the correct API when it is available
 /**

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
@@ -6,14 +6,14 @@
  */
 
 import {
-  createNoteByDocumentId,
+  createNote,
   fetchNotesByDocumentId,
   initialNotesState,
   notesReducer,
   ReqStatus,
   selectAllNotes,
-  selectCreateNoteByDocumentIdError,
-  selectCreateNoteByDocumentIdStatus,
+  selectCreateNoteError,
+  selectCreateNoteStatus,
   selectFetchNotesByDocumentIdError,
   selectFetchNotesByDocumentIdStatus,
   selectNoteById,
@@ -31,8 +31,8 @@ const initialNonEmptyState = {
     [mockNote.noteId]: mockNote,
   },
   ids: [mockNote.noteId],
-  status: { fetchNotesByDocumentId: ReqStatus.Idle, createNoteByDocumentId: ReqStatus.Idle },
-  error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+  status: { fetchNotesByDocumentId: ReqStatus.Idle, createNote: ReqStatus.Idle },
+  error: { fetchNotesByDocumentId: null, createNote: null },
 };
 
 describe('notesSlice', () => {
@@ -41,8 +41,8 @@ describe('notesSlice', () => {
       expect(notesReducer(initalEmptyState, { type: 'unknown' })).toEqual({
         entities: {},
         ids: [],
-        status: { fetchNotesByDocumentId: ReqStatus.Idle, createNoteByDocumentId: ReqStatus.Idle },
-        error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+        status: { fetchNotesByDocumentId: ReqStatus.Idle, createNote: ReqStatus.Idle },
+        error: { fetchNotesByDocumentId: null, createNote: null },
       });
     });
 
@@ -55,9 +55,9 @@ describe('notesSlice', () => {
           ids: [],
           status: {
             fetchNotesByDocumentId: ReqStatus.Loading,
-            createNoteByDocumentId: ReqStatus.Idle,
+            createNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+          error: { fetchNotesByDocumentId: null, createNote: null },
         });
       });
 
@@ -79,9 +79,9 @@ describe('notesSlice', () => {
           ids: action.payload.result,
           status: {
             fetchNotesByDocumentId: ReqStatus.Succeeded,
-            createNoteByDocumentId: ReqStatus.Idle,
+            createNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+          error: { fetchNotesByDocumentId: null, createNote: null },
         });
       });
 
@@ -104,9 +104,9 @@ describe('notesSlice', () => {
           ids: action.payload.result,
           status: {
             fetchNotesByDocumentId: ReqStatus.Succeeded,
-            createNoteByDocumentId: ReqStatus.Idle,
+            createNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+          error: { fetchNotesByDocumentId: null, createNote: null },
         });
       });
 
@@ -118,31 +118,31 @@ describe('notesSlice', () => {
           ids: [],
           status: {
             fetchNotesByDocumentId: ReqStatus.Failed,
-            createNoteByDocumentId: ReqStatus.Idle,
+            createNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: 'error', createNoteByDocumentId: null },
+          error: { fetchNotesByDocumentId: 'error', createNote: null },
         });
       });
     });
 
-    describe('createNoteByDocumentId', () => {
+    describe('createNote', () => {
       it('should set correct state when creating a note by document id', () => {
-        const action = { type: createNoteByDocumentId.pending.type };
+        const action = { type: createNote.pending.type };
 
         expect(notesReducer(initalEmptyState, action)).toEqual({
           entities: {},
           ids: [],
           status: {
             fetchNotesByDocumentId: ReqStatus.Idle,
-            createNoteByDocumentId: ReqStatus.Loading,
+            createNote: ReqStatus.Loading,
           },
-          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+          error: { fetchNotesByDocumentId: null, createNote: null },
         });
       });
 
       it('should set correct state when success on create a note by document id on an empty state', () => {
         const action = {
-          type: createNoteByDocumentId.fulfilled.type,
+          type: createNote.fulfilled.type,
           payload: {
             entities: {
               notes: {
@@ -158,23 +158,23 @@ describe('notesSlice', () => {
           ids: [action.payload.result],
           status: {
             fetchNotesByDocumentId: ReqStatus.Idle,
-            createNoteByDocumentId: ReqStatus.Succeeded,
+            createNote: ReqStatus.Succeeded,
           },
-          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+          error: { fetchNotesByDocumentId: null, createNote: null },
         });
       });
 
       it('should set correct state when error on create a note by document id', () => {
-        const action = { type: createNoteByDocumentId.rejected.type, error: 'error' };
+        const action = { type: createNote.rejected.type, error: 'error' };
 
         expect(notesReducer(initalEmptyState, action)).toEqual({
           entities: {},
           ids: [],
           status: {
             fetchNotesByDocumentId: ReqStatus.Idle,
-            createNoteByDocumentId: ReqStatus.Failed,
+            createNote: ReqStatus.Failed,
           },
-          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: 'error' },
+          error: { fetchNotesByDocumentId: null, createNote: 'error' },
         });
       });
     });
@@ -211,11 +211,11 @@ describe('notesSlice', () => {
     });
 
     it('should return create note by document id status', () => {
-      expect(selectCreateNoteByDocumentIdStatus(mockGlobalState)).toEqual(ReqStatus.Idle);
+      expect(selectCreateNoteStatus(mockGlobalState)).toEqual(ReqStatus.Idle);
     });
 
     it('should return create note by document id error', () => {
-      expect(selectCreateNoteByDocumentIdError(mockGlobalState)).toEqual(null);
+      expect(selectCreateNoteError(mockGlobalState)).toEqual(null);
     });
 
     it('should return all notes for an existing document id', () => {

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
@@ -6,11 +6,14 @@
  */
 
 import {
+  createNoteByDocumentId,
   fetchNotesByDocumentId,
   initialNotesState,
   notesReducer,
   ReqStatus,
   selectAllNotes,
+  selectCreateNoteByDocumentIdError,
+  selectCreateNoteByDocumentIdStatus,
   selectFetchNotesByDocumentIdError,
   selectFetchNotesByDocumentIdStatus,
   selectNoteById,
@@ -28,8 +31,8 @@ const initialNonEmptyState = {
     [mockNote.noteId]: mockNote,
   },
   ids: [mockNote.noteId],
-  status: { fetchNotesByDocumentId: ReqStatus.Idle },
-  error: { fetchNotesByDocumentId: null },
+  status: { fetchNotesByDocumentId: ReqStatus.Idle, createNoteByDocumentId: ReqStatus.Idle },
+  error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
 };
 
 describe('notesSlice', () => {
@@ -38,73 +41,141 @@ describe('notesSlice', () => {
       expect(notesReducer(initalEmptyState, { type: 'unknown' })).toEqual({
         entities: {},
         ids: [],
-        status: { fetchNotesByDocumentId: ReqStatus.Idle },
-        error: { fetchNotesByDocumentId: null },
+        status: { fetchNotesByDocumentId: ReqStatus.Idle, createNoteByDocumentId: ReqStatus.Idle },
+        error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
       });
     });
 
-    it('should set correct state when fetching notes by document id', () => {
-      const action = { type: fetchNotesByDocumentId.pending.type };
+    describe('fetchNotesByDocumentId', () => {
+      it('should set correct state when fetching notes by document id', () => {
+        const action = { type: fetchNotesByDocumentId.pending.type };
 
-      expect(notesReducer(initalEmptyState, action)).toEqual({
-        entities: {},
-        ids: [],
-        status: { fetchNotesByDocumentId: ReqStatus.Loading },
-        error: { fetchNotesByDocumentId: null },
-      });
-    });
-
-    it('should set correct state when success on fetch notes by document id on an empty state', () => {
-      const action = {
-        type: fetchNotesByDocumentId.fulfilled.type,
-        payload: {
-          entities: {
-            notes: {
-              [mockNote.noteId]: mockNote,
-            },
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          entities: {},
+          ids: [],
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Loading,
+            createNoteByDocumentId: ReqStatus.Idle,
           },
-          result: [mockNote.noteId],
-        },
-      };
-
-      expect(notesReducer(initalEmptyState, action)).toEqual({
-        entities: action.payload.entities.notes,
-        ids: action.payload.result,
-        status: { fetchNotesByDocumentId: ReqStatus.Succeeded },
-        error: { fetchNotesByDocumentId: null },
+          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+        });
       });
-    });
 
-    it('should replace notes when success on fetch notes by document id on a non-empty state', () => {
-      const newMockNote = { ...mockNote, timelineId: 'timelineId' };
-      const action = {
-        type: fetchNotesByDocumentId.fulfilled.type,
-        payload: {
-          entities: {
-            notes: {
-              [newMockNote.noteId]: newMockNote,
+      it('should set correct state when success on fetch notes by document id on an empty state', () => {
+        const action = {
+          type: fetchNotesByDocumentId.fulfilled.type,
+          payload: {
+            entities: {
+              notes: {
+                [mockNote.noteId]: mockNote,
+              },
             },
+            result: [mockNote.noteId],
           },
-          result: [newMockNote.noteId],
-        },
-      };
+        };
 
-      expect(notesReducer(initialNonEmptyState, action)).toEqual({
-        entities: action.payload.entities.notes,
-        ids: action.payload.result,
-        status: { fetchNotesByDocumentId: ReqStatus.Succeeded },
-        error: { fetchNotesByDocumentId: null },
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          entities: action.payload.entities.notes,
+          ids: action.payload.result,
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Succeeded,
+            createNoteByDocumentId: ReqStatus.Idle,
+          },
+          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+        });
+      });
+
+      it('should replace notes when success on fetch notes by document id on a non-empty state', () => {
+        const newMockNote = { ...mockNote, timelineId: 'timelineId' };
+        const action = {
+          type: fetchNotesByDocumentId.fulfilled.type,
+          payload: {
+            entities: {
+              notes: {
+                [newMockNote.noteId]: newMockNote,
+              },
+            },
+            result: [newMockNote.noteId],
+          },
+        };
+
+        expect(notesReducer(initialNonEmptyState, action)).toEqual({
+          entities: action.payload.entities.notes,
+          ids: action.payload.result,
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Succeeded,
+            createNoteByDocumentId: ReqStatus.Idle,
+          },
+          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+        });
+      });
+
+      it('should set correct state when error on fetch notes by document id', () => {
+        const action = { type: fetchNotesByDocumentId.rejected.type, error: 'error' };
+
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          entities: {},
+          ids: [],
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Failed,
+            createNoteByDocumentId: ReqStatus.Idle,
+          },
+          error: { fetchNotesByDocumentId: 'error', createNoteByDocumentId: null },
+        });
       });
     });
 
-    it('should set correct state when error on fetch notes by document id', () => {
-      const action = { type: fetchNotesByDocumentId.rejected.type, error: 'error' };
+    describe('createNoteByDocumentId', () => {
+      it('should set correct state when creating a note by document id', () => {
+        const action = { type: createNoteByDocumentId.pending.type };
 
-      expect(notesReducer(initalEmptyState, action)).toEqual({
-        entities: {},
-        ids: [],
-        status: { fetchNotesByDocumentId: ReqStatus.Failed },
-        error: { fetchNotesByDocumentId: 'error' },
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          entities: {},
+          ids: [],
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Idle,
+            createNoteByDocumentId: ReqStatus.Loading,
+          },
+          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+        });
+      });
+
+      it('should set correct state when success on create a note by document id on an empty state', () => {
+        const action = {
+          type: createNoteByDocumentId.fulfilled.type,
+          payload: {
+            entities: {
+              notes: {
+                [mockNote.noteId]: mockNote,
+              },
+            },
+            result: mockNote.noteId,
+          },
+        };
+
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          entities: action.payload.entities.notes,
+          ids: [action.payload.result],
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Idle,
+            createNoteByDocumentId: ReqStatus.Succeeded,
+          },
+          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: null },
+        });
+      });
+
+      it('should set correct state when error on create a note by document id', () => {
+        const action = { type: createNoteByDocumentId.rejected.type, error: 'error' };
+
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          entities: {},
+          ids: [],
+          status: {
+            fetchNotesByDocumentId: ReqStatus.Idle,
+            createNoteByDocumentId: ReqStatus.Failed,
+          },
+          error: { fetchNotesByDocumentId: null, createNoteByDocumentId: 'error' },
+        });
       });
     });
   });
@@ -137,6 +208,14 @@ describe('notesSlice', () => {
 
     it('should return fetch notes by document id error', () => {
       expect(selectFetchNotesByDocumentIdError(mockGlobalState)).toEqual(null);
+    });
+
+    it('should return create note by document id status', () => {
+      expect(selectCreateNoteByDocumentIdStatus(mockGlobalState)).toEqual(ReqStatus.Idle);
+    });
+
+    it('should return create note by document id error', () => {
+      expect(selectCreateNoteByDocumentIdError(mockGlobalState)).toEqual(null);
     });
 
     it('should return all notes for an existing document id', () => {


### PR DESCRIPTION
## Summary

This PR continues to add functionality to the new notes feature for Security Solution. It focuses on adding a add note section to the expandable flyout Notes tab.

The new `AddNote` component within the Notes tab does the following:
- displays the `MarkdownEditor` shared component from Security Solution to allow users to create notes with OsQuery, timeline links and more
- an add button. The add button will be in loading state while the creation of the note is happening. At the same time, the `NotesList` component renders a loading spinner between the last note and the `AddNote` component, where the newly created note will appear once the call finishes.

https://github.com/elastic/kibana/assets/17276605/3a1f4e0e-63cd-4970-b95f-52492abe4071

### How to test

- make sure the feature flag is enabled in your `kibana.yml` file: `xpack.securitySolution.enableExperimental: ['notesEnabled']`
- open the expandable flyout for an alert, click on the Expand details button to expand the left section then navigate to the new Notes tab

_Note: as the server side code isn't implemented yet for fetching alerts by document, the created note are persisted but cannot be retrieved, so refreshing the page makes it look like they are not._

https://github.com/elastic/security-team/issues/9375
https://github.com/elastic/security-team/issues/9605

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios