### PR TITLE
[Security Solution] Add `prebuiltRulesCustomizationEnabled` feature flag

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -267,6 +267,14 @@ export const allowedExperimentalValues = Object.freeze({
    * Adds a new option to filter descendants of a process for Management / Event Filters
    */
   filterProcessDescendantsForEventFiltersEnabled: false,
+
+  /**
+   * Enables an ability to customize Elastic prebuilt rules.
+   *
+   * Ticket: https://github.com/elastic/security-team/issues/1974
+   * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
+   */
+  prebuiltRulesCustomizationEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/180130**

## Summary

This PR adds a `prebuiltRulesCustomizationEnabled` feature flag. 

It unblocks working on the tickets under `Changes hidden behind the feature flag` in the [prebuilt rules customization epic](https://github.com/elastic/kibana/issues/174168).