### PR TITLE
[Security Solution][Notes] - rename notesEnabled feature flag to securitySolutionNotesEnabled

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -117,7 +117,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables new notes
    */
-  notesEnabled: false,
+  securitySolutionNotesEnabled: false,
 
   /**
    * Enables the Assistant Model Evaluation advanced setting and API endpoint, introduced in `8.11.0`.

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/index.tsx
@@ -43,18 +43,20 @@ export const LeftPanel: FC<Partial<LeftPanelProps>> = memo(({ path }) => {
   const { openLeftPanel } = useExpandableFlyoutApi();
   const { eventId, indexName, scopeId, getFieldsData } = useLeftPanelContext();
   const eventKind = getField(getFieldsData('event.kind'));
-  const notesEnabled = useIsExperimentalFeatureEnabled('notesEnabled');
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
 
   const tabsDisplayed = useMemo(() => {
     const tabList =
       eventKind === EventKind.signal
         ? [tabs.insightsTab, tabs.investigationTab, tabs.responseTab]
         : [tabs.insightsTab];
-    if (notesEnabled) {
+    if (securitySolutionNotesEnabled) {
       tabList.push(tabs.notesTab);
     }
     return tabList;
-  }, [eventKind, notesEnabled]);
+  }, [eventKind, securitySolutionNotesEnabled]);
 
   const selectedTabId = useMemo(() => {
     const defaultTab = tabsDisplayed[0].id;

--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -233,7 +233,7 @@ export const links: LinkItem = {
       path: NOTES_MANAGEMENT_PATH,
       skipUrlState: true,
       hideTimeline: true,
-      experimentalKey: 'notesEnabled',
+      experimentalKey: 'securitySolutionNotesEnabled',
     },
   ],
 };


### PR DESCRIPTION
## Summary

This PR renames the `notesEnabled` feature flag to `securitySolutionNotesEnabled`. That way, it's more clear that the new notes functionality only works within the Security Solution application

https://github.com/elastic/security-team/issues/9375