### PR TITLE
[Spacetime][DO NOT MERGE] Enable APM trace waterfall into Obs AI Assistant

### DIFF
--- a/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
+++ b/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
@@ -86,3 +86,12 @@ export interface WaterfallError {
     name: string;
   };
 }
+
+export interface WaterfallTraceItems {
+  exceedsMax: boolean;
+  traceDocs: Array<WaterfallTransaction | WaterfallSpan>;
+  errorDocs: WaterfallError[];
+  spanLinksCountById: Record<string, number>;
+  traceDocsTotal: number;
+  maxTraceItems: number;
+}

--- a/x-pack/plugins/observability_solution/apm/common/waterfall/waterfall_helpers.ts
+++ b/x-pack/plugins/observability_solution/apm/common/waterfall/waterfall_helpers.ts
@@ -1,0 +1,716 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// DUPLICATE
+
+import { euiPaletteColorBlind } from '@elastic/eui';
+import { Dictionary, first, flatten, groupBy, isEmpty, sortBy, uniq } from 'lodash';
+import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import { Transaction } from '../../typings/es_schemas/ui/transaction';
+import {
+  WaterfallError,
+  WaterfallTraceItems,
+  WaterfallSpan,
+  WaterfallTransaction,
+} from './typings';
+import { CriticalPathSegment } from '../critical_path/types';
+import { isRumAgentName } from '../agent_name';
+import { asDuration } from '../utils/formatters';
+
+const ROOT_ID = 'root';
+
+export interface SpanLinksCount {
+  linkedChildren: number;
+  linkedParents: number;
+}
+
+export enum WaterfallLegendType {
+  ServiceName = 'serviceName',
+  SpanType = 'spanType',
+}
+
+export interface IWaterfall {
+  entryTransaction?: Transaction;
+  entryWaterfallTransaction?: IWaterfallTransaction;
+  rootWaterfallTransaction?: IWaterfallTransaction;
+
+  /**
+   * Latency in us
+   */
+  duration: number;
+  items: IWaterfallItem[];
+  childrenByParentId: Record<string | number, IWaterfallSpanOrTransaction[]>;
+  getErrorCount: (parentId: string) => number;
+  legends: IWaterfallLegend[];
+  errorItems: IWaterfallError[];
+  exceedsMax: boolean;
+  totalErrorsCount: number;
+  traceDocsTotal: number;
+  maxTraceItems: number;
+  orphanTraceItemsCount: number;
+}
+
+interface IWaterfallItemBase<TDocument, TDoctype> {
+  doc: TDocument;
+  docType: TDoctype;
+  id: string;
+  parent?: IWaterfallSpanOrTransaction;
+  parentId?: string;
+  color: string;
+  /**
+   * offset from first item in us
+   */
+  offset: number;
+  /**
+   * skew from timestamp in us
+   */
+  skew: number;
+  /**
+   * Latency in us
+   */
+  duration: number;
+  legendValues: Record<WaterfallLegendType, string>;
+  spanLinksCount: SpanLinksCount;
+}
+
+export type IWaterfallError = Omit<
+  IWaterfallItemBase<WaterfallError, 'error'>,
+  'duration' | 'legendValues' | 'spanLinksCount'
+>;
+
+export type IWaterfallTransaction = IWaterfallItemBase<WaterfallTransaction, 'transaction'>;
+
+export type IWaterfallSpan = IWaterfallItemBase<WaterfallSpan, 'span'>;
+
+export type IWaterfallSpanOrTransaction = IWaterfallTransaction | IWaterfallSpan;
+
+export type IWaterfallItem = IWaterfallSpanOrTransaction;
+
+export interface IWaterfallLegend {
+  type: WaterfallLegendType;
+  value: string | undefined;
+  color: string;
+}
+
+export interface IWaterfallNode {
+  id: string;
+  item: IWaterfallItem;
+  // children that are loaded
+  children: IWaterfallNode[];
+  // total number of children that needs to be loaded
+  childrenToLoad: number;
+  // collapsed or expanded state
+  expanded: boolean;
+  // level in the tree
+  level: number;
+  // flag to indicate if children are loaded
+  hasInitializedChildren: boolean;
+}
+
+export type IWaterfallNodeFlatten = Omit<IWaterfallNode, 'children'>;
+
+function getLegendValues(transactionOrSpan: WaterfallTransaction | WaterfallSpan) {
+  return {
+    [WaterfallLegendType.ServiceName]: transactionOrSpan.service.name,
+    [WaterfallLegendType.SpanType]:
+      transactionOrSpan.processor.event === ProcessorEvent.span
+        ? (transactionOrSpan as WaterfallSpan).span.subtype ||
+          (transactionOrSpan as WaterfallSpan).span.type
+        : '',
+  };
+}
+
+function getTransactionItem(
+  transaction: WaterfallTransaction,
+  linkedChildrenCount: number = 0
+): IWaterfallTransaction {
+  return {
+    docType: 'transaction',
+    doc: transaction,
+    id: transaction.transaction.id,
+    parentId: transaction.parent?.id,
+    duration: transaction.transaction.duration.us,
+    offset: 0,
+    skew: 0,
+    legendValues: getLegendValues(transaction),
+    color: '',
+    spanLinksCount: {
+      linkedParents: transaction.span?.links?.length ?? 0,
+      linkedChildren: linkedChildrenCount,
+    },
+  };
+}
+
+function getSpanItem(span: WaterfallSpan, linkedChildrenCount: number = 0): IWaterfallSpan {
+  return {
+    docType: 'span',
+    doc: span,
+    id: span.span.id,
+    parentId: span.parent?.id,
+    duration: span.span.duration.us,
+    offset: 0,
+    skew: 0,
+    legendValues: getLegendValues(span),
+    color: '',
+    spanLinksCount: {
+      linkedParents: span.span.links?.length ?? 0,
+      linkedChildren: linkedChildrenCount,
+    },
+  };
+}
+
+function getErrorItem(
+  error: WaterfallError,
+  items: IWaterfallItem[],
+  entryWaterfallTransaction?: IWaterfallTransaction
+): IWaterfallError {
+  const entryTimestamp = entryWaterfallTransaction?.doc.timestamp.us ?? 0;
+  const parent = items.find((waterfallItem) => waterfallItem.id === error.parent?.id) as
+    | IWaterfallSpanOrTransaction
+    | undefined;
+
+  const errorItem: IWaterfallError = {
+    docType: 'error',
+    doc: error,
+    id: error.error.id,
+    parent,
+    parentId: parent?.id,
+    offset: error.timestamp.us - entryTimestamp,
+    skew: 0,
+    color: '',
+  };
+
+  return {
+    ...errorItem,
+    skew: getClockSkew(errorItem, parent),
+  };
+}
+
+export function getClockSkew(
+  item: IWaterfallItem | IWaterfallError,
+  parentItem?: IWaterfallSpanOrTransaction
+) {
+  if (!parentItem) {
+    return 0;
+  }
+  switch (item.docType) {
+    // don't calculate skew for spans and errors. Just use parent's skew
+    case 'error':
+    case 'span':
+      return parentItem.skew;
+    // transaction is the initial entry in a service. Calculate skew for this, and it will be propagated to all child spans
+    case 'transaction': {
+      const parentStart = parentItem.doc.timestamp.us + parentItem.skew;
+
+      // determine if child starts before the parent
+      const offsetStart = parentStart - item.doc.timestamp.us;
+      if (offsetStart > 0) {
+        const latency = Math.max(parentItem.duration - item.duration, 0) / 2;
+        return offsetStart + latency;
+      }
+
+      // child transaction starts after parent thus no adjustment is needed
+      return 0;
+    }
+  }
+}
+
+export function getOrderedWaterfallItems(
+  childrenByParentId: Record<string, IWaterfallSpanOrTransaction[]>,
+  entryWaterfallTransaction?: IWaterfallTransaction
+) {
+  if (!entryWaterfallTransaction) {
+    return [];
+  }
+  const entryTimestamp = entryWaterfallTransaction.doc.timestamp.us;
+  const visitedWaterfallItemSet = new Set();
+
+  function getSortedChildren(
+    item: IWaterfallSpanOrTransaction,
+    parentItem?: IWaterfallSpanOrTransaction
+  ): IWaterfallSpanOrTransaction[] {
+    if (visitedWaterfallItemSet.has(item)) {
+      return [];
+    }
+    visitedWaterfallItemSet.add(item);
+
+    const children = sortBy(childrenByParentId[item.id] || [], 'doc.timestamp.us');
+
+    item.parent = parentItem;
+    // get offset from the beginning of trace
+    item.offset = item.doc.timestamp.us - entryTimestamp;
+    // move the item to the right if it starts before its parent
+    item.skew = getClockSkew(item, parentItem);
+
+    const deepChildren = flatten(children.map((child) => getSortedChildren(child, item)));
+    return [item, ...deepChildren];
+  }
+
+  return getSortedChildren(entryWaterfallTransaction);
+}
+
+function getRootWaterfallTransaction(
+  childrenByParentId: Record<string, IWaterfallSpanOrTransaction[]>
+) {
+  const item = first(childrenByParentId.root);
+  if (item && item.docType === 'transaction') {
+    return item;
+  }
+}
+
+function getLegends(waterfallItems: IWaterfallItem[]) {
+  const onlyBaseSpanItems = waterfallItems.filter(
+    (item) => item.docType === 'span' || item.docType === 'transaction'
+  ) as IWaterfallSpanOrTransaction[];
+
+  const legends = [WaterfallLegendType.ServiceName, WaterfallLegendType.SpanType].flatMap(
+    (legendType) => {
+      const allLegendValues = uniq(onlyBaseSpanItems.map((item) => item.legendValues[legendType]));
+
+      const palette = euiPaletteColorBlind({
+        rotations: Math.ceil(allLegendValues.length / 10),
+      });
+
+      return allLegendValues.map((value, index) => ({
+        type: legendType,
+        value,
+        color: palette[index],
+      }));
+    }
+  );
+
+  return legends;
+}
+
+const getWaterfallDuration = (waterfallItems: IWaterfallItem[]) =>
+  Math.max(
+    ...waterfallItems.map(
+      (item) => item.offset + item.skew + ('duration' in item ? item.duration : 0)
+    ),
+    0
+  );
+
+const getWaterfallItems = (
+  items: Array<WaterfallTransaction | WaterfallSpan>,
+  spanLinksCountById: Record<string, number>
+) =>
+  items.map((item) => {
+    const docType = item.processor.event;
+    switch (docType) {
+      case 'span': {
+        const span = item as WaterfallSpan;
+        return getSpanItem(span, spanLinksCountById[span.span.id]);
+      }
+      case 'transaction':
+        const transaction = item as WaterfallTransaction;
+        return getTransactionItem(transaction, spanLinksCountById[transaction.transaction.id]);
+    }
+  });
+
+function reparentSpans(waterfallItems: IWaterfallSpanOrTransaction[]) {
+  // find children that needs to be re-parented and map them to their correct parent id
+  const childIdToParentIdMapping = Object.fromEntries(
+    flatten(
+      waterfallItems.map((waterfallItem) => {
+        if (waterfallItem.docType === 'span') {
+          const childIds = waterfallItem.doc.child?.id ?? [];
+          return childIds.map((id) => [id, waterfallItem.id]);
+        }
+        return [];
+      })
+    )
+  );
+
+  // update parent id for children that needs it or return unchanged
+  return waterfallItems.map((waterfallItem) => {
+    const newParentId = childIdToParentIdMapping[waterfallItem.id];
+    if (newParentId) {
+      return {
+        ...waterfallItem,
+        parentId: newParentId,
+      };
+    }
+
+    return waterfallItem;
+  });
+}
+
+const getChildrenGroupedByParentId = (waterfallItems: IWaterfallSpanOrTransaction[]) =>
+  groupBy(waterfallItems, (item) => (item.parentId ? item.parentId : ROOT_ID));
+
+const getEntryWaterfallTransaction = (
+  entryTransactionId: string,
+  waterfallItems: IWaterfallItem[]
+): IWaterfallTransaction | undefined =>
+  waterfallItems.find(
+    (item) => item.docType === 'transaction' && item.id === entryTransactionId
+  ) as IWaterfallTransaction;
+
+function isInEntryTransaction(
+  parentIdLookup: Map<string, string>,
+  entryTransactionId: string,
+  currentId: string
+): boolean {
+  if (currentId === entryTransactionId) {
+    return true;
+  }
+  const parentId = parentIdLookup.get(currentId);
+  if (parentId) {
+    return isInEntryTransaction(parentIdLookup, entryTransactionId, parentId);
+  }
+  return false;
+}
+
+function getWaterfallErrors(
+  errorDocs: WaterfallError[],
+  items: IWaterfallItem[],
+  entryWaterfallTransaction?: IWaterfallTransaction
+) {
+  const errorItems = errorDocs.map((errorDoc) =>
+    getErrorItem(errorDoc, items, entryWaterfallTransaction)
+  );
+  if (!entryWaterfallTransaction) {
+    return errorItems;
+  }
+  const parentIdLookup = [...items, ...errorItems].reduce((map, { id, parentId }) => {
+    map.set(id, parentId ?? ROOT_ID);
+    return map;
+  }, new Map<string, string>());
+  return errorItems.filter((errorItem) =>
+    isInEntryTransaction(parentIdLookup, entryWaterfallTransaction?.id, errorItem.id)
+  );
+}
+
+// map parent.id to the number of errors
+/*
+  { 'parentId': 2 }
+  */
+function getErrorCountByParentId(errorDocs: WaterfallError[]) {
+  return errorDocs.reduce<Record<string, number>>((acc, doc) => {
+    const parentId = doc.parent?.id;
+
+    if (!parentId) {
+      return acc;
+    }
+
+    acc[parentId] = (acc[parentId] ?? 0) + 1;
+
+    return acc;
+  }, {});
+}
+
+export const getOrphanTraceItemsCount = (
+  traceDocs: Array<WaterfallTransaction | WaterfallSpan>
+) => {
+  const waterfallItemsIds = new Set(
+    traceDocs.map((doc) =>
+      doc.processor.event === 'span'
+        ? (doc?.span as WaterfallSpan['span']).id
+        : doc?.transaction?.id
+    )
+  );
+
+  let missingTraceItemsCounter = 0;
+  traceDocs.some((item) => {
+    if (item.parent?.id && !waterfallItemsIds.has(item.parent.id)) {
+      missingTraceItemsCounter++;
+    }
+  });
+  return missingTraceItemsCounter;
+};
+
+export function getWaterfall({
+  traceItems,
+  entryTransaction,
+}: {
+  traceItems: WaterfallTraceItems;
+  entryTransaction?: Transaction;
+}): IWaterfall {
+  if (isEmpty(traceItems.traceDocs) || !entryTransaction) {
+    return {
+      duration: 0,
+      items: [],
+      legends: [],
+      errorItems: [],
+      childrenByParentId: {},
+      getErrorCount: () => 0,
+      exceedsMax: false,
+      totalErrorsCount: 0,
+      traceDocsTotal: 0,
+      maxTraceItems: 0,
+      orphanTraceItemsCount: 0,
+    };
+  }
+
+  const errorCountByParentId = getErrorCountByParentId(traceItems.errorDocs);
+
+  const waterfallItems: IWaterfallSpanOrTransaction[] = getWaterfallItems(
+    traceItems.traceDocs,
+    traceItems.spanLinksCountById
+  );
+
+  const childrenByParentId = getChildrenGroupedByParentId(reparentSpans(waterfallItems));
+
+  const entryWaterfallTransaction = getEntryWaterfallTransaction(
+    entryTransaction.transaction.id,
+    waterfallItems
+  );
+
+  const items = getOrderedWaterfallItems(childrenByParentId, entryWaterfallTransaction);
+  const errorItems = getWaterfallErrors(traceItems.errorDocs, items, entryWaterfallTransaction);
+
+  const rootWaterfallTransaction = getRootWaterfallTransaction(childrenByParentId);
+
+  const duration = getWaterfallDuration(items);
+  const legends = getLegends(items);
+
+  const orphanTraceItemsCount = getOrphanTraceItemsCount(traceItems.traceDocs);
+
+  return {
+    entryWaterfallTransaction,
+    rootWaterfallTransaction,
+    entryTransaction,
+    duration,
+    items,
+    legends,
+    errorItems,
+    childrenByParentId: getChildrenGroupedByParentId(items),
+    getErrorCount: (parentId: string) => errorCountByParentId[parentId] ?? 0,
+    exceedsMax: traceItems.exceedsMax,
+    totalErrorsCount: traceItems.errorDocs.length,
+    traceDocsTotal: traceItems.traceDocsTotal,
+    maxTraceItems: traceItems.maxTraceItems,
+    orphanTraceItemsCount,
+  };
+}
+
+function getChildren({
+  path,
+  waterfall,
+  waterfallItemId,
+}: {
+  waterfallItemId: string;
+  waterfall: IWaterfall;
+  path: {
+    criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
+    showCriticalPath: boolean;
+  };
+}) {
+  const children = waterfall.childrenByParentId[waterfallItemId] ?? [];
+  return path.showCriticalPath
+    ? children.filter((child) => path.criticalPathSegmentsById[child.id]?.length)
+    : children;
+}
+
+function buildTree({
+  root,
+  waterfall,
+  maxLevelOpen,
+  path,
+}: {
+  root: IWaterfallNode;
+  waterfall: IWaterfall;
+  maxLevelOpen: number;
+  path: {
+    criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
+    showCriticalPath: boolean;
+  };
+}) {
+  const tree = { ...root };
+  const queue: IWaterfallNode[] = [tree];
+
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+    const node = queue[queueIndex];
+
+    const children = getChildren({ path, waterfall, waterfallItemId: node.item.id });
+
+    // Set childrenToLoad for all nodes enqueued.
+    // this allows lazy loading of child nodes
+    node.childrenToLoad = children.length;
+
+    if (maxLevelOpen > node.level) {
+      children.forEach((child, index) => {
+        const level = node.level + 1;
+
+        const currentNode: IWaterfallNode = {
+          id: `${level}-${child.id}-${index}`,
+          item: child,
+          children: [],
+          level,
+          expanded: level < maxLevelOpen,
+          childrenToLoad: 0,
+          hasInitializedChildren: false,
+        };
+
+        node.children.push(currentNode);
+        queue.push(currentNode);
+      });
+
+      node.hasInitializedChildren = true;
+    }
+  }
+
+  return tree;
+}
+
+export function buildTraceTree({
+  waterfall,
+  maxLevelOpen,
+  isOpen,
+  path,
+}: {
+  waterfall: IWaterfall;
+  maxLevelOpen: number;
+  isOpen: boolean;
+  path: {
+    criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
+    showCriticalPath: boolean;
+  };
+}): IWaterfallNode | null {
+  const entry = waterfall.entryWaterfallTransaction;
+  if (!entry) {
+    return null;
+  }
+
+  const root: IWaterfallNode = {
+    id: entry.id,
+    item: entry,
+    children: [],
+    level: 0,
+    expanded: isOpen,
+    childrenToLoad: 0,
+    hasInitializedChildren: false,
+  };
+
+  return buildTree({ root, maxLevelOpen, waterfall, path });
+}
+
+export const convertTreeToList = (root: IWaterfallNode | null): IWaterfallNodeFlatten[] => {
+  if (!root) {
+    return [];
+  }
+
+  const result: IWaterfallNodeFlatten[] = [];
+  const stack: IWaterfallNode[] = [root];
+
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+
+    const { children, ...nodeWithoutChildren } = node;
+    result.push(nodeWithoutChildren);
+
+    if (node.expanded) {
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        stack.push(node.children[i]);
+      }
+    }
+  }
+
+  return result;
+};
+
+export function treeToASCII(root: IWaterfallNode): string {
+  let output = '';
+  const stack: Array<{ node: IWaterfallNode; prefix: string; isLast: boolean }> = [
+    { node: root, prefix: '', isLast: true },
+  ];
+
+  while (stack.length > 0) {
+    const { node, prefix, isLast } = stack.pop()!;
+
+    output += `${prefix}${isLast ? '└── ' : '├── '}${
+      node.item.docType === 'span' ? node.item.doc.span.name : node.item.doc.transaction.name
+    }`;
+
+    const requestType =
+      node.item.docType === 'transaction'
+        ? isRumAgentName(node.item.doc.agent.name)
+          ? 'HTTP Request'
+          : 'Async call'
+        : node.item.docType === 'span' && node.item.doc.span.type.startsWith('db')
+        ? 'DB operation'
+        : '';
+    if (requestType) {
+      output += ` --(${requestType})--`;
+    }
+
+    if (node.item.duration !== undefined) {
+      output += ` [${asDuration(node.item.duration)}]`;
+    }
+
+    output += '\n';
+
+    const childPrefix = prefix + (isLast ? '    ' : '│   ');
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      stack.push({
+        node: node.children[i],
+        prefix: childPrefix,
+        isLast: i === node.children.length - 1,
+      });
+    }
+  }
+
+  return output;
+}
+
+export const updateTraceTreeNode = ({
+  root,
+  updatedNode,
+  waterfall,
+  path,
+}: {
+  root: IWaterfallNode;
+  updatedNode: IWaterfallNodeFlatten;
+  waterfall: IWaterfall;
+  path: {
+    criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
+    showCriticalPath: boolean;
+  };
+}) => {
+  if (!root) {
+    return;
+  }
+
+  const tree = { ...root };
+  const stack: Array<{ parent: IWaterfallNode | null; index: number; node: IWaterfallNode }> = [
+    { parent: null, index: 0, node: root },
+  ];
+
+  while (stack.length > 0) {
+    const { parent, index, node } = stack.pop()!;
+
+    if (node.id === updatedNode.id) {
+      Object.assign(node, updatedNode);
+
+      if (updatedNode.expanded && !updatedNode.hasInitializedChildren) {
+        Object.assign(
+          node,
+          buildTree({
+            root: node,
+            waterfall,
+            maxLevelOpen: node.level + 1, // Only one level above the current node will be loaded
+            path,
+          })
+        );
+      }
+
+      if (parent) {
+        parent.children[index] = node;
+      } else {
+        Object.assign(tree, node);
+      }
+
+      return tree;
+    }
+
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      stack.push({ parent: node, index: i, node: node.children[i] });
+    }
+  }
+
+  return tree;
+};

--- a/x-pack/plugins/observability_solution/apm/public/assistant_functions/get_apm_trace_watefall.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/assistant_functions/get_apm_trace_watefall.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import {
+  RegisterRenderFunctionDefinition,
+  RenderFunction,
+} from '@kbn/observability-ai-assistant-plugin/public/types';
+import { isEmpty } from 'lodash';
+import { getWaterfall } from '../../common/waterfall/waterfall_helpers';
+import type {
+  GetApmTraceWaterfallFunctionArguments,
+  GetApmTraceWaterfallFunctionResponse,
+} from '../../server/assistant_functions/get_apm_trace_waterfall';
+import { ResettingHeightRetainer } from '../components/shared/height_retainer/resetting_height_container';
+import { ApmThemeProvider } from '../components/routing/app_root';
+import { WaterfallContent } from '../components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_content';
+
+export function registerGetApmTraceWaterfallFunction({
+  registerRenderFunction,
+}: {
+  registerRenderFunction: RegisterRenderFunctionDefinition;
+}) {
+  registerRenderFunction('get_apm_trace_waterfall', (parameters) => {
+    const { response } = parameters as Parameters<
+      RenderFunction<GetApmTraceWaterfallFunctionArguments, GetApmTraceWaterfallFunctionResponse>
+    >[0];
+
+    if (!response.data || isEmpty(response.data)) {
+      return null;
+    }
+
+    const waterfall = getWaterfall(response.data);
+
+    return (
+      <ApmThemeProvider>
+        <ResettingHeightRetainer reset>
+          <WaterfallContent
+            waterfall={waterfall}
+            scrollElement={parameters.scrollElement}
+            serviceName={waterfall.entryWaterfallTransaction?.doc.service.name}
+            showCriticalPath={false}
+            showRelatedErrors={false}
+            stickyHeader={false}
+          />
+        </ResettingHeightRetainer>
+      </ApmThemeProvider>
+    );
+  });
+}

--- a/x-pack/plugins/observability_solution/apm/public/assistant_functions/index.ts
+++ b/x-pack/plugins/observability_solution/apm/public/assistant_functions/index.ts
@@ -7,6 +7,7 @@
 
 import { RegisterRenderFunctionDefinition } from '@kbn/observability-ai-assistant-plugin/public/types';
 import { registerGetApmTimeseriesFunction } from './get_apm_timeseries';
+import { registerGetApmTraceWaterfallFunction } from './get_apm_trace_watefall';
 
 export async function registerAssistantFunctions({
   registerRenderFunction,
@@ -14,6 +15,9 @@ export async function registerAssistantFunctions({
   registerRenderFunction: RegisterRenderFunctionDefinition;
 }) {
   registerGetApmTimeseriesFunction({
+    registerRenderFunction,
+  });
+  registerGetApmTraceWaterfallFunction({
     registerRenderFunction,
   });
 }

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
@@ -30,6 +30,7 @@ import {
 import { WaterfallItem } from './waterfall_item';
 import { WaterfallContextProvider } from './context/waterfall_context';
 import { useWaterfallContext } from './context/use_waterfall';
+import { TraceMap } from './trace_map';
 
 interface AccordionWaterfallProps {
   isOpen: boolean;
@@ -102,6 +103,7 @@ export function AccordionWaterfall({
       isOpen={isOpen}
     >
       <Waterfall {...props} />
+      <TraceMap />
     </WaterfallContextProvider>
   );
 }

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/context/waterfall_context.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/context/waterfall_context.tsx
@@ -30,6 +30,7 @@ export const WaterfallContext = React.createContext<
     criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
     showCriticalPath: boolean;
     traceList: IWaterfallNodeFlatten[];
+    tree: IWaterfallNode | null;
     totalDuration: number;
     getErrorCount: (waterfallItemId: string) => number;
     updateTreeNode: (newTree: IWaterfallNodeFlatten) => void;
@@ -38,6 +39,7 @@ export const WaterfallContext = React.createContext<
   criticalPathSegmentsById: {} as Dictionary<CriticalPathSegment[]>,
   showCriticalPath: false,
   traceList: [],
+  tree: null,
   totalDuration: 0,
   getErrorCount: () => 0,
   updateTreeNode: () => undefined,
@@ -107,6 +109,7 @@ export function WaterfallContextProvider({
   return (
     <WaterfallContext.Provider
       value={{
+        tree,
         showCriticalPath,
         criticalPathSegmentsById,
         getErrorCount,

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/context/waterfall_context.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/context/waterfall_context.tsx
@@ -30,6 +30,7 @@ export const WaterfallContext = React.createContext<
     criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
     showCriticalPath: boolean;
     traceList: IWaterfallNodeFlatten[];
+    totalDuration: number;
     getErrorCount: (waterfallItemId: string) => number;
     updateTreeNode: (newTree: IWaterfallNodeFlatten) => void;
   } & Pick<WaterfallContextProps, 'showCriticalPath'>
@@ -37,6 +38,7 @@ export const WaterfallContext = React.createContext<
   criticalPathSegmentsById: {} as Dictionary<CriticalPathSegment[]>,
   showCriticalPath: false,
   traceList: [],
+  totalDuration: 0,
   getErrorCount: () => 0,
   updateTreeNode: () => undefined,
 });
@@ -63,7 +65,7 @@ export function WaterfallContextProvider({
   }, [tree]);
 
   const getErrorCount = useCallback(
-    (waterfallItemId) => waterfall.getErrorCount(waterfallItemId),
+    (waterfallItemId) => waterfall.getErrorCount?.(waterfallItemId),
     [waterfall]
   );
 
@@ -110,6 +112,7 @@ export function WaterfallContextProvider({
         getErrorCount,
         traceList,
         updateTreeNode,
+        totalDuration: waterfall.duration,
       }}
     >
       {children}

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/trace_map.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/trace_map.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import cytoscape from 'cytoscape';
+import dagre from 'cytoscape-dagre';
+import { isEqual } from 'lodash';
+import React, {
+  createContext,
+  CSSProperties,
+  memo,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useTraceExplorerEnabledSetting } from '../../../../../../hooks/use_trace_explorer_enabled_setting';
+import { useTheme } from '../../../../../../hooks/use_theme';
+import { getCytoscapeOptions } from '../../../../service_map/cytoscape_options';
+import { useCytoscapeEventHandlers } from '../../../../service_map/use_cytoscape_event_handlers';
+import { useWaterfallContext } from './context/use_waterfall';
+import type { IWaterfallNode } from './waterfall_helpers/waterfall_helpers';
+import { useRefDimensions } from '../../../../service_map/use_ref_dimensions';
+
+cytoscape.use(dagre);
+
+export const convertTreeToCytoscapeElements = (
+  root: IWaterfallNode | null
+): cytoscape.ElementDefinition[] => {
+  if (!root) {
+    return [];
+  }
+
+  const result: cytoscape.ElementDefinition[] = [];
+  const stack: Array<{
+    source: string | undefined;
+    node: IWaterfallNode;
+  }> = [{ source: root.item.doc.parent?.id, node: root }];
+
+  while (stack.length > 0) {
+    const { node, source } = stack.pop()!;
+
+    const { children } = node;
+
+    const label =
+      node.item.docType === 'span' ? node.item.doc.span.name : node.item.doc.transaction.name;
+
+    result.push({
+      data: {
+        id: node.id,
+        label,
+      },
+    });
+
+    if (node.expanded) {
+      for (let i = children.length - 1; i >= 0; i--) {
+        result.push({
+          data: {
+            id: `${node.id}~${children[i].id}`,
+            label,
+            source: node.id,
+            target: children[i].id,
+          },
+        });
+
+        stack.push({ node: children[i], source: node.id });
+      }
+    }
+  }
+
+  return result;
+};
+
+export const CytoscapeContext = createContext<cytoscape.Core | undefined>(undefined);
+
+export interface CytoscapeProps {
+  children?: ReactNode;
+  elements: cytoscape.ElementDefinition[];
+  height: number;
+  style?: CSSProperties;
+}
+
+function useCytoscape(options: cytoscape.CytoscapeOptions) {
+  const [cy, setCy] = useState<cytoscape.Core | undefined>(undefined);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!cy) {
+      setCy(
+        cytoscape({
+          ...options,
+          container: ref.current,
+        })
+      );
+    }
+  }, [options, cy]);
+
+  // Destroy the cytoscape instance on unmount
+  useEffect(() => {
+    return () => {
+      if (cy) {
+        cy.destroy();
+      }
+    };
+  }, [cy]);
+
+  return [ref, cy] as [React.MutableRefObject<any>, cytoscape.Core | undefined];
+}
+
+function CytoscapeComponent({ children, elements, height, style }: CytoscapeProps) {
+  const theme = useTheme();
+  const isTraceExplorerEnabled = useTraceExplorerEnabledSetting();
+  const [ref, cy] = useCytoscape({
+    ...getCytoscapeOptions(theme, isTraceExplorerEnabled),
+    elements,
+  });
+  useCytoscapeEventHandlers({ cy, serviceName: undefined, theme });
+
+  // Add items from the elements prop to the cytoscape collection and remove
+  // items that no longer are in the list, then trigger an event to notify
+  // the handlers that data has changed.
+  useEffect(() => {
+    if (cy && elements.length > 0) {
+      // We do a fit if we're going from 0 to >0 elements
+      const fit = cy.elements().length === 0;
+
+      cy.add(elements);
+      // Remove any old elements that don't exist in the new set of elements.
+      const elementIds = elements.map((element) => element.data.id);
+      cy.elements().forEach((element) => {
+        if (!elementIds.includes(element.data('id'))) {
+          cy.remove(element);
+        } else {
+          // Doing an "add" with an element with the same id will keep the original
+          // element. Set the data with the new element data.
+          const newElement = elements.find((el) => el.data.id === element.id());
+          element.data(newElement?.data ?? element.data());
+        }
+      });
+      cy.trigger('custom:data', [fit]);
+    }
+  }, [cy, elements]);
+
+  // Add the height to the div style. The height is a separate prop because it
+  // is required and can trigger rendering when changed.
+  const divStyle = { ...style, height };
+
+  return (
+    <CytoscapeContext.Provider value={cy}>
+      <div ref={ref} style={divStyle}>
+        {children}
+      </div>
+    </CytoscapeContext.Provider>
+  );
+}
+
+const Cytoscape = memo(CytoscapeComponent, (prevProps, nextProps) => {
+  const prevElementIds = prevProps.elements.map((element) => element.data.id).sort();
+  const nextElementIds = nextProps.elements.map((element) => element.data.id).sort();
+
+  const propsAreEqual =
+    prevProps.height === nextProps.height &&
+    isEqual(prevProps.style, nextProps.style) &&
+    isEqual(prevElementIds, nextElementIds);
+
+  return propsAreEqual;
+});
+
+export function TraceMap() {
+  const { ref, height } = useRefDimensions();
+  const [elements, setElements] = useState<cytoscape.ElementDefinition[]>([]);
+  const { tree } = useWaterfallContext();
+  useEffect(() => {
+    setElements(convertTreeToCytoscapeElements(tree));
+  }, [tree]);
+
+  const PADDING_BOTTOM = 24;
+  const heightWithPadding = height - PADDING_BOTTOM;
+
+  return (
+    <div style={{ height: heightWithPadding }} ref={ref}>
+      <Cytoscape elements={elements} height={heightWithPadding} style={{}} />
+    </div>
+  );
+}

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -549,7 +549,6 @@ function buildTree({
 
   return tree;
 }
-
 export function buildTraceTree({
   waterfall,
   maxLevelOpen,
@@ -597,8 +596,8 @@ export const convertTreeToList = (root: IWaterfallNode | null): IWaterfallNodeFl
     result.push(nodeWithoutChildren);
 
     if (node.expanded) {
-      for (let i = node.children.length - 1; i >= 0; i--) {
-        stack.push(node.children[i]);
+      for (let i = children.length - 1; i >= 0; i--) {
+        stack.push(children[i]);
       }
     }
   }

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
@@ -114,6 +114,7 @@ interface IWaterfallItemProps {
   isSelected: boolean;
   errorCount: number;
   marginLeftLevel: number;
+  showRelatedErrors?: boolean;
   segments?: Array<{
     id: string;
     left: number;
@@ -223,6 +224,7 @@ export function WaterfallItem({
   marginLeftLevel,
   onClick,
   segments,
+  showRelatedErrors = true,
 }: IWaterfallItemProps) {
   const [widthFactor, setWidthFactor] = useState(1);
   const waterfallItemRef: React.RefObject<any> = useRef(null);
@@ -287,7 +289,7 @@ export function WaterfallItem({
         <NameLabel item={item} />
 
         <Duration item={item} />
-        <RelatedErrors item={item} errorCount={errorCount} />
+        {showRelatedErrors && <RelatedErrors item={item} errorCount={errorCount} />}
         {item.docType === 'span' && (
           <SyncBadge sync={item.doc.span.sync} agentName={item.doc.agent.name} />
         )}

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_content.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_content.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { keyBy } from 'lodash';
+import { Waterfall } from './waterfall';
+import {
+  IWaterfall,
+  WaterfallLegendType,
+  IWaterfallItem,
+} from './waterfall/waterfall_helpers/waterfall_helpers';
+import { WaterfallLegends } from './waterfall_legends';
+import { OrphanTraceItemsWarning } from './waterfall/orphan_trace_items_warning';
+
+interface Props {
+  waterfallItemId?: string;
+  serviceName?: string;
+  waterfall: IWaterfall;
+  showCriticalPath: boolean;
+  // when rendering in a container, this should be the element that should be scrolled
+  scrollElement?: React.RefObject<HTMLDivElement>;
+  showRelatedErrors?: boolean;
+  stickyHeader?: boolean;
+  onClickWaterfallItem?: (item: IWaterfallItem, flyoutDetailTab: string) => void;
+}
+
+export function WaterfallContent({
+  serviceName,
+  waterfallItemId,
+  waterfall,
+  showCriticalPath,
+  scrollElement,
+  showRelatedErrors = true,
+  stickyHeader = true,
+  onClickWaterfallItem,
+}: Props) {
+  if (!waterfall) {
+    return null;
+  }
+  const { legends, items, orphanTraceItemsCount } = waterfall;
+
+  // Service colors are needed to color the dot in the error popover
+  const serviceLegends = legends.filter(({ type }) => type === WaterfallLegendType.ServiceName);
+  const serviceColors = serviceLegends.reduce((colorMap, legend) => {
+    return {
+      ...colorMap,
+      [legend.value!]: legend.color,
+    };
+  }, {} as Record<string, string>);
+
+  // only color by span type if there are only events for one service
+  const colorBy =
+    serviceLegends.length > 1 ? WaterfallLegendType.ServiceName : WaterfallLegendType.SpanType;
+
+  const displayedLegends = legends.filter((legend) => legend.type === colorBy);
+
+  const legendsByValue = keyBy(displayedLegends, 'value');
+
+  // mutate items rather than rebuilding both items and childrenByParentId
+  items.forEach((item) => {
+    let color = '';
+    if ('legendValues' in item) {
+      color = legendsByValue[item.legendValues[colorBy]].color;
+    }
+
+    if (!color) {
+      // fall back to service color if there's no span.type, e.g. for transactions
+      color = serviceColors[item.doc.service.name];
+    }
+
+    item.color = color;
+  });
+
+  // default to serviceName if value is empty, e.g. for transactions (which don't
+  // have span.type or span.subtype)
+  const legendsWithFallbackLabel = displayedLegends.map((legend) => {
+    return { ...legend, value: !legend.value ? serviceName : legend.value };
+  });
+
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <WaterfallLegends legends={legendsWithFallbackLabel} type={colorBy} />
+          </EuiFlexItem>
+          {orphanTraceItemsCount > 0 ? (
+            <EuiFlexItem grow={false}>
+              <OrphanTraceItemsWarning orphanTraceItemsCount={orphanTraceItemsCount} />
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <Waterfall
+          showCriticalPath={showCriticalPath}
+          waterfallItemId={waterfallItemId}
+          waterfall={waterfall}
+          scrollElement={scrollElement}
+          onClickWaterfallItem={onClickWaterfallItem}
+          showRelatedErrors={showRelatedErrors}
+          stickyHeader={stickyHeader}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/plugins/observability_solution/apm/server/assistant_functions/get_apm_trace_waterfall.ts
+++ b/x-pack/plugins/observability_solution/apm/server/assistant_functions/get_apm_trace_waterfall.ts
@@ -111,10 +111,9 @@ export function registerGetApmTraceWaterfallFunction({
   registerFunction(
     {
       name: 'get_apm_trace_waterfall',
-      description: `Use this function to show a trace visualization for any services, transactions, or trace IDs.
-        Users DO NOT need to see an ASCII representation of the trace nor the listed sequence of events.
-        Your ONLY job is to analyze the entire data and provide valuable insights of potential areas of improvements.
-        DO NOT UNDER ANY CIRCUMSTANCES display or render an ASCII trace waterfall, any ASCII visual representations, any code blocks, nor the listed sequence of operations in your response.
+      description: `Use this function to show a visualization of distributed traces for any services, transactions, or trace IDs.
+        Your ONLY job is to analyze the entire data and provide insights.
+        Users DO NOT need to see an ASCII representation of the trace. DO NOT UNDER ANY CIRCUMSTANCES display or render an ASCII trace waterfall, any ASCII visual representations, nor the listed sequence of operations in your response.
      `,
       parameters,
       // deprecated

--- a/x-pack/plugins/observability_solution/apm/server/assistant_functions/get_apm_trace_waterfall.ts
+++ b/x-pack/plugins/observability_solution/apm/server/assistant_functions/get_apm_trace_waterfall.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { FromSchema } from 'json-schema-to-ts';
+import { FunctionVisibility } from '@kbn/observability-ai-assistant-plugin/common';
+import type { Logger } from '@kbn/logging';
+import { Environment } from '../../common/environment_rt';
+import { FunctionRegistrationParameters } from '.';
+import type { APMConfig } from '..';
+import {
+  type ApmTraceWaterfall,
+  getApmTraceWaterfall,
+} from '../routes/assistant_functions/get_apm_trace_waterfall';
+
+const parameters = {
+  type: 'object',
+  properties: {
+    start: {
+      type: 'string',
+      description: 'The start of the time range, in Elasticsearch date math, like `now-24h`.',
+    },
+    end: {
+      type: 'string',
+      description: 'The end of the time range, in Elasticsearch date math, like `now`.',
+    },
+    'service.environment': {
+      type: 'string',
+      description:
+        'The environment that the service is running in. Leave empty to query for all environments.',
+    },
+    filter: {
+      type: 'string',
+      description:
+        'a KQL query to filter the data by. If no filter should be applied, leave it empty.',
+    },
+    // traceParams: {
+    //   description: 'The filter to be applied',
+    //   oneOf: [
+    //     {
+    //       type: 'object',
+    //       properties: {
+    //         'service.name': {
+    //           type: 'string',
+    //           description: 'The name of the service',
+    //         },
+    //       },
+    //       required: ['service.name'],
+    //     },
+    //     {
+    //       type: 'object',
+    //       properties: {
+    //         traceId: {
+    //           type: 'string',
+    //           description: 'The trace ID',
+    //         },
+    //       },
+    //       required: ['traceId'],
+    //     },
+    //     {
+    //       type: 'object',
+    //       properties: {
+    //         transactionId: {
+    //           type: 'string',
+    //           description: 'The transaction ID',
+    //         },
+    //       },
+    //       required: ['transactionId'],
+    //     },
+    //     {
+    //       type: 'object',
+    //       properties: {
+    //         transactionName: {
+    //           type: 'string',
+    //           description: 'The transaction name',
+    //         },
+    //       },
+    //       required: ['transactionName'],
+    //     },
+    //     {
+    //       type: 'object',
+    //       properties: {
+    //         filter: {
+    //           type: 'string',
+    //           description:
+    //             'a KQL query to filter the data by. If no filter should be applied, leave it empty.',
+    //         },
+
+    //         required: ['filter'],
+    //       },
+    //     },
+    //   ],
+    // },
+  },
+  required: ['start', 'end', 'filter'],
+} as const;
+
+interface TraceWaterfallFunctionRegistrationParams extends FunctionRegistrationParameters {
+  logger: Logger;
+  config: APMConfig;
+}
+
+export function registerGetApmTraceWaterfallFunction({
+  apmEventClient,
+  logger,
+  config,
+  registerFunction,
+}: TraceWaterfallFunctionRegistrationParams) {
+  registerFunction(
+    {
+      name: 'get_apm_trace_waterfall',
+      description: `Use this function to show a trace visualization for any services, transactions, or trace IDs.
+        Users DO NOT need to see an ASCII representation of the trace nor the listed sequence of events.
+        Your ONLY job is to analyze the entire data and provide valuable insights of potential areas of improvements.
+        DO NOT UNDER ANY CIRCUMSTANCES display or render an ASCII trace waterfall, any ASCII visual representations, any code blocks, nor the listed sequence of operations in your response.
+     `,
+      parameters,
+      // deprecated
+      visibility: FunctionVisibility.AssistantOnly,
+    },
+    async ({ arguments: args }, signal): Promise<GetApmTraceWaterfallFunctionResponse> => {
+      const waterfall = await getApmTraceWaterfall({
+        apmEventClient,
+        logger,
+        config,
+        arguments: {
+          ...args,
+          'service.environment': args['service.environment'] as Environment | undefined,
+        },
+      });
+
+      return {
+        content: {
+          start: waterfall.start,
+          end: waterfall.end,
+          ascii: waterfall.ascii,
+        },
+        data: waterfall.data,
+      };
+    }
+  );
+}
+
+export type GetApmTraceWaterfallFunctionArguments = FromSchema<typeof parameters>;
+export interface GetApmTraceWaterfallFunctionResponse {
+  content: Omit<ApmTraceWaterfall, 'data' | 'environment'> & { ascii: string };
+  data: ApmTraceWaterfall['data'];
+}

--- a/x-pack/plugins/observability_solution/apm/server/assistant_functions/get_apm_trace_waterfall.ts
+++ b/x-pack/plugins/observability_solution/apm/server/assistant_functions/get_apm_trace_waterfall.ts
@@ -112,8 +112,8 @@ export function registerGetApmTraceWaterfallFunction({
     {
       name: 'get_apm_trace_waterfall',
       description: `Use this function to show a visualization of distributed traces for any services, transactions, or trace IDs.
-        Your ONLY job is to analyze the entire data and provide insights.
-        Users DO NOT need to see an ASCII representation of the trace. DO NOT UNDER ANY CIRCUMSTANCES display or render an ASCII trace waterfall, any ASCII visual representations, nor the listed sequence of operations in your response.
+        Your ONLY job is to analyze the entire content and provide insights of bottlenecks and points that require attention.
+        IMPORTANT: Users DO NOT need to see an ASCII representation of the trace. DO NOT UNDER ANY CIRCUMSTANCES display or render an ASCII trace waterfall, any ASCII visual representations, any code blocks, nor the listed sequence of operations in your response.
      `,
       parameters,
       // deprecated

--- a/x-pack/plugins/observability_solution/apm/server/assistant_functions/index.ts
+++ b/x-pack/plugins/observability_solution/apm/server/assistant_functions/index.ts
@@ -25,6 +25,7 @@ import { hasHistoricalAgentData } from '../routes/historical_data/has_historical
 import { registerGetApmDatasetInfoFunction } from './get_apm_dataset_info';
 import { registerGetApmDownstreamDependenciesFunction } from './get_apm_downstream_dependencies';
 import { registerGetApmTimeseriesFunction } from './get_apm_timeseries';
+import { registerGetApmTraceWaterfallFunction } from './get_apm_trace_waterfall';
 
 export interface FunctionRegistrationParameters {
   apmEventClient: APMEventClient;
@@ -101,6 +102,7 @@ export function registerAssistantFunctions({
 
     registerGetApmDownstreamDependenciesFunction({ ...parameters, randomSampler });
     registerGetApmTimeseriesFunction(parameters);
+    registerGetApmTraceWaterfallFunction({ ...parameters, config, logger });
     registerGetApmDatasetInfoFunction(parameters);
   };
 }

--- a/x-pack/plugins/observability_solution/apm/server/routes/assistant_functions/get_apm_trace_waterfall/index.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/assistant_functions/get_apm_trace_waterfall/index.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import datemath from '@elastic/datemath';
+import * as t from 'io-ts';
+import type { Logger } from '@kbn/logging';
+import { Transaction } from '../../../../typings/es_schemas/ui/transaction';
+import {
+  buildTraceTree,
+  getWaterfall,
+  treeToASCII,
+} from '../../../../common/waterfall/waterfall_helpers';
+import type { APMConfig } from '../../..';
+import { TraceSearchType } from '../../../../common/trace_explorer';
+import { Environment, environmentStringRt } from '../../../../common/environment_rt';
+import { ENVIRONMENT_ALL } from '../../../../common/environment_filter_values';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { getTraceSamplesByQuery } from '../../traces/get_trace_samples_by_query';
+import { getTraceItems, type TraceItems } from '../../traces/get_trace_items';
+import { getTransaction } from '../../transactions/get_transaction';
+
+export const getApmTracesRt = t.intersection([
+  t.type({
+    start: t.string,
+    end: t.string,
+  }),
+  t.partial({
+    filter: t.string,
+    'service.environment': environmentStringRt,
+  }),
+]);
+
+export interface ApmTraceWaterfall {
+  start: number;
+  end: number;
+  environment: Environment;
+  ascii: string;
+  data?: { traceItems: TraceItems; entryTransaction?: Transaction };
+}
+
+export async function getApmTraceWaterfall({
+  arguments: args,
+  apmEventClient,
+  config,
+  logger,
+}: {
+  arguments: t.TypeOf<typeof getApmTracesRt>;
+  apmEventClient: APMEventClient;
+  config: APMConfig;
+  logger: Logger;
+}): Promise<ApmTraceWaterfall> {
+  const start = datemath.parse(args.start)!.valueOf();
+  const end = datemath.parse(args.end)!.valueOf();
+  const environment = args['service.environment'] ?? ENVIRONMENT_ALL.value;
+
+  const traceSamples = await getTraceSamplesByQuery({
+    apmEventClient,
+    start,
+    end,
+    environment,
+    query: args.filter ?? '',
+    type: TraceSearchType.kql,
+  });
+
+  if (traceSamples.length === 0) {
+    return {
+      start,
+      end,
+      environment,
+      ascii: '',
+      data: undefined,
+    };
+  }
+
+  const [traceItems, entryTransaction] = await Promise.all([
+    getTraceItems({
+      traceId: traceSamples[0].traceId,
+      config,
+      apmEventClient,
+      start,
+      end,
+      logger,
+    }),
+    getTransaction({
+      transactionId: traceSamples[0].transactionId,
+      traceId: traceSamples[0].traceId,
+      apmEventClient,
+      start,
+      end,
+    }),
+  ]);
+
+  const waterfall = getWaterfall({ traceItems, entryTransaction });
+  const maxLevelOpen = waterfall.traceDocsTotal > 500 ? 2 : waterfall.traceDocsTotal;
+
+  // const criticalPath = getCriticalPath(waterfall);
+  // const criticalPathSegmentsById = groupBy(criticalPath.segments, (segment) => segment.item.id);
+
+  const tree = buildTraceTree({
+    waterfall,
+    maxLevelOpen,
+    isOpen: true,
+    path: {
+      criticalPathSegmentsById: {},
+      showCriticalPath: false,
+    },
+  });
+
+  return {
+    start,
+    end,
+    environment,
+    ascii: tree ? treeToASCII(tree) : '',
+    data: { traceItems, entryTransaction },
+  };
+}

--- a/x-pack/plugins/observability_solution/apm/server/routes/assistant_functions/route.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/assistant_functions/route.ts
@@ -9,13 +9,17 @@ import { omit } from 'lodash';
 import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
 import { getRandomSampler } from '../../lib/helpers/get_random_sampler';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
-
 import {
   downstreamDependenciesRouteRt,
   getAssistantDownstreamDependencies,
   type APMDownstreamDependency,
 } from './get_apm_downstream_dependencies';
 import { getApmTimeseries, getApmTimeseriesRt, type ApmTimeseries } from './get_apm_timeseries';
+import {
+  type ApmTraceWaterfall,
+  getApmTracesRt,
+  getApmTraceWaterfall,
+} from './get_apm_trace_waterfall';
 
 const getApmTimeSeriesRoute = createApmServerRoute({
   endpoint: 'POST /internal/apm/assistant/get_apm_timeseries',
@@ -78,7 +82,46 @@ const getDownstreamDependenciesRoute = createApmServerRoute({
   },
 });
 
+const getApmTraceWatefallRoute = createApmServerRoute({
+  endpoint: 'GET /internal/apm/assistant/get_apm_trace_waterfall',
+  options: {
+    tags: ['access:apm', 'access:ai_assistant'],
+  },
+  params: t.type({
+    query: getApmTracesRt,
+  }),
+  handler: async (
+    resources
+  ): Promise<{
+    content: Omit<ApmTraceWaterfall, 'data'>;
+    data: ApmTraceWaterfall['data'];
+  }> => {
+    const { config, logger } = resources;
+    const { query } = resources.params;
+
+    const apmEventClient = await getApmEventClient(resources);
+
+    const waterfall = await getApmTraceWaterfall({
+      apmEventClient,
+      arguments: query,
+      config,
+      logger,
+    });
+
+    return {
+      content: {
+        environment: waterfall.environment,
+        start: waterfall.start,
+        end: waterfall.end,
+        ascii: waterfall.ascii,
+      },
+      data: waterfall.data,
+    };
+  },
+});
+
 export const assistantRouteRepository = {
   ...getApmTimeSeriesRoute,
   ...getDownstreamDependenciesRoute,
+  ...getApmTraceWatefallRoute,
 };

--- a/x-pack/plugins/observability_solution/infra/public/components/lens/lens_wrapper.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/lens/lens_wrapper.tsx
@@ -117,6 +117,12 @@ export const LensWrapper = ({
               query={state.query}
               timeRange={dateRange}
               viewMode={ViewMode.VIEW}
+              executionContext={{
+                id: props.id,
+                type: 'lens',
+                name: `test-kibana-test-${props.id}`,
+                description: 'test-kibana-test',
+              }}
             />
           </>
         )}

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/public/service/create_chat_service.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/public/service/create_chat_service.ts
@@ -244,7 +244,7 @@ export async function createChatService({
     sendAnalyticsEvent: (event) => {
       sendEvent(analytics, event);
     },
-    renderFunction: (name, args, response, onActionClick) => {
+    renderFunction: (name, args, response, onActionClick, scrollElement) => {
       const fn = renderFunctionRegistry.get(name);
 
       if (!fn) {
@@ -262,6 +262,7 @@ export async function createChatService({
         response: parsedResponse,
         arguments: parsedArguments,
         onActionClick,
+        scrollElement,
       });
     },
     getFunctions,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/public/types.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/public/types.ts
@@ -78,7 +78,8 @@ export interface ObservabilityAIAssistantChatService {
     name: string,
     args: string | undefined,
     response: { data?: string; content?: string },
-    onActionClick: ChatActionClickHandler
+    onActionClick: ChatActionClickHandler,
+    scrollElement?: React.RefObject<HTMLDivElement>
   ) => React.ReactNode;
 }
 
@@ -101,6 +102,7 @@ export interface ObservabilityAIAssistantService {
 export type RenderFunction<TArguments, TResponse extends FunctionResponse> = (options: {
   arguments: TArguments;
   response: TResponse;
+  scrollElement?: React.RefObject<HTMLDivElement>;
   onActionClick: ChatActionClickHandler;
 }) => React.ReactNode;
 

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_body.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_body.tsx
@@ -141,6 +141,7 @@ export function ChatBody({
   });
 
   const timelineContainerRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   let footer: React.ReactNode;
 
@@ -195,7 +196,7 @@ export function ChatBody({
   }, []);
 
   useEffect(() => {
-    const parent = timelineContainerRef.current?.parentElement;
+    const parent = scrollRef.current;
     if (!parent) {
       return;
     }
@@ -210,10 +211,10 @@ export function ChatBody({
       parent.removeEventListener('scroll', onScroll);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timelineContainerRef.current]);
+  }, [timelineContainerRef.current, scrollRef.current]);
 
   useEffect(() => {
-    const parent = timelineContainerRef.current?.parentElement;
+    const parent = scrollRef.current;
     if (!parent) {
       return;
     }
@@ -335,7 +336,7 @@ export function ChatBody({
   } else {
     footer = (
       <>
-        <EuiFlexItem grow className={timelineClassName(scrollBarStyles)}>
+        <EuiFlexItem grow className={timelineClassName(scrollBarStyles)} ref={scrollRef}>
           <div ref={timelineContainerRef} className={fullHeightClassName}>
             <EuiPanel
               grow
@@ -381,6 +382,7 @@ export function ChatBody({
                   }
                   onStopGenerating={stop}
                   onActionClick={handleActionClick}
+                  scrollElement={scrollRef}
                 />
               )}
             </EuiPanel>

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_timeline.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/chat/chat_timeline.tsx
@@ -52,6 +52,7 @@ export interface ChatTimelineProps {
   hasConnector: boolean;
   chatState: ChatState;
   currentUser?: Pick<AuthenticatedUser, 'full_name' | 'username'>;
+  scrollElement?: React.RefObject<HTMLDivElement>;
   onEdit: (message: Message, messageAfterEdit: Message) => void;
   onFeedback: (message: Message, feedback: Feedback) => void;
   onRegenerate: (message: Message) => void;
@@ -71,6 +72,7 @@ export function ChatTimeline({
   chatService,
   hasConnector,
   currentUser,
+  scrollElement,
   onEdit,
   onFeedback,
   onRegenerate,
@@ -87,6 +89,7 @@ export function ChatTimeline({
       currentUser,
       chatState,
       onActionClick,
+      scrollElement,
     });
 
     const consolidatedChatItems: Array<ChatTimelineItem | ChatTimelineItem[]> = [];
@@ -109,7 +112,7 @@ export function ChatTimeline({
     }
 
     return consolidatedChatItems;
-  }, [chatService, hasConnector, messages, currentUser, chatState, onActionClick]);
+  }, [chatService, hasConnector, messages, currentUser, chatState, onActionClick, scrollElement]);
 
   return (
     <EuiCommentList

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/render_function.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/components/render_function.tsx
@@ -15,6 +15,7 @@ interface Props {
   name: string;
   arguments: string | undefined;
   response: Message['message'];
+  scrollElement?: React.RefObject<HTMLDivElement>;
   onActionClick: ChatActionClickHandler;
 }
 
@@ -22,7 +23,13 @@ export function RenderFunction(props: Props) {
   const chatService = useObservabilityAIAssistantChatService();
   return (
     <>
-      {chatService.renderFunction(props.name, props.arguments, props.response, props.onActionClick)}
+      {chatService.renderFunction(
+        props.name,
+        props.arguments,
+        props.response,
+        props.onActionClick,
+        props.scrollElement
+      )}
     </>
   );
 }

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/utils/get_timeline_items_from_conversation.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/utils/get_timeline_items_from_conversation.tsx
@@ -65,6 +65,7 @@ export function getTimelineItemsfromConversation({
   hasConnector,
   messages,
   chatState,
+  scrollElement,
   onActionClick,
 }: {
   chatService: ObservabilityAIAssistantChatService;
@@ -72,6 +73,7 @@ export function getTimelineItemsfromConversation({
   hasConnector: boolean;
   messages: Message[];
   chatState: ChatState;
+  scrollElement?: React.RefObject<HTMLDivElement>;
   onActionClick: ({
     message,
     payload,
@@ -170,6 +172,7 @@ export function getTimelineItemsfromConversation({
                 <RenderFunction
                   name={message.message.name}
                   arguments={prevFunctionCall?.arguments}
+                  scrollElement={scrollElement}
                   response={message.message}
                   onActionClick={(payload) => {
                     onActionClick({ message, payload });


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
