### PR TITLE
[Onboarding] Fix failing Cypress tests

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
@@ -261,7 +261,9 @@ describe('[Logs onboarding] Custom logs - install elastic agent', () => {
           });
 
           it('shows a success callout when elastic agent status is healthy', () => {
-            cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+            cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+              agentId: 'test-agent-id',
+            });
             cy.getByTestSubj('obltOnboardingStepStatus-complete')
               .contains('Connected to the Elastic Agent')
               .should('exist');
@@ -299,7 +301,9 @@ describe('[Logs onboarding] Custom logs - install elastic agent', () => {
         cy.updateInstallationStepStatus(onboardingId, 'ea-download', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-extract', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-install', 'complete');
-        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+          agentId: 'test-agent-id',
+        });
       });
 
       it('shows loading callout when config is being downloaded to the host', () => {
@@ -340,7 +344,9 @@ describe('[Logs onboarding] Custom logs - install elastic agent', () => {
         cy.updateInstallationStepStatus(onboardingId, 'ea-download', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-extract', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-install', 'complete');
-        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+          agentId: 'test-agent-id',
+        });
       });
 
       it('shows loading callout when config is being downloaded to the host', () => {
@@ -424,7 +430,9 @@ describe('[Logs onboarding] Custom logs - install elastic agent', () => {
           cy.updateInstallationStepStatus(onboardingId, 'ea-download', 'complete');
           cy.updateInstallationStepStatus(onboardingId, 'ea-extract', 'complete');
           cy.updateInstallationStepStatus(onboardingId, 'ea-install', 'complete');
-          cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+          cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+            agentId: 'test-agent-id',
+          });
           cy.updateInstallationStepStatus(onboardingId, 'ea-config', 'complete');
         });
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
@@ -291,7 +291,9 @@ describe('[Logs onboarding] System logs', () => {
           });
 
           it('shows a success callout when elastic agent status is healthy', () => {
-            cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+            cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+              agentId: 'test-agent-id',
+            });
             cy.getByTestSubj('obltOnboardingStepStatus-complete')
               .contains('Connected to the Elastic Agent')
               .should('exist');
@@ -330,7 +332,9 @@ describe('[Logs onboarding] System logs', () => {
         cy.updateInstallationStepStatus(onboardingId, 'ea-download', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-extract', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-install', 'complete');
-        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+          agentId: 'test-agent-id',
+        });
       });
 
       it('shows loading callout when config is being downloaded to the host', () => {
@@ -371,7 +375,9 @@ describe('[Logs onboarding] System logs', () => {
         cy.updateInstallationStepStatus(onboardingId, 'ea-download', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-extract', 'complete');
         cy.updateInstallationStepStatus(onboardingId, 'ea-install', 'complete');
-        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+        cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+          agentId: 'test-agent-id',
+        });
       });
 
       it('shows loading callout when config is being downloaded to the host', () => {
@@ -456,7 +462,9 @@ describe('[Logs onboarding] System logs', () => {
           cy.updateInstallationStepStatus(onboardingId, 'ea-download', 'complete');
           cy.updateInstallationStepStatus(onboardingId, 'ea-extract', 'complete');
           cy.updateInstallationStepStatus(onboardingId, 'ea-install', 'complete');
-          cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete');
+          cy.updateInstallationStepStatus(onboardingId, 'ea-status', 'complete', {
+            agentId: 'test-agent-id',
+          });
           cy.updateInstallationStepStatus(onboardingId, 'ea-config', 'complete');
         });
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/support/commands.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/support/commands.ts
@@ -24,6 +24,10 @@ export type InstallationStepStatus =
   | 'danger'
   | 'current';
 
+export interface ElasticAgentStepPayload {
+  agentId: string;
+}
+
 Cypress.Commands.add('loginAsViewerUser', () => {
   return cy.loginAs({
     username: ObservabilityOnboardingUsername.viewerUser,
@@ -151,7 +155,12 @@ Cypress.Commands.add('deleteIntegration', (integrationName: string) => {
 
 Cypress.Commands.add(
   'updateInstallationStepStatus',
-  (onboardingId: string, step: InstallationStep, status: InstallationStepStatus) => {
+  (
+    onboardingId: string,
+    step: InstallationStep,
+    status: InstallationStepStatus,
+    payload: ElasticAgentStepPayload | undefined
+  ) => {
     const kibanaUrl = Cypress.env('KIBANA_URL');
 
     cy.log(onboardingId, step, status);
@@ -166,6 +175,7 @@ Cypress.Commands.add(
       auth: { user: 'editor', pass: 'changeme' },
       body: {
         status,
+        payload,
       },
     });
   }

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/support/types.d.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/support/types.d.ts
@@ -22,7 +22,8 @@ declare namespace Cypress {
     updateInstallationStepStatus(
       onboardingId: string,
       step: InstallationStep,
-      status: InstallationStepStatus
+      status: InstallationStepStatus,
+      payload?: ElasticAgentStepPayload
     ): void;
   }
 }


### PR DESCRIPTION
## Summary

Fixes [failng Cypress tests](https://buildkite.com/elastic/kibana-pull-request/builds/217616#01904f09-ffdb-4ef4-8cc4-84ed91834b25) by adding a payload with required `agentId` to 'ea-status': 'complete' progress step.

