### PR TITLE
[Security Solution][Notes] - add ability to link a note to a timeline, and show an icon to note to launch the timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
@@ -5,12 +5,21 @@
  * 2.0.
  */
 
+import * as uuid from 'uuid';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { createMockStore, mockGlobalState, TestProviders } from '../../../../common/mock';
 import { AddNote, CREATE_NOTE_ERROR } from './add_note';
-import { ADD_NOTE_BUTTON_TEST_ID, ADD_NOTE_MARKDOWN_TEST_ID } from './test_ids';
+import {
+  ADD_NOTE_BUTTON_TEST_ID,
+  ADD_NOTE_MARKDOWN_TEST_ID,
+  ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID,
+} from './test_ids';
 import { ReqStatus } from '../../../../notes/store/notes.slice';
+import { useIsTimelineFlyoutOpen } from '../../shared/hooks/use_is_timeline_flyout_open';
+import { TimelineId } from '../../../../../common/types';
+
+jest.mock('../../shared/hooks/use_is_timeline_flyout_open');
 
 const mockAddError = jest.fn();
 jest.mock('../../../../common/hooks/use_app_toasts', () => ({
@@ -97,5 +106,64 @@ describe('AddNote', () => {
     expect(mockAddError).toHaveBeenCalledWith(null, {
       title: CREATE_NOTE_ERROR,
     });
+  });
+
+  it('should disable attach to timeline checkbox if flyout is not open from timeline', () => {
+    (useIsTimelineFlyoutOpen as jest.Mock).mockReturnValue(false);
+
+    const { getByTestId } = renderAddNote();
+
+    expect(getByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).toHaveAttribute('disabled');
+  });
+
+  it('should disable attach to timeline checkbox if active timeline is not saved', () => {
+    (useIsTimelineFlyoutOpen as jest.Mock).mockReturnValue(true);
+
+    const store = createMockStore({
+      ...mockGlobalState,
+      timeline: {
+        ...mockGlobalState.timeline,
+        timelineById: {
+          ...mockGlobalState.timeline.timelineById,
+          [TimelineId.active]: {
+            ...mockGlobalState.timeline.timelineById[TimelineId.test],
+          },
+        },
+      },
+    });
+
+    const { getByTestId } = render(
+      <TestProviders store={store}>
+        <AddNote eventId={'event-id'} />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).toHaveAttribute('disabled');
+  });
+
+  it('should have attach to timeline checkbox enabled', () => {
+    (useIsTimelineFlyoutOpen as jest.Mock).mockReturnValue(true);
+
+    const store = createMockStore({
+      ...mockGlobalState,
+      timeline: {
+        ...mockGlobalState.timeline,
+        timelineById: {
+          ...mockGlobalState.timeline.timelineById,
+          [TimelineId.active]: {
+            ...mockGlobalState.timeline.timelineById[TimelineId.test],
+            savedObjectId: uuid.v4(),
+          },
+        },
+      },
+    });
+
+    const { getByTestId } = render(
+      <TestProviders store={store}>
+        <AddNote eventId={'event-id'} />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).not.toHaveAttribute('disabled');
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
@@ -50,6 +50,7 @@ describe('AddNote', () => {
 
     expect(getByTestId(ADD_NOTE_MARKDOWN_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(ADD_NOTE_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).toBeInTheDocument();
   });
 
   it('should create note', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -64,8 +64,7 @@ export const ATTACH_TO_TIMELINE_CHECKBOX = i18n.translate(
 export const ATTACH_TO_TIMELINE_INFO = i18n.translate(
   'xpack.securitySolution.notes.attachToTimelineInfoLabel',
   {
-    defaultMessage:
-      'The active timeline must be saved before a note can be associated with it',
+    defaultMessage: 'The active timeline must be saved before a note can be associated with it',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -100,14 +100,14 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
     dispatch(
       createNote({
         note: {
-          timelineId: (checked && activeTimeline.savedObjectId) || '',
+          timelineId: (checked && activeTimeline?.savedObjectId) || '',
           eventId,
           note: editorValue,
         },
       })
     );
     setEditorValue('');
-  }, [activeTimeline.savedObjectId, checked, dispatch, editorValue, eventId]);
+  }, [activeTimeline?.savedObjectId, checked, dispatch, editorValue, eventId]);
 
   // show a toast if the create note call fails
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -65,7 +65,7 @@ export const ATTACH_TO_TIMELINE_INFO = i18n.translate(
   'xpack.securitySolution.notes.attachToTimelineInfoLabel',
   {
     defaultMessage:
-      'If you want to create a note associated to a timeline, please save your timeline first.',
+      'The active timeline must be saved before a note can be associated with it',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -8,15 +8,26 @@
 import React, { memo, useCallback, useEffect, useState } from 'react';
 import {
   EuiButton,
+  EuiCheckbox,
   EuiComment,
   EuiCommentList,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
-import { ADD_NOTE_BUTTON_TEST_ID, ADD_NOTE_MARKDOWN_TEST_ID } from './test_ids';
+import { TimelineId } from '../../../../../common/types';
+import { timelineSelectors } from '../../../../timelines/store';
+import { useIsTimelineFlyoutOpen } from '../../shared/hooks/use_is_timeline_flyout_open';
+import {
+  ADD_NOTE_BUTTON_TEST_ID,
+  ADD_NOTE_MARKDOWN_TEST_ID,
+  ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID,
+} from './test_ids';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import type { State } from '../../../../common/store';
 import {
@@ -26,6 +37,8 @@ import {
   selectCreateNoteStatus,
 } from '../../../../notes/store/notes.slice';
 import { MarkdownEditor } from '../../../../common/components/markdown_editor';
+
+const timelineCheckBoxId = 'xpack.securitySolution.notes.attachToTimelineCheckboxId';
 
 export const MARKDOWN_ARIA_LABEL = i18n.translate(
   'xpack.securitySolution.notes.markdownAriaLabel',
@@ -42,6 +55,19 @@ export const CREATE_NOTE_ERROR = i18n.translate(
     defaultMessage: 'Error create note',
   }
 );
+export const ATTACH_TO_TIMELINE_CHECKBOX = i18n.translate(
+  'xpack.securitySolution.notes.attachToTimelineCheckboxLabel',
+  {
+    defaultMessage: 'Attach to active timeline',
+  }
+);
+export const ATTACH_TO_TIMELINE_INFO = i18n.translate(
+  'xpack.securitySolution.notes.attachToTimelineInfoLabel',
+  {
+    defaultMessage:
+      'If you want to create a note associated to a timeline, please save your timeline first.',
+  }
+);
 
 export interface AddNewNoteProps {
   /**
@@ -51,12 +77,22 @@ export interface AddNewNoteProps {
 }
 
 /**
- * Renders a markdown editor and a add button to create new notes
+ * Renders a markdown editor and an add button to create new notes.
+ * The checkbox is automatically checked if the flyout is opened from a timeline and that timeline is saved. It is disabled if the flyout is NOT opened from a timeline.
  */
 export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
   const dispatch = useDispatch();
   const { addError: addErrorToast } = useAppToasts();
   const [editorValue, setEditorValue] = useState('');
+
+  const activeTimeline = useSelector((state: State) =>
+    timelineSelectors.selectTimelineById(state, TimelineId.active)
+  );
+
+  // if the flyout is open from a timeline and that timeline is saved, we automatically check the checkbox to associate the note to it
+  const isTimelineFlyout = useIsTimelineFlyoutOpen();
+  const [checked, setChecked] = useState(isTimelineFlyout && activeTimeline.savedObjectId != null);
+  const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => setChecked(e.target.checked);
 
   const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));
   const createError = useSelector((state: State) => selectCreateNoteError(state));
@@ -65,15 +101,16 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
     dispatch(
       createNote({
         note: {
-          timelineId: '',
+          timelineId: (checked && activeTimeline.savedObjectId) || '',
           eventId,
           note: editorValue,
         },
       })
     );
     setEditorValue('');
-  }, [dispatch, editorValue, eventId]);
+  }, [activeTimeline.savedObjectId, checked, dispatch, editorValue, eventId]);
 
+  // show a toast if the create note call fails
   useEffect(() => {
     if (createStatus === ReqStatus.Failed && createError) {
       addErrorToast(null, {
@@ -96,7 +133,33 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
         </EuiComment>
       </EuiCommentList>
       <EuiSpacer />
-      <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+      <EuiFlexGroup alignItems="center" justifyContent="flexEnd" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <>
+            <EuiCheckbox
+              data-test-subj={ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID}
+              id={timelineCheckBoxId}
+              label={
+                <>
+                  {ATTACH_TO_TIMELINE_CHECKBOX}
+                  <EuiToolTip position="top" content={ATTACH_TO_TIMELINE_INFO}>
+                    <EuiIcon
+                      type="iInCircle"
+                      css={css`
+                        margin-left: 4px;
+                      `}
+                    />
+                  </EuiToolTip>
+                </>
+              }
+              disabled={
+                !isTimelineFlyout || (isTimelineFlyout && activeTimeline.savedObjectId == null)
+              }
+              checked={checked}
+              onChange={(e) => onCheckboxChange(e)}
+            />
+          </>
+        </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButton
             onClick={addNote}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -91,7 +91,10 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
   // if the flyout is open from a timeline and that timeline is saved, we automatically check the checkbox to associate the note to it
   const isTimelineFlyout = useIsTimelineFlyoutOpen();
   const [checked, setChecked] = useState(isTimelineFlyout && activeTimeline.savedObjectId != null);
-  const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => setChecked(e.target.checked);
+  const onCheckboxChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => setChecked(e.target.checked),
+    []
+  );
 
   const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));
   const createError = useSelector((state: State) => selectCreateNoteError(state));
@@ -117,6 +120,9 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
       });
     }
   }, [addErrorToast, createError, createStatus]);
+
+  const checkBoxDisabled =
+    !isTimelineFlyout || (isTimelineFlyout && activeTimeline.savedObjectId == null);
 
   return (
     <>
@@ -151,9 +157,7 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
                   </EuiToolTip>
                 </>
               }
-              disabled={
-                !isTimelineFlyout || (isTimelineFlyout && activeTimeline.savedObjectId == null)
-              }
+              disabled={checkBoxDisabled}
               checked={checked}
               onChange={(e) => onCheckboxChange(e)}
             />

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -17,12 +17,15 @@ import { useDispatch, useSelector } from 'react-redux';
 import { FormattedRelative } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useQueryTimelineById } from '../../../../timelines/components/open_timeline/helpers';
 import {
   ADD_NOTE_LOADING_TEST_ID,
   DELETE_NOTE_BUTTON_TEST_ID,
   NOTE_AVATAR_TEST_ID,
   NOTES_COMMENT_TEST_ID,
   NOTES_LOADING_TEST_ID,
+  OPEN_TIMELINE_BUTTON_TEST_ID,
 } from './test_ids';
 import type { State } from '../../../../common/store';
 import type { Note } from '../../../../../common/api/timeline';
@@ -77,6 +80,10 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
   const dispatch = useDispatch();
   const { addError: addErrorToast } = useAppToasts();
 
+  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineEnabled'
+  );
+
   const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdStatus(state));
   const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdError(state));
   const notes: Note[] = useSelector((state: State) => selectNotesByDocumentId(state, eventId));
@@ -95,6 +102,20 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
     [dispatch]
   );
 
+  const queryTimelineById = useQueryTimelineById();
+  const openTimeline = useCallback(
+    ({ timelineId }) =>
+      queryTimelineById({
+        duplicate: false,
+        onOpenTimeline: undefined,
+        timelineId,
+        timelineType: undefined,
+        unifiedComponentsInTimelineEnabled,
+      }),
+    [queryTimelineById, unifiedComponentsInTimelineEnabled]
+  );
+
+  // show a toast if the fetch notes call fails
   useEffect(() => {
     if (fetchStatus === ReqStatus.Failed && fetchError) {
       addErrorToast(null, {
@@ -129,16 +150,28 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
           timestamp={<>{note.created && <FormattedRelative value={new Date(note.created)} />}</>}
           event={ADDED_A_NOTE}
           actions={
-            <EuiButtonIcon
-              data-test-subj={`${DELETE_NOTE_BUTTON_TEST_ID}-${index}`}
-              title={DELETE_NOTE}
-              aria-label={DELETE_NOTE}
-              color="text"
-              iconType="trash"
-              onClick={() => deleteNoteFc(note.noteId)}
-              disabled={deletingNoteId !== note.noteId && deleteStatus === ReqStatus.Loading}
-              isLoading={deletingNoteId === note.noteId && deleteStatus === ReqStatus.Loading}
-            />
+            <>
+              {note.timelineId && note.timelineId.length > 0 && (
+                <EuiButtonIcon
+                  data-test-subj={`${OPEN_TIMELINE_BUTTON_TEST_ID}-${index}`}
+                  title="Open timeline"
+                  aria-label="Open timeline"
+                  color="text"
+                  iconType="timeline"
+                  onClick={() => openTimeline(note)}
+                />
+              )}
+              <EuiButtonIcon
+                data-test-subj={`${DELETE_NOTE_BUTTON_TEST_ID}-${index}`}
+                title={DELETE_NOTE}
+                aria-label={DELETE_NOTE}
+                color="text"
+                iconType="trash"
+                onClick={() => deleteNoteFc(note.noteId)}
+                disabled={deletingNoteId !== note.noteId && deleteStatus === ReqStatus.Loading}
+                isLoading={deletingNoteId === note.noteId && deleteStatus === ReqStatus.Loading}
+              />
+            </>
           }
           timelineAvatar={
             <EuiAvatar

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/test_ids.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/test_ids.ts
@@ -99,3 +99,5 @@ export const ADD_NOTE_MARKDOWN_TEST_ID = `${PREFIX}AddNotesMarkdown` as const;
 export const ADD_NOTE_BUTTON_TEST_ID = `${PREFIX}AddNotesButton` as const;
 export const NOTE_AVATAR_TEST_ID = `${PREFIX}NoteAvatar` as const;
 export const DELETE_NOTE_BUTTON_TEST_ID = `${PREFIX}DeleteNotesButton` as const;
+export const ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID = `${PREFIX}AttachToTimelineCheckbox` as const;
+export const OPEN_TIMELINE_BUTTON_TEST_ID = `${PREFIX}OpenTimelineButton` as const;


### PR DESCRIPTION
## Summary

This PR continues to add functionality to the new notes feature for Security Solution. It focuses on adding a UI to link a note to a timeline.

The logic built here is slightly different from the current logic of notes and timeline. Currently, you can create a note associated to an unsaved timeline. The way we're doing this is by _saving_ a draft timeline, retrieving the id of that draft timeline and associating it to the created note.

This logic isn't implemented in this PR, because we're now creating an note via the flyout, and it's not super clear in the UI that flyout opened from timeline should have a different behavior from the one opened from the alerts page.

Therefore, here's the behavior:
- if a note is created from a flyout opened from the alerts page, the `Attach to active timeline` checkbox is unchecked and disabled
- if a note is created from a flyout opened from a unsaved timeline, the `Attach to active timeline` checkbox is also disabled, and show an info icon with a tooltip saying `If you want to create a note associated to a timeline, please save your timeline first.`
- if a note is created from a flyout opened from a saved timeline, the `Attach to active timeline` checkbox is checked and the `savedObjectId` of the timeline will be passed to the server when creating the note.

In the latter scenario, a timeline icon is displayed in the UI so that users can navigate to the saved timeline from the note in the expandable flyout.

#### Note created without timeline

https://github.com/elastic/kibana/assets/17276605/b5ffbaba-05ca-4c00-8c4f-50e0545354f9

#### Note created for an unsaved timeline

Uploading Screen Recording 2024-06-25 at 6.18.27 PM.mov…

#### Note created for a saved timeline

https://github.com/elastic/kibana/assets/17276605/2d5254cf-9d75-42fb-9003-7d4bd144c624

_Notes: we can always improve this logic later by creating a draft timeline, retrieving its id and use it in the flyout._

### How to test

- make sure the feature flag is enabled in your `kibana.yml` file: `xpack.securitySolution.enableExperimental: ['securitySolutionNotesEnabled']`
- open the expandable flyout, click on the Expand details button to expand the left section then navigate to the new Notes tab

_Note: You'll need to create new notes, but as the server side to fetch notes does not exist yet, it is expected to not see the notes persisted between refreshes._

https://github.com/elastic/security-team/issues/9375

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

