### PR TITLE
[Files] Use server-side authc.getCurrentUser from core.security

### DIFF
--- a/src/plugins/files/server/routes/file_kind/create.ts
+++ b/src/plugins/files/server/routes/file_kind/create.ts
@@ -31,12 +31,12 @@ export type Endpoint<M = unknown> = CreateRouteDefinition<
   FilesClient['create']
 >;
 
-export const handler: CreateHandler<Endpoint> = async ({ fileKind, files }, req, res) => {
-  const { fileService, security } = await files;
+export const handler: CreateHandler<Endpoint> = async ({ core, fileKind, files }, req, res) => {
+  const [{ security }, { fileService }] = await Promise.all([core, files]);
   const {
     body: { name, alt, meta, mimeType },
   } = req;
-  const user = security?.authc.getCurrentUser(req);
+  const user = security.authc.getCurrentUser();
   const file = await fileService.asCurrentUser().create({
     fileKind,
     name,

--- a/src/plugins/files/server/routes/types.ts
+++ b/src/plugins/files/server/routes/types.ts
@@ -17,14 +17,12 @@ import type {
   ResponseError,
   RouteMethod,
 } from '@kbn/core/server';
-import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { FileServiceStart } from '../file_service';
 import { Counters } from '../usage';
 import { AnyEndpoint } from './api_routes';
 
 export interface FilesRequestHandlerContext extends RequestHandlerContext {
   files: Promise<{
-    security?: SecurityPluginStart;
     fileService: {
       asCurrentUser: () => FileServiceStart;
       asInternalUser: () => FileServiceStart;


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/186574

Background: This PR serves as an example of a plugin migrating away from depending on the Security plugin, which is a high priority effort for the last release before 9.0. The Files plugin uses the `authc.getCurrentUser` method to attribute the current user to files that are created in the system.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios