### PR TITLE
Update obs-onboarding cypress CI config

### DIFF
--- a/.buildkite/pipelines/pull_request/observability_onboarding_cypress.yml
+++ b/.buildkite/pipelines/pull_request/observability_onboarding_cypress.yml
@@ -8,7 +8,6 @@ steps:
       - build
       - quick_checks
     timeout_in_minutes: 120
-    parallelism: 2
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -83,7 +83,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
 
     if (
       (await doAnyChangesMatch([
-        /^x-pack\/plugins\/observability_onboarding/,
+        /^x-pack\/plugins\/observability_solution\/observability_onboarding/,
         /^x-pack\/plugins\/fleet/,
       ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites')

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-describe('[Logs onboarding] Custom logs - install elastic agent', () => {
+// Failing: See https://github.com/elastic/kibana/issues/186925
+describe.skip('[Logs onboarding] Custom logs - install elastic agent', () => {
   const CUSTOM_INTEGRATION_NAME = 'mylogs';
 
   const configureCustomLogs = (loginFn = () => cy.loginAsLogMonitoringUser()) => {

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-// Failing: See https://github.com/elastic/kibana/issues/186925
-describe.skip('[Logs onboarding] Custom logs - install elastic agent', () => {
+describe('[Logs onboarding] Custom logs - install elastic agent', () => {
   const CUSTOM_INTEGRATION_NAME = 'mylogs';
 
   const configureCustomLogs = (loginFn = () => cy.loginAsLogMonitoringUser()) => {

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-// Failing: See https://github.com/elastic/kibana/issues/186925
-describe.skip('[Logs onboarding] System logs', () => {
+describe('[Logs onboarding] System logs', () => {
   describe('System integration', () => {
     beforeEach(() => {
       cy.deleteIntegration('system');

--- a/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-describe('[Logs onboarding] System logs', () => {
+// Failing: See https://github.com/elastic/kibana/issues/186925
+describe.skip('[Logs onboarding] System logs', () => {
   describe('System integration', () => {
     beforeEach(() => {
       cy.deleteIntegration('system');


### PR DESCRIPTION
- removes parallelism: 2 from step definition.  The test suites are not sharded.
- Updates the path used to trigger a test run.  The previous path is out of date.