### PR TITLE
[Security Solution][Endpoint] Enable `get-file` response action feature for SentinelOne hosts

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -79,7 +79,7 @@ export const allowedExperimentalValues = Object.freeze({
   responseActionsSentinelOneV2Enabled: true,
 
   /** Enables the `get-file` response action for SentinelOne */
-  responseActionsSentinelOneGetFileEnabled: false,
+  responseActionsSentinelOneGetFileEnabled: true,
 
   /**
    * 8.15


### PR DESCRIPTION
## Summary

- Enables the `responseActionsSentinelOneGetFileEnabled` feature flag. Makes `get-file` response action available on SentinelOne host



