### PR TITLE
[Security Solution][Notes] - note icon to all tables and timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -10,11 +10,15 @@ import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { dataTableActions, TableId } from '@kbn/securitysolution-data-table';
+import { LeftPanelNotesTab } from '../../../../flyout/document_details/left';
 import { useRouteSpy } from '../../../utils/route/use_route_spy';
 import { useKibana } from '../../../lib/kibana';
 import { timelineActions } from '../../../../timelines/store';
 import { SecurityPageName } from '../../../../../common/constants';
-import { DocumentDetailsRightPanelKey } from '../../../../flyout/document_details/shared/constants/panel_keys';
+import {
+  DocumentDetailsLeftPanelKey,
+  DocumentDetailsRightPanelKey,
+} from '../../../../flyout/document_details/shared/constants/panel_keys';
 import type {
   SetEventsDeleted,
   SetEventsLoading,
@@ -100,6 +104,9 @@ const RowActionComponent = ({
 
   // TODO remove when https://github.com/elastic/security-team/issues/7462 is merged
   const expandableFlyoutDisabled = useIsExperimentalFeatureEnabled('expandableFlyoutDisabled');
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
   const showExpandableFlyout =
     pageName === SecurityPageName.attackDiscovery ? true : !expandableFlyoutDisabled;
 
@@ -162,6 +169,32 @@ const RowActionComponent = ({
     tabType,
   ]);
 
+  const toggleShowNotes = useCallback(
+    () =>
+      openFlyout({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: tableId,
+          },
+        },
+        left: {
+          id: DocumentDetailsLeftPanelKey,
+          path: {
+            tab: LeftPanelNotesTab,
+          },
+          params: {
+            id: eventId,
+            indexName,
+            scopeId: tableId,
+          },
+        },
+      }),
+    [eventId, indexName, openFlyout, tableId]
+  );
+
   const Action = controlColumn.rowCellRender;
 
   if (!timelineNonEcsData || !ecsData || !eventId) {
@@ -191,6 +224,9 @@ const RowActionComponent = ({
           showCheckboxes={showCheckboxes}
           tabType={tabType}
           timelineId={tableId}
+          toggleShowNotes={
+            !expandableFlyoutDisabled && securitySolutionNotesEnabled ? toggleShowNotes : undefined
+          }
           width={width}
           setEventsLoading={setEventsLoading}
           setEventsDeleted={setEventsDeleted}

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/use_timelines_events.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/use_timelines_events.tsx
@@ -29,6 +29,7 @@ import type {
   TimelineStrategyResponseType,
 } from '@kbn/timelines-plugin/common/search_strategy';
 import { dataTableActions, Direction, TableId } from '@kbn/securitysolution-data-table';
+import { fetchNotesByDocumentIds } from '../../../notes/store/notes.slice';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
 import { TimelineEventsQueries } from '../../../../common/search_strategy';
 import type { KueryFilterQueryKind } from '../../../../common/types';
@@ -434,6 +435,8 @@ export const useTimelineEvents = ({
   timerangeKind,
   data,
 }: UseTimelineEventsProps): [boolean, TimelineArgs] => {
+  const dispatch = useDispatch();
+
   const [loading, timelineResponse, timelineSearchHandler] = useTimelineEventsHandler({
     alertConsumers,
     dataViewId,
@@ -458,7 +461,11 @@ export const useTimelineEvents = ({
   useEffect(() => {
     if (!timelineSearchHandler) return;
     timelineSearchHandler();
-  }, [timelineSearchHandler]);
+
+    // fetch notes for the events
+    const events = timelineResponse.events.map((event: TimelineItem) => event._id);
+    dispatch(fetchNotesByDocumentIds({ documentIds: events }));
+  }, [dispatch, timelineResponse.events, timelineSearchHandler]);
 
   return [loading, timelineResponse];
 };

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -6,11 +6,13 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import styled from 'styled-components';
 
 import { TimelineTabs, TableId } from '@kbn/securitysolution-data-table';
+import { selectNotesByDocumentId } from '../../../notes/store/notes.slice';
+import type { State } from '../../store';
 import { selectTimelineById } from '../../../timelines/store/selectors';
 import {
   eventHasNotes,
@@ -32,6 +34,7 @@ import { useGlobalFullScreen, useTimelineFullScreen } from '../../containers/use
 import { ALERTS_ACTIONS } from '../../lib/apm/user_actions';
 import { setActiveTabTimeline } from '../../../timelines/store/actions';
 import { EventsTdContent } from '../../../timelines/components/timeline/styles';
+import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 import { AlertContextMenu } from '../../../detections/components/alerts_table/timeline_actions/alert_context_menu';
 import { InvestigateInTimelineAction } from '../../../detections/components/alerts_table/timeline_actions/investigate_in_timeline_action';
 import * as i18n from './translations';
@@ -63,6 +66,11 @@ const ActionsComponent: React.FC<ActionProps> = ({
   refetch,
 }) => {
   const dispatch = useDispatch();
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
+  const expandableFlyoutDisabled = useIsExperimentalFeatureEnabled('expandableFlyoutDisabled');
+
   const emptyNotes: string[] = [];
   const { timelineType } = useShallowEqualSelector((state) =>
     isTimelineScope(timelineId) ? selectTimelineById(state, timelineId) : timelineDefaults
@@ -101,6 +109,8 @@ const ActionsComponent: React.FC<ActionProps> = ({
       !(ecsData.event?.kind?.includes('event') && ecsData.agent?.type?.includes('endpoint'))
     );
   }, [ecsData, eventType]);
+
+  const notes = useSelector((state: State) => selectNotesByDocumentId(state, eventId));
 
   const isDisabled = !useIsInvestigateInResolverActionEnabled(ecsData);
   const { setGlobalFullScreen } = useGlobalFullScreen();
@@ -244,27 +254,40 @@ const ActionsComponent: React.FC<ActionProps> = ({
             />
           )}
         </>
-        {!isEventViewer && toggleShowNotes && (
-          <>
-            <AddEventNoteAction
-              ariaLabel={i18n.ADD_NOTES_FOR_ROW({ ariaRowindex, columnValues })}
-              key="add-event-note"
-              showNotes={showNotes ?? false}
-              toggleShowNotes={toggleShowNotes}
-              timelineType={timelineType}
-              eventId={eventId}
-            />
-            <PinEventAction
-              ariaLabel={i18n.PIN_EVENT_FOR_ROW({ ariaRowindex, columnValues, isEventPinned })}
-              isAlert={isAlert(eventType)}
-              key="pin-event"
-              onPinClicked={handlePinClicked}
-              noteIds={eventIdToNoteIds ? eventIdToNoteIds[eventId] || emptyNotes : emptyNotes}
-              eventIsPinned={isEventPinned}
-              timelineType={timelineType}
-            />
-          </>
+        {securitySolutionNotesEnabled && !expandableFlyoutDisabled && toggleShowNotes && (
+          <AddEventNoteAction
+            ariaLabel={i18n.ADD_NOTES_FOR_ROW({ ariaRowindex, columnValues })}
+            key="add-event-note"
+            showNotes={false}
+            toggleShowNotes={toggleShowNotes}
+            timelineType={timelineType}
+            eventId={eventId}
+            notesCount={notes.length}
+          />
         )}
+        {(!securitySolutionNotesEnabled || expandableFlyoutDisabled) &&
+          !isEventViewer &&
+          toggleShowNotes && (
+            <>
+              <AddEventNoteAction
+                ariaLabel={i18n.ADD_NOTES_FOR_ROW({ ariaRowindex, columnValues })}
+                key="add-event-note"
+                showNotes={showNotes ?? false}
+                toggleShowNotes={toggleShowNotes}
+                timelineType={timelineType}
+                eventId={eventId}
+              />
+              <PinEventAction
+                ariaLabel={i18n.PIN_EVENT_FOR_ROW({ ariaRowindex, columnValues, isEventPinned })}
+                isAlert={isAlert(eventType)}
+                key="pin-event"
+                onPinClicked={handlePinClicked}
+                noteIds={eventIdToNoteIds ? eventIdToNoteIds[eventId] || emptyNotes : emptyNotes}
+                eventIsPinned={isEventPinned}
+                timelineType={timelineType}
+              />
+            </>
+          )}
         <AlertContextMenu
           ariaLabel={i18n.MORE_ACTIONS_FOR_ROW({ ariaRowindex, columnValues })}
           ariaRowindex={ariaRowindex}

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -255,15 +255,26 @@ const ActionsComponent: React.FC<ActionProps> = ({
           )}
         </>
         {securitySolutionNotesEnabled && !expandableFlyoutDisabled && toggleShowNotes && (
-          <AddEventNoteAction
-            ariaLabel={i18n.ADD_NOTES_FOR_ROW({ ariaRowindex, columnValues })}
-            key="add-event-note"
-            showNotes={false}
-            toggleShowNotes={toggleShowNotes}
-            timelineType={timelineType}
-            eventId={eventId}
-            notesCount={notes.length}
-          />
+          <>
+            <AddEventNoteAction
+              ariaLabel={i18n.ADD_NOTES_FOR_ROW({ ariaRowindex, columnValues })}
+              key="add-event-note"
+              showNotes={false}
+              toggleShowNotes={toggleShowNotes}
+              timelineType={timelineType}
+              eventId={eventId}
+              notesCount={notes.length}
+            />
+            <PinEventAction
+              ariaLabel={i18n.PIN_EVENT_FOR_ROW({ ariaRowindex, columnValues, isEventPinned })}
+              isAlert={isAlert(eventType)}
+              key="pin-event"
+              onPinClicked={handlePinClicked}
+              noteIds={eventIdToNoteIds ? eventIdToNoteIds[eventId] || emptyNotes : emptyNotes}
+              eventIsPinned={isEventPinned}
+              timelineType={timelineType}
+            />
+          </>
         )}
         {(!securitySolutionNotesEnabled || expandableFlyoutDisabled) &&
           !isEventViewer &&

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/add_note_icon_item.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/add_note_icon_item.tsx
@@ -18,6 +18,10 @@ interface AddEventNoteActionProps {
   timelineType: TimelineType;
   toggleShowNotes: () => void;
   eventId?: string;
+  /**
+   * Number of notes associated with the event
+   */
+  notesCount?: number;
 }
 
 const AddEventNoteActionComponent: React.FC<AddEventNoteActionProps> = ({
@@ -26,8 +30,16 @@ const AddEventNoteActionComponent: React.FC<AddEventNoteActionProps> = ({
   timelineType,
   toggleShowNotes,
   eventId,
+  notesCount,
 }) => {
   const { kibanaSecuritySolutionsPrivileges } = useUserPrivileges();
+
+  const tooltip =
+    notesCount && notesCount > 0
+      ? i18n.NOTE_COUNT_TOOLTIP(notesCount)
+      : timelineType === TimelineType.template
+      ? i18n.NOTES_DISABLE_TOOLTIP
+      : i18n.NOTES_TOOLTIP;
 
   return (
     <ActionIconItem>
@@ -38,10 +50,9 @@ const AddEventNoteActionComponent: React.FC<AddEventNoteActionProps> = ({
         showNotes={showNotes}
         timelineType={timelineType}
         toggleShowNotes={toggleShowNotes}
-        toolTip={
-          timelineType === TimelineType.template ? i18n.NOTES_DISABLE_TOOLTIP : i18n.NOTES_TOOLTIP
-        }
+        toolTip={tooltip}
         eventId={eventId}
+        notesCount={notesCount}
       />
     </ActionIconItem>
   );

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/translations.ts
@@ -21,6 +21,12 @@ export const NOTES_DISABLE_TOOLTIP = i18n.translate(
   }
 );
 
+export const NOTE_COUNT_TOOLTIP = (notesCount: number) =>
+  i18n.translate('xpack.securitySolution.notes.noteCountTooltip', {
+    defaultMessage: '{notesCount} {notesCount, plural, one { note } other { notes }}',
+    values: { notesCount },
+  });
+
 export const NOTES_TOOLTIP = i18n.translate(
   'xpack.securitySolution.timeline.body.notes.addNoteTooltip',
   {

--- a/x-pack/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/global_state.ts
@@ -519,12 +519,12 @@ export const mockGlobalState: State = {
       },
     },
     status: {
-      fetchNotesByDocumentId: ReqStatus.Idle,
+      fetchNotesByDocumentIds: ReqStatus.Idle,
       createNote: ReqStatus.Idle,
       deleteNote: ReqStatus.Idle,
     },
     error: {
-      fetchNotesByDocumentId: null,
+      fetchNotesByDocumentIds: null,
       createNote: null,
       deleteNote: null,
     },

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -11,7 +11,7 @@ import type { Filter } from '@kbn/es-query';
 import type { FC } from 'react';
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import type { AlertsTableStateProps } from '@kbn/triggers-actions-ui-plugin/public/application/sections/alerts_table/alerts_table_state';
-import type { Alert } from '@kbn/triggers-actions-ui-plugin/public/types';
+import type { Alert, Alerts } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { ALERT_BUILDING_BLOCK_TYPE } from '@kbn/rule-data-utils';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
@@ -22,6 +22,7 @@ import {
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
+import { fetchNotesByDocumentIds } from '../../../notes/store/notes.slice';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useLicense } from '../../../common/hooks/use_license';
 import { VIEW_SELECTION } from '../../../../common/constants';
@@ -265,11 +266,19 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
     };
   }, []);
 
+  const onLoaded = useCallback(
+    (alerts: Alerts) => {
+      const alertIds = alerts.map((alert: Alert) => alert._id);
+      dispatch(fetchNotesByDocumentIds({ documentIds: alertIds }));
+    },
+    [dispatch]
+  );
+
   const alertStateProps: AlertsTableStateProps = useMemo(
     () => ({
       alertsTableConfigurationRegistry: triggersActionsUi.alertsTableConfigurationRegistry,
       configurationId: configId,
-      // stores saperate configuration based on the view of the table
+      // stores separate configuration based on the view of the table
       id: `detection-engine-alert-table-${configId}-${tableView}`,
       featureIds: ['siem'],
       query: finalBoolQuery,
@@ -280,6 +289,7 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
       browserFields: finalBrowserFields,
       onUpdate: onAlertTableUpdate,
       cellContext,
+      onLoaded,
       runtimeMappings,
       toolbarVisibility: {
         showColumnSelector: !isEventRenderedView,
@@ -300,6 +310,7 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
       runtimeMappings,
       isEventRenderedView,
       cellContext,
+      onLoaded,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_actions_column.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_actions_column.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { AlertsTableConfigurationRegistry } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { StatefulEventContext } from '../../../common/components/events_viewer/stateful_event_context';
 import { eventsViewerSelector } from '../../../common/components/events_viewer/selectors';
 import { getDefaultControlColumn } from '../../../timelines/components/timeline/body/control_columns';
@@ -24,7 +25,17 @@ export const getUseActionColumnHook =
   () => {
     const license = useLicense();
     const isEnterprisePlus = license.isEnterprise();
-    const ACTION_BUTTON_COUNT = tableId === TableId.alertsOnCasePage ? 3 : isEnterprisePlus ? 5 : 4;
+    let ACTION_BUTTON_COUNT = tableId === TableId.alertsOnCasePage ? 4 : isEnterprisePlus ? 6 : 5;
+
+    // we only want to show the note icon if the expandable flyout and the new notes system are enabled
+    // TODO delete most likely in 8.16
+    const expandableFlyoutDisabled = useIsExperimentalFeatureEnabled('expandableFlyoutDisabled');
+    const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+      'securitySolutionNotesEnabled'
+    );
+    if (expandableFlyoutDisabled || !securitySolutionNotesEnabled) {
+      ACTION_BUTTON_COUNT--;
+    }
 
     const eventContext = useContext(StatefulEventContext);
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
@@ -10,7 +10,7 @@ import { useDispatch } from 'react-redux';
 import { EuiSpacer } from '@elastic/eui';
 import { AddNote } from './add_note';
 import { NotesList } from './notes_list';
-import { fetchNotesByDocumentId } from '../../../../notes/store/notes.slice';
+import { fetchNotesByDocumentIds } from '../../../../notes/store/notes.slice';
 import { useDocumentDetailsContext } from '../../shared/context';
 
 /**
@@ -22,7 +22,7 @@ export const NotesDetails = memo(() => {
   const { eventId } = useDocumentDetailsContext();
 
   useEffect(() => {
-    dispatch(fetchNotesByDocumentId({ documentId: eventId }));
+    dispatch(fetchNotesByDocumentIds({ documentIds: [eventId] }));
   }, [dispatch, eventId]);
 
   return (

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
@@ -62,7 +62,7 @@ describe('NotesList', () => {
         ...mockGlobalState.notes,
         status: {
           ...mockGlobalState.notes.status,
-          fetchNotesByDocumentId: ReqStatus.Loading,
+          fetchNotesByDocumentIds: ReqStatus.Loading,
         },
       },
     });
@@ -83,7 +83,7 @@ describe('NotesList', () => {
         ...mockGlobalState.notes,
         status: {
           ...mockGlobalState.notes.status,
-          fetchNotesByDocumentId: ReqStatus.Succeeded,
+          fetchNotesByDocumentIds: ReqStatus.Succeeded,
         },
       },
     });
@@ -104,11 +104,11 @@ describe('NotesList', () => {
         ...mockGlobalState.notes,
         status: {
           ...mockGlobalState.notes.status,
-          fetchNotesByDocumentId: ReqStatus.Failed,
+          fetchNotesByDocumentIds: ReqStatus.Failed,
         },
         error: {
           ...mockGlobalState.notes.error,
-          fetchNotesByDocumentId: { type: 'http', status: 500 },
+          fetchNotesByDocumentIds: { type: 'http', status: 500 },
         },
       },
     });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -35,8 +35,8 @@ import {
   selectCreateNoteStatus,
   selectDeleteNoteError,
   selectDeleteNoteStatus,
-  selectFetchNotesByDocumentIdError,
-  selectFetchNotesByDocumentIdStatus,
+  selectFetchNotesByDocumentIdsError,
+  selectFetchNotesByDocumentIdsStatus,
   selectNotesByDocumentId,
 } from '../../../../notes/store/notes.slice';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
@@ -84,8 +84,9 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
     'unifiedComponentsInTimelineEnabled'
   );
 
-  const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdStatus(state));
-  const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdError(state));
+  const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdsStatus(state));
+  const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdsError(state));
+
   const notes: Note[] = useSelector((state: State) => selectNotesByDocumentId(state, eventId));
 
   const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));

--- a/x-pack/plugins/security_solution/public/notes/api/api.ts
+++ b/x-pack/plugins/security_solution/public/notes/api/api.ts
@@ -32,28 +32,29 @@ export const createNote = async ({ note }: { note: BareNote }) => {
 
 // TODO point to the correct API when it is available
 /**
- * Fetches all the notes for a document id
+ * Fetches all the notes for an array of document ids
  */
-export const fetchNotesByDocumentId = async (documentId: string) => {
+export const fetchNotesByDocumentIds = async (documentIds: string[]) => {
   const response = {
     totalCount: 1,
-    notes: [generateNoteMock(documentId)],
+    notes: generateNoteMock(documentIds),
   };
   return response.notes;
 };
 
 // TODO remove when the API is available
-export const generateNoteMock = (documentId: string) => ({
-  noteId: uuid.v4(),
-  version: 'WzU1MDEsMV0=',
-  timelineId: '',
-  eventId: documentId,
-  note: 'This is a mocked note',
-  created: new Date().getTime(),
-  createdBy: 'elastic',
-  updated: new Date().getTime(),
-  updatedBy: 'elastic',
-});
+export const generateNoteMock = (documentIds: string[]) =>
+  documentIds.map((documentId: string) => ({
+    noteId: uuid.v4(),
+    version: 'WzU1MDEsMV0=',
+    timelineId: '',
+    eventId: documentId,
+    note: 'This is a mocked note',
+    created: new Date().getTime(),
+    createdBy: 'elastic',
+    updated: new Date().getTime(),
+    updatedBy: 'elastic',
+  }));
 
 /**
  * Deletes a note

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
@@ -8,7 +8,7 @@
 import {
   createNote,
   deleteNote,
-  fetchNotesByDocumentId,
+  fetchNotesByDocumentIds,
   initialNotesState,
   notesReducer,
   ReqStatus,
@@ -17,8 +17,8 @@ import {
   selectCreateNoteStatus,
   selectDeleteNoteError,
   selectDeleteNoteStatus,
-  selectFetchNotesByDocumentIdError,
-  selectFetchNotesByDocumentIdStatus,
+  selectFetchNotesByDocumentIdsError,
+  selectFetchNotesByDocumentIdsStatus,
   selectNoteById,
   selectNoteIds,
   selectNotesByDocumentId,
@@ -28,18 +28,18 @@ import { mockGlobalState } from '../../common/mock';
 
 const initalEmptyState = initialNotesState;
 
-const mockNote = { ...generateNoteMock('1') };
+const mockNote = { ...generateNoteMock(['1'])[0] };
 const initialNonEmptyState = {
   entities: {
     [mockNote.noteId]: mockNote,
   },
   ids: [mockNote.noteId],
   status: {
-    fetchNotesByDocumentId: ReqStatus.Idle,
+    fetchNotesByDocumentIds: ReqStatus.Idle,
     createNote: ReqStatus.Idle,
     deleteNote: ReqStatus.Idle,
   },
-  error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+  error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
 };
 
 describe('notesSlice', () => {
@@ -49,33 +49,33 @@ describe('notesSlice', () => {
         entities: {},
         ids: [],
         status: {
-          fetchNotesByDocumentId: ReqStatus.Idle,
+          fetchNotesByDocumentIds: ReqStatus.Idle,
           createNote: ReqStatus.Idle,
           deleteNote: ReqStatus.Idle,
         },
-        error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+        error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
       });
     });
 
-    describe('fetchNotesByDocumentId', () => {
+    describe('fetchNotesByDocumentIds', () => {
       it('should set correct status state when fetching notes by document id', () => {
-        const action = { type: fetchNotesByDocumentId.pending.type };
+        const action = { type: fetchNotesByDocumentIds.pending.type };
 
         expect(notesReducer(initalEmptyState, action)).toEqual({
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Loading,
+            fetchNotesByDocumentIds: ReqStatus.Loading,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
       it('should set correct state when success on fetch notes by document id on an empty state', () => {
         const action = {
-          type: fetchNotesByDocumentId.fulfilled.type,
+          type: fetchNotesByDocumentIds.fulfilled.type,
           payload: {
             entities: {
               notes: {
@@ -90,18 +90,18 @@ describe('notesSlice', () => {
           entities: action.payload.entities.notes,
           ids: action.payload.result,
           status: {
-            fetchNotesByDocumentId: ReqStatus.Succeeded,
+            fetchNotesByDocumentIds: ReqStatus.Succeeded,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
       it('should replace notes when success on fetch notes by document id on a non-empty state', () => {
         const newMockNote = { ...mockNote, timelineId: 'timelineId' };
         const action = {
-          type: fetchNotesByDocumentId.fulfilled.type,
+          type: fetchNotesByDocumentIds.fulfilled.type,
           payload: {
             entities: {
               notes: {
@@ -116,27 +116,27 @@ describe('notesSlice', () => {
           entities: action.payload.entities.notes,
           ids: action.payload.result,
           status: {
-            fetchNotesByDocumentId: ReqStatus.Succeeded,
+            fetchNotesByDocumentIds: ReqStatus.Succeeded,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
       it('should set correct error state when failing to fetch notes by document id', () => {
-        const action = { type: fetchNotesByDocumentId.rejected.type, error: 'error' };
+        const action = { type: fetchNotesByDocumentIds.rejected.type, error: 'error' };
 
         expect(notesReducer(initalEmptyState, action)).toEqual({
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Failed,
+            fetchNotesByDocumentIds: ReqStatus.Failed,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Idle,
           },
           error: {
-            fetchNotesByDocumentId: 'error',
+            fetchNotesByDocumentIds: 'error',
             createNote: null,
             deleteNote: null,
           },
@@ -152,11 +152,11 @@ describe('notesSlice', () => {
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Idle,
+            fetchNotesByDocumentIds: ReqStatus.Idle,
             createNote: ReqStatus.Loading,
             deleteNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
@@ -177,11 +177,11 @@ describe('notesSlice', () => {
           entities: action.payload.entities.notes,
           ids: [action.payload.result],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Idle,
+            fetchNotesByDocumentIds: ReqStatus.Idle,
             createNote: ReqStatus.Succeeded,
             deleteNote: ReqStatus.Idle,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
@@ -192,12 +192,12 @@ describe('notesSlice', () => {
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Idle,
+            fetchNotesByDocumentIds: ReqStatus.Idle,
             createNote: ReqStatus.Failed,
             deleteNote: ReqStatus.Idle,
           },
           error: {
-            fetchNotesByDocumentId: null,
+            fetchNotesByDocumentIds: null,
             createNote: 'error',
             deleteNote: null,
           },
@@ -213,11 +213,11 @@ describe('notesSlice', () => {
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Idle,
+            fetchNotesByDocumentIds: ReqStatus.Idle,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Loading,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
@@ -231,11 +231,11 @@ describe('notesSlice', () => {
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Idle,
+            fetchNotesByDocumentIds: ReqStatus.Idle,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Succeeded,
           },
-          error: { fetchNotesByDocumentId: null, createNote: null, deleteNote: null },
+          error: { fetchNotesByDocumentIds: null, createNote: null, deleteNote: null },
         });
       });
 
@@ -246,12 +246,12 @@ describe('notesSlice', () => {
           entities: {},
           ids: [],
           status: {
-            fetchNotesByDocumentId: ReqStatus.Idle,
+            fetchNotesByDocumentIds: ReqStatus.Idle,
             createNote: ReqStatus.Idle,
             deleteNote: ReqStatus.Failed,
           },
           error: {
-            fetchNotesByDocumentId: null,
+            fetchNotesByDocumentIds: null,
             createNote: null,
             deleteNote: 'error',
           },
@@ -283,11 +283,11 @@ describe('notesSlice', () => {
     });
 
     it('should return fetch notes by document id status', () => {
-      expect(selectFetchNotesByDocumentIdStatus(mockGlobalState)).toEqual(ReqStatus.Idle);
+      expect(selectFetchNotesByDocumentIdsStatus(mockGlobalState)).toEqual(ReqStatus.Idle);
     });
 
     it('should return fetch notes by document id error', () => {
-      expect(selectFetchNotesByDocumentIdError(mockGlobalState)).toEqual(null);
+      expect(selectFetchNotesByDocumentIdsError(mockGlobalState)).toEqual(null);
     });
 
     it('should return create note by document id status', () => {

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.ts
@@ -12,7 +12,7 @@ import type { State } from '../../common/store';
 import {
   createNote as createNoteApi,
   deleteNote as deleteNoteApi,
-  fetchNotesByDocumentId as fetchNotesByDocumentIdApi,
+  fetchNotesByDocumentIds as fetchNotesByDocumentIdsApi,
 } from '../api/api';
 import type { NormalizedEntities, NormalizedEntity } from './normalize';
 import { normalizeEntities, normalizeEntity } from './normalize';
@@ -32,12 +32,12 @@ interface HttpError {
 
 export interface NotesState extends EntityState<Note> {
   status: {
-    fetchNotesByDocumentId: ReqStatus;
+    fetchNotesByDocumentIds: ReqStatus;
     createNote: ReqStatus;
     deleteNote: ReqStatus;
   };
   error: {
-    fetchNotesByDocumentId: SerializedError | HttpError | null;
+    fetchNotesByDocumentIds: SerializedError | HttpError | null;
     createNote: SerializedError | HttpError | null;
     deleteNote: SerializedError | HttpError | null;
   };
@@ -49,24 +49,24 @@ const notesAdapter = createEntityAdapter<Note>({
 
 export const initialNotesState: NotesState = notesAdapter.getInitialState({
   status: {
-    fetchNotesByDocumentId: ReqStatus.Idle,
+    fetchNotesByDocumentIds: ReqStatus.Idle,
     createNote: ReqStatus.Idle,
     deleteNote: ReqStatus.Idle,
   },
   error: {
-    fetchNotesByDocumentId: null,
+    fetchNotesByDocumentIds: null,
     createNote: null,
     deleteNote: null,
   },
 });
 
-export const fetchNotesByDocumentId = createAsyncThunk<
+export const fetchNotesByDocumentIds = createAsyncThunk<
   NormalizedEntities<Note>,
-  { documentId: string },
+  { documentIds: string[] },
   {}
->('notes/fetchNotesByDocumentId', async (args) => {
-  const { documentId } = args;
-  const res = await fetchNotesByDocumentIdApi(documentId);
+>('notes/fetchNotesByDocumentIds', async (args) => {
+  const { documentIds } = args;
+  const res = await fetchNotesByDocumentIdsApi(documentIds);
   return normalizeEntities(res);
 });
 
@@ -94,16 +94,16 @@ const notesSlice = createSlice({
   reducers: {},
   extraReducers(builder) {
     builder
-      .addCase(fetchNotesByDocumentId.pending, (state) => {
-        state.status.fetchNotesByDocumentId = ReqStatus.Loading;
+      .addCase(fetchNotesByDocumentIds.pending, (state) => {
+        state.status.fetchNotesByDocumentIds = ReqStatus.Loading;
       })
-      .addCase(fetchNotesByDocumentId.fulfilled, (state, action) => {
+      .addCase(fetchNotesByDocumentIds.fulfilled, (state, action) => {
         notesAdapter.upsertMany(state, action.payload.entities.notes);
-        state.status.fetchNotesByDocumentId = ReqStatus.Succeeded;
+        state.status.fetchNotesByDocumentIds = ReqStatus.Succeeded;
       })
-      .addCase(fetchNotesByDocumentId.rejected, (state, action) => {
-        state.status.fetchNotesByDocumentId = ReqStatus.Failed;
-        state.error.fetchNotesByDocumentId = action.payload ?? action.error;
+      .addCase(fetchNotesByDocumentIds.rejected, (state, action) => {
+        state.status.fetchNotesByDocumentIds = ReqStatus.Failed;
+        state.error.fetchNotesByDocumentIds = action.payload ?? action.error;
       })
       .addCase(createNote.pending, (state) => {
         state.status.createNote = ReqStatus.Loading;
@@ -138,11 +138,11 @@ export const {
   selectIds: selectNoteIds,
 } = notesAdapter.getSelectors((state: State) => state.notes);
 
-export const selectFetchNotesByDocumentIdStatus = (state: State) =>
-  state.notes.status.fetchNotesByDocumentId;
+export const selectFetchNotesByDocumentIdsStatus = (state: State) =>
+  state.notes.status.fetchNotesByDocumentIds;
 
-export const selectFetchNotesByDocumentIdError = (state: State) =>
-  state.notes.error.fetchNotesByDocumentId;
+export const selectFetchNotesByDocumentIdsError = (state: State) =>
+  state.notes.error.fetchNotesByDocumentIds;
 
 export const selectCreateNoteStatus = (state: State) => state.notes.status.createNote;
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/helpers.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import { EuiBadge, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
@@ -20,15 +20,22 @@ const NotesCountBadge = styled(EuiBadge)`
 
 NotesCountBadge.displayName = 'NotesCountBadge';
 
-interface NotesButtonProps {
-  ariaLabel?: string;
-  isDisabled?: boolean;
-  showNotes: boolean;
-  toggleShowNotes: () => void | ((eventId: string) => void);
-  toolTip?: string;
-  timelineType: TimelineTypeLiteral;
-  eventId?: string;
-}
+export const NotificationDot = styled.span`
+  position: absolute;
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.eui.euiColorDanger};
+  top: 17%;
+  left: 52%;
+`;
+
+const NotesButtonContainer = styled(EuiFlexGroup)`
+  position: relative;
+`;
+
+export const NOTES_BUTTON_CLASS_NAME = 'notes-button';
 
 interface SmallNotesButtonProps {
   ariaLabel?: string;
@@ -36,12 +43,14 @@ interface SmallNotesButtonProps {
   toggleShowNotes: (eventId?: string) => void;
   timelineType: TimelineTypeLiteral;
   eventId?: string;
+  /**
+   * Number of notes. If > 0, then a red dot is shown in the top right corner of the icon.
+   */
+  notesCount: number;
 }
 
-export const NOTES_BUTTON_CLASS_NAME = 'notes-button';
-
 const SmallNotesButton = React.memo<SmallNotesButtonProps>(
-  ({ ariaLabel = i18n.NOTES, isDisabled, toggleShowNotes, timelineType, eventId }) => {
+  ({ ariaLabel = i18n.NOTES, isDisabled, toggleShowNotes, timelineType, eventId, notesCount }) => {
     const isTemplate = timelineType === TimelineType.template;
     const onClick = useCallback(() => {
       if (eventId != null) {
@@ -52,23 +61,52 @@ const SmallNotesButton = React.memo<SmallNotesButtonProps>(
     }, [toggleShowNotes, eventId]);
 
     return (
-      <EuiButtonIcon
-        aria-label={ariaLabel}
-        className={NOTES_BUTTON_CLASS_NAME}
-        data-test-subj="timeline-notes-button-small"
-        disabled={isDisabled}
-        iconType="editorComment"
-        onClick={onClick}
-        size="s"
-        isDisabled={isTemplate}
-      />
+      <NotesButtonContainer>
+        <EuiFlexItem grow={false}>
+          {notesCount > 0 ? <NotificationDot /> : null}
+          <EuiButtonIcon
+            aria-label={ariaLabel}
+            className={NOTES_BUTTON_CLASS_NAME}
+            data-test-subj="timeline-notes-button-small"
+            disabled={isDisabled}
+            iconType="editorComment"
+            onClick={onClick}
+            size="s"
+            isDisabled={isTemplate}
+          />
+        </EuiFlexItem>
+      </NotesButtonContainer>
     );
   }
 );
 SmallNotesButton.displayName = 'SmallNotesButton';
 
+interface NotesButtonProps {
+  ariaLabel?: string;
+  isDisabled?: boolean;
+  showNotes: boolean;
+  toggleShowNotes: () => void | ((eventId: string) => void);
+  toolTip?: string;
+  timelineType: TimelineTypeLiteral;
+  eventId?: string;
+  /**
+   * Number of notes associated with the event.
+   * Defaults to 0
+   */
+  notesCount?: number;
+}
+
 export const NotesButton = React.memo<NotesButtonProps>(
-  ({ ariaLabel, isDisabled, showNotes, timelineType, toggleShowNotes, toolTip, eventId }) =>
+  ({
+    ariaLabel,
+    isDisabled,
+    showNotes,
+    timelineType,
+    toggleShowNotes,
+    toolTip,
+    eventId,
+    notesCount = 0,
+  }) =>
     showNotes ? (
       <SmallNotesButton
         ariaLabel={ariaLabel}
@@ -76,6 +114,7 @@ export const NotesButton = React.memo<NotesButtonProps>(
         toggleShowNotes={toggleShowNotes}
         timelineType={timelineType}
         eventId={eventId}
+        notesCount={notesCount}
       />
     ) : (
       <EuiToolTip content={toolTip || ''} data-test-subj="timeline-notes-tool-tip">
@@ -85,6 +124,7 @@ export const NotesButton = React.memo<NotesButtonProps>(
           toggleShowNotes={toggleShowNotes}
           timelineType={timelineType}
           eventId={eventId}
+          notesCount={notesCount}
         />
       </EuiToolTip>
     )

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -14,6 +14,11 @@ import { connect } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { DataLoadingState } from '@kbn/unified-data-table';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import {
+  DocumentDetailsLeftPanelKey,
+  DocumentDetailsRightPanelKey,
+} from '../../../../../flyout/document_details/shared/constants/panel_keys';
 import type { ControlColumnProps } from '../../../../../../common/types';
 import { timelineActions, timelineSelectors } from '../../../../store';
 import type { Direction } from '../../../../../../common/search_strategy';
@@ -46,6 +51,7 @@ import {
 import type { TimelineTabCommonProps } from '../shared/types';
 import { useTimelineColumns } from '../shared/use_timeline_columns';
 import { useTimelineControlColumn } from '../shared/use_timeline_control_columns';
+import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
 
 const ExitFullScreenContainer = styled.div`
   width: 180px;
@@ -171,12 +177,54 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
       timerangeKind: undefined,
     });
 
+  const expandableFlyoutDisabled = useIsExperimentalFeatureEnabled('expandableFlyoutDisabled');
+  const { openFlyout } = useExpandableFlyoutApi();
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
+  const onToggleShowNotes = useCallback(
+    (eventId?: string) => {
+      const indexName = selectedPatterns.join(',');
+      if (eventId && !expandableFlyoutDisabled && securitySolutionNotesEnabled) {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
+          },
+          left: {
+            id: DocumentDetailsLeftPanelKey,
+            path: {
+              tab: LeftPanelNotesTab,
+            },
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
+          },
+        });
+      }
+    },
+    [
+      expandableFlyoutDisabled,
+      openFlyout,
+      securitySolutionNotesEnabled,
+      selectedPatterns,
+      timelineId,
+    ]
+  );
+
   const leadingControlColumns = useTimelineControlColumn({
     columns,
     sort,
     timelineId,
     activeTab: TimelineTabs.pinned,
     refetch,
+    onToggleShowNotes,
   });
 
   const isQueryLoading = useMemo(

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -14,6 +14,12 @@ import deepEqual from 'fast-deep-equal';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { DataLoadingState } from '@kbn/unified-data-table';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import {
+  DocumentDetailsLeftPanelKey,
+  DocumentDetailsRightPanelKey,
+} from '../../../../../flyout/document_details/shared/constants/panel_keys';
+import { LeftPanelNotesTab } from '../../../../../flyout/document_details/left';
 import { useDeepEqualSelector } from '../../../../../common/hooks/use_selector';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useTimelineDataFilters } from '../../../../containers/use_timeline_data_filters';
@@ -203,12 +209,54 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     timerangeKind,
   });
 
+  const expandableFlyoutDisabled = useIsExperimentalFeatureEnabled('expandableFlyoutDisabled');
+  const { openFlyout } = useExpandableFlyoutApi();
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
+  const onToggleShowNotes = useCallback(
+    (eventId?: string) => {
+      const indexName = selectedPatterns.join(',');
+      if (eventId && !expandableFlyoutDisabled && securitySolutionNotesEnabled) {
+        openFlyout({
+          right: {
+            id: DocumentDetailsRightPanelKey,
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
+          },
+          left: {
+            id: DocumentDetailsLeftPanelKey,
+            path: {
+              tab: LeftPanelNotesTab,
+            },
+            params: {
+              id: eventId,
+              indexName,
+              scopeId: timelineId,
+            },
+          },
+        });
+      }
+    },
+    [
+      expandableFlyoutDisabled,
+      openFlyout,
+      securitySolutionNotesEnabled,
+      selectedPatterns,
+      timelineId,
+    ]
+  );
+
   const leadingControlColumns = useTimelineControlColumn({
     columns,
     sort,
     timelineId,
     activeTab: TimelineTabs.query,
     refetch,
+    onToggleShowNotes,
   });
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.test.tsx
@@ -51,6 +51,7 @@ describe('useTimelineColumns', () => {
             timelineId: TimelineId.test,
             activeTab: TimelineTabs.query,
             refetch: refetchMock,
+            onToggleShowNotes: jest.fn(),
           }),
         {
           wrapper: TestProviders,
@@ -70,6 +71,7 @@ describe('useTimelineColumns', () => {
             timelineId: TimelineId.test,
             activeTab: TimelineTabs.query,
             refetch: refetchMock,
+            onToggleShowNotes: jest.fn(),
           }),
         {
           wrapper: TestProviders,
@@ -90,6 +92,7 @@ describe('useTimelineColumns', () => {
             timelineId: TimelineId.test,
             activeTab: TimelineTabs.query,
             refetch: refetchMock,
+            onToggleShowNotes: jest.fn(),
           }),
         {
           wrapper: TestProviders,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.tsx
@@ -27,6 +27,7 @@ interface UseTimelineControlColumnArgs {
   timelineId: string;
   activeTab: TimelineTabs;
   refetch: () => void;
+  onToggleShowNotes: (eventId?: string) => void;
 }
 
 const EMPTY_STRING_ARRAY: string[] = [];
@@ -39,6 +40,7 @@ export const useTimelineControlColumn = ({
   timelineId,
   activeTab,
   refetch,
+  onToggleShowNotes,
 }: UseTimelineControlColumnArgs) => {
   const { browserFields } = useSourcererDataView(SourcererScopeName.timeline);
 
@@ -95,6 +97,7 @@ export const useTimelineControlColumn = ({
               showCheckboxes={false}
               setEventsLoading={noOp}
               setEventsDeleted={noOp}
+              onToggleShowNotes={onToggleShowNotes}
             />
           );
         },
@@ -106,14 +109,15 @@ export const useTimelineControlColumn = ({
       })) as unknown as ColumnHeaderOptions[];
     }
   }, [
-    ACTION_BUTTON_COUNT,
+    unifiedComponentsInTimelineEnabled,
     UNIFIED_COMPONENTS_ACTION_BUTTON_COUNT,
     browserFields,
     localColumns,
     sort,
-    unifiedComponentsInTimelineEnabled,
-    timelineId,
     activeTab,
+    timelineId,
     refetch,
+    onToggleShowNotes,
+    ACTION_BUTTON_COUNT,
   ]);
 };

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table_state.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table_state.tsx
@@ -78,7 +78,7 @@ export type AlertsTableStateProps = {
   pageSize?: number;
   browserFields?: BrowserFields;
   onUpdate?: (args: TableUpdateHandlerArgs) => void;
-  onLoaded?: () => void;
+  onLoaded?: (alerts: Alerts) => void;
   runtimeMappings?: MappingRuntimeFields;
   showAlertStatusWithFlapping?: boolean;
   toolbarVisibility?: EuiDataGridToolBarVisibilityOptions;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_fetch_alerts.tsx
@@ -36,7 +36,7 @@ export interface FetchAlertsArgs {
     pageIndex: number;
     pageSize: number;
   };
-  onLoaded?: () => void;
+  onLoaded?: (alerts: Alerts) => void;
   onPageChange: (pagination: RuleRegistrySearchRequestPagination) => void;
   runtimeMappings?: MappingRuntimeFields;
   sort: SortCombinations[];
@@ -259,13 +259,13 @@ const useFetchAlerts = ({
                     totalAlerts,
                   });
                   dispatch({ type: 'loading', loading: false });
-                  onLoaded?.();
+                  onLoaded?.(alerts);
                   searchSubscription$.current.unsubscribe();
                 }
               },
               error: (msg) => {
                 dispatch({ type: 'loading', loading: false });
-                onLoaded?.();
+                onLoaded?.([]);
                 data.search.showError(msg);
                 searchSubscription$.current.unsubscribe();
               },


### PR DESCRIPTION
## Summary

This PR continues to add functionality to the new notes feature for Security Solution. It focuses on adding a note icon to the alerts table.

- add a note icon to a few tables in the application:
  - alerts table on the alerts page
  - alerts table on the cases page
  - events table in the hosts page
  - events table in the network page
  - events table in the users page
  - all timeline screens, with the `unifiedComponentsInTimelineEnabled` on and off
- add a red dot the the notes icon in the tables mentioned above as well as the timeline tables, signifying when an document has notes associated with it

When the table is loaded, a call is made to fetch all the notes for the documents visible on that page.

### TODO

- [x] add similar logic for the events table
- [x] verify that things work correctly in timeline

https://github.com/elastic/kibana/assets/17276605/f7ce26ab-b344-464f-bca1-369b70c72503

### How to test

- make sure the feature flag is enabled in your `kibana.yml` file: `xpack.securitySolution.enableExperimental: ['securitySolutionNotesEnabled']`
- verify that the note icon appears on all the tables mentioned above as well as timeline
- verify that when creating a note for an alert or event, the note icon reflect that in all other places for the same document id
- verify that no changes should be visible if either `securitySolutionNotesEnabled` or `expandableFlyoutDisabled` are on

_Note: as the server side code isn't ready, the frontend is mocking the fectch notes call and always returns one note per document id. If you load the alerts page in this PR, it is expected to see one note for each row of the table._

![Screenshot 2024-06-26 at 10 36 53 AM](https://github.com/elastic/kibana/assets/17276605/a4b25b4a-36c5-48f3-a2c1-d40f751c6e6f)

https://github.com/elastic/security-team/issues/9375

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios