### PR TITLE
[CI] Switch to prod FIPS image

### DIFF
--- a/.buildkite/pipeline-utils/agent_images.ts
+++ b/.buildkite/pipeline-utils/agent_images.ts
@@ -20,7 +20,7 @@ const DEFAULT_AGENT_IMAGE_CONFIG: AgentImageConfig = {
 const FIPS_AGENT_IMAGE_CONFIG: AgentImageConfig = {
   provider: 'gcp',
   image: 'family/kibana-fips-ubuntu-2004',
-  imageProject: 'elastic-images-qa',
+  imageProject: 'elastic-images-prod',
 };
 
 const GITHUB_PR_LABELS = process.env.GITHUB_PR_LABELS ?? '';


### PR DESCRIPTION
## Summary

The FIPS image has been promoted to `prod` project so use it instead of `qa`.
