### PR TITLE
[ResponseOps][Connectors] Remove feature flag for ServiceNow additional fields

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/additional_fields.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/additional_fields.test.tsx
@@ -36,32 +36,16 @@ describe('Credentials', () => {
     expect(await screen.findByText(value)).toBeInTheDocument();
   });
 
-  /**
-   * Test for the intermediate release process
-   */
-  it('does not show the component if the value is undefined', async () => {
+  it('changes the value correctly', async () => {
+    const newValue = JSON.stringify({ bar: 'test' });
+
     render(
       <IntlProvider locale="en">
         <AdditionalFields {...props} value={undefined} />
       </IntlProvider>
     );
 
-    expect(screen.queryByTestId('additional_fieldsJsonEditor')).not.toBeInTheDocument();
-  });
-
-  it('changes the value correctly', async () => {
-    const newValue = JSON.stringify({ bar: 'test' });
-
-    render(
-      <IntlProvider locale="en">
-        <AdditionalFields {...props} />
-      </IntlProvider>
-    );
-
-    const editor = await screen.findByTestId('additional_fieldsJsonEditor');
-
-    userEvent.clear(editor);
-    userEvent.paste(editor, newValue);
+    userEvent.paste(await screen.findByTestId('additional_fieldsJsonEditor'), newValue);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(newValue);
@@ -75,7 +59,7 @@ describe('Credentials', () => {
 
     render(
       <IntlProvider locale="en">
-        <AdditionalFields {...props} />
+        <AdditionalFields {...props} value={undefined} />
       </IntlProvider>
     );
 

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/additional_fields.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/additional_fields.tsx
@@ -25,16 +25,6 @@ export const AdditionalFieldsComponent: React.FC<AdditionalFieldsProps> = ({
   messageVariables,
   onChange,
 }) => {
-  /**
-   * Hide the component if the value is not defined.
-   * This is needed for the intermediate release process.
-   * Users will not be able to use the field if they have never set it.
-   * On the next Serverless release the check will be removed.
-   */
-  if (value === undefined) {
-    return null;
-  }
-
   return (
     <JsonEditorWithMessageVariables
       messageVariables={messageVariables}


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/184023, we introduced the "additional fields" field for ServiceNow ITSM and SecOps. The field was under a feature flag to follow the intermediate release process. This PR reverts commit 6a593e930802353ee5189e72db2e28f15bf0da42 to remove the feature flag.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
