### PR TITLE
[Security Solution][Notes] - use correct mardowneditor and avatar

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -7,18 +7,20 @@
 
 import React, { memo, useCallback, useEffect, useState } from 'react';
 import {
+  EuiAvatar,
   EuiButtonIcon,
   EuiComment,
   EuiCommentList,
   EuiLoadingElastic,
-  EuiMarkdownFormat,
 } from '@elastic/eui';
 import { useDispatch, useSelector } from 'react-redux';
 import { FormattedRelative } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { MarkdownRenderer } from '../../../../common/components/markdown_editor';
 import {
   ADD_NOTE_LOADING_TEST_ID,
   DELETE_NOTE_BUTTON_TEST_ID,
+  NOTE_AVATAR_TEST_ID,
   NOTES_COMMENT_TEST_ID,
   NOTES_LOADING_TEST_ID,
 } from './test_ids';
@@ -138,8 +140,15 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
               isLoading={deletingNoteId === note.noteId && deleteStatus === ReqStatus.Loading}
             />
           }
+          timelineAvatar={
+            <EuiAvatar
+              data-test-subj={`${NOTE_AVATAR_TEST_ID}-${index}`}
+              size="l"
+              name={note.updatedBy || '?'}
+            />
+          }
         >
-          <EuiMarkdownFormat textSize="s">{note.note || ''}</EuiMarkdownFormat>
+          <MarkdownRenderer>{note.note || ''}</MarkdownRenderer>
         </EuiComment>
       ))}
       {createStatus === ReqStatus.Loading && (

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/test_ids.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/test_ids.ts
@@ -97,4 +97,5 @@ export const NOTES_COMMENT_TEST_ID = `${PREFIX}NotesComment` as const;
 export const ADD_NOTE_LOADING_TEST_ID = `${PREFIX}AddNotesLoading` as const;
 export const ADD_NOTE_MARKDOWN_TEST_ID = `${PREFIX}AddNotesMarkdown` as const;
 export const ADD_NOTE_BUTTON_TEST_ID = `${PREFIX}AddNotesButton` as const;
+export const NOTE_AVATAR_TEST_ID = `${PREFIX}NoteAvatar` as const;
 export const DELETE_NOTE_BUTTON_TEST_ID = `${PREFIX}DeleteNotesButton` as const;


### PR DESCRIPTION
## Summary

This PR fixes a small issue, where the expandable flyout Notes tab was not using the same UI components as the timeline Notes tab:
- replaced `EuiMarkdownFormat` with our `MarkdownRenderer`
- customized the default avatar from `EuiComment` with our own `EuiAvatar`

#### Before

![Screenshot 2024-06-26 at 11 04 07 AM](https://github.com/elastic/kibana/assets/17276605/1a7712d5-13c5-403a-a317-b89d47e59db4)

#### After

![Screenshot 2024-06-26 at 11 04 41 AM](https://github.com/elastic/kibana/assets/17276605/7eb695a1-b82b-4d34-ac07-a05f5d4e274d)

### How to test

- make sure the feature flag is enabled in your `kibana.yml` file: `xpack.securitySolution.enableExperimental: ['securitySolutionNotesEnabled']`
- open the expandable flyout, click on the Expand details button to expand the left section then navigate to the new Notes tab

https://github.com/elastic/security-team/issues/9375

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios