### PR TITLE
[Security Solution] Fix `prebuiltRulesCustomizationEnabled` feature flag

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -234,6 +234,17 @@ export const allowedExperimentalValues = Object.freeze({
   perFieldPrebuiltRulesDiffingEnabled: true,
 
   /**
+   * Enables an ability to customize Elastic prebuilt rules.
+   *
+   * Ticket: https://github.com/elastic/kibana/issues/174168
+   * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
+   * Added: on Jun 24, 2024 in https://github.com/elastic/kibana/pull/186823
+   * Turned: TBD
+   * Expires: TBD
+   */
+  prebuiltRulesCustomizationEnabled: false,
+
+  /**
    * Makes Elastic Defend integration's Malware On-Write Scan option available to edit.
    */
   malwareOnWriteScanOptionAvailable: true,
@@ -267,14 +278,6 @@ export const allowedExperimentalValues = Object.freeze({
    * Adds a new option to filter descendants of a process for Management / Event Filters
    */
   filterProcessDescendantsForEventFiltersEnabled: false,
-
-  /**
-   * Enables an ability to customize Elastic prebuilt rules.
-   *
-   * Ticket: https://github.com/elastic/security-team/issues/1974
-   * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
-   */
-  prebuiltRulesCustomizationEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/180130**
**Follow-up to:** https://github.com/elastic/kibana/pull/186823

## Summary

- Adds more information to the feature flag's JSDoc comment according to the template we use for feature flags.
- Changes the ticket's link to a public one.