### PR TITLE
[Security Solution] Remove expired feature flags for prebuilt rules UI

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -192,18 +192,6 @@ export const allowedExperimentalValues = Object.freeze({
    */
   jamfDataInAnalyzerEnabled: false,
 
-  /**
-   * Enables experimental "Updates" tab in the prebuilt rule upgrade flyout.
-   * This tab shows the JSON diff between the installed prebuilt rule
-   * version and the latest available version.
-   *
-   * Ticket: https://github.com/elastic/kibana/issues/169160
-   * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
-   * Added: on Dec 06, 2023 in https://github.com/elastic/kibana/pull/172535
-   * Turned: on Dec 20, 2023 in https://github.com/elastic/kibana/pull/173368
-   * Expires: on Feb 20, 2024
-   */
-  jsonPrebuiltRulesDiffingEnabled: true,
   /*
    * Disables discover esql tab within timeline
    *
@@ -219,17 +207,6 @@ export const allowedExperimentalValues = Object.freeze({
    *
    */
   analyzerDatePickersAndSourcererDisabled: false,
-
-  /**
-   * Enables per-field rule diffs tab in the prebuilt rule upgrade flyout
-   *
-   * Ticket: https://github.com/elastic/kibana/issues/166489
-   * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
-   * Added: on Feb 12, 2024 in https://github.com/elastic/kibana/pull/174564
-   * Turned: on Feb 23, 2024 in https://github.com/elastic/kibana/pull/177495
-   * Expires: on Apr 23, 2024
-   */
-  perFieldPrebuiltRulesDiffingEnabled: true,
 
   /**
    * Enables an ability to customize Elastic prebuilt rules.

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -32,7 +32,6 @@ import {
 } from '../../../../rule_management/components/rule_details/rule_details_flyout';
 import { RuleDiffTab } from '../../../../rule_management/components/rule_details/rule_diff_tab';
 import { MlJobUpgradeModal } from '../../../../../detections/components/modals/ml_job_upgrade_modal';
-import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import * as ruleDetailsI18n from '../../../../rule_management/components/rule_details/translations';
 import * as i18n from './translations';
 
@@ -119,14 +118,6 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     filter: '',
     tags: [],
   });
-
-  const isJsonPrebuiltRulesDiffingEnabled = useIsExperimentalFeatureEnabled(
-    'jsonPrebuiltRulesDiffingEnabled'
-  );
-
-  const isPerFieldPrebuiltRulesDiffingEnabled = useIsExperimentalFeatureEnabled(
-    'perFieldPrebuiltRulesDiffingEnabled'
-  );
 
   const isUpgradingSecurityPackages = useIsUpgradingSecurityPackages();
 
@@ -282,53 +273,34 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     }
 
     return [
-      ...(isPerFieldPrebuiltRulesDiffingEnabled
-        ? [
-            {
-              id: 'updates',
-              name: (
-                <EuiToolTip
-                  position="top"
-                  content={i18n.UPDATE_FLYOUT_PER_FIELD_TOOLTIP_DESCRIPTION}
-                >
-                  <>{ruleDetailsI18n.UPDATES_TAB_LABEL}</>
-                </EuiToolTip>
-              ),
-              content: (
-                <TabContentPadding>
-                  <PerFieldRuleDiffTab ruleDiff={activeRule.diff} />
-                </TabContentPadding>
-              ),
-            },
-          ]
-        : []),
-      ...(isJsonPrebuiltRulesDiffingEnabled
-        ? [
-            {
-              id: 'jsonViewUpdates',
-              name: (
-                <EuiToolTip
-                  position="top"
-                  content={i18n.UPDATE_FLYOUT_JSON_VIEW_TOOLTIP_DESCRIPTION}
-                >
-                  <>{ruleDetailsI18n.JSON_VIEW_UPDATES_TAB_LABEL}</>
-                </EuiToolTip>
-              ),
-              content: (
-                <TabContentPadding>
-                  <RuleDiffTab oldRule={activeRule.current_rule} newRule={activeRule.target_rule} />
-                </TabContentPadding>
-              ),
-            },
-          ]
-        : []),
+      {
+        id: 'updates',
+        name: (
+          <EuiToolTip position="top" content={i18n.UPDATE_FLYOUT_PER_FIELD_TOOLTIP_DESCRIPTION}>
+            <>{ruleDetailsI18n.UPDATES_TAB_LABEL}</>
+          </EuiToolTip>
+        ),
+        content: (
+          <TabContentPadding>
+            <PerFieldRuleDiffTab ruleDiff={activeRule.diff} />
+          </TabContentPadding>
+        ),
+      },
+      {
+        id: 'jsonViewUpdates',
+        name: (
+          <EuiToolTip position="top" content={i18n.UPDATE_FLYOUT_JSON_VIEW_TOOLTIP_DESCRIPTION}>
+            <>{ruleDetailsI18n.JSON_VIEW_UPDATES_TAB_LABEL}</>
+          </EuiToolTip>
+        ),
+        content: (
+          <TabContentPadding>
+            <RuleDiffTab oldRule={activeRule.current_rule} newRule={activeRule.target_rule} />
+          </TabContentPadding>
+        ),
+      },
     ];
-  }, [
-    previewedRule,
-    filteredRules,
-    isJsonPrebuiltRulesDiffingEnabled,
-    isPerFieldPrebuiltRulesDiffingEnabled,
-  ]);
+  }, [previewedRule, filteredRules]);
 
   return (
     <UpgradePrebuiltRulesTableContext.Provider value={providerValue}>
@@ -344,7 +316,7 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
         {previewedRule && (
           <RuleDetailsFlyout
             rule={previewedRule}
-            size={isJsonPrebuiltRulesDiffingEnabled ? 'l' : 'm'}
+            size="l"
             id={PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR}
             dataTestSubj="updatePrebuiltRulePreview"
             closeFlyout={closeRulePreview}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
@@ -9,7 +9,6 @@ import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/
 import { MaintenanceWindowCallout } from '@kbn/alerts-ui-shared';
 import React, { useCallback } from 'react';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { APP_UI_ID } from '../../../../../common/constants';
 import { SecurityPageName } from '../../../../app/types';
 import { ImportDataModal } from '../../../../common/components/import_data_modal';
@@ -55,9 +54,6 @@ const RulesPageComponent: React.FC = () => {
     invalidateFetchRuleManagementFilters,
     invalidateFetchCoverageOverviewQuery,
   ]);
-  const isPerFieldPrebuiltRulesDiffingEnabled = useIsExperimentalFeatureEnabled(
-    'perFieldPrebuiltRulesDiffingEnabled'
-  );
 
   const [
     {
@@ -177,7 +173,7 @@ const RulesPageComponent: React.FC = () => {
             kibanaServices={kibanaServices}
             categories={[DEFAULT_APP_CATEGORIES.security.id]}
           />
-          {isPerFieldPrebuiltRulesDiffingEnabled && <RuleFeatureTour />}
+          <RuleFeatureTour />
           <AllRules data-test-subj="all-rules" />
         </SecuritySolutionPageWrapper>
       </RulesTableContextProvider>

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/prebuilt_rules_preview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/prebuilt_rules/prebuilt_rules_preview.cy.ts
@@ -1143,111 +1143,96 @@ describe('Detection rules, Prebuilt Rules Installation and Update workflow', () 
       });
     });
 
-    describe(
-      'Viewing rule changes in per-field diff view',
-      {
-        tags: TEST_ENV_TAGS,
-        env: {
-          ftrConfig: {
-            kbnServerArgs: [
-              `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-                'perFieldPrebuiltRulesDiffingEnabled',
-              ])}`,
-            ],
-          },
-        },
-      },
-      () => {
-        it('User can see changes in a side-by-side per-field diff view', () => {
-          clickRuleUpdatesTab();
+    describe('Viewing rule changes in per-field diff view', { tags: TEST_ENV_TAGS }, () => {
+      it('User can see changes in a side-by-side per-field diff view', () => {
+        clickRuleUpdatesTab();
 
-          openRuleUpdatePreview(OUTDATED_RULE_1['security-rule'].name);
-          assertSelectedPreviewTab(PREVIEW_TABS.UPDATES); // Should be open by default
+        openRuleUpdatePreview(OUTDATED_RULE_1['security-rule'].name);
+        assertSelectedPreviewTab(PREVIEW_TABS.UPDATES); // Should be open by default
 
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Current rule').should('be.visible');
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Elastic update').should('be.visible');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Current rule').should('be.visible');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Elastic update').should('be.visible');
 
-          cy.get(PER_FIELD_DIFF_WRAPPER).should('have.length', 2);
+        cy.get(PER_FIELD_DIFF_WRAPPER).should('have.length', 2);
 
-          /* Version should be the first field in the order */
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('Version').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('1').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('2').should('be.visible');
+        /* Version should be the first field in the order */
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('Version').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('1').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('2').should('be.visible');
 
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Name').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Outdated rule 1').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Updated rule 1').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Name').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Outdated rule 1').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Updated rule 1').should('be.visible');
+      });
+
+      it('User can switch between rules upgrades without closing flyout', () => {
+        clickRuleUpdatesTab();
+
+        openRuleUpdatePreview(OUTDATED_RULE_1['security-rule'].name);
+        assertSelectedPreviewTab(PREVIEW_TABS.UPDATES); // Should be open by default
+
+        /* Version should be the first field in the order */
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('Version').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('1').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('2').should('be.visible');
+
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Name').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Outdated rule 1').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Updated rule 1').should('be.visible');
+
+        /* Select another rule without closing the preview for the current rule */
+        openRuleUpdatePreview(OUTDATED_RULE_2['security-rule'].name);
+
+        /* Make sure the per-field diff is displayed for the newly selected rule */
+        cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Name').should('be.visible');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Outdated rule 2').should('be.visible');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Updated rule 2').should('be.visible');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Outdated rule 1').should('not.exist');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Updated rule 1').should('not.exist');
+
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('Version').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('1').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('2').should('be.visible');
+      });
+
+      it('User can see changes when updated rule is a different rule type', () => {
+        const OUTDATED_RULE_WITH_QUERY_TYPE = createRuleAssetSavedObject({
+          name: 'Query rule',
+          rule_id: 'rule_id',
+          version: 1,
+          type: 'query',
+          language: 'kuery',
         });
-
-        it('User can switch between rules upgrades without closing flyout', () => {
-          clickRuleUpdatesTab();
-
-          openRuleUpdatePreview(OUTDATED_RULE_1['security-rule'].name);
-          assertSelectedPreviewTab(PREVIEW_TABS.UPDATES); // Should be open by default
-
-          /* Version should be the first field in the order */
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('Version').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('1').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('2').should('be.visible');
-
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Name').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Outdated rule 1').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Updated rule 1').should('be.visible');
-
-          /* Select another rule without closing the preview for the current rule */
-          openRuleUpdatePreview(OUTDATED_RULE_2['security-rule'].name);
-
-          /* Make sure the per-field diff is displayed for the newly selected rule */
-          cy.get(PER_FIELD_DIFF_WRAPPER).last().contains('Name').should('be.visible');
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Outdated rule 2').should('be.visible');
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Updated rule 2').should('be.visible');
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Outdated rule 1').should('not.exist');
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Updated rule 1').should('not.exist');
-
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('Version').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('1').should('be.visible');
-          cy.get(PER_FIELD_DIFF_WRAPPER).first().contains('2').should('be.visible');
+        const UPDATED_RULE_WITH_EQL_TYPE = createRuleAssetSavedObject({
+          language: 'eql',
+          name: 'EQL rule',
+          rule_id: 'rule_id',
+          version: 2,
+          type: 'eql',
         });
+        /* Create a new rule and install it */
+        createAndInstallMockedPrebuiltRules([OUTDATED_RULE_WITH_QUERY_TYPE]);
+        /* Create a second version of the rule, making it available for update */
+        installPrebuiltRuleAssets([UPDATED_RULE_WITH_EQL_TYPE]);
 
-        it('User can see changes when updated rule is a different rule type', () => {
-          const OUTDATED_RULE_WITH_QUERY_TYPE = createRuleAssetSavedObject({
-            name: 'Query rule',
-            rule_id: 'rule_id',
-            version: 1,
-            type: 'query',
-            language: 'kuery',
-          });
-          const UPDATED_RULE_WITH_EQL_TYPE = createRuleAssetSavedObject({
-            language: 'eql',
-            name: 'EQL rule',
-            rule_id: 'rule_id',
-            version: 2,
-            type: 'eql',
-          });
-          /* Create a new rule and install it */
-          createAndInstallMockedPrebuiltRules([OUTDATED_RULE_WITH_QUERY_TYPE]);
-          /* Create a second version of the rule, making it available for update */
-          installPrebuiltRuleAssets([UPDATED_RULE_WITH_EQL_TYPE]);
+        cy.reload();
+        clickRuleUpdatesTab();
 
-          cy.reload();
-          clickRuleUpdatesTab();
+        openRuleUpdatePreview(OUTDATED_RULE_WITH_QUERY_TYPE['security-rule'].name);
+        assertSelectedPreviewTab(PREVIEW_TABS.UPDATES); // Should be open by default
 
-          openRuleUpdatePreview(OUTDATED_RULE_WITH_QUERY_TYPE['security-rule'].name);
-          assertSelectedPreviewTab(PREVIEW_TABS.UPDATES); // Should be open by default
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Current rule').should('be.visible');
+        cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Elastic update').should('be.visible');
 
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Current rule').should('be.visible');
-          cy.get(UPDATE_PREBUILT_RULE_PREVIEW).contains('Elastic update').should('be.visible');
+        cy.get(PER_FIELD_DIFF_WRAPPER).should('have.length', 5);
 
-          cy.get(PER_FIELD_DIFF_WRAPPER).should('have.length', 5);
+        cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('Type').should('be.visible');
+        cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('query').should('be.visible');
+        cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('eql').should('be.visible');
 
-          cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('Type').should('be.visible');
-          cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('query').should('be.visible');
-          cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('eql').should('be.visible');
-
-          cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('KQL query').should('exist');
-          cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('EQL query').should('exist');
-        });
-      }
-    );
+        cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('KQL query').should('exist');
+        cy.get(PER_FIELD_DIFF_DEFINITION_SECTION).contains('EQL query').should('exist');
+      });
+    });
   });
 });


### PR DESCRIPTION
**Related to:** https://github.com/elastic/kibana/issues/174168

## Summary

Removes the `jsonPrebuiltRulesDiffingEnabled` and `perFieldPrebuiltRulesDiffingEnabled` feature flags that have been expired. See details in the code.

