### PR TITLE
[Security Solution] Fix flaky risk engine upgrade cypress test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/upgrade_risk_score.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/upgrade_risk_score.cy.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { getNewRule } from '../../../objects/rule';
 import {
   UPGRADE_RISK_SCORE_BUTTON,
   USERS_TABLE,
@@ -23,7 +22,6 @@ import {
 } from '../../../tasks/api_calls/risk_scores';
 import { clickUpgradeRiskScore } from '../../../tasks/risk_scores';
 
-import { createRule } from '../../../tasks/api_calls/rules';
 import { login } from '../../../tasks/login';
 import { visitWithTimeRange } from '../../../tasks/navigation';
 
@@ -32,15 +30,15 @@ import { RiskScoreEntity } from '../../../tasks/risk_scores/common';
 import { ENTITY_ANALYTICS_URL } from '../../../urls/navigation';
 import { upgradeRiskEngine } from '../../../tasks/entity_analytics';
 import { deleteRiskEngineConfiguration } from '../../../tasks/api_calls/risk_engine';
+import { deleteAlertsAndRules } from '../../../tasks/api_calls/common';
 
 const spaceId = 'default';
 
-// Failing: See https://github.com/elastic/kibana/issues/185024
-describe.skip('Upgrade risk scores', { tags: ['@ess'] }, () => {
+describe('Upgrade risk scores', { tags: ['@ess'] }, () => {
   beforeEach(() => {
     login();
     deleteRiskEngineConfiguration();
-    createRule(getNewRule({ rule_id: 'rule1' }));
+    deleteAlertsAndRules();
   });
 
   describe('show upgrade risk button', () => {


### PR DESCRIPTION
## Summary

I took a quick look at the test. It asserts that the risk score table inside the dashboard page will show no data after an upgrade. But it still shows one row of data, and the test fails.

All the failures show the same data inside the table. `user:test` and `host:siem-kibana` which are common test values
If the test logic is correct, there are 2 possibilities:
1. A previous test populated the risk-score index and didn't clean it up.
2. A previous test or the rule created on the before hook populates the `alerts` index and the risk engine init populates the `risk-score` index with that alert score.

If we clean the alerts and ensure that no rule creates more alerts, the test should pass.


flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6407



