### PR TITLE
[Security Solution] Fixes api tests executed on MKI

### DIFF
--- a/x-pack/test/security_solution_api_integration/scripts/mki_api_ftr_execution.ts
+++ b/x-pack/test/security_solution_api_integration/scripts/mki_api_ftr_execution.ts
@@ -161,6 +161,7 @@ export const cli = () => {
           TEST_CLOUD: testCloud.toString(),
           TEST_ES_URL: testEsUrl,
           TEST_KIBANA_URL: testKibanaUrl,
+          TEST_CLOUD_HOST_NAME: new URL(BASE_ENV_URL).hostname,
         };
 
         statusCode = await executeCommand(command, envVars, log);


### PR DESCRIPTION
## Summary

After moving [from basic to API authentication](https://github.com/elastic/kibana/pull/185870), API tests started to fail on MKI environments since the `TEST_CLOUD_HOST_NAME` environment variable is needed to get the correct information in this type of environments.

In this PR we are fixing it by adding the needed environment variable.