### PR TITLE
chore(launchdarkly): Update renovate rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,6 @@
       "reviewers": ["team:kibana-security", "team:kibana-core"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "Team:Security", "Team:Core", "backport:prev-minor"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

According to the docs `"prCreation": "not-pending",` means _Wait for branch tests to pass or fail before creating the PR._.

AFAIK, Renovate is not allowed to run CI steps, so that could be the reason for this rule to have never worked.

N.B.: If this works, we need to revisit all other Core-owned rules that have this same setting.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
