### PR TITLE
[Security Solution][Detections] Broken value lists

### DIFF
--- a/packages/kbn-securitysolution-lists-common/api/find_list/find_list.gen.ts
+++ b/packages/kbn-securitysolution-lists-common/api/find_list/find_list.gen.ts
@@ -24,7 +24,7 @@ export type FindListsCursor = z.infer<typeof FindListsCursor>;
 export const FindListsCursor = NonEmptyString;
 
 export type FindListsFilter = z.infer<typeof FindListsFilter>;
-export const FindListsFilter = NonEmptyString;
+export const FindListsFilter = z.string();
 
 export type FindListsRequestQuery = z.infer<typeof FindListsRequestQuery>;
 export const FindListsRequestQuery = z.object({

--- a/packages/kbn-securitysolution-lists-common/api/find_list/find_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/find_list/find_list.schema.yaml
@@ -116,4 +116,4 @@ components:
       $ref: '../../../kbn-openapi-common/schemas/primitives.schema.yaml#/components/schemas/NonEmptyString'
 
     FindListsFilter:
-      $ref: '../../../kbn-openapi-common/schemas/primitives.schema.yaml#/components/schemas/NonEmptyString'
+      type: string

--- a/packages/kbn-securitysolution-lists-common/api/find_list_item/find_list_item.gen.ts
+++ b/packages/kbn-securitysolution-lists-common/api/find_list_item/find_list_item.gen.ts
@@ -25,7 +25,7 @@ export type FindListItemsCursor = z.infer<typeof FindListItemsCursor>;
 export const FindListItemsCursor = NonEmptyString;
 
 export type FindListItemsFilter = z.infer<typeof FindListItemsFilter>;
-export const FindListItemsFilter = NonEmptyString;
+export const FindListItemsFilter = z.string();
 
 export type FindListItemsRequestQuery = z.infer<typeof FindListItemsRequestQuery>;
 export const FindListItemsRequestQuery = z.object({

--- a/packages/kbn-securitysolution-lists-common/api/find_list_item/find_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/find_list_item/find_list_item.schema.yaml
@@ -122,4 +122,4 @@ components:
       $ref: '../../../kbn-openapi-common/schemas/primitives.schema.yaml#/components/schemas/NonEmptyString'
 
     FindListItemsFilter:
-      $ref: '../../../kbn-openapi-common/schemas/primitives.schema.yaml#/components/schemas/NonEmptyString'
+      type: string

--- a/x-pack/test/security_solution_api_integration/test_suites/lists_and_exception_lists/lists_items/trial_license_complete_tier/items/find_list_items.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/lists_and_exception_lists/lists_items/trial_license_complete_tier/items/find_list_items.ts
@@ -79,6 +79,28 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
+      it('should accept empty string filter', async () => {
+        await supertest
+          .post(LIST_URL)
+          .set('kbn-xsrf', 'true')
+          .send(getCreateMinimalListSchemaMock())
+          .expect(200);
+
+        const { body } = await supertest
+          .get(`${LIST_ITEM_URL}/_find?list_id=${LIST_ID}&filter=`)
+          .set('kbn-xsrf', 'true')
+          .send()
+          .expect(200);
+
+        expect(body).toEqual({
+          cursor: 'WzBd',
+          data: [],
+          page: 1,
+          per_page: 20,
+          total: 0,
+        });
+      });
+
       it('should return a single list item when a single list item is loaded from a find with defaults added', async () => {
         const listMock = getCreateMinimalListSchemaMock();
         const listItemMock = getCreateMinimalListItemSchemaMock();


### PR DESCRIPTION
## Summary

While investigation one of the SDHs, I noticed that our value lists modal does not show list items anymore and shows `Failed to load list items. You can change the search query or contact your administrator` error instead.

The root cause is update API which were migrated in [this PR](https://github.com/elastic/kibana/pull/185865) to OpenAPI specifications. One of the query parameters was updated to be non-empty strings when that was not required before.

Since those list APIs are public, we should keep them as they were specified before, otherwise it makes breaking changes.

Previously `filter` parameter was specified as a string without limitation of being non-empty:
- [Find list schema](https://github.com/elastic/kibana/blob/main/packages/kbn-securitysolution-io-ts-list-types/src/request/find_list_schema/index.ts)
- [Find list item schema](https://github.com/elastic/kibana/blob/main/packages/kbn-securitysolution-io-ts-list-types/src/request/find_list_item_schema/index.ts)

**Current broken behaviour**:

https://github.com/elastic/kibana/assets/2700761/383dfd0f-5358-4325-88fe-b4820b4e2726

**Fixed state**:

https://github.com/elastic/kibana/assets/2700761/2d9adcc2-a55e-4aac-a8ff-5921222067c4

cc @maximpn