### PR TITLE
[UII] Drop `processors.add_fields` when global data tag array is empty

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_inputs.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_inputs.test.ts
@@ -877,4 +877,51 @@ describe('Fleet - storedPackagePoliciesToAgentInputs', () => {
       },
     ]);
   });
+
+  it('does not include processor add_fields when global tags array is empty', async () => {
+    expect(
+      await storedPackagePoliciesToAgentInputs(
+        [
+          {
+            ...mockPackagePolicy,
+            package: {
+              name: 'mock_package',
+              title: 'Mock package',
+              version: '0.0.0',
+            },
+            inputs: [
+              {
+                ...mockInput,
+                compiled_input: {
+                  inputVar: 'input-value',
+                },
+                streams: [],
+              },
+            ],
+          },
+        ],
+        packageInfoCache,
+        undefined,
+        undefined,
+        []
+      )
+    ).toEqual([
+      {
+        id: 'test-logs-some-uuid',
+        name: 'mock_package-policy',
+        package_policy_id: 'some-uuid',
+        revision: 1,
+        type: 'test-logs',
+        data_stream: { namespace: 'default' },
+        use_output: 'default',
+        meta: {
+          package: {
+            name: 'mock_package',
+            version: '0.0.0',
+          },
+        },
+        inputVar: 'input-value',
+      },
+    ]);
+  });
 });

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_inputs.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_inputs.ts
@@ -146,7 +146,10 @@ export const storedPackagePoliciesToAgentInputs = async (
 ): Promise<FullAgentPolicyInput[]> => {
   const fullInputs: FullAgentPolicyInput[] = [];
 
-  const addFields = globalDataTags ? globalDataTagsToAddFields(globalDataTags) : undefined;
+  const addFields =
+    globalDataTags && globalDataTags.length > 0
+      ? globalDataTagsToAddFields(globalDataTags)
+      : undefined;
 
   for (const packagePolicy of packagePolicies) {
     if (!isPolicyEnabled(packagePolicy)) {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/186993.

When `global_data_tags` array on an agent policy is empty due to user deleting all existing fields, this PR fixes the generated yaml by dropping the `processors.add_fields` entirely. Previously, it was being set with null values leading to agent health issues.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios