### PR TITLE
[Fleet] Make Fleet privileges space aware

### DIFF
--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -292,6 +292,7 @@ export class FleetPlugin
     core.status.set(this.fleetStatus$.asObservable());
 
     const experimentalFeatures = parseExperimentalConfigValue(config.enableExperimental ?? []);
+    const requireAllSpaces = experimentalFeatures.useSpaceAwareness ? false : true;
 
     registerSavedObjects(core.savedObjects, {
       useSpaceAwareness: experimentalFeatures.useSpaceAwareness,
@@ -331,7 +332,7 @@ export class FleetPlugin
           ? [
               {
                 name: 'Agents',
-                requireAllSpaces: true,
+                requireAllSpaces,
                 privilegeGroups: [
                   {
                     groupType: 'mutually_exclusive',
@@ -365,7 +366,7 @@ export class FleetPlugin
               },
               {
                 name: 'Agent policies',
-                requireAllSpaces: true,
+                requireAllSpaces,
                 privilegeGroups: [
                   {
                     groupType: 'mutually_exclusive',
@@ -402,7 +403,7 @@ export class FleetPlugin
               },
               {
                 name: 'Settings',
-                requireAllSpaces: true,
+                requireAllSpaces,
                 privilegeGroups: [
                   {
                     groupType: 'mutually_exclusive',
@@ -440,7 +441,7 @@ export class FleetPlugin
           all: {
             api: [`${PLUGIN_ID}-read`, `${PLUGIN_ID}-all`],
             app: [PLUGIN_ID],
-            requireAllSpaces: true,
+            requireAllSpaces,
             catalogue: ['fleet'],
             savedObject: {
               all: allSavedObjectTypes,
@@ -452,7 +453,7 @@ export class FleetPlugin
             api: [`${PLUGIN_ID}-read`],
             app: [PLUGIN_ID],
             catalogue: ['fleet'],
-            requireAllSpaces: true,
+            requireAllSpaces,
             savedObject: {
               all: [],
               read: allSavedObjectTypes,


### PR DESCRIPTION
## Summary

As part of making Fleet space aware, we should remove the `requireAllSpaces` on Fleet privileges. 
That PR does that.

It's done behind the fleet feature flag `useSpaceAwareness`

## Test

You can test this by specifying a different space than `*` one creating a role with Fleet privileges

<img width="810" alt="Screenshot 2024-06-26 at 2 01 37 PM" src="https://github.com/elastic/kibana/assets/1336873/ad6b85e7-3834-4b56-ac1c-a8914b8c7750">
<img width="746" alt="Screenshot 2024-06-26 at 2 01 45 PM" src="https://github.com/elastic/kibana/assets/1336873/34bb9243-c74f-4b67-bae4-1bd9c07d936a">
