### PR TITLE
[LogsExplorer] Remove unused plugin deps !!

### DIFF
--- a/x-pack/plugins/observability_solution/logs_explorer/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/logs_explorer/kibana.jsonc
@@ -12,21 +12,16 @@
       "logsExplorer"
     ],
     "requiredPlugins": [
-      "controls",
       "data",
       "dataViews",
       "discover",
-      "embeddable",
       "fieldFormats",
-      "fleet",
-      "kibanaReact",
-      "kibanaUtils",
       "navigation",
       "share",
       "unifiedSearch",
     ],
     "optionalPlugins": [],
-    "requiredBundles": [],
+    "requiredBundles": ["controls","embeddable","fleet", "kibanaReact", "kibanaUtils"],
     "extraPublicDirs": [
       "common",
     ]


### PR DESCRIPTION
## Summary

Remove unused plugin deps , found this while fixing circuler deps unrelated !!

`node scripts/plugin_check --dependencies logsExplorer
`

<img width="924" alt="image" src="https://github.com/elastic/kibana/assets/3505601/f623b896-ff5f-49bf-8978-e52b1fca3abd">
