### PR TITLE
[Cloud Security] Fix configurations integration test error

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/configurations.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/configurations.test.tsx
@@ -69,7 +69,7 @@ describe('<Findings />', () => {
     // loading findings
     await waitFor(() => expect(screen.getByText(/loading results/i)).toBeInTheDocument());
 
-    expect(screen.getByText(/2 findings/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/2 findings/i)).toBeInTheDocument());
 
     expect(screen.getByText(finding1.resource.name)).toBeInTheDocument();
     expect(screen.getByText(finding1.resource.id)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

It fixes #187015 

This PR fixes integration test error by wrapping the expect with the `waitFor` after the loading results.