### PR TITLE
fix(renovate): remove `"prCreation":"not-pending"`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,7 +67,6 @@
       "reviewers": ["team:kibana-core"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "Team:Core", "backport:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -77,7 +76,6 @@
       "reviewers": ["team:kibana-core"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "Team:Core", "backport:all-open"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -88,7 +86,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -98,7 +95,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -108,7 +104,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -119,7 +114,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -129,7 +123,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "backport:all-open", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -139,7 +132,6 @@
       "reviewers": ["team:kibana-visualizations"],
       "matchBaseBranches": ["main"],
       "labels": ["Feature:Vega", "Team:Visualizations"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -149,7 +141,6 @@
       "reviewers": ["Team:apm", "Team: SecuritySolution"],
       "matchBaseBranches": ["main"],
       "labels": ["buildkite-ci", "ci:all-cypress-suites"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -159,7 +150,6 @@
       "reviewers": ["Team: SecuritySolution"],
       "matchBaseBranches": ["main"],
       "labels": ["Team: SecuritySolution"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -180,7 +170,6 @@
       "reviewers": ["team:kibana-security"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Security", "release_note:skip", "backport:all-open"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -197,7 +186,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -207,7 +195,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip", "backport:all-open"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -217,7 +204,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -234,7 +220,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -259,7 +244,6 @@
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -270,7 +254,6 @@
       "matchDepPatterns": ["^@storybook"],
       "excludeDepNames": ["@storybook/testing-react"],
       "labels": ["Team:Operations", "release_note:skip", "ci:build-storybooks", "backport:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "allowedVersions": "<7.0",
       "enabled": true
@@ -281,7 +264,6 @@
       "matchBaseBranches": ["main"],
       "matchDepNames": ["@storybook/testing-react"],
       "labels": ["Team:Operations", "release_note:skip", "ci:build-storybooks", "backport:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "allowedVersions": "<2.0",
       "enabled": true
@@ -299,7 +281,6 @@
       ],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:skip", "ci:all-cypress-suites"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -309,7 +290,6 @@
       "reviewers": ["team:security-asset-management", "team:uptime"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:skip", "ci:all-cypress-suites"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -326,7 +306,6 @@
       ],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:skip", "ci:all-cypress-suites"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -363,7 +342,6 @@
       "reviewers": ["team:response-ops", "team:kibana-core"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:all-open"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -383,7 +361,6 @@
       "reviewers": ["team:monitoring"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Monitoring"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -393,7 +370,6 @@
       "reviewers": ["team:kibana-security", "team:kibana-core"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:skip", "ci:serverless-test-all"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -403,7 +379,6 @@
       "reviewers": ["team:response-ops"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:prev-minor"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -413,7 +388,6 @@
       "reviewers": ["team:ml-ui"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:ML", "release_note:skip", "backport:all-open"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },
@@ -423,7 +397,6 @@
       "reviewers": ["team:kibana-esql"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:ESQL", "release_note:skip"],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "7 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

After https://github.com/elastic/kibana/pull/186979 proved that this option doesn't work with our CI and renovate's permissions on it, removing all other usages of this setting.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
