### PR TITLE
[integration] Fix check_pipeline response schema

### DIFF
--- a/x-pack/plugins/integration_assistant/common/api/model/common_attributes.schema.yaml
+++ b/x-pack/plugins/integration_assistant/common/api/model/common_attributes.schema.yaml
@@ -142,15 +142,3 @@ components:
         logo:
           type: string
           description: The logo of the integration.
-
-    PipelineResults:
-      type: array
-      description: An array of pipeline results.
-      items:
-        type: object
-
-    Errors:
-      type: array
-      description: An array of errors.
-      items:
-        type: object

--- a/x-pack/plugins/integration_assistant/common/api/model/common_attributes.ts
+++ b/x-pack/plugins/integration_assistant/common/api/model/common_attributes.ts
@@ -155,15 +155,3 @@ export const Integration = z.object({
    */
   logo: z.string().optional(),
 });
-
-/**
- * An array of pipeline results.
- */
-export type PipelineResults = z.infer<typeof PipelineResults>;
-export const PipelineResults = z.array(z.object({}));
-
-/**
- * An array of errors.
- */
-export type Errors = z.infer<typeof Errors>;
-export const Errors = z.array(z.object({}));

--- a/x-pack/plugins/integration_assistant/common/api/model/response_schemas.schema.yaml
+++ b/x-pack/plugins/integration_assistant/common/api/model/response_schemas.schema.yaml
@@ -57,9 +57,12 @@ components:
     CheckPipelineAPIResponse:
       type: object
       required:
-        - pipelineResults
+        - results
       properties:
-        pipelineResults:
-          $ref: "./common_attributes.schema.yaml#/components/schemas/PipelineResults"
-        errors:
-          $ref: "./common_attributes.schema.yaml#/components/schemas/Errors"
+        results:
+          type: object
+          required:
+            - docs
+          properties:
+            docs:
+              $ref: "./common_attributes.schema.yaml#/components/schemas/Docs"

--- a/x-pack/plugins/integration_assistant/common/api/model/response_schemas.ts
+++ b/x-pack/plugins/integration_assistant/common/api/model/response_schemas.ts
@@ -16,7 +16,7 @@
 
 import { z } from 'zod';
 
-import { Docs, Errors, Mapping, Pipeline, PipelineResults } from './common_attributes';
+import { Docs, Mapping, Pipeline } from './common_attributes';
 
 export type EcsMappingAPIResponse = z.infer<typeof EcsMappingAPIResponse>;
 export const EcsMappingAPIResponse = z.object({
@@ -44,6 +44,7 @@ export const RelatedAPIResponse = z.object({
 
 export type CheckPipelineAPIResponse = z.infer<typeof CheckPipelineAPIResponse>;
 export const CheckPipelineAPIResponse = z.object({
-  pipelineResults: PipelineResults,
-  errors: Errors.optional(),
+  results: z.object({
+    docs: Docs,
+  }),
 });

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/review_step/use_check_pipeline.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/review_step/use_check_pipeline.ts
@@ -49,17 +49,17 @@ export const useCheckPipeline = ({
 
         const ecsGraphResult = await runCheckPipelineResults(parameters, deps);
         if (abortController.signal.aborted) return;
-        if (isEmpty(ecsGraphResult?.pipelineResults) || ecsGraphResult?.errors?.length) {
+        if (isEmpty(ecsGraphResult?.results.docs)) {
           setError('No results for the pipeline');
           return;
         }
         setResult({
           pipeline: customPipeline,
-          docs: ecsGraphResult.pipelineResults,
+          docs: ecsGraphResult.results.docs,
         });
       } catch (e) {
         if (abortController.signal.aborted) return;
-        setError(`Error: ${e.body.message}`);
+        setError(`Error: ${e.body.message ?? e.message}`);
       } finally {
         setIsGenerating(false);
       }

--- a/x-pack/plugins/integration_assistant/server/routes/pipeline_routes.ts
+++ b/x-pack/plugins/integration_assistant/server/routes/pipeline_routes.ts
@@ -37,11 +37,13 @@ export function registerPipelineRoutes(router: IRouter<IntegrationAssistantRoute
         const services = await context.resolve(['core']);
         const { client } = services.core.elasticsearch;
         try {
-          const results = await testPipeline(rawSamples, pipeline, client);
-          if (results?.errors && results.errors.length > 0) {
-            return res.badRequest({ body: JSON.stringify(results.errors) });
+          const { errors, pipelineResults } = await testPipeline(rawSamples, pipeline, client);
+          if (errors?.length) {
+            return res.badRequest({ body: JSON.stringify(errors) });
           }
-          return res.ok({ body: CheckPipelineResponse.parse(results) });
+          return res.ok({
+            body: CheckPipelineResponse.parse({ results: { docs: pipelineResults } }),
+          });
         } catch (e) {
           return res.badRequest({ body: e });
         }


### PR DESCRIPTION
## Summary

The response schema for the /pipeline (checkPipeline) route is incorrect. By defining it with:
```
export const PipelineResults = z.array(z.object({}));
export const Errors = z.array(z.object({}));
```
makes the pipelineResults items response to be always empty objects after parsing:

<img width="628" alt="pipeline_response" src="https://github.com/elastic/kibana/assets/17747913/9582460c-ea31-43ea-854c-b15ee28ad0f2">

### Changes

Docs: 
These objects in the array are documents (`Docs` schema), so the correct type (already existing) has been assigned.
`"./common_attributes.schema.yaml#/components/schemas/Docs"`

Errors:
Since we check them and respond with 400 in case they exist, the `errors` entry will never exist in a 200 response. It has been removed from the (200) response schema.

Response shape:
The response results shape has also been aligned with the rest of API routes: `response.results.docs`


