### PR TITLE
[Security Solution][MKI] Fixed custom role file name for api key authentication 

### DIFF
--- a/packages/kbn-test/src/auth/session_manager.ts
+++ b/packages/kbn-test/src/auth/session_manager.ts
@@ -54,12 +54,7 @@ export class SamlSessionManager {
     this.isCloud = options.isCloud;
     this.log = options.log;
     // if the rolesFilename is provided, respect it. Otherwise use DEFAULT_ROLES_FILE_NAME.
-    let rolesFile: string;
-    if (process.env.ROLES_FILENAME_OVERRIDE) {
-      rolesFile = process.env.ROLES_FILENAME_OVERRIDE;
-    } else {
-      rolesFile = rolesFilename ? rolesFilename : this.DEFAULT_ROLES_FILE_NAME;
-    }
+    const rolesFile = rolesFilename ? rolesFilename : this.DEFAULT_ROLES_FILE_NAME;
     this.log.info(`Using the file ${rolesFile} for the role users`);
     this.userRoleFilePath = resolve(REPO_ROOT, '.ftr', rolesFile);
     const hostOptionsWithoutAuth = {

--- a/packages/kbn-test/src/auth/session_manager.ts
+++ b/packages/kbn-test/src/auth/session_manager.ts
@@ -54,7 +54,12 @@ export class SamlSessionManager {
     this.isCloud = options.isCloud;
     this.log = options.log;
     // if the rolesFilename is provided, respect it. Otherwise use DEFAULT_ROLES_FILE_NAME.
-    const rolesFile = rolesFilename ? rolesFilename : this.DEFAULT_ROLES_FILE_NAME;
+    let rolesFile: string;
+    if (process.env.ROLES_FILENAME_OVERRIDE) {
+      rolesFile = process.env.ROLES_FILENAME_OVERRIDE;
+    } else {
+      rolesFile = rolesFilename ? rolesFilename : this.DEFAULT_ROLES_FILE_NAME;
+    }
     this.log.info(`Using the file ${rolesFile} for the role users`);
     this.userRoleFilePath = resolve(REPO_ROOT, '.ftr', rolesFile);
     const hostOptionsWithoutAuth = {

--- a/x-pack/test/security_solution_api_integration/scripts/mki_api_ftr_execution.ts
+++ b/x-pack/test/security_solution_api_integration/scripts/mki_api_ftr_execution.ts
@@ -118,6 +118,9 @@ export const cli = () => {
 
       // Creating project for the test to run
       const project = await cloudHandler.createSecurityProject(PROJECT_NAME, productTypes);
+      // Check if proxy service is used to define which org executes the tests.
+      const proxyOrg = cloudHandler instanceof ProxyHandler ? project?.proxy_org_name : undefined;
+      log.info(`Proxy Organization used id : ${proxyOrg}`);
 
       if (!project) {
         log.error('Failed to create project.');
@@ -162,6 +165,7 @@ export const cli = () => {
           TEST_ES_URL: testEsUrl,
           TEST_KIBANA_URL: testKibanaUrl,
           TEST_CLOUD_HOST_NAME: new URL(BASE_ENV_URL).hostname,
+          ROLES_FILENAME_OVERRIDE: proxyOrg ? `${proxyOrg}.json` : undefined,
         };
 
         statusCode = await executeCommand(command, envVars, log);

--- a/x-pack/test_serverless/shared/services/svl_user_manager.ts
+++ b/x-pack/test_serverless/shared/services/svl_user_manager.ts
@@ -55,19 +55,23 @@ export function SvlUserManagerProvider({ getService }: FtrProviderContext) {
     }
   };
 
+  const customRolesFileName: string | undefined = process.env.ROLES_FILENAME_OVERRIDE;
   // Sharing the instance within FTR config run means cookies are persistent for each role between tests.
-  const sessionManager = new SamlSessionManager({
-    hostOptions: {
-      protocol: config.get('servers.kibana.protocol'),
-      hostname: config.get('servers.kibana.hostname'),
-      port: isCloud ? undefined : config.get('servers.kibana.port'),
-      username: config.get('servers.kibana.username'),
-      password: config.get('servers.kibana.password'),
+  const sessionManager = new SamlSessionManager(
+    {
+      hostOptions: {
+        protocol: config.get('servers.kibana.protocol'),
+        hostname: config.get('servers.kibana.hostname'),
+        port: isCloud ? undefined : config.get('servers.kibana.port'),
+        username: config.get('servers.kibana.username'),
+        password: config.get('servers.kibana.password'),
+      },
+      log,
+      isCloud,
+      supportedRoles,
     },
-    log,
-    isCloud,
-    supportedRoles,
-  });
+    customRolesFileName
+  );
 
   const DEFAULT_ROLE = getDefaultRole();
 


### PR DESCRIPTION
## Summary

The  changes made to use API Key instead of Basic Authentication, required a change in the API Tests in order to be able to provide the filename where the createApiKey method will read from. 

The existing design, is based on multiple organizations creating projects so one `role_users.json` file is not either suitable or sufficient. We needed to be able to provide somehow the filename matching the organization which created the project and we decided to do so with an environment variable called: `ROLES_FILENAME_OVERRIDE`. In case this environment variable does not exist or is undefined, it automatically follows the default way of looking into the role_users.json file. 