### PR TITLE
fix: [Obs Applications > Dependencies][SCREEN READER]: Tooltips must be able to take keyboard focus: 0004

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiToolTip, RIGHT_ALIGNMENT } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIconTip, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ChartType, getTimeSeriesColor } from '../charts/helper/get_timeseries_color';
 import { ListMetric } from '../list_metric';
@@ -107,20 +107,22 @@ export function getSpanMetricColumns({
     {
       field: 'failureRate',
       name: (
-        <EuiToolTip
-          content={i18n.translate('xpack.apm.dependenciesTable.columnErrorRateTip', {
-            defaultMessage:
-              "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
+        <>
+          {i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
+            defaultMessage: 'Failed transaction rate',
           })}
-        >
-          <>
-            {i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
-              defaultMessage: 'Failed transaction rate',
+          &nbsp;
+          <EuiIconTip
+            size="s"
+            color="subdued"
+            type="questionInCircle"
+            content={i18n.translate('xpack.apm.dependenciesTable.columnErrorRateTip', {
+              defaultMessage:
+                "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
             })}
-            &nbsp;
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignCenter" />
-          </>
-        </EuiToolTip>
+            className="eui-alignCenter"
+          />
+        </>
       ),
       align: RIGHT_ALIGNMENT,
       render: (_, { failureRate, currentStats, previousStats }) => {
@@ -146,20 +148,22 @@ export function getSpanMetricColumns({
     {
       field: 'impact',
       name: (
-        <EuiToolTip
-          content={i18n.translate('xpack.apm.dependenciesTable.columnImpactTip', {
-            defaultMessage:
-              'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
+        <>
+          {i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
+            defaultMessage: 'Impact',
           })}
-        >
-          <>
-            {i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
-              defaultMessage: 'Impact',
+          &nbsp;
+          <EuiIconTip
+            size="s"
+            color="subdued"
+            type="questionInCircle"
+            className="eui-alignCenter"
+            content={i18n.translate('xpack.apm.dependenciesTable.columnImpactTip', {
+              defaultMessage:
+                'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
             })}
-            &nbsp;
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignCenter" />
-          </>
-        </EuiToolTip>
+          />
+        </>
       ),
       align: RIGHT_ALIGNMENT,
       render: (_, { impact, previousStats }) => {

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/transactions_table/get_columns.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/transactions_table/get_columns.tsx
@@ -9,8 +9,8 @@ import {
   EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIcon,
   EuiToolTip,
+  EuiIconTip,
   RIGHT_ALIGNMENT,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -204,20 +204,25 @@ export function getColumns({
       field: 'errorRate',
       sortable: true,
       name: (
-        <EuiToolTip
-          content={i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnErrorRateTip', {
-            defaultMessage:
-              "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
+        <>
+          {i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnErrorRate', {
+            defaultMessage: 'Failed transaction rate',
           })}
-        >
-          <>
-            {i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnErrorRate', {
-              defaultMessage: 'Failed transaction rate',
-            })}
-            &nbsp;
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignCenter" />
-          </>
-        </EuiToolTip>
+          &nbsp;
+          <EuiIconTip
+            size="s"
+            color="subdued"
+            type="questionInCircle"
+            className="eui-alignCenter"
+            content={i18n.translate(
+              'xpack.apm.serviceOverview.transactionsTableColumnErrorRateTip',
+              {
+                defaultMessage:
+                  "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
+              }
+            )}
+          />
+        </>
       ),
       align: RIGHT_ALIGNMENT,
       render: (_, { errorRate, name }) => {
@@ -246,20 +251,22 @@ export function getColumns({
       field: 'impact',
       sortable: true,
       name: (
-        <EuiToolTip
-          content={i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnImpactTip', {
-            defaultMessage:
-              'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
+        <>
+          {i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnImpact', {
+            defaultMessage: 'Impact',
           })}
-        >
-          <>
-            {i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnImpact', {
-              defaultMessage: 'Impact',
+          &nbsp;
+          <EuiIconTip
+            size="s"
+            color="subdued"
+            type="questionInCircle"
+            className="eui-alignCenter"
+            content={i18n.translate('xpack.apm.serviceOverview.transactionsTableColumnImpactTip', {
+              defaultMessage:
+                'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
             })}
-            &nbsp;
-            <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignCenter" />
-          </>
-        </EuiToolTip>
+          />
+        </>
       ),
       align: RIGHT_ALIGNMENT,
       render: (_, { name }) => {


### PR DESCRIPTION
Closes: https://github.com/elastic/observability-dev/issues/3598

## Summary
This PR enhances accessibility by replacing `EuiTooltips` to `EuiIconTip` for the following table 

<img width="1184" alt="image" src="https://github.com/elastic/kibana/assets/20072247/2ecf7902-c184-4fa2-93d2-cc309f768d3e">


