### PR TITLE
[Security Solution] Attempt to fix flaky MKI test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/new_risk_score.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/dashboards/entity_analytics/new_risk_score.cy.ts
@@ -78,8 +78,7 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
       });
     });
 
-    // https://github.com/elastic/kibana/issues/179687
-    describe('When risk engine is enabled', { tags: ['@skipInServerlessMKI'] }, () => {
+    describe('When risk engine is enabled', () => {
       beforeEach(() => {
         login();
         mockRiskEngineEnabled();
@@ -151,7 +150,6 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
           });
 
           beforeEach(() => {
-            login();
             visitWithTimeRange(ALERTS_URL);
             waitForAlertsToPopulate();
             visitWithTimeRange(ENTITY_ANALYTICS_URL);
@@ -244,7 +242,6 @@ describe('Entity Analytics Dashboard', { tags: ['@ess', '@serverless'] }, () => 
           });
 
           beforeEach(() => {
-            login();
             visitWithTimeRange(ALERTS_URL);
             waitForAlertsToPopulate();
             visitWithTimeRange(ENTITY_ANALYTICS_URL);


### PR DESCRIPTION
## Summary

Glo (@MadameSheema) solved the problem!! 🥳 🎈🍾 


Flaky test https://github.com/elastic/kibana/issues/179687


The assumption is that logging twice for a single test (`it`) generates some concurrency that logs off the user.

