### PR TITLE
Skip serverless search source alert tests for MKI runs

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover_ml_uptime/discover/search_source_alert.ts
@@ -354,7 +354,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     expect(await titleElem.getAttribute('value')).to.equal(dataView);
   };
 
-  describe('Search source Alert', () => {
+  describe('Search source Alert', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/187069
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await security.testUser.setRoles(['discover_alert']);
       await PageObjects.svlCommonPage.loginAsAdmin();


### PR DESCRIPTION
## Summary

This PR skips the serverless search source alert UI tests for MKI runs.
Details about the failure in https://github.com/elastic/kibana/issues/187069.
