### PR TITLE
[Spacetime] Small step for keyboard shortcuts in kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -550,6 +550,7 @@
     "@kbn/kbn-top-nav-plugin": "link:test/plugin_functional/plugins/kbn_top_nav",
     "@kbn/kbn-tp-custom-visualizations-plugin": "link:test/plugin_functional/plugins/kbn_tp_custom_visualizations",
     "@kbn/kbn-tp-run-pipeline-plugin": "link:test/interpreter_functional/plugins/kbn_tp_run_pipeline",
+    "@kbn/keyboard-shortcut-utils": "link:packages/kbn-keyboard-shortcut-utils",
     "@kbn/kibana-cors-test-plugin": "link:x-pack/test/functional_cors/plugins/kibana_cors_test",
     "@kbn/kibana-overview-plugin": "link:src/plugins/kibana_overview",
     "@kbn/kibana-react-plugin": "link:src/plugins/kibana_react",

--- a/packages/core/chrome/core-chrome-browser-internal/src/nav_controls/nav_controls_service.test.ts
+++ b/packages/core/chrome/core-chrome-browser-internal/src/nav_controls/nav_controls_service.test.ts
@@ -9,48 +9,56 @@
 import { take } from 'rxjs';
 import { NavControlsService } from './nav_controls_service';
 
-describe('RecentlyAccessed#start()', () => {
-  const getStart = () => {
-    return new NavControlsService().start();
-  };
-
-  describe('left side', () => {
-    it('allows registration', async () => {
-      const navControls = getStart();
-      const nc = { mount: jest.fn() };
-      navControls.registerLeft(nc);
-      expect(await navControls.getLeft$().pipe(take(1)).toPromise()).toEqual([nc]);
-    });
-
-    it('sorts controls by order property', async () => {
-      const navControls = getStart();
-      const nc1 = { mount: jest.fn(), order: 10 };
-      const nc2 = { mount: jest.fn(), order: 0 };
-      const nc3 = { mount: jest.fn(), order: 20 };
-      navControls.registerLeft(nc1);
-      navControls.registerLeft(nc2);
-      navControls.registerLeft(nc3);
-      expect(await navControls.getLeft$().pipe(take(1)).toPromise()).toEqual([nc2, nc1, nc3]);
-    });
+describe('NavControlsService#start()', () => {
+  let navControls: ReturnType<NavControlsService['start']>;
+  beforeEach(() => {
+    navControls = new NavControlsService().start();
   });
 
-  describe('right side', () => {
-    it('allows registration', async () => {
-      const navControls = getStart();
-      const nc = { mount: jest.fn() };
-      navControls.registerRight(nc);
-      expect(await navControls.getRight$().pipe(take(1)).toPromise()).toEqual([nc]);
-    });
+  const testCases = [
+    {
+      name: 'left',
+      register: 'registerLeft' as const,
+      get$: 'getLeft$' as const,
+    },
+    {
+      name: 'right',
+      register: 'registerRight' as const,
+      get$: 'getRight$' as const,
+    },
+    {
+      name: 'center',
+      register: 'registerCenter' as const,
+      get$: 'getCenter$' as const,
+    },
+    {
+      name: 'extension',
+      register: 'registerExtension' as const,
+      get$: 'getExtension$' as const,
+    },
+  ];
 
-    it('sorts controls by order property', async () => {
-      const navControls = getStart();
-      const nc1 = { mount: jest.fn(), order: 10 };
-      const nc2 = { mount: jest.fn(), order: 0 };
-      const nc3 = { mount: jest.fn(), order: 20 };
-      navControls.registerRight(nc1);
-      navControls.registerRight(nc2);
-      navControls.registerRight(nc3);
-      expect(await navControls.getRight$().pipe(take(1)).toPromise()).toEqual([nc2, nc1, nc3]);
-    });
+  it.each(testCases)('$name - allow registration', async ({ register, get$ }) => {
+    const nc = { mount: jest.fn() };
+    navControls[register](nc);
+    expect(await navControls[get$]().pipe(take(1)).toPromise()).toEqual([nc]);
+  });
+
+  it.each(testCases)('$name allows unregistration', async ({ register, get$ }) => {
+    const nc = { mount: jest.fn() };
+    navControls[register](nc);
+    expect(await navControls[get$]().pipe(take(1)).toPromise()).toEqual([nc]);
+    navControls[`un${register}`](nc);
+    expect(await navControls.getLeft$().pipe(take(1)).toPromise()).toEqual([]);
+  });
+
+  it.each(testCases)('$name - sorts controls by order property', async ({ register, get$ }) => {
+    const nc1 = { mount: jest.fn(), order: 10 };
+    const nc2 = { mount: jest.fn(), order: 0 };
+    const nc3 = { mount: jest.fn(), order: 20 };
+    navControls[register](nc1);
+    navControls[register](nc2);
+    navControls[register](nc3);
+    expect(await navControls[get$]().pipe(take(1)).toPromise()).toEqual([nc2, nc1, nc3]);
   });
 });

--- a/packages/core/chrome/core-chrome-browser-internal/src/nav_controls/nav_controls_service.ts
+++ b/packages/core/chrome/core-chrome-browser-internal/src/nav_controls/nav_controls_service.ts
@@ -26,20 +26,34 @@ export class NavControlsService {
     const navControlsExtension$ = new BehaviorSubject<ReadonlySet<ChromeNavControl>>(new Set());
     const helpMenuLinks$ = new BehaviorSubject<ChromeHelpMenuLink[]>([]);
 
+    function register(control$: BehaviorSubject<ReadonlySet<ChromeNavControl>>) {
+      return (toAdd: ChromeNavControl) => {
+        control$.next(new Set([...control$.getValue().values(), toAdd]));
+      };
+    }
+
+    function unregister(control$: BehaviorSubject<ReadonlySet<ChromeNavControl>>) {
+      return (toDelete: ChromeNavControl) => {
+        const set = control$.getValue();
+        if (!set.has(toDelete)) return;
+        const clone = new Set(set);
+        clone.delete(toDelete);
+        control$.next(clone);
+      };
+    }
+
     return {
-      // In the future, registration should be moved to the setup phase. This
-      // is not possible until the legacy nav controls are no longer supported.
-      registerLeft: (navControl: ChromeNavControl) =>
-        navControlsLeft$.next(new Set([...navControlsLeft$.value.values(), navControl])),
+      registerLeft: register(navControlsLeft$),
+      unregisterLeft: unregister(navControlsLeft$),
 
-      registerRight: (navControl: ChromeNavControl) =>
-        navControlsRight$.next(new Set([...navControlsRight$.value.values(), navControl])),
+      registerRight: register(navControlsRight$),
+      unregisterRight: unregister(navControlsRight$),
 
-      registerCenter: (navControl: ChromeNavControl) =>
-        navControlsCenter$.next(new Set([...navControlsCenter$.value.values(), navControl])),
+      registerCenter: register(navControlsCenter$),
+      unregisterCenter: unregister(navControlsCenter$),
 
-      registerExtension: (navControl: ChromeNavControl) =>
-        navControlsExtension$.next(new Set([...navControlsExtension$.value.values(), navControl])),
+      registerExtension: register(navControlsExtension$),
+      unregisterExtension: unregister(navControlsExtension$),
 
       setHelpMenuLinks: (links: ChromeHelpMenuLink[]) => {
         // This extension point is only intended to be used once by the cloud integration > cloud_links plugin

--- a/packages/core/chrome/core-chrome-browser/src/nav_controls.ts
+++ b/packages/core/chrome/core-chrome-browser/src/nav_controls.ts
@@ -43,15 +43,35 @@ export interface ChromeHelpMenuLink {
 export interface ChromeNavControls {
   /** Register a nav control to be presented on the bottom-left side of the chrome header. */
   registerLeft(navControl: ChromeNavControl): void;
+  /**
+   * Unregister a nav control to be presented on the bottom-left side of the chrome header.
+   * @remark Noop if control is not present
+   */
+  unregisterLeft(navControl: ChromeNavControl): void;
 
   /** Register a nav control to be presented on the top-right side of the chrome header. */
   registerRight(navControl: ChromeNavControl): void;
+  /**
+   * Unregister a nav control to be presented on the top-right side of the chrome header.
+   * @remark Noop if control is not present
+   */
+  unregisterRight(navControl: ChromeNavControl): void;
 
   /** Register a nav control to be presented on the top-center side of the chrome header. */
   registerCenter(navControl: ChromeNavControl): void;
+  /**
+   * Unregister a nav control to be presented on the top-center side of the chrome header.
+   * @remark Noop if control is not present
+   */
+  unregisterCenter(navControl: ChromeNavControl): void;
 
   /** Register an extension to be presented to the left of the top-right side of the chrome header. */
   registerExtension(navControl: ChromeNavControl): void;
+  /**
+   * Unregister an extension to be presented to the left of the top-right side of the chrome header.
+   * @remark Noop if control is not present
+   */
+  unregisterExtension(navControl: ChromeNavControl): void;
 
   /** Set the help menu links */
   setHelpMenuLinks(links: ChromeHelpMenuLink[]): void;

--- a/packages/kbn-keyboard-shortcut-utils/README.md
+++ b/packages/kbn-keyboard-shortcut-utils/README.md
@@ -1,0 +1,3 @@
+# @kbn/keyboard-shortcut-utils
+
+TODO(jloleysens)

--- a/packages/kbn-keyboard-shortcut-utils/index.ts
+++ b/packages/kbn-keyboard-shortcut-utils/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { registerGlobalKeyboardShortcuts } from './src';

--- a/packages/kbn-keyboard-shortcut-utils/jest.config.js
+++ b/packages/kbn-keyboard-shortcut-utils/jest.config.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../..',
+  roots: ['<rootDir>/packages/kbn-keyboard-shortcut-utils'],
+};

--- a/packages/kbn-keyboard-shortcut-utils/kibana.jsonc
+++ b/packages/kbn-keyboard-shortcut-utils/kibana.jsonc
@@ -1,0 +1,5 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/keyboard-shortcut-utils",
+  "owner": "@elastic/appex-sharedux"
+}

--- a/packages/kbn-keyboard-shortcut-utils/package.json
+++ b/packages/kbn-keyboard-shortcut-utils/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/keyboard-shortcut-utils",
+  "private": true,
+  "version": "1.0.0",
+  "license": "SSPL-1.0 OR Elastic License 2.0"
+}

--- a/packages/kbn-keyboard-shortcut-utils/src/index.tsx
+++ b/packages/kbn-keyboard-shortcut-utils/src/index.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import React from 'react';
+import type { CoreStart } from '@kbn/core-lifecycle-browser';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+import { KeyboardShortcutChrome } from './keyboard_shortcut_chrome';
+
+type Core = Pick<CoreStart, 'chrome' | 'notifications' | 'theme' | 'i18n'>;
+
+interface RegisterHelpChromeDeps {
+  core: Core;
+  appName: string;
+  copyPaste?: CopyPasteHandlers;
+}
+
+function registerHelpChrome({ appName, copyPaste, core }: RegisterHelpChromeDeps) {
+  const chromeHelper = {
+    order: -Infinity,
+    mount: toMountPoint(<KeyboardShortcutChrome appName={appName} copyPaste={copyPaste} />, core),
+  };
+  core.chrome.navControls.registerRight(chromeHelper);
+  return () => core.chrome.navControls.unregisterRight(chromeHelper);
+}
+
+interface TimeRange {
+  from: string;
+  to: string;
+}
+
+/** @internal */
+export type CopyPasteHandlers =
+  | {
+      topicId: 'global';
+      onCopy: () => object | undefined;
+      onPaste: (t: object) => void;
+    }
+  | {
+      topicId: 'timerange';
+      onCopy: () => TimeRange | undefined;
+      onPaste: (t: TimeRange) => void;
+    };
+
+const GLOBAL_CLIPBOARD_DATA_PREFIX = 'KBN_COPY_PASTE';
+function registerCopyPasteTimeRange({
+  core,
+  copyPaste,
+}: {
+  core: Core;
+  copyPaste: CopyPasteHandlers;
+}) {
+  const clipboardDataPrefix = `${GLOBAL_CLIPBOARD_DATA_PREFIX}:${copyPaste.topicId ?? 'global'}:`;
+  const onCopy = (eve: ClipboardEvent) => {
+    // If the user is actually copying something, ignore it
+    if (window.getSelection()?.toString() || !eve.clipboardData) return;
+    const activeBounds = copyPaste.onCopy();
+    if (!activeBounds) return;
+
+    eve.preventDefault();
+    eve.clipboardData.setData('text', `${clipboardDataPrefix}${JSON.stringify(activeBounds)}`);
+    core.notifications.toasts.addSuccess({
+      title: 'Copied time range to clipboard!',
+    });
+  };
+  const onPaste = (eve: ClipboardEvent) => {
+    if (!eve.clipboardData) return;
+    const clipboardData = eve.clipboardData.getData('text');
+    if (!clipboardData.startsWith(clipboardDataPrefix)) return;
+
+    const bounds = JSON.parse(clipboardData.slice(clipboardDataPrefix.length));
+    copyPaste.onPaste(bounds);
+    core.notifications.toasts.addSuccess({
+      title: 'Pasted time range!',
+    });
+  };
+  document.addEventListener('copy', onCopy);
+  document.addEventListener('paste', onPaste);
+  return () => {
+    document.removeEventListener('copy', onCopy);
+    document.removeEventListener('paste', onPaste);
+  };
+}
+
+interface RegisterArgs {
+  appName: string;
+  core: Core;
+  /** Create listeners for setting timerange on copy */
+  copyPaste?: CopyPasteHandlers;
+}
+
+export function registerGlobalKeyboardShortcuts({ copyPaste, appName, core }: RegisterArgs) {
+  const unregisterHelpChrome = registerHelpChrome({ appName, copyPaste, core });
+  const unregisterCopyPaste = copyPaste
+    ? registerCopyPasteTimeRange({ core, copyPaste })
+    : undefined;
+  return () => {
+    unregisterHelpChrome();
+    unregisterCopyPaste?.();
+  };
+}

--- a/packages/kbn-keyboard-shortcut-utils/src/keyboard_shortcut_chrome.tsx
+++ b/packages/kbn-keyboard-shortcut-utils/src/keyboard_shortcut_chrome.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import {
+  EuiBetaBadge,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiHeaderSectionItemButton,
+  EuiIcon,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useState } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { type CopyPasteHandlers } from '.';
+
+interface Props {
+  appName: string;
+  copyPaste?: CopyPasteHandlers;
+}
+
+export const KeyboardShortcutChrome: React.FC<Props> = ({ appName, copyPaste }) => {
+  const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
+
+  const [isOpen, setOpen] = useState(false);
+  const button = (
+    <EuiHeaderSectionItemButton
+      onClick={() => setOpen((prev) => !prev)}
+      aria-label={i18n.translate('unifiedSearch.keyboardShortcuts.icon.label', {
+        defaultMessage: 'Keyboard shortcuts',
+      })}
+      aria-haspopup="true"
+    >
+      <EuiIcon type="keyboard" />
+    </EuiHeaderSectionItemButton>
+  );
+
+  const listItems = [];
+  const metaKey = isMac ? 'Cmd' : 'Ctrl';
+
+  if (copyPaste?.topicId === 'timerange') {
+    listItems.push(
+      {
+        title: (
+          <>
+            <kbd>{metaKey}</kbd> + <kbd>C</kbd>
+          </>
+        ),
+        description: i18n.translate(
+          'keyboardShortcuts.headerGlobalNav.helpMenu.copyTimeRangeDescription',
+          {
+            defaultMessage: 'Copy the current time range to your clipboard.',
+          }
+        ),
+      },
+      {
+        title: (
+          <>
+            <kbd>{metaKey}</kbd> + <kbd>V</kbd>
+          </>
+        ),
+        description: i18n.translate(
+          'keyboardShortcuts.headerGlobalNav.helpMenu.pasteTimeRangeDescription',
+          {
+            defaultMessage:
+              'Paste the time range from your clipboard. Try copying a time range from another tab first.',
+          }
+        ),
+      }
+    );
+  }
+
+  return (
+    <EuiPopover isOpen={isOpen} button={button} closePopover={() => setOpen(false)}>
+      <EuiPopoverTitle>
+        <EuiFlexGroup justifyContent="spaceBetween" wrap={false}>
+          <h2>
+            <FormattedMessage
+              id="keyboardShortcuts.headerGlobalNav.helpMenuTitle"
+              defaultMessage="Keyboard shortcuts"
+            />
+          </h2>
+          <EuiBetaBadge
+            label={i18n.translate('keyboardShortcuts.headerGlobalNav.helpMenu.betaBadgeLabel', {
+              defaultMessage: 'Experimental',
+            })}
+            iconType="beaker"
+            size="s"
+          />
+        </EuiFlexGroup>
+      </EuiPopoverTitle>
+
+      <div style={{ maxWidth: 300 }}>
+        <EuiTitle size="xxs">
+          <h3>{appName}</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="xs">
+          <EuiDescriptionList
+            compressed
+            listItems={listItems}
+            type="column"
+            align="left"
+            rowGutterSize="m"
+          />
+        </EuiText>
+      </div>
+    </EuiPopover>
+  );
+};

--- a/packages/kbn-keyboard-shortcut-utils/tsconfig.json
+++ b/packages/kbn-keyboard-shortcut-utils/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts", "src/*.tsx",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/src/plugins/discover/public/application/index.tsx
+++ b/src/plugins/discover/public/application/index.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { toMountPoint } from '@kbn/react-kibana-mount';
+import { registerGlobalKeyboardShortcuts } from '@kbn/keyboard-shortcut-utils';
 import type { Observable } from 'rxjs';
 import { ExperimentalFeatures } from '../../common/config';
 import { DiscoverRouter } from './discover_router';
@@ -51,7 +52,18 @@ export const renderApp = ({
     core
   )(element);
 
+  const unregisterKbShortcuts = registerGlobalKeyboardShortcuts({
+    core,
+    appName: 'Discover', // TODO i18n
+    copyPaste: {
+      topicId: 'timerange',
+      onCopy: () => services.data.query.timefilter.timefilter.getTime(),
+      onPaste: (timeRange) => services.data.query.timefilter.timefilter.setTime(timeRange),
+    },
+  });
+
   return () => {
+    unregisterKbShortcuts();
     unmount();
     data.search.session.clear();
   };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1026,6 +1026,8 @@
       "@kbn/kbn-tp-custom-visualizations-plugin/*": ["test/plugin_functional/plugins/kbn_tp_custom_visualizations/*"],
       "@kbn/kbn-tp-run-pipeline-plugin": ["test/interpreter_functional/plugins/kbn_tp_run_pipeline"],
       "@kbn/kbn-tp-run-pipeline-plugin/*": ["test/interpreter_functional/plugins/kbn_tp_run_pipeline/*"],
+      "@kbn/keyboard-shortcut-utils": ["packages/kbn-keyboard-shortcut-utils"],
+      "@kbn/keyboard-shortcut-utils/*": ["packages/kbn-keyboard-shortcut-utils/*"],
       "@kbn/kibana-cors-test-plugin": ["x-pack/test/functional_cors/plugins/kibana_cors_test"],
       "@kbn/kibana-cors-test-plugin/*": ["x-pack/test/functional_cors/plugins/kibana_cors_test/*"],
       "@kbn/kibana-manifest-schema": ["packages/kbn-kibana-manifest-schema"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5265,6 +5265,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/keyboard-shortcut-utils@link:packages/kbn-keyboard-shortcut-utils":
+  version "0.0.0"
+  uid ""
+
 "@kbn/kibana-cors-test-plugin@link:x-pack/test/functional_cors/plugins/kibana_cors_test":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

* Added a utility that attempts to create a simple pattern for creating simple keyboard shortcuts: started with a simple (copy+paste time range shortcut). Feedback on the [original PR](https://github.com/elastic/kibana/pull/179810#issuecomment-2037416798) indicated the possibility of using the "quick select" for instead of this copy-paste capability, but I think these could be orthogonal features
* Made keyboard shortcuts more discoverable using chrome
<img width="481" alt="Screenshot 2024-06-27 at 16 35 42" src="https://github.com/elastic/kibana/assets/8155004/52cac066-2e2e-49d1-9a27-0308f69c3c52">
* Hooked up keyboard shortcust in discover (see vid in [original PR](https://github.com/elastic/kibana/pull/179810))

## TODO

- [ ] Toggle to disable shortcuts?
- [ ] Integrate into Dashboard