### PR TITLE
[OnWeek] Discover histogram annotations for time-based data PoC

### DIFF
--- a/packages/kbn-event-annotation-components/components/annotation_editor_controls/annotation_editor_controls.tsx
+++ b/packages/kbn-event-annotation-components/components/annotation_editor_controls/annotation_editor_controls.tsx
@@ -55,6 +55,7 @@ export interface Props {
   calendarClassName?: string;
   queryInputServices: QueryInputServices;
   appName: string;
+  sections?: ['placement', 'appearance'];
 }
 
 export const idPrefix = htmlIdGenerator()();
@@ -67,6 +68,7 @@ const AnnotationEditorControls = ({
   calendarClassName,
   queryInputServices,
   appName,
+  sections,
 }: Props) => {
   const { hasFieldData } = useExistingFieldsReader();
 
@@ -99,255 +101,262 @@ const AnnotationEditorControls = ({
 
   return (
     <>
-      <DimensionEditorSection
-        title={i18n.translate('eventAnnotationComponents.xyChart.placement', {
-          defaultMessage: 'Placement',
-        })}
-      >
-        <EuiFormRow
-          label={i18n.translate('eventAnnotationComponents.xyChart.annotationDate.placementType', {
-            defaultMessage: 'Placement type',
+      {!sections || sections.includes('placement') ? (
+        <DimensionEditorSection
+          title={i18n.translate('eventAnnotationComponents.xyChart.placement', {
+            defaultMessage: 'Placement',
           })}
-          display="rowCompressed"
-          fullWidth
         >
-          <EuiButtonGroup
-            legend={i18n.translate(
+          <EuiFormRow
+            label={i18n.translate(
               'eventAnnotationComponents.xyChart.annotationDate.placementType',
               {
                 defaultMessage: 'Placement type',
               }
             )}
-            data-test-subj="lns-xyAnnotation-placementType"
-            name="placementType"
-            buttonSize="compressed"
-            options={[
-              {
-                id: `lens_xyChart_annotation_manual`,
-                label: i18n.translate('eventAnnotationComponents.xyChart.annotation.manual', {
-                  defaultMessage: 'Static date',
-                }),
-                'data-test-subj': 'lnsXY_annotation_manual',
-              },
-              {
-                id: `lens_xyChart_annotation_query`,
-                label: i18n.translate('eventAnnotationComponents.xyChart.annotation.query', {
-                  defaultMessage: 'Custom query',
-                }),
-                'data-test-subj': 'lnsXY_annotation_query',
-              },
-            ]}
-            idSelected={`lens_xyChart_annotation_${currentAnnotation?.type}`}
-            onChange={(id) => {
-              const typeFromId = id.replace(
-                'lens_xyChart_annotation_',
-                ''
-              ) as EventAnnotationConfig['type'];
-              if (currentAnnotation?.type === typeFromId) {
-                return;
-              }
-              if (typeFromId === 'query') {
-                // If coming from a range type, it requires some additional resets
-                const additionalRangeResets = isRangeAnnotationConfig(currentAnnotation)
-                  ? {
-                      label:
-                        currentAnnotation.label === defaultRangeAnnotationLabel
-                          ? defaultAnnotationLabel
-                          : currentAnnotation.label,
-                      color: toLineAnnotationColor(currentAnnotation.color),
-                    }
-                  : {};
-                return update({
-                  type: typeFromId,
-                  timeField:
-                    (dataView.timeFieldName ||
-                      // fallback to the first avaiable date field in the dataView
-                      dataView.fields
-                        .filter(isFieldLensCompatible)
-                        .find(({ type: fieldType }) => fieldType === 'date')?.displayName) ??
-                    '',
-                  key: { type: 'point_in_time' },
-                  ...additionalRangeResets,
-                });
-              }
-              // From query to manual annotation
-              return update<PointInTimeEventAnnotationConfig>({
-                type: typeFromId,
-                key: { type: 'point_in_time', timestamp: moment().toISOString() },
-              });
-            }}
-            isFullWidth
-          />
-        </EuiFormRow>
-        {isQueryBased ? (
-          <ConfigPanelQueryAnnotation
-            annotation={currentAnnotation}
-            onChange={update}
-            dataView={dataView}
-            queryInputShouldOpen={queryInputShouldOpen}
-            queryInputServices={queryInputServices}
-            appName={appName}
-          />
-        ) : (
-          <ConfigPanelManualAnnotation
-            annotation={currentAnnotation}
-            onChange={update}
-            getDefaultRangeEnd={getDefaultRangeEnd}
-            calendarClassName={calendarClassName}
-          />
-        )}
-      </DimensionEditorSection>
-      <DimensionEditorSection
-        title={i18n.translate('eventAnnotationComponents.xyChart.appearance', {
-          defaultMessage: 'Appearance',
-        })}
-      >
-        <NameInput
-          value={currentAnnotation?.label || defaultAnnotationLabel}
-          defaultValue={defaultAnnotationLabel}
-          onChange={(value) => {
-            update({ label: value });
-          }}
-        />
-        {!isRange && (
-          <>
-            <IconSelectSetting<AvailableAnnotationIcon>
-              currentIcon={currentAnnotation.icon}
-              setIcon={(icon) => update({ icon })}
-              defaultIcon="triangle"
-              customIconSet={annotationsIconSet}
-            />
-            <TextDecorationSetting
-              idPrefix={idPrefix}
-              setConfig={update}
-              currentConfig={currentAnnotation}
-              isQueryBased={isQueryBased}
-            >
-              {(textDecorationSelected) => {
-                if (textDecorationSelected !== 'field') {
-                  return null;
-                }
-                const options = dataView.fields
-                  .filter(isFieldLensCompatible)
-                  .filter(({ displayName, type }) => displayName && type !== 'document')
-                  .map(
-                    (field) =>
-                      ({
-                        label: field.displayName,
-                        value: {
-                          type: 'field',
-                          field: field.name,
-                          dataType: field.type,
-                        },
-                        exists: hasFieldData(dataView.id!, field.name),
-                        compatible: true,
-                        'data-test-subj': `lnsXY-annotation-fieldOption-${field.name}`,
-                      } as FieldOption<FieldOptionValue>)
-                  );
-                const selectedField = (currentAnnotation as QueryPointEventAnnotationConfig)
-                  .textField;
-
-                const fieldIsValid = selectedField
-                  ? Boolean(dataView.getFieldByName(selectedField))
-                  : true;
-
-                return (
-                  <>
-                    <EuiSpacer size="xs" />
-                    <FieldPicker
-                      activeField={
-                        selectedField
-                          ? {
-                              label: selectedField,
-                              value: { type: 'field', field: selectedField },
-                            }
-                          : undefined
-                      }
-                      options={options}
-                      onChoose={function (choice: FieldOptionValue | undefined): void {
-                        if (choice) {
-                          update({ textField: choice.field, textVisibility: true });
-                        }
-                      }}
-                      fieldIsInvalid={!fieldIsValid}
-                      data-test-subj="lnsXY-annotation-query-based-text-decoration-field-picker"
-                      autoFocus={!selectedField}
-                    />
-                  </>
-                );
-              }}
-            </TextDecorationSetting>
-            <LineStyleSettings
-              idPrefix={idPrefix}
-              setConfig={update}
-              currentConfig={currentLineConfig}
-            />
-          </>
-        )}
-        {isRange && (
-          <EuiFormRow
-            label={i18n.translate('eventAnnotationComponents.xyChart.fillStyle', {
-              defaultMessage: 'Fill',
-            })}
-            display="columnCompressed"
+            display="rowCompressed"
             fullWidth
           >
             <EuiButtonGroup
-              legend={i18n.translate('eventAnnotationComponents.xyChart.fillStyle', {
-                defaultMessage: 'Fill',
-              })}
-              data-test-subj="lns-xyAnnotation-fillStyle"
-              name="fillStyle"
+              legend={i18n.translate(
+                'eventAnnotationComponents.xyChart.annotationDate.placementType',
+                {
+                  defaultMessage: 'Placement type',
+                }
+              )}
+              data-test-subj="lns-xyAnnotation-placementType"
+              name="placementType"
               buttonSize="compressed"
               options={[
                 {
-                  id: `lens_xyChart_fillStyle_inside`,
-                  label: i18n.translate('eventAnnotationComponents.xyChart.fillStyle.inside', {
-                    defaultMessage: 'Inside',
+                  id: `lens_xyChart_annotation_manual`,
+                  label: i18n.translate('eventAnnotationComponents.xyChart.annotation.manual', {
+                    defaultMessage: 'Static date',
                   }),
-                  'data-test-subj': 'lnsXY_fillStyle_inside',
+                  'data-test-subj': 'lnsXY_annotation_manual',
                 },
                 {
-                  id: `lens_xyChart_fillStyle_outside`,
-                  label: i18n.translate('eventAnnotationComponents.xyChart.fillStyle.outside', {
-                    defaultMessage: 'Outside',
+                  id: `lens_xyChart_annotation_query`,
+                  label: i18n.translate('eventAnnotationComponents.xyChart.annotation.query', {
+                    defaultMessage: 'Custom query',
                   }),
-                  'data-test-subj': 'lnsXY_fillStyle_inside',
+                  'data-test-subj': 'lnsXY_annotation_query',
                 },
               ]}
-              idSelected={`lens_xyChart_fillStyle_${
-                Boolean(currentAnnotation?.outside) ? 'outside' : 'inside'
-              }`}
+              idSelected={`lens_xyChart_annotation_${currentAnnotation?.type}`}
               onChange={(id) => {
-                update({
-                  outside: id === `lens_xyChart_fillStyle_outside`,
+                const typeFromId = id.replace(
+                  'lens_xyChart_annotation_',
+                  ''
+                ) as EventAnnotationConfig['type'];
+                if (currentAnnotation?.type === typeFromId) {
+                  return;
+                }
+                if (typeFromId === 'query') {
+                  // If coming from a range type, it requires some additional resets
+                  const additionalRangeResets = isRangeAnnotationConfig(currentAnnotation)
+                    ? {
+                        label:
+                          currentAnnotation.label === defaultRangeAnnotationLabel
+                            ? defaultAnnotationLabel
+                            : currentAnnotation.label,
+                        color: toLineAnnotationColor(currentAnnotation.color),
+                      }
+                    : {};
+                  return update({
+                    type: typeFromId,
+                    timeField:
+                      (dataView.timeFieldName ||
+                        // fallback to the first avaiable date field in the dataView
+                        dataView.fields
+                          .filter(isFieldLensCompatible)
+                          .find(({ type: fieldType }) => fieldType === 'date')?.displayName) ??
+                      '',
+                    key: { type: 'point_in_time' },
+                    ...additionalRangeResets,
+                  });
+                }
+                // From query to manual annotation
+                return update<PointInTimeEventAnnotationConfig>({
+                  type: typeFromId,
+                  key: { type: 'point_in_time', timestamp: moment().toISOString() },
                 });
               }}
               isFullWidth
             />
           </EuiFormRow>
-        )}
+          {isQueryBased ? (
+            <ConfigPanelQueryAnnotation
+              annotation={currentAnnotation}
+              onChange={update}
+              dataView={dataView}
+              queryInputShouldOpen={queryInputShouldOpen}
+              queryInputServices={queryInputServices}
+              appName={appName}
+            />
+          ) : (
+            <ConfigPanelManualAnnotation
+              annotation={currentAnnotation}
+              onChange={update}
+              getDefaultRangeEnd={getDefaultRangeEnd}
+              calendarClassName={calendarClassName}
+            />
+          )}
+        </DimensionEditorSection>
+      ) : null}
+      {!sections || sections.includes('appearance') ? (
+        <DimensionEditorSection
+          title={i18n.translate('eventAnnotationComponents.xyChart.appearance', {
+            defaultMessage: 'Appearance',
+          })}
+        >
+          <NameInput
+            value={currentAnnotation?.label || defaultAnnotationLabel}
+            defaultValue={defaultAnnotationLabel}
+            onChange={(value) => {
+              update({ label: value });
+            }}
+          />
+          {!isRange && (
+            <>
+              <IconSelectSetting<AvailableAnnotationIcon>
+                currentIcon={currentAnnotation.icon}
+                setIcon={(icon) => update({ icon })}
+                defaultIcon="triangle"
+                customIconSet={annotationsIconSet}
+              />
+              <TextDecorationSetting
+                idPrefix={idPrefix}
+                setConfig={update}
+                currentConfig={currentAnnotation}
+                isQueryBased={isQueryBased}
+              >
+                {(textDecorationSelected) => {
+                  if (textDecorationSelected !== 'field') {
+                    return null;
+                  }
+                  const options = dataView.fields
+                    .filter(isFieldLensCompatible)
+                    .filter(({ displayName, type }) => displayName && type !== 'document')
+                    .map(
+                      (field) =>
+                        ({
+                          label: field.displayName,
+                          value: {
+                            type: 'field',
+                            field: field.name,
+                            dataType: field.type,
+                          },
+                          exists: hasFieldData(dataView.id!, field.name),
+                          compatible: true,
+                          'data-test-subj': `lnsXY-annotation-fieldOption-${field.name}`,
+                        } as FieldOption<FieldOptionValue>)
+                    );
+                  const selectedField = (currentAnnotation as QueryPointEventAnnotationConfig)
+                    .textField;
 
-        <ColorPicker
-          overwriteColor={currentAnnotation.color}
-          isClearable={false}
-          defaultColor={isRange ? defaultAnnotationRangeColor : defaultAnnotationColor}
-          showAlpha={isRange}
-          setConfig={update}
-          disableHelpTooltip
-          label={i18n.translate('eventAnnotationComponents.xyChart.lineColor.label', {
-            defaultMessage: 'Color',
-          })}
-        />
-        <ConfigPanelGenericSwitch
-          label={i18n.translate('eventAnnotationComponents.xyChart.annotation.hide', {
-            defaultMessage: 'Hide annotation',
-          })}
-          data-test-subj="lns-annotations-hide-annotation"
-          value={Boolean(currentAnnotation.isHidden)}
-          onChange={(ev) => update({ isHidden: ev.target.checked })}
-        />
-      </DimensionEditorSection>
+                  const fieldIsValid = selectedField
+                    ? Boolean(dataView.getFieldByName(selectedField))
+                    : true;
+
+                  return (
+                    <>
+                      <EuiSpacer size="xs" />
+                      <FieldPicker
+                        activeField={
+                          selectedField
+                            ? {
+                                label: selectedField,
+                                value: { type: 'field', field: selectedField },
+                              }
+                            : undefined
+                        }
+                        options={options}
+                        onChoose={function (choice: FieldOptionValue | undefined): void {
+                          if (choice) {
+                            update({ textField: choice.field, textVisibility: true });
+                          }
+                        }}
+                        fieldIsInvalid={!fieldIsValid}
+                        data-test-subj="lnsXY-annotation-query-based-text-decoration-field-picker"
+                        autoFocus={!selectedField}
+                      />
+                    </>
+                  );
+                }}
+              </TextDecorationSetting>
+              <LineStyleSettings
+                idPrefix={idPrefix}
+                setConfig={update}
+                currentConfig={currentLineConfig}
+              />
+            </>
+          )}
+          {isRange && (
+            <EuiFormRow
+              label={i18n.translate('eventAnnotationComponents.xyChart.fillStyle', {
+                defaultMessage: 'Fill',
+              })}
+              display="columnCompressed"
+              fullWidth
+            >
+              <EuiButtonGroup
+                legend={i18n.translate('eventAnnotationComponents.xyChart.fillStyle', {
+                  defaultMessage: 'Fill',
+                })}
+                data-test-subj="lns-xyAnnotation-fillStyle"
+                name="fillStyle"
+                buttonSize="compressed"
+                options={[
+                  {
+                    id: `lens_xyChart_fillStyle_inside`,
+                    label: i18n.translate('eventAnnotationComponents.xyChart.fillStyle.inside', {
+                      defaultMessage: 'Inside',
+                    }),
+                    'data-test-subj': 'lnsXY_fillStyle_inside',
+                  },
+                  {
+                    id: `lens_xyChart_fillStyle_outside`,
+                    label: i18n.translate('eventAnnotationComponents.xyChart.fillStyle.outside', {
+                      defaultMessage: 'Outside',
+                    }),
+                    'data-test-subj': 'lnsXY_fillStyle_inside',
+                  },
+                ]}
+                idSelected={`lens_xyChart_fillStyle_${
+                  Boolean(currentAnnotation?.outside) ? 'outside' : 'inside'
+                }`}
+                onChange={(id) => {
+                  update({
+                    outside: id === `lens_xyChart_fillStyle_outside`,
+                  });
+                }}
+                isFullWidth
+              />
+            </EuiFormRow>
+          )}
+
+          <ColorPicker
+            overwriteColor={currentAnnotation.color}
+            isClearable={false}
+            defaultColor={isRange ? defaultAnnotationRangeColor : defaultAnnotationColor}
+            showAlpha={isRange}
+            setConfig={update}
+            disableHelpTooltip
+            label={i18n.translate('eventAnnotationComponents.xyChart.lineColor.label', {
+              defaultMessage: 'Color',
+            })}
+          />
+          <ConfigPanelGenericSwitch
+            label={i18n.translate('eventAnnotationComponents.xyChart.annotation.hide', {
+              defaultMessage: 'Hide annotation',
+            })}
+            data-test-subj="lns-annotations-hide-annotation"
+            value={Boolean(currentAnnotation.isHidden)}
+            onChange={(ev) => update({ isHidden: ev.target.checked })}
+          />
+        </DimensionEditorSection>
+      ) : null}
       {isQueryBased && currentAnnotation && (
         <DimensionEditorSection
           title={i18n.translate('eventAnnotationComponents.xyChart.tooltip', {

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -363,6 +363,15 @@ export const useDiscoverHistogram = ({
           );
           break;
         case UnifiedHistogramExternalVisContextStatus.automaticallyCreated:
+          // it's necessary now for annotations to work properly
+          stateContainer.savedSearchState.updateVisContext({
+            nextVisContext,
+          });
+          // clearing the value in the internal state so we don't use it during saved search saving
+          stateContainer.internalState.transitions.setOverriddenVisContextAfterInvalidation(
+            undefined
+          );
+          break;
         case UnifiedHistogramExternalVisContextStatus.applied:
           // clearing the value in the internal state so we don't use it during saved search saving
           stateContainer.internalState.transitions.setOverriddenVisContextAfterInvalidation(

--- a/src/plugins/discover/public/application/main/state_management/discover_state_provider.tsx
+++ b/src/plugins/discover/public/application/main/state_management/discover_state_provider.tsx
@@ -16,6 +16,10 @@ import { DiscoverStateContainer } from './discover_state';
 function createStateHelpers() {
   const context = React.createContext<DiscoverStateContainer | null>(null);
   const useContainer = () => useContext(context);
+  const useSavedSearchContainer = () => {
+    const container = useContainer();
+    return container!.savedSearchState;
+  };
   const useSavedSearch = () => {
     const container = useContainer();
     return useObservable<SavedSearch>(
@@ -40,6 +44,7 @@ function createStateHelpers() {
 
   return {
     Provider: context.Provider,
+    useSavedSearchContainer,
     useSavedSearch,
     useSavedSearchInitial,
     useSavedSearchHasChanged,
@@ -48,6 +53,7 @@ function createStateHelpers() {
 
 export const {
   Provider: DiscoverStateProvider,
+  useSavedSearchContainer,
   useSavedSearchInitial,
   useSavedSearch,
   useSavedSearchHasChanged,

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
@@ -16,6 +16,8 @@ import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { PLUGIN_ID } from '../../../../common';
 import { useDocViewerAnnotationContext } from './doc_viewer_annotation_context';
 
+const VISIBLE_SECTIONS = ['appearance'];
+
 export const DocViewerAnnotation: React.FC<DocViewRenderProps> = ({ dataView, hit }) => {
   const { docVisAnnotation, onDocVisAnnotationChanged } = useDocViewerAnnotationContext();
   const services = useDiscoverServices();
@@ -63,6 +65,7 @@ export const DocViewerAnnotation: React.FC<DocViewRenderProps> = ({ dataView, hi
         dataView={dataView}
         appName={PLUGIN_ID}
         queryInputServices={services}
+        sections={VISIBLE_SECTIONS}
       />
       <EuiSpacer size="s" />
       <EuiFlexGroup justifyContent="flexEnd" direction="row" responsive={false}>

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
@@ -5,7 +5,9 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { EuiButton, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { v4 as uuidv4 } from 'uuid';
 import { css } from '@emotion/react';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
@@ -23,10 +25,30 @@ export const DocViewerAnnotation = ({ dataView, hit }: DocViewRenderProps) => {
   //     : hit.flattened[timeFieldName]
   //   : undefined;
   // const timestamp = timeFieldValue ? timeFieldValue : undefined;
-  const [currentAnnotation, setCurrentAnnotation] = useState<EventAnnotationConfig>(() =>
-    getDefaultManualAnnotation(uuidv4(), new Date().toISOString())
-  );
+  const [currentAnnotation, setCurrentAnnotation] = useState<EventAnnotationConfig>();
   const services = useDiscoverServices();
+
+  const createAnnotation = useCallback(() => {
+    setCurrentAnnotation(getDefaultManualAnnotation(uuidv4(), new Date().toISOString()));
+  }, [setCurrentAnnotation]);
+
+  const deleteAnnotation = useCallback(() => {
+    setCurrentAnnotation(undefined);
+  }, [setCurrentAnnotation]);
+
+  if (!currentAnnotation) {
+    return (
+      <>
+        <EuiSpacer />
+        <EuiButton onClick={createAnnotation}>
+          {i18n.translate('discover.grid.docVisAnnotation.createButton', {
+            defaultMessage: 'Create annotation',
+          })}
+        </EuiButton>
+      </>
+    );
+  }
+
   return (
     <div
       css={css`
@@ -49,6 +71,16 @@ export const DocViewerAnnotation = ({ dataView, hit }: DocViewRenderProps) => {
         appName={PLUGIN_ID}
         queryInputServices={services}
       />
+      <EuiSpacer size="s" />
+      <EuiFlexGroup justifyContent="flexEnd" direction="row" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={deleteAnnotation}>
+            {i18n.translate('discover.grid.docVisAnnotation.deleteButton', {
+              defaultMessage: 'Delete annotation',
+            })}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </div>
   );
 };

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
@@ -5,19 +5,20 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { EuiButton, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { v4 as uuidv4 } from 'uuid';
 import { css } from '@emotion/react';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import AnnotationEditorControls from '@kbn/event-annotation-components/components/annotation_editor_controls/annotation_editor_controls';
-import { EventAnnotationConfig } from '@kbn/event-annotation-common/types';
 import { getDefaultManualAnnotation } from '@kbn/event-annotation-common';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { PLUGIN_ID } from '../../../../common';
+import { useDocViewerAnnotationContext } from './doc_viewer_annotation_context';
 
-export const DocViewerAnnotation = ({ dataView, hit }: DocViewRenderProps) => {
+export const DocViewerAnnotation: React.FC<DocViewRenderProps> = ({ dataView }) => {
+  const { docVisAnnotation, onDocVisAnnotationChanged } = useDocViewerAnnotationContext();
   // const timeFieldName = dataView.getTimeField()?.name;
   // const timeFieldValue = timeFieldName
   //   ? Array.isArray(hit.flattened[timeFieldName])
@@ -25,18 +26,17 @@ export const DocViewerAnnotation = ({ dataView, hit }: DocViewRenderProps) => {
   //     : hit.flattened[timeFieldName]
   //   : undefined;
   // const timestamp = timeFieldValue ? timeFieldValue : undefined;
-  const [currentAnnotation, setCurrentAnnotation] = useState<EventAnnotationConfig>();
   const services = useDiscoverServices();
 
   const createAnnotation = useCallback(() => {
-    setCurrentAnnotation(getDefaultManualAnnotation(uuidv4(), new Date().toISOString()));
-  }, [setCurrentAnnotation]);
+    onDocVisAnnotationChanged?.(getDefaultManualAnnotation(uuidv4(), new Date().toISOString()));
+  }, [onDocVisAnnotationChanged]);
 
   const deleteAnnotation = useCallback(() => {
-    setCurrentAnnotation(undefined);
-  }, [setCurrentAnnotation]);
+    onDocVisAnnotationChanged?.(undefined);
+  }, [onDocVisAnnotationChanged]);
 
-  if (!currentAnnotation) {
+  if (!docVisAnnotation) {
     return (
       <>
         <EuiSpacer />
@@ -62,7 +62,7 @@ export const DocViewerAnnotation = ({ dataView, hit }: DocViewRenderProps) => {
       `}
     >
       <AnnotationEditorControls
-        annotation={currentAnnotation}
+        annotation={docVisAnnotation}
         onAnnotationChange={(annotation) => {
           // console.log(annotation);
         }}

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
@@ -8,7 +8,6 @@
 import React, { useCallback } from 'react';
 import { EuiButton, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { v4 as uuidv4 } from 'uuid';
 import { css } from '@emotion/react';
 import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
 import AnnotationEditorControls from '@kbn/event-annotation-components/components/annotation_editor_controls/annotation_editor_controls';
@@ -17,20 +16,14 @@ import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { PLUGIN_ID } from '../../../../common';
 import { useDocViewerAnnotationContext } from './doc_viewer_annotation_context';
 
-export const DocViewerAnnotation: React.FC<DocViewRenderProps> = ({ dataView }) => {
+export const DocViewerAnnotation: React.FC<DocViewRenderProps> = ({ dataView, hit }) => {
   const { docVisAnnotation, onDocVisAnnotationChanged } = useDocViewerAnnotationContext();
-  // const timeFieldName = dataView.getTimeField()?.name;
-  // const timeFieldValue = timeFieldName
-  //   ? Array.isArray(hit.flattened[timeFieldName])
-  //     ? hit.flattened[timeFieldName][0]
-  //     : hit.flattened[timeFieldName]
-  //   : undefined;
-  // const timestamp = timeFieldValue ? timeFieldValue : undefined;
   const services = useDiscoverServices();
 
+  const timestamp = String(hit.flattened['@timestamp']); // TODO: This is a temporary logic to get the timestamp from the hit
   const createAnnotation = useCallback(() => {
-    onDocVisAnnotationChanged?.(getDefaultManualAnnotation(uuidv4(), new Date().toISOString()));
-  }, [onDocVisAnnotationChanged]);
+    onDocVisAnnotationChanged?.(getDefaultManualAnnotation(timestamp, timestamp));
+  }, [onDocVisAnnotationChanged, timestamp]);
 
   const deleteAnnotation = useCallback(() => {
     onDocVisAnnotationChanged?.(undefined);
@@ -64,7 +57,7 @@ export const DocViewerAnnotation: React.FC<DocViewRenderProps> = ({ dataView }) 
       <AnnotationEditorControls
         annotation={docVisAnnotation}
         onAnnotationChange={(annotation) => {
-          // console.log(annotation);
+          onDocVisAnnotationChanged?.(annotation);
         }}
         getDefaultRangeEnd={(rangeStart) => rangeStart}
         dataView={dataView}

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import React, { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { css } from '@emotion/react';
+import { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import AnnotationEditorControls from '@kbn/event-annotation-components/components/annotation_editor_controls/annotation_editor_controls';
+import { EventAnnotationConfig } from '@kbn/event-annotation-common/types';
+import { getDefaultManualAnnotation } from '@kbn/event-annotation-common';
+import { useDiscoverServices } from '../../../hooks/use_discover_services';
+import { PLUGIN_ID } from '../../../../common';
+
+export const DocViewerAnnotation = ({ dataView, hit }: DocViewRenderProps) => {
+  // const timeFieldName = dataView.getTimeField()?.name;
+  // const timeFieldValue = timeFieldName
+  //   ? Array.isArray(hit.flattened[timeFieldName])
+  //     ? hit.flattened[timeFieldName][0]
+  //     : hit.flattened[timeFieldName]
+  //   : undefined;
+  // const timestamp = timeFieldValue ? timeFieldValue : undefined;
+  const [currentAnnotation, setCurrentAnnotation] = useState<EventAnnotationConfig>(() =>
+    getDefaultManualAnnotation(uuidv4(), new Date().toISOString())
+  );
+  const services = useDiscoverServices();
+  return (
+    <div
+      css={css`
+        .lnsDimensionEditorSection:first-child {
+          margin-top: 8px;
+
+          .lnsDimensionEditorSection__border {
+            display: none;
+          }
+        }
+      `}
+    >
+      <AnnotationEditorControls
+        annotation={currentAnnotation}
+        onAnnotationChange={(annotation) => {
+          // console.log(annotation);
+        }}
+        getDefaultRangeEnd={(rangeStart) => rangeStart}
+        dataView={dataView}
+        appName={PLUGIN_ID}
+        queryInputServices={services}
+      />
+    </div>
+  );
+};

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation_context.ts
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/doc_viewer_annotation_context.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { EventAnnotationConfig } from '@kbn/event-annotation-common';
+
+interface DocViewerAnnotationContextParams {
+  docVisAnnotation?: EventAnnotationConfig;
+  onDocVisAnnotationChanged?: (annotation: EventAnnotationConfig | undefined) => void;
+}
+
+export const DocViewerAnnotationContext = React.createContext<DocViewerAnnotationContextParams>({});
+
+export const useDocViewerAnnotationContext = () => {
+  return React.useContext(DocViewerAnnotationContext);
+};

--- a/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/index.ts
+++ b/src/plugins/discover/public/components/discover_grid_flyout/doc_viewer_annotation/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { DocViewerAnnotation } from './doc_viewer_annotation';
+
+// Required for usage in React.lazy
+// eslint-disable-next-line import/no-default-export
+export default DocViewerAnnotation;


### PR DESCRIPTION
> [!NOTE]  
> At the moment works only for ES|QL with time based results and might be unstable.

## Summary

This is a PoC which allows to:
- add an annotation for any fetched document from the data grid via a new DocViewer tab
- the added annotation will show up in the histogram
- users can save this search and the annotations would be persisted too
- users can add the histogram to a Dashboard and the annotations would be carried over too
- users can view and edit annotations via the same DocViewer tab

<img width="1940" alt="Screenshot 2024-06-27 at 17 41 44" src="https://github.com/elastic/kibana/assets/1415710/38602719-8b82-4425-9690-8d6df87e382b">


Creating an annotation:
![Jun-27-2024 17-44-55](https://github.com/elastic/kibana/assets/1415710/d7d72570-5a66-46a0-948c-23269441795d)

Also works when saving to Dashboard:
![Jun-27-2024 17-29-00](https://github.com/elastic/kibana/assets/1415710/8a815d86-1336-4960-b1e8-005b2877e1cd)

- Related to https://github.com/elastic/kibana/issues/101455