### PR TITLE
[POC][Timeline] - Use doc viewer tabs in security

### DIFF
--- a/packages/kbn-unified-doc-viewer/index.ts
+++ b/packages/kbn-unified-doc-viewer/index.ts
@@ -6,4 +6,10 @@
  * Side Public License, v 1.
  */
 
-export { DocViewer, DocViewsRegistry, ElasticRequestState, FieldName } from './src';
+export {
+  DocViewer,
+  getDocViewerTabs,
+  DocViewsRegistry,
+  ElasticRequestState,
+  FieldName,
+} from './src';

--- a/packages/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/packages/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -8,12 +8,7 @@
 
 import React from 'react';
 import { EuiTabbedContent } from '@elastic/eui';
-import { DocViewerTab } from './doc_viewer_tab';
-import type { DocView, DocViewRenderProps } from '../../types';
-
-export interface DocViewerProps extends DocViewRenderProps {
-  docViews: DocView[];
-}
+import { DocViewerProps, getDocViewerTabs } from './get_doc_viewer_tabs';
 
 /**
  * Rendering tabs with different views of 1 Elasticsearch hit in Discover.
@@ -22,30 +17,7 @@ export interface DocViewerProps extends DocViewRenderProps {
  * a `render` function.
  */
 export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
-  const tabs = docViews
-    .filter(({ enabled }) => enabled) // Filter out disabled doc views
-    .map(({ id, title, render, component }: DocView) => {
-      return {
-        id: `kbn_doc_viewer_tab_${id}`,
-        name: title,
-        content: (
-          <DocViewerTab
-            id={id}
-            title={title}
-            component={component}
-            renderProps={renderProps}
-            render={render}
-          />
-        ),
-        ['data-test-subj']: `docViewerTab-${id}`,
-      };
-    });
-
-  if (!tabs.length) {
-    // There's a minimum of 2 tabs active in Discover.
-    // This condition takes care of unit tests with 0 tabs.
-    return null;
-  }
+  const tabs = getDocViewerTabs({ docViews, ...renderProps });
 
   return (
     <div className="kbnDocViewer" data-test-subj="kbnDocViewer">

--- a/packages/kbn-unified-doc-viewer/src/components/doc_viewer/get_doc_viewer_tabs.tsx
+++ b/packages/kbn-unified-doc-viewer/src/components/doc_viewer/get_doc_viewer_tabs.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { DocViewerTab } from './doc_viewer_tab';
+import type { DocView, DocViewRenderProps } from '../../types';
+
+export interface DocViewerProps extends DocViewRenderProps {
+  docViews: DocView[];
+}
+
+export function getDocViewerTabs({ docViews, ...renderProps }: DocViewerProps) {
+  const tabs = docViews
+    .filter(({ enabled }) => enabled) // Filter out disabled doc views
+    .map(({ id, title, render, component }: DocView) => {
+      return {
+        id: `kbn_doc_viewer_tab_${id}`,
+        name: title,
+        content: (
+          <DocViewerTab
+            id={id}
+            title={title}
+            component={component}
+            renderProps={renderProps}
+            render={render}
+          />
+        ),
+        ['data-test-subj']: `docViewerTab-${id}`,
+      };
+    });
+
+  return tabs;
+}

--- a/packages/kbn-unified-doc-viewer/src/components/doc_viewer/index.ts
+++ b/packages/kbn-unified-doc-viewer/src/components/doc_viewer/index.ts
@@ -6,3 +6,4 @@
  * Side Public License, v 1.
  */
 export { DocViewer } from './doc_viewer';
+export { getDocViewerTabs } from './get_doc_viewer_tabs';

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer/doc_viewer_tabs.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer/doc_viewer_tabs.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
+import { getDocViewerTabs } from '@kbn/unified-doc-viewer';
+import { getUnifiedDocViewerServices } from '../../plugin';
+
+export function getUnifiedDocViewerTabs({ docViewsRegistry, ...props }: DocViewRenderProps) {
+  const { unifiedDocViewer } = getUnifiedDocViewerServices();
+
+  let registry = unifiedDocViewer.registry;
+  if (docViewsRegistry) {
+    registry =
+      typeof docViewsRegistry === 'function'
+        ? docViewsRegistry(unifiedDocViewer.registry.clone())
+        : docViewsRegistry;
+  }
+
+  return getDocViewerTabs({ docViews: registry.getAll(), ...props });
+}

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer/index.ts
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer/index.ts
@@ -8,6 +8,8 @@
 
 import { UnifiedDocViewer } from './doc_viewer';
 
+export { getUnifiedDocViewerTabs } from './doc_viewer_tabs';
+
 // Required for usage in React.lazy
 // eslint-disable-next-line import/no-default-export
 export default UnifiedDocViewer;

--- a/src/plugins/unified_doc_viewer/public/index.tsx
+++ b/src/plugins/unified_doc_viewer/public/index.tsx
@@ -26,6 +26,7 @@ export const JsonCodeEditor = withSuspense<JsonCodeEditorProps>(
 );
 
 export { useEsDocSearch } from './hooks';
+export { getUnifiedDocViewerTabs } from './components/doc_viewer';
 export { UnifiedDocViewer } from './components/lazy_doc_viewer';
 export { UnifiedDocViewerFlyout } from './components/lazy_doc_viewer_flyout';
 

--- a/x-pack/plugins/security_solution/kibana.jsonc
+++ b/x-pack/plugins/security_solution/kibana.jsonc
@@ -80,7 +80,8 @@
       "usageCollection",
       "lists",
       "ml",
-      "unifiedSearch"
+      "unifiedSearch",
+      "unifiedDocViewer"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_tabs.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_tabs.ts
@@ -43,12 +43,12 @@ export interface UseTabsResult {
  */
 export const useTabs = ({ flyoutIsExpandable, path }: UseTabsParams): UseTabsResult => {
   const { storage } = useKibana().services;
-
+  const defaultTabs = tabs.useDefaultTabs();
   // if the flyout is expandable we render all 3 tabs (overview, table and json)
   // if the flyout is not, we render only table and json
   const tabsDisplayed = useMemo(
-    () => (flyoutIsExpandable ? allThreeTabs : twoTabs),
-    [flyoutIsExpandable]
+    () => (flyoutIsExpandable ? [tabs.overviewTab, ...defaultTabs] : defaultTabs),
+    [defaultTabs, flyoutIsExpandable]
   );
 
   const selectedTabId = useMemo(() => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/tabs.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/tabs.tsx
@@ -8,6 +8,8 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { getUnifiedDocViewerTabs } from '@kbn/unified-doc-viewer-plugin/public';
+import { useGetScopedSourcererDataView } from '../../../sourcerer/components/use_get_sourcerer_data_view';
 import {
   JSON_TAB_TEST_ID,
   OVERVIEW_TAB_LABEL_TEST_ID,
@@ -18,6 +20,9 @@ import type { RightPanelPaths } from '.';
 import { JsonTab } from './tabs/json_tab';
 import { OverviewTab } from './tabs/overview_tab';
 import { TableTab } from './tabs/table_tab';
+import { SourcererScopeName } from '../../../sourcerer/store/model';
+import { transformTimelineDetailItemToUnifiedRows } from '../../../timelines/components/timeline/unified_components/utils';
+import { useDocumentDetailsContext } from '../shared/context';
 
 export interface RightPanelTabType {
   id: RightPanelPaths;
@@ -62,4 +67,13 @@ export const jsonTab: RightPanelTabType = {
     />
   ),
   content: <JsonTab />,
+};
+
+export const useDefaultTabs = () => {
+  const dataView = useGetScopedSourcererDataView({ sourcererScope: SourcererScopeName.timeline });
+  const { searchHit } = useDocumentDetailsContext();
+  if (!dataView) return [];
+  const hit = transformTimelineDetailItemToUnifiedRows({ hit: searchHit, dataView });
+  if (!hit) return [];
+  return getUnifiedDocViewerTabs({ hit, dataView }) ?? [];
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/utils.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/utils.ts
@@ -7,8 +7,8 @@
 
 import { flattenHit } from '@kbn/data-service';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import type { DataTableRecord } from '@kbn/discover-utils/types';
-import type { TimelineItem } from '../../../../../common/search_strategy';
+import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils/types';
+import type { SearchHit, TimelineItem } from '../../../../../common/search_strategy';
 
 interface TransformTimelineItemToUnifiedRows {
   events: TimelineItem[];
@@ -41,4 +41,23 @@ export function transformTimelineItemToUnifiedRows(
   });
 
   return unifiedDataTableRows;
+}
+
+// TODO: Type should be simplified to use the same data type as the table ideally..
+interface TransformTimelineDetailItemToUnifiedItem {
+  hit: SearchHit;
+  dataView: DataView;
+}
+export function transformTimelineDetailItemToUnifiedRows(
+  args: TransformTimelineDetailItemToUnifiedItem
+): DataTableRecord {
+  const { hit, dataView } = args;
+
+  return {
+    id: hit._id as string,
+    raw: hit as EsHitRecord,
+    flattened: flattenHit(hit, dataView, {
+      includeIgnoredValues: true,
+    }),
+  };
 }


### PR DESCRIPTION
## Summary

Simple PR testing just the export of the doc viewer tabs for use in security


https://github.com/elastic/kibana/assets/17211684/7f5a7600-9478-4b83-9ce3-57a50736e947

