### PR TITLE
[Cloud Security] Update mock server timeout config

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/configurations.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/configurations.test.tsx
@@ -63,12 +63,6 @@ describe('<Findings />', () => {
     // Loading while checking the status API
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(screen.getByTestId('latest_findings_container')).toBeInTheDocument()
-    );
-    // loading findings
-    await waitFor(() => expect(screen.getByText(/loading results/i)).toBeInTheDocument());
-
     await waitFor(() => expect(screen.getByText(/2 findings/i)).toBeInTheDocument());
 
     expect(screen.getByText(finding1.resource.name)).toBeInTheDocument();
@@ -99,12 +93,6 @@ describe('<Findings />', () => {
       // Loading while checking the status API
       expect(screen.getByText(/loading/i)).toBeInTheDocument();
 
-      await waitFor(() =>
-        expect(screen.getByTestId('latest_findings_container')).toBeInTheDocument()
-      );
-      // loading findings
-      await waitFor(() => expect(screen.getByText(/loading results/i)).toBeInTheDocument());
-
       await waitFor(() => expect(screen.getByText(/2 findings/i)).toBeInTheDocument());
 
       const queryInput = screen.getByTestId('queryInput');
@@ -133,12 +121,6 @@ describe('<Findings />', () => {
 
       // Loading while checking the status API
       expect(screen.getByText(/loading/i)).toBeInTheDocument();
-
-      await waitFor(() =>
-        expect(screen.getByTestId('latest_findings_container')).toBeInTheDocument()
-      );
-      // loading findings
-      await waitFor(() => expect(screen.getByText(/loading results/i)).toBeInTheDocument());
 
       await waitFor(() => expect(screen.getByText(/2 findings/i)).toBeInTheDocument());
 
@@ -170,12 +152,6 @@ describe('<Findings />', () => {
 
       // Loading while checking the status API
       expect(screen.getByText(/loading/i)).toBeInTheDocument();
-
-      await waitFor(() =>
-        expect(screen.getByTestId('latest_findings_container')).toBeInTheDocument()
-      );
-      // loading findings
-      await waitFor(() => expect(screen.getByText(/loading results/i)).toBeInTheDocument());
 
       await waitFor(() => expect(screen.getByText(/2 findings/i)).toBeInTheDocument());
 
@@ -212,7 +188,7 @@ describe('<Findings />', () => {
       await waitFor(() => expect(screen.getByText(/1 findings/i)).toBeInTheDocument());
       expect(screen.getByText(finding1.resource.name)).toBeInTheDocument();
       expect(screen.queryByText(finding2.resource.id)).not.toBeInTheDocument();
-    }, 10000);
+    });
     it('remove filter', async () => {
       const finding1 = generateCspFinding('0001', 'failed');
       const finding2 = generateCspFinding('0002', 'passed');
@@ -255,12 +231,6 @@ describe('<Findings />', () => {
 
       // Loading while checking the status API
       expect(screen.getByText(/loading/i)).toBeInTheDocument();
-
-      await waitFor(() =>
-        expect(screen.getByTestId('latest_findings_container')).toBeInTheDocument()
-      );
-      // loading findings
-      await waitFor(() => expect(screen.getByText(/loading results/i)).toBeInTheDocument());
 
       await waitFor(() => expect(screen.getByText(/1 findings/i)).toBeInTheDocument());
       expect(screen.getByText(finding1.resource.name)).toBeInTheDocument();

--- a/x-pack/plugins/cloud_security_posture/public/test/mock_server/mock_server.ts
+++ b/x-pack/plugins/cloud_security_posture/public/test/mock_server/mock_server.ts
@@ -33,6 +33,9 @@ jest.mock('rxjs', () => {
   };
 });
 
+// Set the default timeout for all mock server tests to 30 seconds
+jest.setTimeout(10 * 3000);
+
 /**
  * Setup a mock server with the default handlers
  * @param debug - If true, log all requests to the console


### PR DESCRIPTION
## Summary

It fixes #187076

This fixes timeout CI errors by setting a higher jest timeout for integration tests as they are allowed to take more time to run than unit tests.