### PR TITLE
[8.14] Update dependency launchdarkly-js-client-sdk to ^3.4.0 (main) (#187086)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1038,7 +1038,7 @@
     "kea": "^2.6.0",
     "langchain": "^0.1.30",
     "langsmith": "^0.1.14",
-    "launchdarkly-js-client-sdk": "^3.3.0",
+    "launchdarkly-js-client-sdk": "^3.4.0",
     "load-json-file": "^6.2.0",
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21272,18 +21272,18 @@ launchdarkly-eventsource@2.0.3:
   resolved "https://registry.yarnpkg.com/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.3.tgz#8a7b8da5538153f438f7d452b1c87643d900f984"
   integrity sha512-VhFjppK7jXlcEKaS7bxdoibB5j01NKyeDR7a8XfssdDGNWCTsbF0/5IExSmPi44eDncPhkoPNxlSZhEZvrbD5w==
 
-launchdarkly-js-client-sdk@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.3.0.tgz#33573b884438b63f1501039c4bf0b174694a06d0"
-  integrity sha512-Hb+EF/5m43jsKrkXLPrdklX5g+XUJiwJQlVfa4y+ZPEqSnP4w4GrFp+Iv5ftWCcRhhpQuw/rygoNZlL1e1vmgg==
+launchdarkly-js-client-sdk@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.4.0.tgz#5b5959b548edac8a0f368eb40b079d942573d37b"
+  integrity sha512-3v1jKy1RECT0SG/3SGlyRO32vweoNxvWiJuIChRh/Zhk98cHpANuwameXVhwJ4WEDNZJTur73baaKAyatSP46A==
   dependencies:
     escape-string-regexp "^4.0.0"
-    launchdarkly-js-sdk-common "5.2.0"
+    launchdarkly-js-sdk-common "5.3.0"
 
-launchdarkly-js-sdk-common@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.2.0.tgz#be9fadc59786c060087a3b818d15af700faf0fd2"
-  integrity sha512-aLv2ZrUv229RIwLtFhdILu2aJS/fqGSJzTk4L/bCDZA8RuIh7PutI3ui/AJeNnzPzjKzdEQZw6wVhkVc84baog==
+launchdarkly-js-sdk-common@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.3.0.tgz#336a54843f5ba3541632e10014e49dff45d41674"
+  integrity sha512-NI5wFF8qhjtpRb4KelGdnwNIOf/boLlbLiseV7uf1jxSeoM/L30DAz87RT8VhYCSGCo4LedGILQFednI/MKFkA==
   dependencies:
     base64-js "^1.3.0"
     fast-deep-equal "^2.0.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Update dependency launchdarkly-js-client-sdk to ^3.4.0 (main) (#187086)](https://github.com/elastic/kibana/pull/187086)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"renovate[bot]","email":"29139614+renovate[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-06-27T19:32:05Z","message":"Update dependency launchdarkly-js-client-sdk to ^3.4.0 (main) (#187086)","sha":"47e0111384b0784a13593ac3bc616c08ba5fc8e0","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","Team:Security","release_note:skip","backport:prev-minor","v8.15.0"],"number":187086,"url":"https://github.com/elastic/kibana/pull/187086","mergeCommit":{"message":"Update dependency launchdarkly-js-client-sdk to ^3.4.0 (main) (#187086)","sha":"47e0111384b0784a13593ac3bc616c08ba5fc8e0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/187086","number":187086,"mergeCommit":{"message":"Update dependency launchdarkly-js-client-sdk to ^3.4.0 (main) (#187086)","sha":"47e0111384b0784a13593ac3bc616c08ba5fc8e0"}}]}] BACKPORT-->