### PR TITLE
[Search] [Playground] fix for when multiple semantic_text indices

### DIFF
--- a/x-pack/plugins/search_playground/public/utils/create_query.test.ts
+++ b/x-pack/plugins/search_playground/public/utils/create_query.test.ts
@@ -452,7 +452,11 @@ describe('create_query', () => {
                     standard: {
                       query: {
                         nested: {
-                          inner_hits: { _source: ['field2.inference.chunks.text'], size: 2 },
+                          inner_hits: {
+                            _source: ['field2.inference.chunks.text'],
+                            name: 'index1.field2',
+                            size: 2,
+                          },
                           path: 'field2.inference.chunks',
                           query: {
                             sparse_vector: {
@@ -570,7 +574,11 @@ describe('create_query', () => {
                     standard: {
                       query: {
                         nested: {
-                          inner_hits: { _source: ['field2.inference.chunks.text'], size: 2 },
+                          inner_hits: {
+                            _source: ['field2.inference.chunks.text'],
+                            name: 'index1.field2',
+                            size: 2,
+                          },
                           path: 'field2.inference.chunks',
                           query: {
                             knn: {

--- a/x-pack/plugins/search_playground/public/utils/create_query.ts
+++ b/x-pack/plugins/search_playground/public/utils/create_query.ts
@@ -89,6 +89,7 @@ export function createQuery(
                 },
                 inner_hits: {
                   size: 2,
+                  name: `${index}.${semanticField.field}`,
                   _source: [`${semanticField.field}.inference.chunks.text`],
                 },
               },
@@ -106,6 +107,7 @@ export function createQuery(
                 },
                 inner_hits: {
                   size: 2,
+                  name: `${index}.${semanticField.field}`,
                   _source: [`${semanticField.field}.inference.chunks.text`],
                 },
               },

--- a/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -224,7 +224,7 @@ describe('conversational chain', () => {
           _index: 'index',
           _id: '1',
           inner_hits: {
-            'field.inference.chunks': {
+            'index.field': {
               hits: {
                 hits: [
                   {

--- a/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.test.ts
+++ b/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.test.ts
@@ -91,7 +91,7 @@ describe('getValueForSelectedField', () => {
         },
       },
       inner_hits: {
-        'test.inference.chunks': {
+        'sample-index.test': {
           hits: {
             hits: [
               {

--- a/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.ts
+++ b/x-pack/plugins/search_playground/server/utils/get_value_for_selected_field.ts
@@ -14,8 +14,9 @@ export const getValueForSelectedField = (hit: SearchHit, path: string): string =
   }
 
   // for semantic_text matches
-  if (!!hit.inner_hits?.[`${path}.inference.chunks`]) {
-    return hit.inner_hits[`${path}.inference.chunks`].hits.hits
+  const innerHitPath = `${hit._index}.${path}`;
+  if (!!hit.inner_hits?.[innerHitPath]) {
+    return hit.inner_hits[innerHitPath].hits.hits
       .map((innerHit) => innerHit._source.text)
       .join('\n --- \n');
   }


### PR DESCRIPTION
## Summary

Issue occurs when there are two semantic_text indices that share the same fields, the inner_hits query collides and throws an exception on search.

This pr introduces a unique name to each inner_hit query so this doesn't occur. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

