### PR TITLE
[Security Solution][Detection Engine][MKI] Addresses failing tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/custom_query_rule.cy.ts
@@ -61,7 +61,7 @@ describe('Create custom query rule', { tags: ['@ess', '@serverless'] }, () => {
     });
 
     // FLAKEY - see https://github.com/elastic/kibana/issues/182891
-    it('@skipInServerless Adds filter on define step', () => {
+    it('Adds filter on define step', { tags: ['@skipInServerless'] }, () => {
       visit(CREATE_RULE_URL);
       fillDefineCustomRule(rule);
       openAddFilterPopover();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/machine_learning_rule.cy.ts
@@ -70,10 +70,10 @@ describe('Machine Learning rules', { tags: ['@ess', '@serverless'] }, () => {
     );
     // ensure no ML jobs are started before the suite
     machineLearningJobIds.forEach((jobId) => forceStopAndCloseJob({ jobId }));
-    deleteAlertsAndRules();
   });
 
   beforeEach(() => {
+    deleteAlertsAndRules();
     login();
     visit(CREATE_RULE_URL);
   });

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -214,7 +214,6 @@ export const filterByDisabledRules = () => {
 export const goToRuleDetailsOf = (ruleName: string) => {
   cy.contains(RULE_NAME, ruleName).click();
 
-  cy.get(PAGE_CONTENT_SPINNER).should('be.visible');
   cy.contains(RULE_NAME_HEADER, ruleName).should('be.visible');
   cy.get(PAGE_CONTENT_SPINNER).should('not.exist');
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -802,14 +802,16 @@ export const continueFromDefineStep = () => {
   getDefineContinueButton().should('exist').click({ force: true });
 };
 
+const optionsToComboboxText = (options: string[]) => {
+  return options.map((o) => `${o}{downArrow}{enter}{esc}`).join('');
+};
+
 export const fillDefineMachineLearningRule = (rule: MachineLearningRuleCreateProps) => {
   const jobsAsArray = isArray(rule.machine_learning_job_id)
     ? rule.machine_learning_job_id
     : [rule.machine_learning_job_id];
   cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).click({ force: true });
-  jobsAsArray.forEach((job) => {
-    cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type(`${job}{downArrow}{enter}{esc}`);
-  });
+  cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type(optionsToComboboxText(jobsAsArray));
   cy.get(ANOMALY_THRESHOLD_INPUT).type(`{selectall}${rule.anomaly_threshold}`, {
     force: true,
   });

--- a/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -807,8 +807,9 @@ export const fillDefineMachineLearningRule = (rule: MachineLearningRuleCreatePro
     ? rule.machine_learning_job_id
     : [rule.machine_learning_job_id];
   cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).click({ force: true });
-  cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type(optionsToComboboxText(jobsAsArray));
-
+  jobsAsArray.forEach((job) => {
+    cy.get(MACHINE_LEARNING_DROPDOWN_INPUT).type(`${job}{downArrow}{enter}{esc}`);
+  });
   cy.get(ANOMALY_THRESHOLD_INPUT).type(`{selectall}${rule.anomaly_threshold}`, {
     force: true,
   });
@@ -910,7 +911,6 @@ export const enablesAndPopulatesThresholdSuppression = (
 
 export const fillAlertSuppressionFields = (fields: string[]) => {
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).should('not.be.disabled');
-  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).clear();
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).click();
   fields.forEach((field) => {
     cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(`${field}{downArrow}{enter}{esc}`);

--- a/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -908,14 +908,13 @@ export const enablesAndPopulatesThresholdSuppression = (
   cy.get(ALERT_SUPPRESSION_DURATION_PER_TIME_INTERVAL).should('be.enabled').should('be.checked');
 };
 
-const optionsToComboboxText = (options: string[]) => {
-  return options.map((o) => `${o}{downArrow}{enter}{esc}`).join('');
-};
-
 export const fillAlertSuppressionFields = (fields: string[]) => {
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).should('not.be.disabled');
+  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).clear();
   cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).click();
-  cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(optionsToComboboxText(fields));
+  fields.forEach((field) => {
+    cy.get(ALERT_SUPPRESSION_FIELDS_COMBO_BOX).type(`${field}{downArrow}{enter}{esc}`);
+  });
 };
 
 export const clearAlertSuppressionFields = () => {


### PR DESCRIPTION
## Summary

The tests that are currently failing on the periodic pipeline are all alert suppression-related. 

After checking the screenshots we saw the same problem everywhere, we were trying to add more than one field but we ended up having just one that does not exist in the index.

![image](https://github.com/elastic/kibana/assets/17427073/a25831a7-4046-4769-8f2c-e835bbeab51d)

The code used to fill the alert suppression dropdown is prone to be flaky. this is because we were creating a single string by joining all the options.

We made that piece more reliable by adding each option individually.

With the new approach we ensure that each option is treated separately so the combobox can register each option as a distinct selection.

As part of this PR we are also fixing a tag that was not correctly added to a test.
