### PR TITLE
[OnWeek][FieldFormatters] Add a new field formatter subtype "badge"

### DIFF
--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/__snapshots__/format_editor.test.tsx.snap
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/__snapshots__/format_editor.test.tsx.snap
@@ -23,6 +23,26 @@ exports[`FieldFormatEditor should render normally 1`] = `
     }
   >
     <lazy
+      fieldFormats={
+        Object {
+          "deserialize": [MockFunction],
+          "getByFieldType": [MockFunction],
+          "getDefaultConfig": [MockFunction],
+          "getDefaultInstance": [MockFunction],
+          "getDefaultInstanceCacheResolver": [MockFunction],
+          "getDefaultInstancePlain": [MockFunction],
+          "getDefaultType": [MockFunction],
+          "getDefaultTypeName": [MockFunction],
+          "getInstance": [MockFunction],
+          "getType": [MockFunction],
+          "getTypeNameByEsTypes": [MockFunction],
+          "getTypeWithoutMetaParams": [MockFunction],
+          "has": [MockFunction],
+          "init": [MockFunction],
+          "parseDefaultTypeMap": [MockFunction],
+          "register": [MockFunction],
+        }
+      }
       fieldType="number"
       format={Object {}}
       formatParams={Object {}}
@@ -56,6 +76,26 @@ exports[`FieldFormatEditor should render nothing if there is no editor for the f
     }
   >
     <lazy
+      fieldFormats={
+        Object {
+          "deserialize": [MockFunction],
+          "getByFieldType": [MockFunction],
+          "getDefaultConfig": [MockFunction],
+          "getDefaultInstance": [MockFunction],
+          "getDefaultInstanceCacheResolver": [MockFunction],
+          "getDefaultInstancePlain": [MockFunction],
+          "getDefaultType": [MockFunction],
+          "getDefaultTypeName": [MockFunction],
+          "getInstance": [MockFunction],
+          "getType": [MockFunction],
+          "getTypeNameByEsTypes": [MockFunction],
+          "getTypeWithoutMetaParams": [MockFunction],
+          "has": [MockFunction],
+          "init": [MockFunction],
+          "parseDefaultTypeMap": [MockFunction],
+          "register": [MockFunction],
+        }
+      }
       fieldType="number"
       format={Object {}}
       formatParams={Object {}}

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/editors/color/__snapshots__/color.test.tsx.snap
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/editors/color/__snapshots__/color.test.tsx.snap
@@ -2,6 +2,30 @@
 
 exports[`ColorFormatEditor should render multiple colors 1`] = `
 <Fragment>
+  <EuiFormRow
+    describedByIds={Array []}
+    display="row"
+    hasChildLabel={true}
+    hasEmptyLabelSpace={false}
+    isInvalid={false}
+    label={
+      <Memo(MemoizedFormattedMessage)
+        defaultMessage="Transform"
+        id="indexPatternFieldEditor.color.transformLabel"
+      />
+    }
+    labelType="label"
+  >
+    <EuiSelect
+      data-test-subj="colorEditorTransform"
+      isInvalid={false}
+      onChange={[Function]}
+      options={Array []}
+    />
+  </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
   <EuiBasicTable
     columns={
       Array [
@@ -102,6 +126,30 @@ exports[`ColorFormatEditor should render multiple colors 1`] = `
 
 exports[`ColorFormatEditor should render other type normally (range field) 1`] = `
 <Fragment>
+  <EuiFormRow
+    describedByIds={Array []}
+    display="row"
+    hasChildLabel={true}
+    hasEmptyLabelSpace={false}
+    isInvalid={false}
+    label={
+      <Memo(MemoizedFormattedMessage)
+        defaultMessage="Transform"
+        id="indexPatternFieldEditor.color.transformLabel"
+      />
+    }
+    labelType="label"
+  >
+    <EuiSelect
+      data-test-subj="colorEditorTransform"
+      isInvalid={false}
+      onChange={[Function]}
+      options={Array []}
+    />
+  </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
   <EuiBasicTable
     columns={
       Array [
@@ -195,6 +243,30 @@ exports[`ColorFormatEditor should render other type normally (range field) 1`] =
 
 exports[`ColorFormatEditor should render string type normally (regex field) 1`] = `
 <Fragment>
+  <EuiFormRow
+    describedByIds={Array []}
+    display="row"
+    hasChildLabel={true}
+    hasEmptyLabelSpace={false}
+    isInvalid={false}
+    label={
+      <Memo(MemoizedFormattedMessage)
+        defaultMessage="Transform"
+        id="indexPatternFieldEditor.color.transformLabel"
+      />
+    }
+    labelType="label"
+  >
+    <EuiSelect
+      data-test-subj="colorEditorTransform"
+      isInvalid={false}
+      onChange={[Function]}
+      options={Array []}
+    />
+  </EuiFormRow>
+  <EuiSpacer
+    size="m"
+  />
   <EuiBasicTable
     columns={
       Array [

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/editors/color/color.test.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/editors/color/color.test.tsx
@@ -11,6 +11,7 @@ import { shallowWithI18nProvider } from '@kbn/test-jest-helpers';
 
 import { ColorFormatEditor } from './color';
 import { FieldFormat, DEFAULT_CONVERTER_COLOR } from '@kbn/field-formats-plugin/common';
+import { fieldFormatsMock as fieldFormats } from '@kbn/field-formats-plugin/common/mocks';
 
 const fieldType = 'string';
 const format = {
@@ -18,6 +19,7 @@ const format = {
 };
 const formatParams = {
   colors: [{ ...DEFAULT_CONVERTER_COLOR }],
+  transform: undefined,
 };
 const onChange = jest.fn();
 const onError = jest.fn();
@@ -33,6 +35,7 @@ describe('ColorFormatEditor', () => {
         fieldType={fieldType}
         format={format as unknown as FieldFormat}
         formatParams={formatParams}
+        fieldFormats={fieldFormats}
         onChange={onChange}
         onError={onError}
       />
@@ -47,6 +50,7 @@ describe('ColorFormatEditor', () => {
         fieldType={'number'}
         format={format as unknown as FieldFormat}
         formatParams={formatParams}
+        fieldFormats={fieldFormats}
         onChange={onChange}
         onError={onError}
       />
@@ -60,7 +64,11 @@ describe('ColorFormatEditor', () => {
       <ColorFormatEditor
         fieldType={fieldType}
         format={format as unknown as FieldFormat}
-        formatParams={{ colors: [...formatParams.colors, ...formatParams.colors] }}
+        formatParams={{
+          colors: [...formatParams.colors, ...formatParams.colors],
+          transform: undefined,
+        }}
+        fieldFormats={fieldFormats}
         onChange={onChange}
         onError={onError}
       />

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/editors/types.ts
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/editors/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { FieldFormat, FieldFormatParams } from '@kbn/field-formats-plugin/common';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { ComponentType } from 'react';
 import type { FormatSelectEditorProps } from '../field_format_editor';
 
@@ -18,6 +19,7 @@ export interface FormatEditorProps<P> {
   fieldType: string;
   format: FieldFormat;
   formatParams: { type?: string } & P;
+  fieldFormats: FieldFormatsStart;
   onChange: (newParams: FieldFormatParams) => void;
   onError: FormatSelectEditorProps['onError'];
 }

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/field_format_editor.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/field_format_editor.tsx
@@ -152,6 +152,7 @@ export class FormatSelectEditor extends PureComponent<
             fieldFormatId={fieldFormatId}
             fieldFormatParams={fieldFormatParams}
             fieldFormatEditors={fieldFormatEditors}
+            fieldFormats={fieldFormats}
             onChange={(params) => {
               this.onFormatChange(fieldFormatId, params);
             }}

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/format_editor.test.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/format_editor.test.tsx
@@ -8,6 +8,7 @@
 
 import React, { PureComponent } from 'react';
 import { shallow } from 'enzyme';
+import { fieldFormatsMock as fieldFormats } from '@kbn/field-formats-plugin/common/mocks';
 import { FormatEditor } from './format_editor';
 
 class TestEditor extends PureComponent {
@@ -37,6 +38,7 @@ describe('FieldFormatEditor', () => {
         fieldFormatId="number"
         fieldFormatParams={{}}
         fieldFormatEditors={formatEditors}
+        fieldFormats={fieldFormats}
         onChange={() => {}}
         onError={() => {}}
       />
@@ -53,6 +55,7 @@ describe('FieldFormatEditor', () => {
         fieldFormatId="ip"
         fieldFormatParams={{}}
         fieldFormatEditors={formatEditors}
+        fieldFormats={fieldFormats}
         onChange={() => {}}
         onError={() => {}}
       />

--- a/src/plugins/data_view_field_editor/public/components/field_format_editor/format_editor.tsx
+++ b/src/plugins/data_view_field_editor/public/components/field_format_editor/format_editor.tsx
@@ -8,6 +8,7 @@
 
 import { EuiDelayRender, EuiSkeletonText } from '@elastic/eui';
 import type { FieldFormat, FieldFormatParams } from '@kbn/field-formats-plugin/common';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { memoize } from 'lodash';
 import React, { LazyExoticComponent, PureComponent } from 'react';
 import { FormatEditorServiceStart } from '../../service';
@@ -19,6 +20,7 @@ export interface FormatEditorProps {
   fieldFormatId: string;
   fieldFormatParams: FieldFormatParams;
   fieldFormatEditors: FormatEditorServiceStart['fieldFormatEditors'];
+  fieldFormats: FieldFormatsStart;
   onChange: (change: FieldFormatParams) => void;
   onError: (error?: string) => void;
 }
@@ -54,7 +56,8 @@ export class FormatEditor extends PureComponent<FormatEditorProps, FormatEditorS
 
   render() {
     const { EditorComponent } = this.state;
-    const { fieldType, fieldFormat, fieldFormatParams, onChange, onError } = this.props;
+    const { fieldType, fieldFormat, fieldFormatParams, fieldFormats, onChange, onError } =
+      this.props;
 
     return (
       <>
@@ -74,6 +77,7 @@ export class FormatEditor extends PureComponent<FormatEditorProps, FormatEditorS
               fieldType={fieldType}
               format={fieldFormat}
               formatParams={fieldFormatParams}
+              fieldFormats={fieldFormats}
               onChange={onChange}
               onError={onError}
             />


### PR DESCRIPTION
## Summary

We already have `Color` field formatter but it looks like this:
<img width="1592" alt="Screenshot 2024-06-28 at 19 41 58" src="https://github.com/elastic/kibana/assets/1415710/4b5d2ab8-aa95-4795-89cc-92431752e0a0">

This PR extends `Color` field formatter by adding a `badge` transform option which renders with `EuiBadge`:
<img width="1202" alt="Screenshot 2024-06-28 at 20 04 32" src="https://github.com/elastic/kibana/assets/1415710/b49f49b9-a71e-446c-aa8b-fe30c8b06742">

<img width="1590" alt="Screenshot 2024-06-28 at 19 41 27" src="https://github.com/elastic/kibana/assets/1415710/b00aacc4-03f6-49bc-97b5-79550e7dc0fe">
<img width="1593" alt="Screenshot 2024-06-28 at 19 41 02" src="https://github.com/elastic/kibana/assets/1415710/268f34ed-6aab-4e2d-b5cf-3684c9e90f1d">

![Jun-28-2024 19-58-29](https://github.com/elastic/kibana/assets/1415710/71fd8010-7140-40dd-9649-22c32a468229)


### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

