### PR TITLE
[Lists Plugin] Migrate authc.getCurrentUser usage to coreContext.secu…

### DIFF
--- a/x-pack/plugins/lists/server/get_user.test.ts
+++ b/x-pack/plugins/lists/server/get_user.test.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
-import { httpServerMock } from '@kbn/core/server/mocks';
-import { CoreKibanaRequest } from '@kbn/core/server';
-import { securityMock } from '@kbn/security-plugin/server/mocks';
+import { securityServiceMock } from '@kbn/core/server/mocks';
+import { SecurityRequestHandlerContext } from '@kbn/core-security-server';
 
 import { getUser } from './get_user';
 
 describe('get_user', () => {
-  let request = CoreKibanaRequest.from(httpServerMock.createRawRequest({}));
+  let security: SecurityRequestHandlerContext;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    request = CoreKibanaRequest.from(httpServerMock.createRawRequest({}));
+    security = securityServiceMock.createRequestHandlerContext();
   });
 
   afterEach(() => {
@@ -23,44 +23,38 @@ describe('get_user', () => {
   });
 
   test('it returns "bob" as the user given a security request with "bob"', () => {
-    const security = securityMock.createStart();
     security.authc.getCurrentUser = jest.fn().mockReturnValue({ username: 'bob' });
-    const user = getUser({ request, security });
+    const user = getUser({ security });
     expect(user).toEqual('bob');
   });
 
   test('it returns "alice" as the user given a security request with "alice"', () => {
-    const security = securityMock.createStart();
     security.authc.getCurrentUser = jest.fn().mockReturnValue({ username: 'alice' });
-    const user = getUser({ request, security });
+    const user = getUser({ security });
     expect(user).toEqual('alice');
   });
 
   test('it returns "elastic" as the user given null as the current user', () => {
-    const security = securityMock.createStart();
     security.authc.getCurrentUser = jest.fn().mockReturnValue(null);
-    const user = getUser({ request, security });
+    const user = getUser({ security });
     expect(user).toEqual('elastic');
   });
 
   test('it returns "elastic" as the user given undefined as the current user', () => {
-    const security = securityMock.createStart();
     security.authc.getCurrentUser = jest.fn().mockReturnValue(undefined);
-    const user = getUser({ request, security });
+    const user = getUser({ security });
     expect(user).toEqual('elastic');
   });
 
   test('it returns "elastic" as the user given undefined as the plugin', () => {
-    const security = securityMock.createStart();
     security.authc.getCurrentUser = jest.fn().mockReturnValue(undefined);
-    const user = getUser({ request, security: undefined });
+    const user = getUser({ security });
     expect(user).toEqual('elastic');
   });
 
   test('it returns "elastic" as the user given null as the plugin', () => {
-    const security = securityMock.createStart();
     security.authc.getCurrentUser = jest.fn().mockReturnValue(undefined);
-    const user = getUser({ request, security: null });
+    const user = getUser({ security });
     expect(user).toEqual('elastic');
   });
 });

--- a/x-pack/plugins/lists/server/get_user.ts
+++ b/x-pack/plugins/lists/server/get_user.ts
@@ -5,17 +5,15 @@
  * 2.0.
  */
 
-import { KibanaRequest } from '@kbn/core/server';
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import { SecurityRequestHandlerContext } from '@kbn/core-security-server';
 
 export interface GetUserOptions {
-  security: SecurityPluginStart | null | undefined;
-  request: KibanaRequest;
+  security: SecurityRequestHandlerContext;
 }
 
-export const getUser = ({ security, request }: GetUserOptions): string => {
+export const getUser = ({ security }: GetUserOptions): string => {
   if (security != null) {
-    const authenticatedUser = security.authc.getCurrentUser(request);
+    const authenticatedUser = security.authc.getCurrentUser();
     if (authenticatedUser != null) {
       return authenticatedUser.username;
     } else {

--- a/x-pack/plugins/lists/server/plugin.ts
+++ b/x-pack/plugins/lists/server/plugin.ts
@@ -12,7 +12,6 @@ import type {
   Plugin,
   PluginInitializerContext,
 } from '@kbn/core/server';
-import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 
 import { ConfigType } from './config';
@@ -41,7 +40,6 @@ export class ListPlugin implements Plugin<ListPluginSetup, ListsPluginStart, {},
   private readonly config: ConfigType;
   private readonly extensionPoints: ExtensionPointStorageInterface;
   private spaces: SpacesServiceStart | undefined | null;
-  private security: SecurityPluginStart | undefined | null;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.logger = this.initializerContext.logger.get();
@@ -90,7 +88,6 @@ export class ListPlugin implements Plugin<ListPluginSetup, ListsPluginStart, {},
 
   public start(core: CoreStart, plugins: PluginsStart): ListsPluginStart {
     this.logger.debug('Starting plugin');
-    this.security = plugins.security;
     this.spaces = plugins.spaces?.spacesService;
   }
 
@@ -101,8 +98,9 @@ export class ListPlugin implements Plugin<ListPluginSetup, ListsPluginStart, {},
 
   private createRouteHandlerContext = (): ContextProvider => {
     return async (context, request): ContextProviderReturn => {
-      const { spaces, config, security, extensionPoints } = this;
+      const { spaces, config, extensionPoints } = this;
       const {
+        security,
         savedObjects: { client: savedObjectsClient },
         elasticsearch: {
           client: { asCurrentUser: esClient },
@@ -112,7 +110,7 @@ export class ListPlugin implements Plugin<ListPluginSetup, ListsPluginStart, {},
         throw new TypeError('Configuration is required for this plugin to operate');
       } else {
         const spaceId = getSpaceId({ request, spaces });
-        const user = getUser({ request, security });
+        const user = getUser({ security });
         return {
           getExceptionListClient: (): ExceptionListClient =>
             new ExceptionListClient({

--- a/x-pack/plugins/lists/tsconfig.json
+++ b/x-pack/plugins/lists/tsconfig.json
@@ -39,7 +39,8 @@
     "@kbn/utility-types",
     "@kbn/core-elasticsearch-client-server-mocks",
     "@kbn/core-saved-objects-server",
-    "@kbn/zod-helpers"
+    "@kbn/zod-helpers",
+    "@kbn/core-security-server"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/186574

## Summary

This PR migrates the Lists Plugin's `ListsRequestHandlerContext`, which consumes `authc.getCurrentUser`, to use `coreStart.security`.

Background: This PR serves as an example of a plugin migrating away from depending on the Security plugin, which is a high priority effort for the last release before 9.0.

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios