### PR TITLE
[Serverless Search Plugin] Migrate authc.getCurrentUser usage to coreStart.security in browser

### DIFF
--- a/x-pack/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/plugins/serverless_search/public/plugin.ts
@@ -101,11 +101,10 @@ export class ServerlessSearchPlugin
       async mount({ element, history }: AppMountParameters) {
         const { renderApp } = await import('./application/elasticsearch');
         const [coreStart, services] = await core.getStartServices();
-        const { security } = services;
         docLinks.setDocLinks(coreStart.docLinks.links);
         let user: AuthenticatedUser | undefined;
         try {
-          const response = await security.authc.getCurrentUser();
+          const response = await coreStart.security.authc.getCurrentUser();
           user = response;
         } catch {
           user = undefined;


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/186574

## Summary

This PR migrates a Serverless Search contract, which consumes `authc.getCurrentUser`, to use `coreStart.security`.

Background: This PR serves as an example of a plugin migrating away from depending on the Security plugin, which is a high priority effort for the last release before 9.0.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios