### PR TITLE
[UII] Rollback to 800px for create/edit integration policy form

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/layout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/components/layout.tsx
@@ -17,7 +17,6 @@ import {
   EuiDescriptionListDescription,
   EuiButtonEmpty,
   EuiSpacer,
-  useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 
 import { useAgentless } from '../hooks/setup_technology';
@@ -252,8 +251,7 @@ export const CreatePackagePolicySinglePageLayout: React.FunctionComponent<{
       </EuiDescriptionList>
     ) : undefined;
 
-    const isBiggerScreen = useIsWithinMinBreakpoint('xxl');
-    const maxWidth = isBiggerScreen ? 1200 : 800;
+    const maxWidth = 800;
     return (
       <WithHeaderLayout
         restrictHeaderWidth={maxWidth}


### PR DESCRIPTION
## Summary

Resolves [#187093](https://github.com/elastic/kibana/issues/187093). Reverts create/edit integration policy form back to 800px instead of 1200px.

![image](https://github.com/elastic/kibana/assets/1965714/75739287-c17a-4f27-94f6-138b83b1c813)
