### PR TITLE
[ObsUX][Infra] Fix container image name not being displayed

### DIFF
--- a/x-pack/plugins/observability_solution/infra/common/http_api/metadata_api.ts
+++ b/x-pack/plugins/observability_solution/infra/common/http_api/metadata_api.ts
@@ -48,7 +48,6 @@ export const InfraMetadataContainerRT = rt.partial({
   name: rt.string,
   id: rt.string,
   runtime: rt.string,
-  imageName: rt.string,
   image: rt.partial({ name: rt.string }),
 });
 

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/metadata_summary/metadata_summary_list.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/overview/metadata_summary/metadata_summary_list.tsx
@@ -104,7 +104,7 @@ const containerMetadataData = (metadataInfo: InfraMetadata['info']): MetadataDat
   },
   {
     field: 'containerImageName',
-    value: metadataInfo?.container?.imageName,
+    value: metadataInfo?.container?.image?.name,
     tooltipFieldLabel: 'container.image.name',
   },
   {


### PR DESCRIPTION
## Summary

Small fix, container.image.name wasn't display on the metadata summary fields

<img width="823" alt="image" src="https://github.com/elastic/kibana/assets/31922082/fa2d162a-9f9b-437a-8250-f88074740b70">

<img width="823" alt="image" src="https://github.com/elastic/kibana/assets/31922082/ba0a16b6-b402-4ed3-8836-c6a81a998aa3">

