### PR TITLE
[EDR Workflows] remove checking the step tour

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_cases.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_cases.cy.ts
@@ -23,14 +23,9 @@ import {
   submitQuery,
   viewRecentCaseAndCheckResults,
 } from '../../tasks/live_query';
-import {
-  closeAlertsStepTourIfVisible,
-  generateRandomStringName,
-  interceptCaseId,
-} from '../../tasks/integrations';
+import { generateRandomStringName, interceptCaseId } from '../../tasks/integrations';
 
-// Failing: See https://github.com/elastic/kibana/issues/187182
-describe.skip('Alert Event Details - Cases', { tags: ['@ess', '@serverless'] }, () => {
+describe('Alert Event Details - Cases', { tags: ['@ess', '@serverless'] }, () => {
   let ruleId: string;
   let packId: string;
   let packName: string;
@@ -71,7 +66,6 @@ describe.skip('Alert Event Details - Cases', { tags: ['@ess', '@serverless'] }, 
     it('runs osquery against alert and creates a new case', () => {
       const [caseName, caseDescription] = generateRandomStringName(2);
       cy.getBySel('expand-event').first().click();
-      closeAlertsStepTourIfVisible();
       cy.getBySel('take-action-dropdown-btn').click();
       cy.getBySel('osquery-action-item').click();
       cy.contains(/^\d+ agen(t|ts) selected/);
@@ -107,7 +101,6 @@ describe.skip('Alert Event Details - Cases', { tags: ['@ess', '@serverless'] }, 
 
     it('sees osquery results from last action and add to a case', () => {
       cy.getBySel('expand-event').first().click();
-      closeAlertsStepTourIfVisible();
       cy.getBySel('securitySolutionFlyoutResponseSectionHeader').click();
       cy.getBySel('securitySolutionFlyoutResponseButton').click();
       cy.getBySel('responseActionsViewWrapper').should('exist');

--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_linked_apps.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_linked_apps.cy.ts
@@ -15,15 +15,10 @@ import {
   selectAllAgents,
   submitQuery,
 } from '../../tasks/live_query';
-import {
-  closeAlertsStepTourIfVisible,
-  closeModalIfVisible,
-  closeToastIfVisible,
-} from '../../tasks/integrations';
+import { closeModalIfVisible, closeToastIfVisible } from '../../tasks/integrations';
 import { RESULTS_TABLE, RESULTS_TABLE_BUTTON } from '../../screens/live_query';
 
-// Failing: See https://github.com/elastic/kibana/issues/180852
-describe.skip(
+describe(
   'Alert Event Details',
   {
     tags: ['@ess', '@serverless'],
@@ -74,7 +69,6 @@ describe.skip(
     it('should be able to run live query and add to timeline', () => {
       const TIMELINE_NAME = 'Untitled timeline';
       cy.getBySel('expand-event').first().click();
-      closeAlertsStepTourIfVisible();
       cy.getBySel('take-action-dropdown-btn').click();
       cy.getBySel('osquery-action-item').click();
       cy.contains('1 agent selected.');

--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
@@ -14,10 +14,8 @@ import {
   takeOsqueryActionWithParams,
 } from '../../tasks/live_query';
 import { OSQUERY_FLYOUT_BODY_EDITOR } from '../../screens/live_query';
-import { closeAlertsStepTourIfVisible } from '../../tasks/integrations';
 
-// Failing: See https://github.com/elastic/kibana/issues/180851
-describe.skip(
+describe(
   'Alert Event Details - dynamic params',
   {
     tags: ['@ess', '@serverless'],
@@ -44,7 +42,6 @@ describe.skip(
 
     it('should substitute parameters in investigation guide', () => {
       cy.getBySel('expand-event').first().click();
-      closeAlertsStepTourIfVisible();
       cy.getBySel('securitySolutionFlyoutInvestigationGuideButton').click();
       // Flakes at times if the button is only clicked once
       cy.contains('Get processes').should('be.visible').dblclick({ force: true });

--- a/x-pack/plugins/osquery/cypress/e2e/roles/alert_test.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/roles/alert_test.cy.ts
@@ -9,10 +9,8 @@ import { initializeDataViews } from '../../tasks/login';
 import { checkResults, clickRuleName, submitQuery } from '../../tasks/live_query';
 import { loadRule, cleanupRule } from '../../tasks/api_fixtures';
 import { ServerlessRoleName } from '../../support/roles';
-import { closeAlertsStepTourIfVisible } from '../../tasks/integrations';
 
-// Failing: See https://github.com/elastic/kibana/issues/180853
-describe.skip('Alert Test', { tags: ['@ess'] }, () => {
+describe('Alert Test', { tags: ['@ess'] }, () => {
   let ruleName: string;
   let ruleId: string;
 
@@ -31,7 +29,6 @@ describe.skip('Alert Test', { tags: ['@ess'] }, () => {
       cy.visit('/app/security/rules');
       clickRuleName(ruleName);
       cy.getBySel('expand-event').first().click({ force: true });
-      closeAlertsStepTourIfVisible();
 
       cy.wait(500);
       cy.getBySel('securitySolutionFlyoutInvestigationGuideButton').click();

--- a/x-pack/plugins/osquery/cypress/tasks/integrations.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/integrations.ts
@@ -16,7 +16,6 @@ import {
   DATA_COLLECTION_SETUP_STEP,
   DATE_PICKER_ABSOLUTE_TAB,
   DATE_PICKER_ABSOLUTE_TAB_SEL,
-  SECURITY_SOLUTION_FLYOUT_TOUR_SEL,
   TOAST_CLOSE_BTN,
   TOAST_CLOSE_BTN_SEL,
 } from '../screens/integrations';
@@ -132,16 +131,6 @@ export function closeToastIfVisible() {
       } else {
         cy.getBySel(TOAST_CLOSE_BTN).click();
       }
-    }
-  });
-}
-
-export function closeAlertsStepTourIfVisible() {
-  cy.get(SECURITY_SOLUTION_FLYOUT_TOUR_SEL).then(($el) => {
-    if ($el.length > 0) {
-      cy.wrap($el).within(() => {
-        cy.contains('Exit').click();
-      });
     }
   });
 }


### PR DESCRIPTION
## Description
This pull request addresses and resolves an issue with the Cypress tests:

- Removed Redundant Step: The step to check the step tour in Cypress has been identified as redundant and has been removed.
- Unskipped Tests: Tests that were previously skipped due to this redundant step check have now been unskipped and are active again.

### Closes:

- https://github.com/elastic/kibana/issues/180853
- https://github.com/elastic/kibana/issues/180851
- https://github.com/elastic/kibana/issues/180852