### PR TITLE
[Rollups] Update rollup badges in Data view form

### DIFF
--- a/src/plugins/data_view_editor/public/components/form_fields/type_field.tsx
+++ b/src/plugins/data_view_editor/public/components/form_fields/type_field.tsx
@@ -21,6 +21,7 @@ import {
 } from '@elastic/eui';
 
 import { INDEX_PATTERN_TYPE } from '@kbn/data-views-plugin/public';
+import { RollupDeprecationTooltip } from '@kbn/rollup';
 import { UseField } from '../../shared_imports';
 
 import { IndexPatternConfig } from '../../types';
@@ -57,6 +58,15 @@ const rollupSelectItem = (
       <EuiBadge color={euiLightVars.euiColorAccent}>
         <FormattedMessage id="indexPatternEditor.typeSelect.betaLabel" defaultMessage="Beta" />
       </EuiBadge>
+      &nbsp;
+      <RollupDeprecationTooltip>
+        <EuiBadge color="warning">
+          <FormattedMessage
+            id="indexPatternEditor.typeSelect.deprecatedBadge"
+            defaultMessage="Deprecated"
+          />
+        </EuiBadge>
+      </RollupDeprecationTooltip>
     </EuiDescriptionListTitle>
     <EuiDescriptionListDescription>
       <FormattedMessage

--- a/src/plugins/data_view_editor/public/components/form_fields/type_field.tsx
+++ b/src/plugins/data_view_editor/public/components/form_fields/type_field.tsx
@@ -100,7 +100,7 @@ export const TypeField = ({ onChange }: TypeFieldProps) => {
                   {
                     value: INDEX_PATTERN_TYPE.ROLLUP,
                     inputDisplay: i18n.translate('indexPatternEditor.typeSelect.rollup', {
-                      defaultMessage: 'Rollup',
+                      defaultMessage: 'Rollup (deprecated)',
                     }),
                     dropdownDisplay: rollupSelectItem,
                   },

--- a/src/plugins/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
+++ b/src/plugins/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
@@ -213,7 +213,9 @@ export class IndicesList extends React.Component<IndicesListProps, IndicesListSt
               );
 
               return tag.key === INDEX_PATTERN_TYPE.ROLLUP ? (
-                <RollupDeprecationTooltip>{badge}</RollupDeprecationTooltip>
+                <>
+                  &nbsp;<RollupDeprecationTooltip>{badge}</RollupDeprecationTooltip>
+                </>
               ) : (
                 badge
               );

--- a/src/plugins/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
+++ b/src/plugins/data_view_editor/public/components/preview_panel/indices_list/indices_list.tsx
@@ -27,7 +27,8 @@ import {
 import { Pager } from '@elastic/eui';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { MatchedItem, Tag } from '@kbn/data-views-plugin/public';
+import { INDEX_PATTERN_TYPE, MatchedItem, Tag } from '@kbn/data-views-plugin/public';
+import { RollupDeprecationTooltip } from '@kbn/rollup';
 
 export interface IndicesListProps {
   indices: MatchedItem[];
@@ -205,10 +206,16 @@ export class IndicesList extends React.Component<IndicesListProps, IndicesListSt
           <EuiTableRowCell>{this.highlightIndexName(index.name, query)}</EuiTableRowCell>
           <EuiTableRowCell>
             {index.tags.map((tag: Tag) => {
-              return (
+              const badge = (
                 <EuiBadge key={`index_${key}_tag_${tag.key}`} color={tag.color}>
                   {tag.name}
                 </EuiBadge>
+              );
+
+              return tag.key === INDEX_PATTERN_TYPE.ROLLUP ? (
+                <RollupDeprecationTooltip>{badge}</RollupDeprecationTooltip>
+              ) : (
+                badge
               );
             })}
           </EuiTableRowCell>

--- a/src/plugins/data_view_editor/tsconfig.json
+++ b/src/plugins/data_view_editor/tsconfig.json
@@ -20,6 +20,7 @@
     "@kbn/kibana-utils-plugin",
     "@kbn/react-kibana-mount",
     "@kbn/code-editor",
+    "@kbn/rollup",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/data_views/public/services/get_indices.ts
+++ b/src/plugins/data_views/public/services/get_indices.ts
@@ -26,7 +26,7 @@ const frozenLabel = i18n.translate('dataViews.frozenLabel', {
 });
 
 const rollupLabel = i18n.translate('dataViews.rollupLabel', {
-  defaultMessage: 'Rollup',
+  defaultMessage: 'Rollup (deprecated)',
 });
 
 const getIndexTags = (isRollupIndex: (indexName: string) => boolean) => (indexName: string) =>
@@ -35,7 +35,7 @@ const getIndexTags = (isRollupIndex: (indexName: string) => boolean) => (indexNa
         {
           key: INDEX_PATTERN_TYPE.ROLLUP,
           name: rollupLabel,
-          color: 'primary',
+          color: 'warning',
         },
       ]
     : [];


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/186663

## Summary

Follow-up to https://github.com/elastic/kibana/pull/186321. This PR updates the Rollup badges in the Data view create form so that they show that Rollup is deprecated.

<details>
<summary>Before:</summary>
<img width="1327" alt="Screenshot 2024-07-01 at 11 48 21" src="https://github.com/elastic/kibana/assets/59341489/9f4e1cd1-a34c-42dd-926a-ed6758f06ed7">
</details>

<details>
<summary>Now:</summary>
<img width="1323" alt="Screenshot 2024-07-01 at 17 50 48" src="https://github.com/elastic/kibana/assets/59341489/084873f2-3707-46c4-b4ba-19b4e68c2d87">

<img width="1323" alt="Screenshot 2024-07-01 at 17 50 54" src="https://github.com/elastic/kibana/assets/59341489/d021ef34-3a84-4406-b23e-027aa2e8e868">
<img width="1323" alt="Screenshot 2024-07-01 at 17 50 59" src="https://github.com/elastic/kibana/assets/59341489/ef1246c5-00ed-4eaa-af21-e0515bce956a">
</details>

**How to test:**
1. Start Es and Kibana
2. Add the sample data "Sample web logs"
3. Elasticsearch only allows creating a rollup job if there is an existing rollup usage in the cluster. To simulate rollup usage, create a mock rollup index through Console:

```
PUT /mock_rollup_index
{
  "mappings": {
    "_meta": {
      "_rollup": {
        "id": "logs_job"
      }
    }
  }
}
```


4. Create a sample rollup job through Console:

```
PUT _rollup/job/logs_job
{
  "id": "logs_job",
  "index_pattern": "kibana_sample_data_logs",
  "rollup_index": "rollup_logstash",
  "cron": "* * * * * ?",
  "page_size": 1000,
  "groups": {
    "date_histogram": {
      "interval": "60m",
      "delay": "7d",
      "time_zone": "UTC",
      "field": "@timestamp"
    },
    "terms": {
      "fields": [
        "geo.src",
        "machine.os.keyword"
      ]
    },
    "histogram": {
      "interval": "1003",
      "fields": [
        "bytes",
        "memory"
      ]
    }
  }
}
```


5. Delete the mock rollup index since it causes issues for the rollup API that we use to fetch rollup indices:
`DELETE /mock_rollup_index`
6. Navigate to Stack Management -> Data Views and start creating a new data view.
7. Verify that the rollup badges are updated.




<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

-->