### PR TITLE
[7.17] [Logs UI] Add constraint check (#186872)

### DIFF
--- a/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
+++ b/x-pack/plugins/infra/server/lib/adapters/log_entries/kibana_log_entries_adapter.ts
@@ -27,6 +27,21 @@ import { ResolvedLogSourceConfiguration } from '../../../../common/log_sources';
 
 const TIMESTAMP_FORMAT = 'epoch_millis';
 
+const MAX_BUCKETS = 1000;
+
+function getBucketIntervalStarts(
+  startTimestamp: number,
+  endTimestamp: number,
+  bucketSize: number
+): Date[] {
+  // estimated number of buckets
+  const bucketCount = Math.ceil((endTimestamp - startTimestamp) / bucketSize);
+  if (bucketCount > MAX_BUCKETS) {
+    throw new Error(`Requested too many buckets: ${bucketCount} > ${MAX_BUCKETS}`);
+  }
+  return timeMilliseconds(new Date(startTimestamp), new Date(endTimestamp), bucketSize);
+}
+
 export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
   constructor(private readonly framework: KibanaFramework) {}
 
@@ -132,11 +147,7 @@ export class InfraKibanaLogEntriesAdapter implements LogEntriesAdapter {
     bucketSize: number,
     filterQuery?: LogEntryQuery
   ): Promise<LogSummaryBucket[]> {
-    const bucketIntervalStarts = timeMilliseconds(
-      new Date(startTimestamp),
-      new Date(endTimestamp),
-      bucketSize
-    );
+    const bucketIntervalStarts = getBucketIntervalStarts(startTimestamp, endTimestamp, bucketSize);
 
     const query = {
       allow_no_indices: true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Logs UI] Add constraint check (#186872)](https://github.com/elastic/kibana/pull/186872)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2024-07-01T13:37:32Z","message":"[Logs UI] Add constraint check (#186872)\n\nAdd constraint check to limit max number of buckets that can be\r\nrequested at once.","sha":"2daa13d458519ce821acace2cfc96b40306e7df1","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Logs UI","release_note:skip","backport:prev-minor","backport:prev-MAJOR","ci:project-deploy-observability","Team:obs-ux-logs","v8.15.0"],"title":"[Logs UI] Add constraint check","number":186872,"url":"https://github.com/elastic/kibana/pull/186872","mergeCommit":{"message":"[Logs UI] Add constraint check (#186872)\n\nAdd constraint check to limit max number of buckets that can be\r\nrequested at once.","sha":"2daa13d458519ce821acace2cfc96b40306e7df1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","branchLabelMappingKey":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/186872","number":186872,"mergeCommit":{"message":"[Logs UI] Add constraint check (#186872)\n\nAdd constraint check to limit max number of buckets that can be\r\nrequested at once.","sha":"2daa13d458519ce821acace2cfc96b40306e7df1"}}]}] BACKPORT-->