### PR TITLE
Remove `joi` leakage to the browser in `@kbn/search-connectors`

### DIFF
--- a/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/documents_panel.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 
 import { EuiBasicTable, EuiBasicTableColumn, EuiIcon, EuiToolTip, EuiCode } from '@elastic/eui';
-import { ByteSizeValue } from '@kbn/config-schema';
+import { ByteSizeValue } from '@kbn/config-schema/src/byte_size_value'; // importing from file to avoid leaking `joi` to the browser
 import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';


### PR DESCRIPTION
## Summary

When working on https://github.com/elastic/kibana/pull/186547, I noticed that some bundle sizes were affected... This PR removes leaking point of `joi` to the browser 😇 

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
