### PR TITLE
Update stability.asciidoc

### DIFF
--- a/docs/developer/best-practices/stability.asciidoc
+++ b/docs/developer/best-practices/stability.asciidoc
@@ -29,7 +29,7 @@ access.
 *** We need to make sure security is set up in a specific way for
 non-standard {kib} indices. (create their own custom roles)
 * {kib} running behind a reverse proxy or load balancer, without sticky
-sessions. (we have had many discuss/SDH tickets around this)
+sessions.
 * If a proxy/loadbalancer is running between ES and {kib}
 
 [discrete]


### PR DESCRIPTION
Removed unnecessary line that is a copy/paste error.
Please backport to all relevant versions.

<!--ONMERGE {"backportTargets":["7.17","8.13","8.14"]} ONMERGE-->