### PR TITLE
Remove `joi` leakage to the browser in `synthetics`

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/common/runtime_types/monitor_management/alert_config.ts
+++ b/x-pack/plugins/observability_solution/synthetics/common/runtime_types/monitor_management/alert_config.ts
@@ -6,7 +6,6 @@
  */
 
 import * as t from 'io-ts';
-import { schema } from '@kbn/config-schema';
 
 export const AlertConfigCodec = t.intersection([
   t.interface({
@@ -20,17 +19,6 @@ export const AlertConfigCodec = t.intersection([
 export const AlertConfigsCodec = t.partial({
   tls: AlertConfigCodec,
   status: AlertConfigCodec,
-});
-
-export const AlertConfigSchema = schema.object({
-  tls: schema.maybe(
-    schema.object({
-      enabled: schema.boolean(),
-    })
-  ),
-  status: schema.object({
-    enabled: schema.boolean(),
-  }),
 });
 
 export type AlertConfig = t.TypeOf<typeof AlertConfigCodec>;

--- a/x-pack/plugins/observability_solution/synthetics/common/runtime_types/monitor_management/alert_config_schema.ts
+++ b/x-pack/plugins/observability_solution/synthetics/common/runtime_types/monitor_management/alert_config_schema.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+export const AlertConfigSchema = schema.object({
+  tls: schema.maybe(
+    schema.object({
+      enabled: schema.boolean(),
+    })
+  ),
+  status: schema.object({
+    enabled: schema.boolean(),
+  }),
+});

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_list.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/management/monitor_list_table/monitor_list.tsx
@@ -15,7 +15,7 @@ import {
   useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { MonitorListSortField } from '../../../../../../../common/runtime_types/monitor_management/sort_field';
+import type { MonitorListSortField } from '../../../../../../../common/runtime_types/monitor_management/sort_field';
 import { DeleteMonitor } from './delete_monitor';
 import { IHttpSerializedFetchError } from '../../../../state/utils/http_error';
 import { MonitorListPageState } from '../../../../state';

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/sort_fields.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/sort_fields.tsx
@@ -9,7 +9,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { useDispatch, useSelector } from 'react-redux';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
-import { MonitorListSortField } from '../../../../../../../common/runtime_types/monitor_management/sort_field';
+import type { MonitorListSortField } from '../../../../../../../common/runtime_types/monitor_management/sort_field';
 import { ConfigKey } from '../../../../../../../common/runtime_types';
 
 import { selectOverviewState, setOverviewPageStateAction } from '../../../../state/overview';

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/use_infinite_scroll.ts
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/use_infinite_scroll.ts
@@ -9,7 +9,7 @@ import useThrottle from 'react-use/lib/useThrottle';
 import { useEffect, useState, MutableRefObject } from 'react';
 import useIntersection from 'react-use/lib/useIntersection';
 import { useSelector } from 'react-redux';
-import { MonitorListSortField } from '../../../../../../../common/runtime_types/monitor_management/sort_field';
+import type { MonitorListSortField } from '../../../../../../../common/runtime_types/monitor_management/sort_field';
 import { useGetUrlParams } from '../../../../hooks';
 import { selectOverviewState } from '../../../../state';
 import { MonitorOverviewItem } from '../../../../../../../common/runtime_types';

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/monitor_status.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/monitor_status.tsx
@@ -16,7 +16,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { kibanaService } from '../../../../../utils/kibana_service';
 import { ClientPluginsStart } from '../../../../../plugin';
 import { store } from '../../../state';
-import { StatusRuleParams } from '../../../../../../common/rules/status_rule';
+import type { StatusRuleParams } from '../../../../../../common/rules/status_rule';
 
 interface Props {
   core: CoreStart;

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
@@ -14,7 +14,7 @@ import { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/p
 import { getSyntheticsErrorRouteFromMonitorId } from '../../../../../common/utils/get_synthetics_monitor_url';
 import { STATE_ID } from '../../../../../common/field_names';
 import { SyntheticsMonitorStatusTranslations } from '../../../../../common/rules/synthetics/translations';
-import { StatusRuleParams } from '../../../../../common/rules/status_rule';
+import type { StatusRuleParams } from '../../../../../common/rules/status_rule';
 import { SYNTHETICS_ALERT_RULE_TYPES } from '../../../../../common/constants/synthetics_alerts';
 import { AlertTypeInitializer } from '.';
 const { defaultActionMessage, defaultRecoveryMessage, description } =

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
@@ -16,7 +16,7 @@ import { STATE_ID } from '../../../../../common/field_names';
 import { SyntheticsMonitorStatusTranslations } from '../../../../../common/rules/synthetics/translations';
 import type { StatusRuleParams } from '../../../../../common/rules/status_rule';
 import { SYNTHETICS_ALERT_RULE_TYPES } from '../../../../../common/constants/synthetics_alerts';
-import { AlertTypeInitializer } from '.';
+import type { AlertTypeInitializer } from '.';
 const { defaultActionMessage, defaultRecoveryMessage, description } =
   SyntheticsMonitorStatusTranslations;
 

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
@@ -9,8 +9,8 @@ import React from 'react';
 
 import { ALERT_REASON } from '@kbn/rule-data-utils';
 
-import { ObservabilityRuleTypeModel } from '@kbn/observability-plugin/public';
-import { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
+import type { ObservabilityRuleTypeModel } from '@kbn/observability-plugin/public';
+import type { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
 import { getSyntheticsErrorRouteFromMonitorId } from '../../../../../common/utils/get_synthetics_monitor_url';
 import { STATE_ID } from '../../../../../common/field_names';
 import { SyntheticsMonitorStatusTranslations } from '../../../../../common/rules/synthetics/translations';

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/state/monitor_list/models.ts
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/state/monitor_list/models.ts
@@ -7,7 +7,7 @@
 
 import { ErrorToastOptions } from '@kbn/core-notifications-browser';
 
-import { MonitorListSortField } from '../../../../../common/runtime_types/monitor_management/sort_field';
+import type { MonitorListSortField } from '../../../../../common/runtime_types/monitor_management/sort_field';
 import {
   EncryptedSyntheticsMonitor,
   FetchMonitorManagementListQueryArgs,

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/state/overview/models.ts
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/state/overview/models.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { MonitorListSortField } from '../../../../../common/runtime_types/monitor_management/sort_field';
+import type { MonitorListSortField } from '../../../../../common/runtime_types/monitor_management/sort_field';
 import { ConfigKey, MonitorOverviewResult } from '../../../../../common/runtime_types';
 
 import { IHttpSerializedFetchError } from '../utils/http_error';

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/monitor_validation.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/monitor_validation.ts
@@ -11,7 +11,7 @@ import { formatErrors } from '@kbn/securitysolution-io-ts-utils';
 
 import { omit } from 'lodash';
 import { schema } from '@kbn/config-schema';
-import { AlertConfigSchema } from '../../../common/runtime_types/monitor_management/alert_config';
+import { AlertConfigSchema } from '../../../common/runtime_types/monitor_management/alert_config_schema';
 import { CreateMonitorPayLoad } from './add_monitor/add_monitor_api';
 import { flattenAndFormatObject } from '../../synthetics_service/project_monitor/normalizers/common_fields';
 import { PrivateLocationAttributes } from '../../runtime_types/private_locations';


### PR DESCRIPTION
## Summary

When working on https://github.com/elastic/kibana/pull/186547, I noticed that some bundle sizes were affected... This PR removes the leaking point of `joi` to the browser 😇 

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
