### PR TITLE
[APM] Environment N/A badge for the classic view should not appear

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/get_service_columns.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/get_service_columns.tsx
@@ -68,7 +68,12 @@ export function getServiceColumns({
       sortable: true,
       width: `${unit * 9}px`,
       dataType: 'number',
-      render: (_, { environments }) => <EnvironmentBadge environments={environments} />,
+      render: (_, { environments, signalTypes }) => (
+        <EnvironmentBadge
+          environments={environments}
+          isMetricsSignalType={signalTypes.includes(SignalTypes.METRICS)}
+        />
+      ),
       align: RIGHT_ALIGNMENT,
     },
     {

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/environment_badge/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/environment_badge/index.tsx
@@ -12,12 +12,13 @@ import { NotAvailableEnvironment } from '../not_available_environment';
 
 interface Props {
   environments: string[];
+  isMetricsSignalType?: boolean;
 }
 
-export function EnvironmentBadge({ environments = [] }: Props) {
-  return environments && environments.length > 0 ? (
+export function EnvironmentBadge({ environments = [], isMetricsSignalType = true }: Props) {
+  return isMetricsSignalType || (environments && environments.length > 0) ? (
     <ItemsBadge
-      items={environments}
+      items={environments ?? []}
       multipleItemsMessage={i18n.translate('xpack.apm.servicesTable.environmentCount', {
         values: { environmentCount: environments.length },
         defaultMessage: '{environmentCount, plural, one {1 environment} other {# environments}}',


### PR DESCRIPTION
Closed #187245 

## Summary

This PR removed the Environment N/A badge from the classic view. The Environment N/A badge should still be visible for services coming from logs and if there is an environment value it should still be visible.

<img width="817" alt="image" src="https://github.com/elastic/kibana/assets/14139027/15cf64ca-0a25-4f05-9a4d-f32bec02eb10">

## Testing 

1. Enable `observability:apmEnableMultiSignal` in advanced settings
 
<details>


<summary>2. Run the entities definition in the dev tools</summary>


```
POST kbn:/internal/api/entities/definition
{
  "id": "apm-services-with-metadata",
  "name": "Services from logs and metrics",
  "displayNameTemplate": "test",
  "history": {
    "timestampField": "@timestamp",
    "interval": "5m"
  },
  "type": "service",
  "indexPatterns": [
    "logs-*",
    "metrics-*"
  ],
  "timestampField": "@timestamp",
  "lookback": "5m",
  "identityFields": [
    {
      "field": "service.name",
      "optional": false
    },
    {
      "field": "service.environment",
      "optional": true
    }
  ],
  "identityTemplate": "{{service.name}}:{{service.environment}}",
  "metadata": [
    "tags",
    "host.name",
    "data_stream.type",
    "service.name", 
    "service.instance.id",
    "service.namespace",
    "service.environment",
    "service.version",
    "service.runtime.name",
    "service.runtime.version",
    "service.node.name",
    "service.language.name",
    "agent.name",
    "cloud.provider",
    "cloud.instance.id",
    "cloud.availability_zone",
    "cloud.instance.name",
    "cloud.machine.type",
    "container.id"
  ],
  "metrics": [
    {
      "name": "latency",
      "equation": "A",
      "metrics": [
        {
          "name": "A",
          "aggregation": "avg",
          "field": "transaction.duration.histogram"
           
          
        }
      ]
    },
    {
      "name": "throughput",
      "equation": "A / 5",
      "metrics": [
        {
          "name": "A",
          "aggregation": "doc_count",
          "filter": "transaction.duration.histogram:*"
        }
      ]
    },
    {
      "name": "failedTransactionRate",
      "equation": "A / B",
      "metrics": [
        {
          "name": "A",
          "aggregation": "doc_count",
          "filter": "event.outcome: \"failure\""
        },
        {
          "name": "B",
          "aggregation": "doc_count",
          "filter": "event.outcome: *"
        }
      ]
    },
    {
      "name": "logErrorRate",
      "equation": "A / B",
      "metrics": [
        {
          "name": "A",
          "aggregation": "doc_count",
          "filter": "log.level: \"error\""
        },
        {
          "name": "B",
          "aggregation": "doc_count",
          "filter": "log.level: *"
        }
      ]
    },
     {
      "name": "logRatePerMinute",
      "equation": "A / 5",
      "metrics": [
        {
          "name": "A",
          "aggregation": "doc_count",
          "filter": "log.level: \"error\""
        }
      ]
    }
  ]
}
```

</details>

3. Generate data with synthrace

    1. logs only: `node scripts/synthtrace simple_logs.ts`
    2. APM only: `node scripts/synthtrace simple_trace.ts` 
    3. Modify simple_trace: Change line 29 to 
    ```
     .service({ name: `synth-no-env-${index}`, agentName: 'nodejs' })
    ``` 
    and run it again
4. Oblt Cluster ( No N/A label ) 
<img width="1633" alt="image" src="https://github.com/elastic/kibana/assets/14139027/cb22ac73-3278-4478-b71c-9df604e48c7b">

