### PR TITLE
[Security Solution][Notes] - prevent user from adding note if the markdown is invalid

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.test.tsx
@@ -18,6 +18,7 @@ import {
 import { ReqStatus } from '../../../../notes/store/notes.slice';
 import { useIsTimelineFlyoutOpen } from '../../shared/hooks/use_is_timeline_flyout_open';
 import { TimelineId } from '../../../../../common/types';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('../../shared/hooks/use_is_timeline_flyout_open');
 
@@ -56,9 +57,22 @@ describe('AddNote', () => {
   it('should create note', () => {
     const { getByTestId } = renderAddNote();
 
+    userEvent.type(getByTestId('euiMarkdownEditorTextArea'), 'new note');
     getByTestId(ADD_NOTE_BUTTON_TEST_ID).click();
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should disable add button markdown editor if invalid', () => {
+    const { getByTestId } = renderAddNote();
+
+    const addButton = getByTestId(ADD_NOTE_BUTTON_TEST_ID);
+
+    expect(addButton).toHaveAttribute('disabled');
+
+    userEvent.type(getByTestId('euiMarkdownEditorTextArea'), 'new note');
+
+    expect(addButton).not.toHaveAttribute('disabled');
   });
 
   it('should render the add note button in loading state while creating a new note', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   EuiButton,
   EuiCheckbox,
@@ -83,6 +83,7 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
   const dispatch = useDispatch();
   const { addError: addErrorToast } = useAppToasts();
   const [editorValue, setEditorValue] = useState('');
+  const [isMarkdownInvalid, setIsMarkdownInvalid] = useState(false);
 
   const activeTimeline = useSelector((state: State) =>
     timelineSelectors.selectTimelineById(state, TimelineId.active)
@@ -121,8 +122,15 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
     }
   }, [addErrorToast, createError, createStatus]);
 
-  const checkBoxDisabled =
-    !isTimelineFlyout || (isTimelineFlyout && activeTimeline.savedObjectId == null);
+  const buttonDisabled = useMemo(
+    () => editorValue.trim().length === 0 || isMarkdownInvalid,
+    [editorValue, isMarkdownInvalid]
+  );
+
+  const checkBoxDisabled = useMemo(
+    () => !isTimelineFlyout || (isTimelineFlyout && activeTimeline?.savedObjectId == null),
+    [activeTimeline?.savedObjectId, isTimelineFlyout]
+  );
 
   return (
     <>
@@ -133,7 +141,7 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
             value={editorValue}
             onChange={setEditorValue}
             ariaLabel={MARKDOWN_ARIA_LABEL}
-            setIsMarkdownInvalid={() => {}}
+            setIsMarkdownInvalid={setIsMarkdownInvalid}
           />
         </EuiComment>
       </EuiCommentList>
@@ -167,6 +175,7 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
           <EuiButton
             onClick={addNote}
             isLoading={createStatus === ReqStatus.Loading}
+            disabled={buttonDisabled}
             data-test-subj={ADD_NOTE_BUTTON_TEST_ID}
           >
             {ADD_NOTE_BUTTON}


### PR DESCRIPTION
## Summary

This PR adds a small check to prevent users from creating notes with an empty or invalid description.

#### Before (add button was always enabled)

https://github.com/elastic/kibana/assets/17276605/c1b50407-5eb9-47c7-a80e-441b4df346cb

#### After (add button is now disabled unless a correct value is entered)

https://github.com/elastic/kibana/assets/17276605/bedc5a16-fe7f-4b8e-8a3b-4149dea497b7

https://github.com/elastic/security-team/issues/9605

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios