### PR TITLE
[Connectors] Include `manage_connector` privilege in generated api keys

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
@@ -69,7 +69,7 @@ describe('generateApiKey lib function for connector clients', () => {
       name: 'index_name-connector',
       role_descriptors: {
         ['index-name-connector-role']: {
-          cluster: ['monitor'],
+          cluster: ['monitor', 'manage_connector'],
           index: [
             {
               names: ['index_name', '.search-acl-filter-index_name', `${CONNECTORS_INDEX}*`],
@@ -108,7 +108,7 @@ describe('generateApiKey lib function for connector clients', () => {
       name: 'search-test-connector',
       role_descriptors: {
         ['search-test-connector-role']: {
-          cluster: ['monitor'],
+          cluster: ['monitor', 'manage_connector'],
           index: [
             {
               names: ['search-test', '.search-acl-filter-search-test', `${CONNECTORS_INDEX}*`],
@@ -159,7 +159,7 @@ describe('generateApiKey lib function for connector clients', () => {
       name: 'index_name-connector',
       role_descriptors: {
         ['index-name-connector-role']: {
-          cluster: ['monitor'],
+          cluster: ['monitor', 'manage_connector'],
           index: [
             {
               names: ['index_name', '.search-acl-filter-index_name', `${CONNECTORS_INDEX}*`],
@@ -229,7 +229,7 @@ describe('generateApiKey lib function for native connectors', () => {
       name: 'index_name-connector',
       role_descriptors: {
         ['index-name-connector-role']: {
-          cluster: ['monitor'],
+          cluster: ['monitor', 'manage_connector'],
           index: [
             {
               names: ['index_name', '.search-acl-filter-index_name', `${CONNECTORS_INDEX}*`],
@@ -270,7 +270,7 @@ describe('generateApiKey lib function for native connectors', () => {
       name: 'search-test-connector',
       role_descriptors: {
         ['search-test-connector-role']: {
-          cluster: ['monitor'],
+          cluster: ['monitor', 'manage_connector'],
           index: [
             {
               names: ['search-test', '.search-acl-filter-search-test', `${CONNECTORS_INDEX}*`],
@@ -323,7 +323,7 @@ describe('generateApiKey lib function for native connectors', () => {
       name: 'index_name-connector',
       role_descriptors: {
         ['index-name-connector-role']: {
-          cluster: ['monitor'],
+          cluster: ['monitor', 'manage_connector'],
           index: [
             {
               names: ['index_name', '.search-acl-filter-index_name', `${CONNECTORS_INDEX}*`],

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
@@ -28,7 +28,7 @@ export const generateApiKey = async (
     name: `${indexName}-connector`,
     role_descriptors: {
       [`${toAlphanumeric(indexName)}-connector-role`]: {
-        cluster: ['monitor'],
+        cluster: ['monitor', 'manage_connector'],
         index: [
           {
             names: [indexName, aclIndexName, `${CONNECTORS_INDEX}*`],


### PR DESCRIPTION
## Summary

We introduced `manage_connector` privilege in ES: https://github.com/elastic/elasticsearch/pull/110128

Let's use it for new generated API keys for connectors.

Note: this privilege was merged to ES yesterday, so CI might fail if the ES image was not updated yet.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials 
  - We will add this privilege in ES docs
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
