### PR TITLE
[Fleet] update docs for running a dockerized fleet server

### DIFF
--- a/x-pack/plugins/fleet/dev_docs/local_setup/enrolling_agents.md
+++ b/x-pack/plugins/fleet/dev_docs/local_setup/enrolling_agents.md
@@ -12,6 +12,9 @@ Add the following to your `kibana.dev.yml`. Note that the only differences betwe
 # Set the Kibana server address to Fleet Server default host.
 server.host: 0.0.0.0
 
+# The API version resolution: in dev mode, a version is required for all API requests.
+server.versioned.versionResolution: oldest
+
 # Install Fleet Server package.
 xpack.fleet.packages:
   - name: fleet_server


### PR DESCRIPTION
## 🍒 Summary

When trying to run a dockerized Fleet server using the command specified in the Fleet local setup [docs](https://github.com/elastic/kibana/blob/main/x-pack/plugins/fleet/dev_docs/local_setup/enrolling_agents.md) 

```
docker run \
  -e ELASTICSEARCH_HOST=http://host.docker.internal:9200 \
  -e KIBANA_HOST=http://host.docker.internal:5601/your-base-path \
  -e KIBANA_USERNAME=elastic \
  -e KIBANA_PASSWORD=changeme \
  -e KIBANA_FLEET_SETUP=1 \
  -e FLEET_INSECURE=1 \
  -e FLEET_SERVER_ENABLE=1 \
  -e FLEET_SERVER_POLICY_ID=fleet-server-policy \
  -p 8220:8220 \
  --rm docker.elastic.co/beats/elastic-agent:<version>
```

I got this error 
```
Requesting service_token from Kibana. Error: request to get security token from Kibana failed: Please specify a version via elastic-api-version header. Available versions: [2023-10-31]
```

## Solution

I had to add `server.versioned.versionResolution: oldest` in `kibana.dev.yml`. You can read more about this setting in the Fleet [ReadME](https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet#configure-kibana-settings)