### PR TITLE
[Serverless][SecuritySolution][Endpoint] Update `serverless` tests for scan w.r.to. PLIs

### DIFF
--- a/packages/kbn-es/src/serverless_resources/project_roles/security/roles.yml
+++ b/packages/kbn-es/src/serverless_resources/project_roles/security/roles.yml
@@ -281,6 +281,7 @@ t3_analyst:
         - feature_siem.process_operations_all
         - feature_siem.actions_log_management_all # Response actions history
         - feature_siem.file_operations_all
+        - feature_siem.scan_operations_all
         - feature_securitySolutionCases.all
         - feature_securitySolutionAssistant.all
         - feature_actions.read

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/complete.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/complete.cy.ts
@@ -16,7 +16,14 @@ describe(
   {
     tags: ['@serverless', '@skipInServerlessMKI'],
     env: {
-      ftrConfig: { productTypes: [{ product_line: 'security', product_tier: 'complete' }] },
+      ftrConfig: {
+        productTypes: [{ product_line: 'security', product_tier: 'complete' }],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'responseActionScanEnabled',
+          ])}`,
+        ],
+      },
     },
   },
   () => {
@@ -53,10 +60,9 @@ describe(
       }
 
       // No access to response actions (except `unisolate`)
-      // TODO: update tests when `scan` is included in PLIs
       for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      ).filter((apiName) => apiName !== 'unisolate')) {
+        (apiName) => apiName !== 'unisolate'
+      )) {
         it(`should not allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('none', actionName, username, password);
         });
@@ -79,10 +85,9 @@ describe(
       });
 
       // No access to response actions (except `unisolate`)
-      // TODO: update tests when `scan` is included in PLIs
       for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      ).filter((apiName) => apiName !== 'unisolate')) {
+        (apiName) => apiName !== 'unisolate'
+      )) {
         it(`should not allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('none', actionName, username, password);
         });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/complete_with_endpoint.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/complete_with_endpoint.cy.ts
@@ -24,6 +24,11 @@ describe(
           { product_line: 'security', product_tier: 'complete' },
           { product_line: 'endpoint', product_tier: 'complete' },
         ],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'responseActionScanEnabled',
+          ])}`,
+        ],
       },
     },
   },
@@ -47,10 +52,7 @@ describe(
         });
       }
 
-      // TODO: update tests when `scan` is included in PLIs
-      for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      )) {
+      for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES) {
         it(`should allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('all', actionName, username, password);
         });
@@ -73,10 +75,7 @@ describe(
         });
       });
 
-      // TODO: update tests when `scan` is included in PLIs
-      for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      )) {
+      for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES) {
         it(`should allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('all', actionName, username, password);
         });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/essentials.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/essentials.cy.ts
@@ -18,6 +18,11 @@ describe(
     env: {
       ftrConfig: {
         productTypes: [{ product_line: 'security', product_tier: 'essentials' }],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'responseActionScanEnabled',
+          ])}`,
+        ],
       },
     },
   },
@@ -55,10 +60,9 @@ describe(
       }
 
       // No access to response actions (except `unisolate`)
-      // TODO: update tests when `scan` is included in PLIs
       for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      ).filter((apiName) => apiName !== 'unisolate')) {
+        (apiName) => apiName !== 'unisolate'
+      )) {
         it(`should not allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('none', actionName, username, password);
         });
@@ -81,10 +85,9 @@ describe(
       });
 
       // No access to response actions (except `unisolate`)
-      // TODO: update tests when `scan` is included in PLIs
       for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      ).filter((apiName) => apiName !== 'unisolate')) {
+        (apiName) => apiName !== 'unisolate'
+      )) {
         it(`should not allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('none', actionName, username, password);
         });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/essentials_with_endpoint.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/essentials_with_endpoint.cy.ts
@@ -24,6 +24,11 @@ describe(
           { product_line: 'security', product_tier: 'essentials' },
           { product_line: 'endpoint', product_tier: 'essentials' },
         ],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'responseActionScanEnabled',
+          ])}`,
+        ],
       },
     },
   },
@@ -62,10 +67,9 @@ describe(
         });
       }
 
-      // TODO: update tests when `scan` is included in PLIs
       for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      ).filter((apiName) => apiName !== 'unisolate')) {
+        (apiName) => apiName !== 'unisolate'
+      )) {
         it(`should not allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('none', actionName, username, password);
         });
@@ -92,10 +96,9 @@ describe(
         });
       });
 
-      // TODO: update tests when `scan` is included in PLIs
       for (const actionName of RESPONSE_ACTION_API_COMMANDS_NAMES.filter(
-        (apiName) => apiName !== 'scan'
-      ).filter((apiName) => apiName !== 'unisolate')) {
+        (apiName) => apiName !== 'unisolate'
+      )) {
         it(`should not allow access to Response Action: ${actionName}`, () => {
           ensureResponseActionAuthzAccess('none', actionName, username, password);
         });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/roles/complete_with_endpoint_roles.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/roles/complete_with_endpoint_roles.cy.ts
@@ -40,6 +40,11 @@ describe(
           { product_line: 'security', product_tier: 'complete' },
           { product_line: 'endpoint', product_tier: 'complete' },
         ],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'responseActionScanEnabled',
+          ])}`,
+        ],
       },
     },
   },
@@ -118,7 +123,8 @@ describe(
         'kill-process',
         'suspend-process',
         'get-file',
-        'upload'
+        'upload',
+        'scan'
       );
 
       const deniedResponseActions = pick(consoleHelpPanelResponseActionsTestSubj, 'execute');

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/responder.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/responder.ts
@@ -14,9 +14,8 @@ const TEST_SUBJ = Object.freeze({
   actionLogFlyout: 'responderActionLogFlyout',
 });
 
-// TODO: 8.15 Include `scan` in return type when responseActionsScanEnabled when `scan` is categorized in PLIs
 export const getConsoleHelpPanelResponseActionTestSubj = (): Record<
-  Exclude<ConsoleResponseActionCommands, 'scan'>,
+  ConsoleResponseActionCommands,
   string
 > => {
   return {
@@ -28,8 +27,7 @@ export const getConsoleHelpPanelResponseActionTestSubj = (): Record<
     'get-file': 'endpointResponseActionsConsole-commandList-Responseactions-get-file',
     execute: 'endpointResponseActionsConsole-commandList-Responseactions-execute',
     upload: 'endpointResponseActionsConsole-commandList-Responseactions-upload',
-    // TODO: 8.15 Include `scan` in return type when responseActionsScanEnabled when `scan` is categorized in PLIs
-    // scan: 'endpointResponseActionsConsole-commandList-Responseactions-scan',
+    scan: 'endpointResponseActionsConsole-commandList-Responseactions-scan',
   };
 };
 

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/response_actions.ts
@@ -16,6 +16,7 @@ import {
   GET_PROCESSES_ROUTE,
   ISOLATE_HOST_ROUTE_V2,
   KILL_PROCESS_ROUTE,
+  SCAN_ROUTE,
   SUSPEND_PROCESS_ROUTE,
   UNISOLATE_HOST_ROUTE_V2,
   UPLOAD_ROUTE,
@@ -241,6 +242,11 @@ export const ensureResponseActionAuthzAccess = (
 
         apiPayload = formData;
       }
+      break;
+
+    case 'scan':
+      url = SCAN_ROUTE;
+      Object.assign(apiPayload, { parameters: { path: 'scan/two' } });
       break;
 
     default:

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/roles.yml
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/roles.yml
@@ -303,6 +303,7 @@ t3_analyst:
         - feature_siem.process_operations_all
         - feature_siem.actions_log_management_all # Response actions history
         - feature_siem.file_operations_all
+        - feature_siem.scan_operations_all
         - feature_securitySolutionCases.all
         - feature_securitySolutionAssistant.all
         - feature_actions.read

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/t3_analyst.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/t3_analyst.ts
@@ -31,6 +31,7 @@ export const getT3Analyst: () => Omit<Role, 'name'> = () => {
             'process_operations_all',
             'actions_log_management_all',
             'file_operations_all',
+            'scan_operations_all',
           ],
         },
       },

--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
@@ -284,6 +284,7 @@ t3_analyst:
         - feature_siem.process_operations_all
         - feature_siem.actions_log_management_all # Response actions history
         - feature_siem.file_operations_all
+        - feature_siem.scan_operations_all
         - feature_securitySolutionCases.all
         - feature_securitySolutionAssistant.all
         - feature_actions.read


### PR DESCRIPTION
## Summary

As `scan` response action is categorized now with Endpoint complete PLI include `scan` action in serverless tests using `responseActionScanEnabled` feature flag.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
