### PR TITLE
[ES|QL] Add `weighted_avg` ES|QL function support

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
@@ -290,12 +290,6 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
               noNestingFunctions: true,
               optional: false,
             },
-            {
-              name: 'order',
-              type: 'string',
-              noNestingFunctions: true,
-              optional: false,
-            },
           ],
           returnType: 'number',
         },

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
@@ -295,8 +295,6 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
               type: 'string',
               noNestingFunctions: true,
               optional: false,
-              constantOnly: true,
-              literalOptions: ['asc', 'desc'],
             },
           ],
           returnType: 'number',

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
@@ -264,4 +264,47 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
         `from employees | stats date = top(hire_date, 2, "asc"), double = top(salary_change, 2, "asc"),`,
       ],
     },
+    {
+      name: 'weighted_avg',
+      type: 'agg',
+      description: i18n.translate(
+        'kbn-esql-validation-autocomplete.esql.definitions.weightedAvgDoc',
+        {
+          defaultMessage:
+            'An aggregation that computes the weighted average of numeric values that are extracted from the aggregated documents.',
+        }
+      ),
+      supportedCommands: ['stats', 'metrics'],
+      signatures: [
+        {
+          params: [
+            {
+              name: 'number',
+              type: 'number',
+              noNestingFunctions: true,
+              optional: false,
+            },
+            {
+              name: 'weight',
+              type: 'number',
+              noNestingFunctions: true,
+              optional: false,
+            },
+            {
+              name: 'order',
+              type: 'string',
+              noNestingFunctions: true,
+              optional: false,
+              constantOnly: true,
+              literalOptions: ['asc', 'desc'],
+            },
+          ],
+          returnType: 'number',
+        },
+      ],
+      examples: [
+        `from employees | stats w_avg = weighted_avg(salary, height) by languages | eval w_avg = round(w_avg)`,
+        `from employees | stats w_avg_1 = weighted_avg(salary, 1), avg = avg(salary), w_avg_2 = weighted_avg(salary, height)`,
+      ],
+    },
   ]);

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -26190,102 +26190,102 @@
       "warning": []
     },
     {
-      "query": "from a_index | stats var = weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats var = weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, \"asc\"))",
+      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField))",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats round(weighted_avg(numberField, numberField, \"asc\"))",
+      "query": "from a_index | stats round(weighted_avg(numberField, numberField))",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, \"asc\")) + weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField)) + weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats round(weighted_avg(numberField, numberField, \"asc\")) + weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats round(weighted_avg(numberField, numberField)) + weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats weighted_avg(numberField / 2, numberField, \"asc\")",
+      "query": "from a_index | stats weighted_avg(numberField / 2, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var0 = weighted_avg(numberField / 2, numberField, \"asc\")",
+      "query": "from a_index | stats var0 = weighted_avg(numberField / 2, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, \"asc\")",
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, \"asc\")",
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats weighted_avg(numberField, numberField, \"asc\") by round(numberField / 2)",
+      "query": "from a_index | stats weighted_avg(numberField, numberField) by round(numberField / 2)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, \"asc\") by var1 = round(numberField / 2)",
+      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField) by var1 = round(numberField / 2)",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, \"asc\") by round(numberField / 2), ipField",
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField) by round(numberField / 2), ipField",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, \"asc\") by var1 = round(numberField / 2), ipField",
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField) by var1 = round(numberField / 2), ipField",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, \"asc\") by round(numberField / 2), numberField / 2",
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField) by round(numberField / 2), numberField / 2",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, \"asc\") by var1 = round(numberField / 2), numberField / 2",
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField) by var1 = round(numberField / 2), numberField / 2",
       "error": [],
       "warning": []
     },
     {
-      "query": "from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), \"a\")",
+      "query": "from a_index | stats var = weighted_avg(avg(numberField), avg(numberField))",
       "error": [
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
@@ -26293,7 +26293,7 @@
       "warning": []
     },
     {
-      "query": "from a_index | stats weighted_avg(avg(numberField), avg(numberField), \"a\")",
+      "query": "from a_index | stats weighted_avg(avg(numberField), avg(numberField))",
       "error": [
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
         "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
@@ -26301,7 +26301,7 @@
       "warning": []
     },
     {
-      "query": "from a_index | stats weighted_avg(booleanField, booleanField, \"a\")",
+      "query": "from a_index | stats weighted_avg(booleanField, booleanField)",
       "error": [
         "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]",
         "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]"
@@ -26309,233 +26309,62 @@
       "warning": []
     },
     {
-      "query": "from a_index | sort weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | sort weighted_avg(numberField, numberField)",
       "error": [
         "SORT does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | where weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | where weighted_avg(numberField, numberField)",
       "error": [
         "WHERE does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | where weighted_avg(numberField, numberField, \"asc\") > 0",
+      "query": "from a_index | where weighted_avg(numberField, numberField) > 0",
       "error": [
         "WHERE does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval var = weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | eval var = weighted_avg(numberField, numberField)",
       "error": [
         "EVAL does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval var = weighted_avg(numberField, numberField, \"asc\") > 0",
+      "query": "from a_index | eval var = weighted_avg(numberField, numberField) > 0",
       "error": [
         "EVAL does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval weighted_avg(numberField, numberField, \"asc\")",
+      "query": "from a_index | eval weighted_avg(numberField, numberField)",
       "error": [
         "EVAL does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | eval weighted_avg(numberField, numberField, \"asc\") > 0",
+      "query": "from a_index | eval weighted_avg(numberField, numberField) > 0",
       "error": [
         "EVAL does not support function weighted_avg"
       ],
       "warning": []
     },
     {
-      "query": "from a_index | stats weighted_avg(null, null, null)",
+      "query": "from a_index | stats weighted_avg(null, null)",
       "error": [],
       "warning": []
     },
     {
-      "query": "row nullVar = null | stats weighted_avg(nullVar, nullVar, nullVar)",
+      "query": "row nullVar = null | stats weighted_avg(nullVar, nullVar)",
       "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var = weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, stringField))",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats round(weighted_avg(numberField, numberField, stringField))",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats weighted_avg(numberField / 2, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var0 = weighted_avg(numberField / 2, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats weighted_avg(numberField, numberField, stringField) by round(numberField / 2)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2)",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), ipField",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), ipField",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), numberField / 2",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), numberField / 2",
-      "error": [],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), avg(numberField))",
-      "error": [
-        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats weighted_avg(avg(numberField), avg(numberField), avg(numberField))",
-      "error": [
-        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | stats weighted_avg(booleanField, booleanField, booleanField)",
-      "error": [
-        "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]",
-        "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]",
-        "Argument of [weighted_avg] must be [string], found value [booleanField] type [boolean]"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | sort weighted_avg(numberField, numberField, stringField)",
-      "error": [
-        "SORT does not support function weighted_avg"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | where weighted_avg(numberField, numberField, stringField)",
-      "error": [
-        "WHERE does not support function weighted_avg"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | where weighted_avg(numberField, numberField, stringField) > 0",
-      "error": [
-        "WHERE does not support function weighted_avg"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | eval var = weighted_avg(numberField, numberField, stringField)",
-      "error": [
-        "EVAL does not support function weighted_avg"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | eval var = weighted_avg(numberField, numberField, stringField) > 0",
-      "error": [
-        "EVAL does not support function weighted_avg"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | eval weighted_avg(numberField, numberField, stringField)",
-      "error": [
-        "EVAL does not support function weighted_avg"
-      ],
-      "warning": []
-    },
-    {
-      "query": "from a_index | eval weighted_avg(numberField, numberField, stringField) > 0",
-      "error": [
-        "EVAL does not support function weighted_avg"
-      ],
       "warning": []
     },
     {

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -26062,6 +26062,36 @@
       "warning": []
     },
     {
+      "query": "from a_index | stats var = top(stringField, 5, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats top(stringField, 5, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats top(stringField, numberField, \"asc\")",
+      "error": [
+        "Argument of [top] must be a constant, received [numberField]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats top(null, null, null)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row nullVar = null | stats top(nullVar, nullVar, nullVar)",
+      "error": [
+        "Argument of [top] must be a constant, received [nullVar]",
+        "Argument of [top] must be a constant, received [nullVar]"
+      ],
+      "warning": []
+    },
+    {
       "query": "row var = st_distance(to_cartesianpoint(\"POINT (30 10)\"), to_cartesianpoint(\"POINT (30 10)\"))",
       "error": [],
       "warning": []
@@ -26157,6 +26187,355 @@
     {
       "query": "row nullVar = null | eval st_distance(nullVar, nullVar)",
       "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, \"asc\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats round(weighted_avg(numberField, numberField, \"asc\"))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, \"asc\")) + weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats round(weighted_avg(numberField, numberField, \"asc\")) + weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(numberField / 2, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = weighted_avg(numberField / 2, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, \"asc\")",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(numberField, numberField, \"asc\") by round(numberField / 2)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, \"asc\") by var1 = round(numberField / 2)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, \"asc\") by round(numberField / 2), ipField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, \"asc\") by var1 = round(numberField / 2), ipField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, \"asc\") by round(numberField / 2), numberField / 2",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, \"asc\") by var1 = round(numberField / 2), numberField / 2",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), \"a\")",
+      "error": [
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(avg(numberField), avg(numberField), \"a\")",
+      "error": [
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(booleanField, booleanField, \"a\")",
+      "error": [
+        "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | sort weighted_avg(numberField, numberField, \"asc\")",
+      "error": [
+        "SORT does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where weighted_avg(numberField, numberField, \"asc\")",
+      "error": [
+        "WHERE does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where weighted_avg(numberField, numberField, \"asc\") > 0",
+      "error": [
+        "WHERE does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = weighted_avg(numberField, numberField, \"asc\")",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = weighted_avg(numberField, numberField, \"asc\") > 0",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval weighted_avg(numberField, numberField, \"asc\")",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval weighted_avg(numberField, numberField, \"asc\") > 0",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(null, null, null)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row nullVar = null | stats weighted_avg(nullVar, nullVar, nullVar)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats round(weighted_avg(numberField, numberField, stringField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(numberField / 2, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = weighted_avg(numberField / 2, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(numberField, numberField, stringField) by round(numberField / 2)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), ipField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), ipField",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), numberField / 2",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), numberField / 2",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), avg(numberField))",
+      "error": [
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(avg(numberField), avg(numberField), avg(numberField))",
+      "error": [
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+        "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats weighted_avg(booleanField, booleanField, booleanField)",
+      "error": [
+        "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]",
+        "Argument of [weighted_avg] must be [string], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | sort weighted_avg(numberField, numberField, stringField)",
+      "error": [
+        "SORT does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where weighted_avg(numberField, numberField, stringField)",
+      "error": [
+        "WHERE does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where weighted_avg(numberField, numberField, stringField) > 0",
+      "error": [
+        "WHERE does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = weighted_avg(numberField, numberField, stringField)",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = weighted_avg(numberField, numberField, stringField) > 0",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval weighted_avg(numberField, numberField, stringField)",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval weighted_avg(numberField, numberField, stringField) > 0",
+      "error": [
+        "EVAL does not support function weighted_avg"
+      ],
       "warning": []
     },
     {

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -10253,6 +10253,18 @@ describe('validation logic', () => {
         testErrorsAndWarnings('from a_index | eval top(stringField, 5, "asc") > 0', [
           'EVAL does not support function top',
         ]);
+        testErrorsAndWarnings('from a_index | stats var = top(stringField, 5, "asc")', []);
+        testErrorsAndWarnings('from a_index | stats top(stringField, 5, "asc")', []);
+
+        testErrorsAndWarnings('from a_index | stats top(stringField, numberField, "asc")', [
+          'Argument of [top] must be a constant, received [numberField]',
+        ]);
+
+        testErrorsAndWarnings('from a_index | stats top(null, null, null)', []);
+        testErrorsAndWarnings('row nullVar = null | stats top(nullVar, nullVar, nullVar)', [
+          'Argument of [top] must be a constant, received [nullVar]',
+          'Argument of [top] must be a constant, received [nullVar]',
+        ]);
       });
 
       describe('st_distance', () => {
@@ -10334,6 +10346,323 @@ describe('validation logic', () => {
 
         testErrorsAndWarnings('from a_index | eval st_distance(null, null)', []);
         testErrorsAndWarnings('row nullVar = null | eval st_distance(nullVar, nullVar)', []);
+      });
+
+      describe('weighted_avg', () => {
+        testErrorsAndWarnings(
+          'from a_index | stats var = weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = round(weighted_avg(numberField, numberField, "asc"))',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats round(weighted_avg(numberField, numberField, "asc"))',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = round(weighted_avg(numberField, numberField, "asc")) + weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats round(weighted_avg(numberField, numberField, "asc")) + weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(numberField / 2, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var0 = weighted_avg(numberField / 2, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var0 = weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, "asc")',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(numberField, numberField, "asc") by round(numberField / 2)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var0 = weighted_avg(numberField, numberField, "asc") by var1 = round(numberField / 2)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, "asc") by round(numberField / 2), ipField',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, "asc") by var1 = round(numberField / 2), ipField',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, "asc") by round(numberField / 2), numberField / 2',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, "asc") by var1 = round(numberField / 2), numberField / 2',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), "a")',
+          [
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+          ]
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(avg(numberField), avg(numberField), "a")',
+          [
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+          ]
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(booleanField, booleanField, "a")',
+          [
+            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
+            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
+          ]
+        );
+
+        testErrorsAndWarnings('from a_index | sort weighted_avg(numberField, numberField, "asc")', [
+          'SORT does not support function weighted_avg',
+        ]);
+
+        testErrorsAndWarnings(
+          'from a_index | where weighted_avg(numberField, numberField, "asc")',
+          ['WHERE does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | where weighted_avg(numberField, numberField, "asc") > 0',
+          ['WHERE does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | eval var = weighted_avg(numberField, numberField, "asc")',
+          ['EVAL does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | eval var = weighted_avg(numberField, numberField, "asc") > 0',
+          ['EVAL does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings('from a_index | eval weighted_avg(numberField, numberField, "asc")', [
+          'EVAL does not support function weighted_avg',
+        ]);
+
+        testErrorsAndWarnings(
+          'from a_index | eval weighted_avg(numberField, numberField, "asc") > 0',
+          ['EVAL does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings('from a_index | stats weighted_avg(null, null, null)', []);
+        testErrorsAndWarnings(
+          'row nullVar = null | stats weighted_avg(nullVar, nullVar, nullVar)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = round(weighted_avg(numberField, numberField, stringField))',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats round(weighted_avg(numberField, numberField, stringField))',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(numberField / 2, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var0 = weighted_avg(numberField / 2, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var0 = weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(numberField, numberField, stringField) by round(numberField / 2)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2)',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), ipField',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), ipField',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), numberField / 2',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), numberField / 2',
+          []
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), avg(numberField))',
+          [
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+          ]
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(avg(numberField), avg(numberField), avg(numberField))',
+          [
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
+          ]
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | stats weighted_avg(booleanField, booleanField, booleanField)',
+          [
+            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
+            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
+            'Argument of [weighted_avg] must be [string], found value [booleanField] type [boolean]',
+          ]
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | sort weighted_avg(numberField, numberField, stringField)',
+          ['SORT does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | where weighted_avg(numberField, numberField, stringField)',
+          ['WHERE does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | where weighted_avg(numberField, numberField, stringField) > 0',
+          ['WHERE does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | eval var = weighted_avg(numberField, numberField, stringField)',
+          ['EVAL does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | eval var = weighted_avg(numberField, numberField, stringField) > 0',
+          ['EVAL does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | eval weighted_avg(numberField, numberField, stringField)',
+          ['EVAL does not support function weighted_avg']
+        );
+
+        testErrorsAndWarnings(
+          'from a_index | eval weighted_avg(numberField, numberField, stringField) > 0',
+          ['EVAL does not support function weighted_avg']
+        );
       });
     });
   });

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -10350,102 +10350,98 @@ describe('validation logic', () => {
 
       describe('weighted_avg', () => {
         testErrorsAndWarnings(
-          'from a_index | stats var = weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats var = weighted_avg(numberField, numberField)',
+          []
+        );
+        testErrorsAndWarnings('from a_index | stats weighted_avg(numberField, numberField)', []);
+
+        testErrorsAndWarnings(
+          'from a_index | stats var = round(weighted_avg(numberField, numberField))',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats round(weighted_avg(numberField, numberField))',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats var = round(weighted_avg(numberField, numberField, "asc"))',
+          'from a_index | stats var = round(weighted_avg(numberField, numberField)) + weighted_avg(numberField, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats round(weighted_avg(numberField, numberField, "asc"))',
+          'from a_index | stats round(weighted_avg(numberField, numberField)) + weighted_avg(numberField, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats var = round(weighted_avg(numberField, numberField, "asc")) + weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats weighted_avg(numberField / 2, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats round(weighted_avg(numberField, numberField, "asc")) + weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats var0 = weighted_avg(numberField / 2, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(numberField / 2, numberField, "asc")',
+          'from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats var0 = weighted_avg(numberField / 2, numberField, "asc")',
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, "asc")',
+          'from a_index | stats var0 = weighted_avg(numberField, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, "asc")',
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats var0 = weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats weighted_avg(numberField, numberField) by round(numberField / 2)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, "asc")',
+          'from a_index | stats var0 = weighted_avg(numberField, numberField) by var1 = round(numberField / 2)',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(numberField, numberField, "asc") by round(numberField / 2)',
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField) by round(numberField / 2), ipField',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats var0 = weighted_avg(numberField, numberField, "asc") by var1 = round(numberField / 2)',
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField) by var1 = round(numberField / 2), ipField',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, "asc") by round(numberField / 2), ipField',
+          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField) by round(numberField / 2), numberField / 2',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, "asc") by var1 = round(numberField / 2), ipField',
+          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField) by var1 = round(numberField / 2), numberField / 2',
           []
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, "asc") by round(numberField / 2), numberField / 2',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, "asc") by var1 = round(numberField / 2), numberField / 2',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), "a")',
+          'from a_index | stats var = weighted_avg(avg(numberField), avg(numberField))',
           [
             "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
             "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
@@ -10453,216 +10449,49 @@ describe('validation logic', () => {
         );
 
         testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(avg(numberField), avg(numberField), "a")',
+          'from a_index | stats weighted_avg(avg(numberField), avg(numberField))',
           [
             "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
             "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
           ]
         );
 
-        testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(booleanField, booleanField, "a")',
-          [
-            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
-            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
-          ]
-        );
+        testErrorsAndWarnings('from a_index | stats weighted_avg(booleanField, booleanField)', [
+          'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
+          'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
+        ]);
 
-        testErrorsAndWarnings('from a_index | sort weighted_avg(numberField, numberField, "asc")', [
+        testErrorsAndWarnings('from a_index | sort weighted_avg(numberField, numberField)', [
           'SORT does not support function weighted_avg',
         ]);
 
-        testErrorsAndWarnings(
-          'from a_index | where weighted_avg(numberField, numberField, "asc")',
-          ['WHERE does not support function weighted_avg']
-        );
+        testErrorsAndWarnings('from a_index | where weighted_avg(numberField, numberField)', [
+          'WHERE does not support function weighted_avg',
+        ]);
 
-        testErrorsAndWarnings(
-          'from a_index | where weighted_avg(numberField, numberField, "asc") > 0',
-          ['WHERE does not support function weighted_avg']
-        );
+        testErrorsAndWarnings('from a_index | where weighted_avg(numberField, numberField) > 0', [
+          'WHERE does not support function weighted_avg',
+        ]);
 
-        testErrorsAndWarnings(
-          'from a_index | eval var = weighted_avg(numberField, numberField, "asc")',
-          ['EVAL does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | eval var = weighted_avg(numberField, numberField, "asc") > 0',
-          ['EVAL does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings('from a_index | eval weighted_avg(numberField, numberField, "asc")', [
+        testErrorsAndWarnings('from a_index | eval var = weighted_avg(numberField, numberField)', [
           'EVAL does not support function weighted_avg',
         ]);
 
         testErrorsAndWarnings(
-          'from a_index | eval weighted_avg(numberField, numberField, "asc") > 0',
+          'from a_index | eval var = weighted_avg(numberField, numberField) > 0',
           ['EVAL does not support function weighted_avg']
         );
 
-        testErrorsAndWarnings('from a_index | stats weighted_avg(null, null, null)', []);
-        testErrorsAndWarnings(
-          'row nullVar = null | stats weighted_avg(nullVar, nullVar, nullVar)',
-          []
-        );
+        testErrorsAndWarnings('from a_index | eval weighted_avg(numberField, numberField)', [
+          'EVAL does not support function weighted_avg',
+        ]);
 
-        testErrorsAndWarnings(
-          'from a_index | stats var = weighted_avg(numberField, numberField, stringField)',
-          []
-        );
+        testErrorsAndWarnings('from a_index | eval weighted_avg(numberField, numberField) > 0', [
+          'EVAL does not support function weighted_avg',
+        ]);
 
-        testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(numberField, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var = round(weighted_avg(numberField, numberField, stringField))',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats round(weighted_avg(numberField, numberField, stringField))',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var = round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats round(weighted_avg(numberField, numberField, stringField)) + weighted_avg(numberField, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(numberField / 2, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var0 = weighted_avg(numberField / 2, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField / 2, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField / 2, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var0 = weighted_avg(numberField, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(numberField, numberField, stringField) by round(numberField / 2)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2)',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), ipField',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), ipField',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), weighted_avg(numberField, numberField, stringField) by round(numberField / 2), numberField / 2',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats avg(numberField), var0 = weighted_avg(numberField, numberField, stringField) by var1 = round(numberField / 2), numberField / 2',
-          []
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats var = weighted_avg(avg(numberField), avg(numberField), avg(numberField))',
-          [
-            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-          ]
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(avg(numberField), avg(numberField), avg(numberField))',
-          [
-            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-            "Aggregate function's parameters must be an attribute, literal or a non-aggregation function; found [avg(numberField)] of type [number]",
-          ]
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | stats weighted_avg(booleanField, booleanField, booleanField)',
-          [
-            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
-            'Argument of [weighted_avg] must be [number], found value [booleanField] type [boolean]',
-            'Argument of [weighted_avg] must be [string], found value [booleanField] type [boolean]',
-          ]
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | sort weighted_avg(numberField, numberField, stringField)',
-          ['SORT does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | where weighted_avg(numberField, numberField, stringField)',
-          ['WHERE does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | where weighted_avg(numberField, numberField, stringField) > 0',
-          ['WHERE does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | eval var = weighted_avg(numberField, numberField, stringField)',
-          ['EVAL does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | eval var = weighted_avg(numberField, numberField, stringField) > 0',
-          ['EVAL does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | eval weighted_avg(numberField, numberField, stringField)',
-          ['EVAL does not support function weighted_avg']
-        );
-
-        testErrorsAndWarnings(
-          'from a_index | eval weighted_avg(numberField, numberField, stringField) > 0',
-          ['EVAL does not support function weighted_avg']
-        );
+        testErrorsAndWarnings('from a_index | stats weighted_avg(null, null)', []);
+        testErrorsAndWarnings('row nullVar = null | stats weighted_avg(nullVar, nullVar)', []);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Adds `weighted_avg` function definition
- Adds basic smoke tests


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
