### PR TITLE
[APM] Reenable and stabilize APM correlations API integration tests.

### DIFF
--- a/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/failed_transactions.spec.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
+import { orderBy } from 'lodash';
 import expect from '@kbn/expect';
-
 import type { FailedTransactionsCorrelationsResponse } from '@kbn/apm-plugin/common/correlations/failed_transactions_correlations/types';
 import { EVENT_OUTCOME } from '@kbn/apm-plugin/common/es_fields/apm';
 import { EventOutcome } from '@kbn/apm-plugin/common/event_outcome';
@@ -27,7 +27,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     kuery: '',
   });
 
-  registry.when.skip('failed transactions without data', { config: 'trial', archives: [] }, () => {
+  registry.when('failed transactions without data', { config: 'trial', archives: [] }, () => {
     it('handles the empty state', async () => {
       const overallDistributionResponse = await apmApiClient.readUser({
         endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
@@ -104,127 +104,120 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176544
-  registry.when.skip(
-    'failed transactions with data',
-    { config: 'trial', archives: ['8.0.0'] },
-    () => {
-      it('runs queries and returns results', async () => {
-        const overallDistributionResponse = await apmApiClient.readUser({
-          endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
-          params: {
-            body: {
-              ...getOptions(),
-              percentileThreshold: 95,
-              chartType: LatencyDistributionChartType.failedTransactionsCorrelations,
-            },
+  registry.when('failed transactions with data', { config: 'trial', archives: ['8.0.0'] }, () => {
+    it('runs queries and returns results', async () => {
+      const overallDistributionResponse = await apmApiClient.readUser({
+        endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
+        params: {
+          body: {
+            ...getOptions(),
+            percentileThreshold: 95,
+            chartType: LatencyDistributionChartType.failedTransactionsCorrelations,
           },
-        });
-
-        expect(overallDistributionResponse.status).to.eql(
-          200,
-          `Expected status to be '200', got '${overallDistributionResponse.status}'`
-        );
-
-        const errorDistributionResponse = await apmApiClient.readUser({
-          endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
-          params: {
-            body: {
-              ...getOptions(),
-              percentileThreshold: 95,
-              termFilters: [{ fieldName: EVENT_OUTCOME, fieldValue: EventOutcome.failure }],
-              chartType: LatencyDistributionChartType.failedTransactionsCorrelations,
-            },
-          },
-        });
-
-        expect(errorDistributionResponse.status).to.eql(
-          200,
-          `Expected status to be '200', got '${errorDistributionResponse.status}'`
-        );
-
-        const fieldCandidatesResponse = await apmApiClient.readUser({
-          endpoint: 'GET /internal/apm/correlations/field_candidates/transactions',
-          params: {
-            query: getOptions(),
-          },
-        });
-
-        expect(fieldCandidatesResponse.status).to.eql(
-          200,
-          `Expected status to be '200', got '${fieldCandidatesResponse.status}'`
-        );
-
-        const fieldCandidates = fieldCandidatesResponse.body?.fieldCandidates.filter(
-          (t) => !(t === EVENT_OUTCOME)
-        );
-
-        // Identified 68 fieldCandidates.
-        expect(fieldCandidates.length).to.eql(
-          68,
-          `Expected field candidates length to be '68', got '${fieldCandidates.length}'`
-        );
-
-        const failedTransactionsCorrelationsResponse = await apmApiClient.readUser({
-          endpoint: 'POST /internal/apm/correlations/p_values/transactions',
-          params: {
-            body: {
-              ...getOptions(),
-              fieldCandidates,
-            },
-          },
-        });
-
-        expect(failedTransactionsCorrelationsResponse.status).to.eql(
-          200,
-          `Expected status to be '200', got '${failedTransactionsCorrelationsResponse.status}'`
-        );
-
-        const fieldsToSample = new Set<string>();
-        if (
-          failedTransactionsCorrelationsResponse.body?.failedTransactionsCorrelations.length > 0
-        ) {
-          failedTransactionsCorrelationsResponse.body?.failedTransactionsCorrelations.forEach(
-            (d) => {
-              fieldsToSample.add(d.fieldName);
-            }
-          );
-        }
-
-        const finalRawResponse: FailedTransactionsCorrelationsResponse = {
-          ccsWarning: failedTransactionsCorrelationsResponse.body?.ccsWarning,
-          percentileThresholdValue: overallDistributionResponse.body?.percentileThresholdValue,
-          overallHistogram: overallDistributionResponse.body?.overallHistogram,
-          errorHistogram: errorDistributionResponse.body?.overallHistogram,
-          failedTransactionsCorrelations:
-            failedTransactionsCorrelationsResponse.body?.failedTransactionsCorrelations,
-        };
-
-        expect(finalRawResponse?.percentileThresholdValue).to.be(1309695.875);
-        expect(finalRawResponse?.errorHistogram?.length).to.be(101);
-        expect(finalRawResponse?.overallHistogram?.length).to.be(101);
-
-        expect(finalRawResponse?.failedTransactionsCorrelations?.length).to.eql(
-          30,
-          `Expected 30 identified correlations, got ${finalRawResponse?.failedTransactionsCorrelations?.length}.`
-        );
-
-        const sortedCorrelations = finalRawResponse?.failedTransactionsCorrelations?.sort(
-          (a, b) => b.score - a.score
-        );
-        const correlation = sortedCorrelations?.[0];
-
-        expect(typeof correlation).to.be('object');
-        expect(correlation?.doc_count).to.be(31);
-        expect(correlation?.score).to.be(83.70467673605746);
-        expect(correlation?.bg_count).to.be(31);
-        expect(correlation?.fieldName).to.be('http.response.status_code');
-        expect(correlation?.fieldValue).to.be(500);
-        expect(typeof correlation?.pValue).to.be('number');
-        expect(typeof correlation?.normalizedScore).to.be('number');
-        expect(typeof correlation?.failurePercentage).to.be('number');
-        expect(typeof correlation?.successPercentage).to.be('number');
+        },
       });
-    }
-  );
+
+      expect(overallDistributionResponse.status).to.eql(
+        200,
+        `Expected status to be '200', got '${overallDistributionResponse.status}'`
+      );
+
+      const errorDistributionResponse = await apmApiClient.readUser({
+        endpoint: 'POST /internal/apm/latency/overall_distribution/transactions',
+        params: {
+          body: {
+            ...getOptions(),
+            percentileThreshold: 95,
+            termFilters: [{ fieldName: EVENT_OUTCOME, fieldValue: EventOutcome.failure }],
+            chartType: LatencyDistributionChartType.failedTransactionsCorrelations,
+          },
+        },
+      });
+
+      expect(errorDistributionResponse.status).to.eql(
+        200,
+        `Expected status to be '200', got '${errorDistributionResponse.status}'`
+      );
+
+      const fieldCandidatesResponse = await apmApiClient.readUser({
+        endpoint: 'GET /internal/apm/correlations/field_candidates/transactions',
+        params: {
+          query: getOptions(),
+        },
+      });
+
+      expect(fieldCandidatesResponse.status).to.eql(
+        200,
+        `Expected status to be '200', got '${fieldCandidatesResponse.status}'`
+      );
+
+      const fieldCandidates = fieldCandidatesResponse.body?.fieldCandidates.filter(
+        (t) => !(t === EVENT_OUTCOME)
+      );
+
+      // Identified 80 fieldCandidates.
+      expect(fieldCandidates.length).to.eql(
+        80,
+        `Expected field candidates length to be '80', got '${fieldCandidates.length}'`
+      );
+
+      const failedTransactionsCorrelationsResponse = await apmApiClient.readUser({
+        endpoint: 'POST /internal/apm/correlations/p_values/transactions',
+        params: {
+          body: {
+            ...getOptions(),
+            fieldCandidates,
+          },
+        },
+      });
+
+      expect(failedTransactionsCorrelationsResponse.status).to.eql(
+        200,
+        `Expected status to be '200', got '${failedTransactionsCorrelationsResponse.status}'`
+      );
+
+      const fieldsToSample = new Set<string>();
+      if (failedTransactionsCorrelationsResponse.body?.failedTransactionsCorrelations.length > 0) {
+        failedTransactionsCorrelationsResponse.body?.failedTransactionsCorrelations.forEach((d) => {
+          fieldsToSample.add(d.fieldName);
+        });
+      }
+
+      const finalRawResponse: FailedTransactionsCorrelationsResponse = {
+        ccsWarning: failedTransactionsCorrelationsResponse.body?.ccsWarning,
+        percentileThresholdValue: overallDistributionResponse.body?.percentileThresholdValue,
+        overallHistogram: overallDistributionResponse.body?.overallHistogram,
+        errorHistogram: errorDistributionResponse.body?.overallHistogram,
+        failedTransactionsCorrelations:
+          failedTransactionsCorrelationsResponse.body?.failedTransactionsCorrelations,
+      };
+
+      expect(finalRawResponse?.percentileThresholdValue).to.be(1309695.875);
+      expect(finalRawResponse?.errorHistogram?.length).to.be(101);
+      expect(finalRawResponse?.overallHistogram?.length).to.be(101);
+
+      expect(finalRawResponse?.failedTransactionsCorrelations?.length).to.eql(
+        29,
+        `Expected 29 identified correlations, got ${finalRawResponse?.failedTransactionsCorrelations?.length}.`
+      );
+
+      const sortedCorrelations = orderBy(
+        finalRawResponse?.failedTransactionsCorrelations,
+        ['score', 'fieldName', 'fieldValue'],
+        ['desc', 'asc', 'asc']
+      );
+      const correlation = sortedCorrelations?.[0];
+
+      expect(typeof correlation).to.be('object');
+      expect(correlation?.doc_count).to.be(31);
+      expect(correlation?.score).to.be(83.70467673605746);
+      expect(correlation?.bg_count).to.be(31);
+      expect(correlation?.fieldName).to.be('transaction.result');
+      expect(correlation?.fieldValue).to.be('HTTP 5xx');
+      expect(typeof correlation?.pValue).to.be('number');
+      expect(typeof correlation?.normalizedScore).to.be('number');
+      expect(typeof correlation?.failurePercentage).to.be('number');
+      expect(typeof correlation?.successPercentage).to.be('number');
+    });
+  });
 }

--- a/x-pack/test/apm_api_integration/tests/correlations/field_candidates.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/field_candidates.spec.ts
@@ -25,8 +25,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     },
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/187421
-  registry.when.skip('field candidates without data', { config: 'trial', archives: [] }, () => {
+  registry.when('field candidates without data', { config: 'trial', archives: [] }, () => {
     it('handles the empty state', async () => {
       const response = await apmApiClient.readUser({
         endpoint,
@@ -34,12 +33,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       expect(response.status).to.be(200);
-      expect(response.body?.fieldCandidates.length).to.be(14);
+      // If the source indices are empty, there will be no field candidates
+      // because of the `include_empty_fields: false` option in the query.
+      expect(response.body?.fieldCandidates.length).to.be(0);
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176119
-  registry.when.skip(
+  registry.when(
     'field candidates with data and default args',
     { config: 'trial', archives: ['8.0.0'] },
     () => {
@@ -50,7 +50,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         expect(response.status).to.eql(200);
-        expect(response.body?.fieldCandidates.length).to.be(69);
+        expect(response.body?.fieldCandidates.length).to.be(81);
       });
     }
   );

--- a/x-pack/test/apm_api_integration/tests/correlations/field_value_pairs.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/field_value_pairs.spec.ts
@@ -53,8 +53,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176425
-  registry.when.skip(
+  registry.when(
     'field value pairs with data and default args',
     { config: 'trial', archives: ['8.0.0'] },
     () => {

--- a/x-pack/test/apm_api_integration/tests/correlations/p_values.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/p_values.spec.ts
@@ -53,8 +53,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/175911
-  registry.when.skip(
+  registry.when(
     'p values with data and default args',
     { config: 'trial', archives: ['8.0.0'] },
     () => {

--- a/x-pack/test/apm_api_integration/tests/correlations/significant_correlations.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/correlations/significant_correlations.spec.ts
@@ -77,8 +77,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176780
-  registry.when.skip(
+  registry.when(
     'significant correlations with data and default args',
     { config: 'trial', archives: ['8.0.0'] },
     () => {


### PR DESCRIPTION
## Summary

Fixes #176544.
Fixes #187421.
Fixes #176119.
Fixes #176425.
Fixes #175855.
Fixes #175911.
Fixes #176780.

Follow up to #186182.

Reenables and stabilizes APM correlations API integration tests.

Review hint: View with the `w=1` flag to ignore whitespace changes: https://github.com/elastic/kibana/pull/187444/files?w=1

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
