### PR TITLE
make EntityDefinition 'type' a plain string instead of an enum

### DIFF
--- a/x-pack/packages/kbn-entities-schema/src/schema/common.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/common.ts
@@ -8,16 +8,7 @@
 import { z } from 'zod';
 import moment from 'moment';
 
-export enum EntityType {
-  service = 'service',
-  host = 'host',
-  pod = 'pod',
-  node = 'node',
-}
-
 export const arrayOfStringsSchema = z.array(z.string());
-
-export const entityTypeSchema = z.nativeEnum(EntityType);
 
 export enum BasicAggregations {
   avg = 'avg',

--- a/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
@@ -8,7 +8,6 @@
 import { z } from 'zod';
 import {
   arrayOfStringsSchema,
-  entityTypeSchema,
   keyMetricSchema,
   metadataSchema,
   filterSchema,
@@ -20,7 +19,7 @@ export const entityDefinitionSchema = z.object({
   id: z.string().regex(/^[\w-]+$/),
   name: z.string(),
   description: z.optional(z.string()),
-  type: entityTypeSchema,
+  type: z.string(),
   filter: filterSchema,
   indexPatterns: arrayOfStringsSchema,
   identityFields: z.array(identityFieldsSchema),


### PR DESCRIPTION
make EntityDefinition 'type' a plain string instead of an enum