### PR TITLE
validate that entity definition IDs do not overflow transform ID max length before installing them

### DIFF
--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/errors/entity_definition_id_too_long_error.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/errors/entity_definition_id_too_long_error.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-export class EntityIdTooLong extends Error {
+export class EntityDefinitionIdTooLong extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'EntityIdTooLong';
+    this.name = 'EntityDefinitionIdTooLong';
   }
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/errors/entity_id_too_long_error.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/errors/entity_id_too_long_error.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export class EntityIdTooLong extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EntityIdTooLong';
+  }
+}

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
@@ -17,6 +17,7 @@ import {
   createAndInstallHistoryTransform,
   createAndInstallLatestTransform,
 } from './create_and_install_transform';
+import { validateDefinitionCanCreateValidTransformIds } from './transform/validate_transform_ids';
 import { deleteEntityDefinition } from './delete_entity_definition';
 import { deleteHistoryIngestPipeline, deleteLatestIngestPipeline } from './delete_ingest_pipeline';
 import { findEntityDefinitions } from './find_entity_definition';
@@ -27,6 +28,7 @@ import {
   stopAndDeleteLatestTransform,
 } from './stop_and_delete_transform';
 import { uninstallEntityDefinition } from './uninstall_entity_definition';
+import { EntityIdTooLong } from './errors/entity_id_too_long_error';
 
 export interface InstallDefinitionParams {
   esClient: ElasticsearchClient;
@@ -57,6 +59,11 @@ export async function installEntityDefinition({
 
   try {
     logger.debug(`Installing definition ${JSON.stringify(definition)}`);
+
+    if (!validateDefinitionCanCreateValidTransformIds(definition)) {
+      throw new EntityIdTooLong('ID is too long; the resulting transform ID will be invalid');
+    }
+
     const entityDefinition = await saveEntityDefinition(soClient, definition);
     installState.definition = true;
 

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
@@ -60,9 +60,7 @@ export async function installEntityDefinition({
   try {
     logger.debug(`Installing definition ${JSON.stringify(definition)}`);
 
-    if (!validateDefinitionCanCreateValidTransformIds(definition)) {
-      throw new EntityIdTooLong('ID is too long; the resulting transform ID will be invalid');
-    }
+    validateDefinitionCanCreateValidTransformIds(definition);
 
     const entityDefinition = await saveEntityDefinition(soClient, definition);
     installState.definition = true;

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
@@ -28,7 +28,6 @@ import {
   stopAndDeleteLatestTransform,
 } from './stop_and_delete_transform';
 import { uninstallEntityDefinition } from './uninstall_entity_definition';
-import { EntityIdTooLong } from './errors/entity_id_too_long_error';
 
 export interface InstallDefinitionParams {
   esClient: ElasticsearchClient;

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
@@ -14,9 +14,10 @@ describe('validateDefinitionCanCreateValidTransformIds(definition)', () => {
     expect(valid).toBeTruthy();
   });
 
-  it('shoulw dreturn false for a definition ID which is too long', () => {
+  it('should return false for a definition ID which is too long', () => {
     const entityDefinitionWithLongID = entityDefinition;
-    entityDefinitionWithLongID.id = 'a-really-really-really-really-really-really-really-really-really-really-long-id';
+    entityDefinitionWithLongID.id =
+      'a-really-really-really-really-really-really-really-really-really-really-long-id';
     const valid = validateDefinitionCanCreateValidTransformIds(entityDefinition);
     expect(valid).toBeFalsy();
   });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EntityIdTooLong } from '../errors/entity_id_too_long_error';
+import { EntityDefinitionIdTooLong } from '../errors/entity_definition_id_too_long_error';
 import { entityDefinition } from '../helpers/fixtures/entity_definition';
 import { validateDefinitionCanCreateValidTransformIds } from './validate_transform_ids';
 
@@ -21,6 +21,6 @@ describe('validateDefinitionCanCreateValidTransformIds(definition)', () => {
 
       expect(() => {
         validateDefinitionCanCreateValidTransformIds(entityDefinition);
-      }).toThrow(EntityIdTooLong);
+      }).toThrow(EntityDefinitionIdTooLong);
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { entityDefinition } from '../helpers/fixtures/entity_definition';
+import { validateDefinitionCanCreateValidTransformIds } from './validate_transform_ids';
+
+describe('validateDefinitionCanCreateValidTransformIds(definition)', () => {
+  it('should return true for a definition ID which is not too long', () => {
+    const valid = validateDefinitionCanCreateValidTransformIds(entityDefinition);
+    expect(valid).toBeTruthy();
+  });
+
+  it('shoulw dreturn false for a definition ID which is too long', () => {
+    const entityDefinitionWithLongID = entityDefinition;
+    entityDefinitionWithLongID.id = 'a-really-really-really-really-really-really-really-really-really-really-long-id';
+    const valid = validateDefinitionCanCreateValidTransformIds(entityDefinition);
+    expect(valid).toBeFalsy();
+  });
+});

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
@@ -5,20 +5,22 @@
  * 2.0.
  */
 
+import { EntityIdTooLong } from '../errors/entity_id_too_long_error';
 import { entityDefinition } from '../helpers/fixtures/entity_definition';
 import { validateDefinitionCanCreateValidTransformIds } from './validate_transform_ids';
 
 describe('validateDefinitionCanCreateValidTransformIds(definition)', () => {
-  it('should return true for a definition ID which is not too long', () => {
-    const valid = validateDefinitionCanCreateValidTransformIds(entityDefinition);
-    expect(valid).toBeTruthy();
+  it('should not throw an error for a definition ID which is not too long', () => {
+    validateDefinitionCanCreateValidTransformIds(entityDefinition);
   });
 
-  it('should return false for a definition ID which is too long', () => {
+  it('should throw an error for a definition ID which is too long', () => {
     const entityDefinitionWithLongID = entityDefinition;
     entityDefinitionWithLongID.id =
       'a-really-really-really-really-really-really-really-really-really-really-long-id';
-    const valid = validateDefinitionCanCreateValidTransformIds(entityDefinition);
-    expect(valid).toBeFalsy();
+
+      expect(() => {
+        validateDefinitionCanCreateValidTransformIds(entityDefinition);
+      }).toThrow(EntityIdTooLong);
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.test.ts
@@ -19,8 +19,8 @@ describe('validateDefinitionCanCreateValidTransformIds(definition)', () => {
     entityDefinitionWithLongID.id =
       'a-really-really-really-really-really-really-really-really-really-really-long-id';
 
-      expect(() => {
-        validateDefinitionCanCreateValidTransformIds(entityDefinition);
-      }).toThrow(EntityDefinitionIdTooLong);
+    expect(() => {
+      validateDefinitionCanCreateValidTransformIds(entityDefinition);
+    }).toThrow(EntityDefinitionIdTooLong);
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
@@ -12,15 +12,18 @@ import { EntityDefinitionIdTooLong } from '../errors/entity_definition_id_too_lo
 import { generateHistoryTransformId } from './generate_history_transform_id';
 import { generateLatestTransformId } from './generate_latest_transform_id';
 
-export function validateDefinitionCanCreateValidTransformIds(
-  definition: EntityDefinition
-) {
+export function validateDefinitionCanCreateValidTransformIds(definition: EntityDefinition) {
   const historyTransformId = generateHistoryTransformId(definition);
   const latestTransformId = generateLatestTransformId(definition);
 
-  const spareChars = TRANSFORM_ID_MAX_LENGTH - Math.max(historyTransformId.length, latestTransformId.length);
+  const spareChars =
+    TRANSFORM_ID_MAX_LENGTH - Math.max(historyTransformId.length, latestTransformId.length);
 
   if (spareChars < 0) {
-    throw new EntityDefinitionIdTooLong(`Entity definition ID is too long (max = ${definition.id.length + spareChars}); the resulting transform ID will be invalid`);
+    throw new EntityDefinitionIdTooLong(
+      `Entity definition ID is too long (max = ${
+        definition.id.length + spareChars
+      }); the resulting transform ID will be invalid`
+    );
   }
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const TRANSFORM_ID_MAX_LENGTH = 64;
+
+import { EntityDefinition } from '@kbn/entities-schema';
+import { generateHistoryTransformId } from './generate_history_transform_id';
+import { generateLatestTransformId } from './generate_latest_transform_id';
+
+export function validateDefinitionCanCreateValidTransformIds(definition: EntityDefinition): boolean {
+    const historyTransformId = generateHistoryTransformId(definition);
+    const latestTransformId = generateLatestTransformId(definition);
+
+    return historyTransformId.length <= TRANSFORM_ID_MAX_LENGTH && latestTransformId.length <= TRANSFORM_ID_MAX_LENGTH;
+}

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
@@ -8,7 +8,7 @@
 const TRANSFORM_ID_MAX_LENGTH = 64;
 
 import { EntityDefinition } from '@kbn/entities-schema';
-import { EntityIdTooLong } from '../errors/entity_id_too_long_error';
+import { EntityDefinitionIdTooLong } from '../errors/entity_definition_id_too_long_error';
 import { generateHistoryTransformId } from './generate_history_transform_id';
 import { generateLatestTransformId } from './generate_latest_transform_id';
 
@@ -21,6 +21,6 @@ export function validateDefinitionCanCreateValidTransformIds(
   const spareChars = TRANSFORM_ID_MAX_LENGTH - Math.max(historyTransformId.length, latestTransformId.length);
 
   if (spareChars < 0) {
-    throw new EntityIdTooLong(`Entity definition ID is too long (max = ${definition.id.length + spareChars}); the resulting transform ID will be invalid`);
+    throw new EntityDefinitionIdTooLong(`Entity definition ID is too long (max = ${definition.id.length + spareChars}); the resulting transform ID will be invalid`);
   }
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
@@ -11,9 +11,14 @@ import { EntityDefinition } from '@kbn/entities-schema';
 import { generateHistoryTransformId } from './generate_history_transform_id';
 import { generateLatestTransformId } from './generate_latest_transform_id';
 
-export function validateDefinitionCanCreateValidTransformIds(definition: EntityDefinition): boolean {
-    const historyTransformId = generateHistoryTransformId(definition);
-    const latestTransformId = generateLatestTransformId(definition);
+export function validateDefinitionCanCreateValidTransformIds(
+  definition: EntityDefinition
+): boolean {
+  const historyTransformId = generateHistoryTransformId(definition);
+  const latestTransformId = generateLatestTransformId(definition);
 
-    return historyTransformId.length <= TRANSFORM_ID_MAX_LENGTH && latestTransformId.length <= TRANSFORM_ID_MAX_LENGTH;
+  return (
+    historyTransformId.length <= TRANSFORM_ID_MAX_LENGTH &&
+    latestTransformId.length <= TRANSFORM_ID_MAX_LENGTH
+  );
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/validate_transform_ids.ts
@@ -8,17 +8,19 @@
 const TRANSFORM_ID_MAX_LENGTH = 64;
 
 import { EntityDefinition } from '@kbn/entities-schema';
+import { EntityIdTooLong } from '../errors/entity_id_too_long_error';
 import { generateHistoryTransformId } from './generate_history_transform_id';
 import { generateLatestTransformId } from './generate_latest_transform_id';
 
 export function validateDefinitionCanCreateValidTransformIds(
   definition: EntityDefinition
-): boolean {
+) {
   const historyTransformId = generateHistoryTransformId(definition);
   const latestTransformId = generateLatestTransformId(definition);
 
-  return (
-    historyTransformId.length <= TRANSFORM_ID_MAX_LENGTH &&
-    latestTransformId.length <= TRANSFORM_ID_MAX_LENGTH
-  );
+  const spareChars = TRANSFORM_ID_MAX_LENGTH - Math.max(historyTransformId.length, latestTransformId.length);
+
+  if (spareChars < 0) {
+    throw new EntityIdTooLong(`Entity definition ID is too long (max = ${definition.id.length + spareChars}); the resulting transform ID will be invalid`);
+  }
 }


### PR DESCRIPTION
validate that entity definition IDs do not overflow transform ID max length before installing them