### PR TITLE
[Infra] Fix: Processes tab shows toast with a 500 error when performing a full page refresh

### DIFF
--- a/x-pack/plugins/observability_solution/infra/common/http_api/host_details/process_list.ts
+++ b/x-pack/plugins/observability_solution/infra/common/http_api/host_details/process_list.ts
@@ -14,7 +14,7 @@ const AggValueRT = rt.type({
 
 export const ProcessListAPIRequestRT = rt.type({
   hostTerm: rt.record(rt.string, rt.string),
-  indexPattern: rt.string,
+  sourceId: rt.string,
   to: rt.number,
   sortBy: rt.type({
     name: rt.string,

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_process_list.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_process_list.ts
@@ -29,8 +29,6 @@ export function useProcessList(
   sourceId: string,
   request$?: BehaviorSubject<(() => Promise<unknown>) | undefined>
 ) {
-  const { metricsView } = useMetricsDataViewContext();
-
   const decodeResponse = (response: any) => {
     return pipe(
       ProcessListAPIResponseRT.decode(response),

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_process_list.ts
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/hooks/use_process_list.ts
@@ -26,6 +26,7 @@ export function useProcessList(
   to: number,
   sortBy: SortBy,
   searchFilter: object,
+  sourceId: string,
   request$?: BehaviorSubject<(() => Promise<unknown>) | undefined>
 ) {
   const { metricsView } = useMetricsDataViewContext();
@@ -50,7 +51,7 @@ export function useProcessList(
     'POST',
     JSON.stringify({
       hostTerm,
-      indexPattern: metricsView?.indices,
+      sourceId,
       to,
       sortBy: parsedSortBy,
       searchFilter,

--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/processes/processes.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/processes/processes.tsx
@@ -20,6 +20,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { getFieldByType } from '@kbn/metrics-data-access-plugin/common';
+import { useSourceContext } from '../../../../containers/metrics_source';
 import { parseSearchString } from './parse_search_string';
 import { ProcessesTable } from './processes_table';
 import { STATE_NAMES } from './states';
@@ -44,6 +45,8 @@ export const Processes = () => {
   const { getDateRangeInTimestamp } = useDatePickerContext();
   const [urlState, setUrlState] = useAssetDetailsUrlState();
   const { asset } = useAssetDetailsRenderPropsContext();
+  const { sourceId } = useSourceContext();
+
   const [searchText, setSearchText] = useState(urlState?.processSearch ?? '');
   const [searchQueryError, setSearchQueryError] = useState<Error | null>(null);
   const [searchBarState, setSearchBarState] = useState<Query>(() =>
@@ -75,6 +78,7 @@ export const Processes = () => {
     state.currentTimestamp,
     sortBy,
     parseSearchString(searchText),
+    sourceId,
     request$
   );
 

--- a/x-pack/plugins/observability_solution/infra/server/lib/host_details/process_list.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/host_details/process_list.ts
@@ -8,12 +8,14 @@
 import { TIMESTAMP_FIELD, CMDLINE_FIELD } from '../../../common/constants';
 import { ProcessListAPIRequest, ProcessListAPIQueryAggregation } from '../../../common/http_api';
 import { ESSearchClient } from '../metrics/types';
+import type { InfraSourceConfiguration } from '../sources';
 
 const TOP_N = 10;
 
 export const getProcessList = async (
   search: ESSearchClient,
-  { hostTerm, indexPattern, to, sortBy, searchFilter }: ProcessListAPIRequest
+  sourceConfiguration: InfraSourceConfiguration,
+  { hostTerm, to, sortBy, searchFilter }: ProcessListAPIRequest
 ) => {
   const body = {
     size: 0,
@@ -111,7 +113,7 @@ export const getProcessList = async (
   try {
     const result = await search<{}, ProcessListAPIQueryAggregation>({
       body,
-      index: indexPattern,
+      index: sourceConfiguration.metricAlias,
     });
     const { buckets: processListBuckets } = result.aggregations!.processes.filteredProcs;
     const processList = processListBuckets.map((bucket) => {

--- a/x-pack/plugins/observability_solution/infra/server/routes/process_list/index.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/process_list/index.ts
@@ -41,7 +41,14 @@ export const initProcessListRoute = (libs: InfraBackendLibs) => {
       );
 
       const client = createSearchClient(requestContext, framework);
-      const processListResponse = await getProcessList(client, options);
+      const soClient = (await requestContext.core).savedObjects.client;
+
+      const { configuration } = await libs.sources.getSourceConfiguration(
+        soClient,
+        options.sourceId
+      );
+
+      const processListResponse = await getProcessList(client, configuration, options);
 
       return response.ok({
         body: ProcessListAPIResponseRT.encode(processListResponse),

--- a/x-pack/test/api_integration/apis/metrics_ui/metrics_process_list.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/metrics_process_list.ts
@@ -34,7 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
             hostTerm: {
               'host.name': 'gke-observability-8--observability-8--bc1afd95-nhhw',
             },
-            indexPattern: 'metrics-*,metricbeat-*',
+            sourceId: 'default',
             to: 1564432800000,
             sortBy: {
               name: 'cpu',

--- a/x-pack/test_serverless/api_integration/test_suites/observability/infra/processes.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/infra/processes.ts
@@ -43,7 +43,7 @@ export default function ({ getService }: FtrProviderContext) {
             hostTerm: {
               'host.name': 'serverless-host',
             },
-            indexPattern: 'metrics-*,metricbeat-*',
+            sourceId: 'default',
             to: DATES.serverlessTestingHost.max,
             sortBy: {
               name: 'cpu',


### PR DESCRIPTION
Closes #187385 
## Summary

This PR fixes the issue with the processes tab showing a 500 error in a toast when performing a full page refresh.

## Testing
Go to asset details and open the processes tab. Refresh the page: there should not be any error visible.

https://github.com/elastic/kibana/assets/14139027/8998d141-8841-4138-8c76-7f555f6c44f0

