### PR TITLE
[Fleet] added check for Enterprise license in package policy create/update APIs

### DIFF
--- a/x-pack/plugins/fleet/server/routes/package_policy/utils/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/utils/index.ts
@@ -8,7 +8,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 
 import type { CreatePackagePolicyRequestSchema, PackagePolicyInput } from '../../../types';
-
+import { licenseService } from '../../../services';
 import type { SimplifiedPackagePolicy } from '../../../../common/services/simplified_package_policy_helper';
 
 export function isSimplifiedCreatePackagePolicyRequest(
@@ -38,4 +38,15 @@ export function removeFieldsFromInputSchema(
     delete newInput.compiled_input;
     return newInput;
   });
+}
+
+const LICENCE_FOR_MULTIPLE_AGENT_POLICIES = 'enterprise';
+
+export function canUseMultipleAgentPolicies() {
+  const hasEnterpriseLicence = licenseService.hasAtLeast(LICENCE_FOR_MULTIPLE_AGENT_POLICIES);
+
+  return {
+    canUseReusablePolicies: hasEnterpriseLicence,
+    errorMessage: 'Reusable integration policies are only available with an Enterprise license',
+  };
 }


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/ingest-dev/issues/3464

Added check to reject integration policy shared by multiple agent policies if Enterprise license is not available.

### Testing

- Enable a local enterprise licence ([steps](https://elasticco.atlassian.net/wiki/spaces/PM/pages/46802910/Internal+License+-+X-Pack+and+Endgame))
- Enable flag `enableReusableIntegrationPolicies`
- Try create/update package policy API with multiple `policy_ids`, expect to work

Repeat the steps with any lower licence, the API should reject the request with a 400 error.

```
POST kbn:/api/fleet/package_policies
{
  "policy_ids": [
    "policy-1", "policy-2"
  ],
  "package": {
    "name": "apache",
    "version": "1.20.0"
  },
  "name": "apache-4",
  "description": "",
  "namespace": "",
  "inputs": []
}
```

Test with Basic license:
<img width="910" alt="image" src="https://github.com/elastic/kibana/assets/90178898/d99b3765-0b0b-4abd-ae4c-dc9f396a465a">

Test with Enterprise license:
<img width="910" alt="image" src="https://github.com/elastic/kibana/assets/90178898/d42b761e-32f0-46b6-95a8-0a565f898532">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->