### PR TITLE
Revert a change which uses the computed index name in the 'latest' transform

### DIFF
--- a/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
@@ -33,7 +33,6 @@ export const entityDefinitionSchema = z.object({
     interval: durationSchema.refine((val) => val.asMinutes() >= 1, {
       message: 'The history.interval can not be less than 1m',
     }),
-    lookbackPeriod: z.optional(durationSchema),
     settings: z.optional(
       z.object({
         syncField: z.optional(z.string()),

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/built_in/services.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/built_in/services.ts
@@ -18,9 +18,6 @@ export const builtInServicesEntityDefinition: EntityDefinition = entityDefinitio
     timestampField: '@timestamp',
     interval: '1m',
   },
-  latest: {
-    lookback: '5m',
-  },
   identityFields: ['service.name', { field: 'service.environment', optional: true }],
   displayNameTemplate: '{{service.name}}{{#service.environment}}:{{.}}{{/service.environment}}',
   metadata: [

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
@@ -10,11 +10,12 @@ import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/typ
 import {
   ENTITY_DEFAULT_LATEST_FREQUENCY,
   ENTITY_DEFAULT_LATEST_SYNC_DELAY,
+  ENTITY_LATEST_BASE_PREFIX
 } from '../../../../common/constants_entities';
 import { generateLatestMetadataAggregations } from './generate_metadata_aggregations';
 import { generateLatestIngestPipelineId } from '../ingest_pipeline/generate_latest_ingest_pipeline_id';
 import { generateLatestTransformId } from './generate_latest_transform_id';
-import { generateHistoryIndexName, generateLatestIndexName } from '../helpers/generate_index_name';
+import { generateHistoryIndexName } from '../helpers/generate_index_name';
 import { generateLatestMetricAggregations } from './generate_metric_aggregations';
 
 export function generateLatestTransform(
@@ -27,7 +28,7 @@ export function generateLatestTransform(
       index: `${generateHistoryIndexName(definition)}.*`,
     },
     dest: {
-      index: generateLatestIndexName(definition),
+      index: `${ENTITY_LATEST_BASE_PREFIX}.noop`,
       pipeline: generateLatestIngestPipelineId(definition),
     },
     frequency: definition.latest?.settings?.frequency ?? ENTITY_DEFAULT_LATEST_FREQUENCY,

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
@@ -10,7 +10,7 @@ import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/typ
 import {
   ENTITY_DEFAULT_LATEST_FREQUENCY,
   ENTITY_DEFAULT_LATEST_SYNC_DELAY,
-  ENTITY_LATEST_BASE_PREFIX
+  ENTITY_LATEST_BASE_PREFIX,
 } from '../../../../common/constants_entities';
 import { generateLatestMetadataAggregations } from './generate_metadata_aggregations';
 import { generateLatestIngestPipelineId } from '../ingest_pipeline/generate_latest_ingest_pipeline_id';


### PR DESCRIPTION
Revert a change which uses the computed index name in the 'latest' transform

The destination index is computed in the ingest pipelines. The 'noop' prefix used in this index name indicates that it is not used.

This is not ideal, but having the noop naming at least communicates that we know about the fact it goes unused.

**This PR also includes a small commit which removes an unused field from the entity definition schema (we are not updating the version of the entity definition schema as part of this change, since it's not officially been released at all yet)**