### PR TITLE
[SecuritySolution][Endpoint] Update Responder command definition test so that it fails when new commands are added

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_metadata_generator.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/data_generators/endpoint_metadata_generator.ts
@@ -134,6 +134,11 @@ export class EndpointMetadataGenerator extends BaseDataGenerator {
       capabilities.push('upload_file');
     }
 
+    // v8.15 introduced `scan` capability
+    if (gte(agentVersion, '8.15.0')) {
+      capabilities.push('scan');
+    }
+
     const hostMetadataDoc: HostMetadataInterface = {
       '@timestamp': ts,
       event: {

--- a/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/service/response_actions/constants.ts
@@ -65,9 +65,9 @@ export type EndpointCapabilities = typeof ENDPOINT_CAPABILITIES[number];
 export const CONSOLE_RESPONSE_ACTION_COMMANDS = [
   'isolate',
   'release',
+  'processes',
   'kill-process',
   'suspend-process',
-  'processes',
   'get-file',
   'execute',
   'upload',

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/integration_tests/console_commands_definition.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/integration_tests/console_commands_definition.test.tsx
@@ -77,11 +77,10 @@ describe('When displaying Endpoint Response Actions', () => {
       // add status to the list of expected commands in that order
       expectedCommands.splice(2, 0, 'status');
 
+      const helpCommandsString = commandsInPanel.map((command) => command.split(' ')[0]).join(',');
+
       // verify that the help commands map to the command list in the same order
-      for (let i = 0; i < commandsInPanel.length; i++) {
-        const command = commandsInPanel[i].split(' ')[0];
-        expect(command).toEqual(expectedCommands[i]);
-      }
+      expect(helpCommandsString).toEqual(expectedCommands.join(','));
     });
   });
 

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/integration_tests/console_commands_definition.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/integration_tests/console_commands_definition.test.tsx
@@ -18,6 +18,7 @@ import { HELP_GROUPS } from '../console_commands_definition';
 import { ExperimentalFeaturesService } from '../../../../../common/experimental_features_service';
 import type { CommandDefinition } from '../../../console';
 import type { HostMetadataInterface } from '../../../../../../common/endpoint/types';
+import { CONSOLE_RESPONSE_ACTION_COMMANDS } from '../../../../../../common/endpoint/service/response_actions/constants';
 
 jest.mock('../../../../../common/experimental_features_service');
 
@@ -43,8 +44,9 @@ describe('When displaying Endpoint Response Actions', () => {
 
   describe('for agent type endpoint', () => {
     beforeEach(() => {
-      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValueOnce({
+      (ExperimentalFeaturesService.get as jest.Mock).mockReturnValue({
         responseActionUploadEnabled: true,
+        responseActionScanEnabled: true,
       });
       commands = getEndpointConsoleCommands({
         agentType: 'endpoint',
@@ -71,17 +73,15 @@ describe('When displaying Endpoint Response Actions', () => {
         HELP_GROUPS.responseActions.label
       );
 
-      expect(commandsInPanel).toEqual([
-        'isolate',
-        'release',
-        'status',
-        'processes',
-        'kill-process --pid',
-        'suspend-process --pid',
-        'get-file --path',
-        'execute --command',
-        'upload --file',
-      ]);
+      const expectedCommands: string[] = [...CONSOLE_RESPONSE_ACTION_COMMANDS];
+      // add status to the list of expected commands in that order
+      expectedCommands.splice(2, 0, 'status');
+
+      // verify that the help commands map to the command list in the same order
+      for (let i = 0; i < commandsInPanel.length; i++) {
+        const command = commandsInPanel[i].split(' ')[0];
+        expect(command).toEqual(expectedCommands[i]);
+      }
     });
   });
 

--- a/x-pack/plugins/security_solution/server/config.mock.ts
+++ b/x-pack/plugins/security_solution/server/config.mock.ts
@@ -12,7 +12,10 @@ import { getDefaultConfigSettings } from '../common/config_settings';
 import type { ConfigType } from './config';
 
 export const createMockConfig = (): ConfigType => {
-  const enableExperimental: Array<keyof ExperimentalFeatures> = ['responseActionUploadEnabled'];
+  const enableExperimental: Array<keyof ExperimentalFeatures> = [
+    'responseActionUploadEnabled',
+    'responseActionScanEnabled',
+  ];
 
   return {
     [SIGNALS_INDEX_KEY]: DEFAULT_SIGNALS_INDEX,


### PR DESCRIPTION
## Summary

Updates test so that it fails whenever we add a introduce a new responder command.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->