### PR TITLE
Add quality gate 2 test for Security Entity Risk Scoring

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
@@ -76,7 +76,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
   };
 
-  describe('@ess @serverless Risk Scoring Entity Calculation API', () => {
+  describe('@ess @serverless @serverlessQA Risk Scoring Entity Calculation API', () => {
     before(async () => {
       enableAssetCriticalityAdvancedSetting(kibanaServer, log);
     });


### PR DESCRIPTION
## Summary

Adds the `@serverlessQA` annotated label to a Security integration test which flexes the Entity Risk Scoring capability
