### PR TITLE
[UII] Only show beta integrations setting for settings write privilege

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/integration_preference.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/integration_preference.tsx
@@ -23,7 +23,7 @@ import {
   EuiSwitch,
 } from '@elastic/eui';
 
-import { usePutSettingsMutation, useStartServices } from '../../../hooks';
+import { usePutSettingsMutation, useStartServices, useAuthz } from '../../../hooks';
 
 export type IntegrationPreferenceType = 'recommended' | 'beats' | 'agent';
 
@@ -92,7 +92,7 @@ export const IntegrationPreference = ({
   const [prereleaseIntegrationsChecked, setPrereleaseIntegrationsChecked] = React.useState<
     boolean | undefined
   >(undefined);
-
+  const authz = useAuthz();
   const { docLinks, notifications } = useStartServices();
 
   const { mutateAsync: mutateSettingsAsync } = usePutSettingsMutation();
@@ -153,18 +153,24 @@ export const IntegrationPreference = ({
     updateSettings(event.target.checked);
   };
 
+  const canUpdateBetaSetting = authz.fleet.allSettings;
+
   return (
     <EuiPanel hasShadow={false} paddingSize="none">
-      <EuiSwitchNoWrap
-        label="Display beta integrations"
-        checked={
-          typeof prereleaseIntegrationsChecked !== 'undefined'
-            ? prereleaseIntegrationsChecked
-            : prereleaseIntegrationsEnabled
-        }
-        onChange={onPrereleaseSwitchChange}
-      />
-      <EuiSpacer size="l" />
+      {canUpdateBetaSetting && (
+        <>
+          <EuiSwitchNoWrap
+            label="Display beta integrations"
+            checked={
+              typeof prereleaseIntegrationsChecked !== 'undefined'
+                ? prereleaseIntegrationsChecked
+                : prereleaseIntegrationsEnabled
+            }
+            onChange={onPrereleaseSwitchChange}
+          />
+          <EuiSpacer size="l" />
+        </>
+      )}
       <EuiText size="s">{title}</EuiText>
       <EuiSpacer size="m" />
       <EuiForm>


### PR DESCRIPTION
## Summary

Resolves [#184639](https://github.com/elastic/kibana/issues/184639).

This PR hides the beta integrations toggle if user does not have sufficient privileges to write this to Fleet settings SO. The real fix should be handled with #187511.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->