### PR TITLE
[UII] Fix unsupported input callout not showing for Cloud Defend

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -25,37 +25,23 @@ export const FLEET_CLOUD_SECURITY_POSTURE_KSPM_POLICY_TEMPLATE = 'kspm';
 export const FLEET_CLOUD_SECURITY_POSTURE_CSPM_POLICY_TEMPLATE = 'cspm';
 export const FLEET_CLOUD_SECURITY_POSTURE_CNVM_POLICY_TEMPLATE = 'vuln_mgmt';
 export const FLEET_CLOUD_DEFEND_PACKAGE = 'cloud_defend';
-export const FLEET_PF_HOST_AGENT_PACKAGE = 'pf-host-agent';
-export const FLEET_PF_ELASTIC_SYMBOLIZER_PACKAGE = 'pf-elastic-symbolizer';
-export const FLEET_PF_ELASTIC_COLLECTOR_PACKAGE = 'pf-elastic-collector';
 export const FLEET_CLOUD_BEAT_PACKAGE = 'cloudbeat';
-export const FLEET_CLOUD_BEAT_CIS_K8S_PACKAGE = `${FLEET_CLOUD_BEAT_PACKAGE}/cis_k8s`;
-export const FLEET_CLOUD_BEAT_CIS_EKS_PACKAGE = `${FLEET_CLOUD_BEAT_PACKAGE}/cis_eks`;
-export const FLEET_CLOUD_BEAT_CIS_AWS_PACKAGE = `${FLEET_CLOUD_BEAT_PACKAGE}/cis_aws`;
-export const FLEET_CLOUD_BEAT_CIS_GCP_PACKAGE = `${FLEET_CLOUD_BEAT_PACKAGE}/cis_gcp`;
-export const FLEET_CLOUD_BEAT_CIS_AZURE_PACKAGE = `${FLEET_CLOUD_BEAT_PACKAGE}/cis_azure`;
-export const FLEET_CLOUD_BEAT_VULN_MGMT_AWS_PACKAGE = `${FLEET_CLOUD_BEAT_PACKAGE}/vuln_mgmt_aws`;
 
 export const GLOBAL_DATA_TAG_EXCLUDED_INPUTS = new Set<string>([
   FLEET_APM_PACKAGE,
-  FLEET_PF_HOST_AGENT_PACKAGE,
-  FLEET_PF_ELASTIC_SYMBOLIZER_PACKAGE,
-  FLEET_PF_ELASTIC_COLLECTOR_PACKAGE,
-  /* The package names and input types are not the same. For example package
-   * name for fleet server is "fleet_server" whereas the input type is "fleet-server".
-   * This is the same case for cloud defend. That's why we are replacing the
-   * underscores with dashes for the two of them. Global data tag functionality
-   * relies on input types.
-   */
-  FLEET_SERVER_PACKAGE.replace(/_/g, '-'),
-  FLEET_CLOUD_DEFEND_PACKAGE.replace(/_/g, '-'),
+  `pf-host-agent`,
+  `pf-elastic-symbolizer`,
+  `pf-elastic-collector`,
+  `fleet-server`,
+  FLEET_CLOUD_DEFEND_PACKAGE,
+  `${FLEET_CLOUD_DEFEND_PACKAGE}/control`,
   FLEET_CLOUD_BEAT_PACKAGE,
-  FLEET_CLOUD_BEAT_CIS_K8S_PACKAGE,
-  FLEET_CLOUD_BEAT_CIS_EKS_PACKAGE,
-  FLEET_CLOUD_BEAT_CIS_AWS_PACKAGE,
-  FLEET_CLOUD_BEAT_CIS_GCP_PACKAGE,
-  FLEET_CLOUD_BEAT_CIS_AZURE_PACKAGE,
-  FLEET_CLOUD_BEAT_VULN_MGMT_AWS_PACKAGE,
+  `${FLEET_CLOUD_BEAT_PACKAGE}/cis_k8s`,
+  `${FLEET_CLOUD_BEAT_PACKAGE}/cis_eks`,
+  `${FLEET_CLOUD_BEAT_PACKAGE}/cis_aws`,
+  `${FLEET_CLOUD_BEAT_PACKAGE}/cis_gcp`,
+  `${FLEET_CLOUD_BEAT_PACKAGE}/cis_azure`,
+  `${FLEET_CLOUD_BEAT_PACKAGE}/vuln_mgmt_aws`,
 ]);
 
 export const PACKAGE_TEMPLATE_SUFFIX = '@package';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/global_data_tags_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/global_data_tags_table.tsx
@@ -20,6 +20,7 @@ import {
   EuiFieldText,
   EuiButtonIcon,
   EuiCode,
+  EuiSpacer,
   type EuiBasicTableColumn,
 } from '@elastic/eui';
 
@@ -423,15 +424,16 @@ export const GlobalDataTagsTable: React.FunctionComponent<Props> = ({
   return (
     <>
       {globalDataTags.length === 0 && !isAdding ? (
-        <EuiPanel hasShadow={false}>
+        <EuiPanel color="subdued" paddingSize="l" className="eui-textCenter">
           <EuiText>
-            <h4>
+            <h5>
               <FormattedMessage
                 id="xpack.fleet.globalDataTagsTable.noFieldsMessage"
                 defaultMessage="This policy has no custom fields"
               />
-            </h4>
+            </h5>
           </EuiText>
+          <EuiSpacer size="xs" />
           <EuiFlexGroup justifyContent="center">
             <EuiFlexItem grow={false}>
               <EuiButton

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/index.test.tsx
@@ -66,7 +66,7 @@ describe('CustomFields', () => {
 
     renderComponent(mockAgentPolicy);
 
-    const unsupportedInputsWarning = renderResult.getByText('Unsupported Inputs');
+    const unsupportedInputsWarning = renderResult.getByText('Unsupported inputs');
     expect(unsupportedInputsWarning).toBeInTheDocument();
 
     const strongElements = renderResult.container.querySelector('strong');
@@ -87,7 +87,7 @@ describe('CustomFields', () => {
       ],
     });
     renderComponent(mockAgentPolicy);
-    expect(renderResult.queryByText('Unsupported Inputs')).not.toBeInTheDocument();
+    expect(renderResult.queryByText('Unsupported inputs')).not.toBeInTheDocument();
   });
 
   it('should render global data tags table with initial tags', () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/index.tsx
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { EuiDescribedFormGroup, EuiSpacer, EuiCallOut } from '@elastic/eui';
-
-import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
+import styled from 'styled-components';
+import { EuiDescribedFormGroup, EuiSpacer, EuiCallOut } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import type {
   NewAgentPolicy,
@@ -26,6 +25,13 @@ interface Props {
   updateAgentPolicy: (u: Partial<NewAgentPolicy | AgentPolicy>) => void;
   isDisabled?: boolean;
 }
+
+// Fix to align description to top during empty state w/ unsupported callout
+const DescribedFormGroup = styled(EuiDescribedFormGroup)`
+  .euiFlexGroup {
+    align-items: flex-start;
+  }
+`;
 
 export const CustomFields: React.FunctionComponent<Props> = ({
   agentPolicy,
@@ -58,7 +64,7 @@ export const CustomFields: React.FunctionComponent<Props> = ({
   const unsupportedInputs = findUnsupportedInputs(agentPolicy, GLOBAL_DATA_TAG_EXCLUDED_INPUTS);
 
   return (
-    <EuiDescribedFormGroup
+    <DescribedFormGroup
       fullWidth
       title={
         <h3>
@@ -81,7 +87,7 @@ export const CustomFields: React.FunctionComponent<Props> = ({
                 title={
                   <FormattedMessage
                     id="xpack.fleet.agentPolicyForm.globalDataTagUnsupportedInputTitle"
-                    defaultMessage="Unsupported Inputs"
+                    defaultMessage="Unsupported inputs"
                   />
                 }
                 color="warning"
@@ -109,6 +115,6 @@ export const CustomFields: React.FunctionComponent<Props> = ({
         updateAgentPolicy={updateAgentPolicy}
         globalDataTags={agentPolicy.global_data_tags ? agentPolicy.global_data_tags : []}
       />
-    </EuiDescribedFormGroup>
+    </DescribedFormGroup>
   );
 };


### PR DESCRIPTION
## Summary

Resolves #186785

This PR:
- Fixes unsupported input callout in data tagging UI not showing for Cloud Defend
- Simplifies the constants list for unsupported inputs
- Tweaks copy and UI for empty state to match closer to [designs](https://github.com/elastic/kibana/issues/179915#issuecomment-2034365557)

<img width="1406" alt="image" src="https://github.com/elastic/kibana/assets/1965714/d34ca840-901f-4770-b7c2-1cae7fcb0e53">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios