### PR TITLE
[7.17] Update failing snapshot for kbn dev cli

### DIFF
--- a/packages/kbn-cli-dev-mode/src/dev_server.test.ts
+++ b/packages/kbn-cli-dev-mode/src/dev_server.test.ts
@@ -135,7 +135,6 @@ describe('#run$', () => {
             "env": Object {
               "<inheritted process.env>": true,
               "ELASTIC_APM_SERVICE_NAME": "kibana",
-              "FORCE_COLOR": "true",
               "isDevCliChild": "true",
             },
             "nodeOptions": Array [


### PR DESCRIPTION
## Summary

This snapshot is failing across 7.17 branches, [example](https://buildkite.com/elastic/kibana-pull-request/builds/219517#01907a5d-ef74-4848-86f8-6a2786af9e9b). It was recently changed in #184210

Related #117173