### PR TITLE
[Fleet] fix telemetry errors

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/agent_policies.ts
+++ b/x-pack/plugins/fleet/server/collectors/agent_policies.ts
@@ -49,9 +49,11 @@ export const getAgentPoliciesUsage = async (
   });
 
   const uniqueOutputTypes = new Set(
-    Array.from(uniqueOutputIds).map((outputId) => {
-      return outputsById[outputId]?.attributes.type;
-    })
+    Array.from(uniqueOutputIds)
+      .map((outputId) => {
+        return outputsById[outputId]?.attributes.type;
+      })
+      .filter((outputType) => outputType)
   );
 
   const [policiesWithGlobalDataTag, totalNumberOfGlobalDataTagFields] = agentPolicies.reduce(

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usage_sender.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usage_sender.ts
@@ -24,7 +24,7 @@ const FLEET_AGENTS_EVENT_TYPE = 'fleet_agents';
 
 export class FleetUsageSender {
   private taskManager?: TaskManagerStartContract;
-  private taskVersion = '1.1.6';
+  private taskVersion = '1.1.7';
   private taskType = 'Fleet-Usage-Sender';
   private wasStarted: boolean = false;
   private interval = '1h';

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -357,6 +357,7 @@ export const fleetUsagesSchema: RootSchema<any> = {
         _meta: {
           description:
             'Average number of global data tags defined per agent policy (accross policies using global data tags)',
+          optional: true,
         },
       },
     },


### PR DESCRIPTION
## Summary

Small fix to address telemetry related errors.

Closes https://github.com/elastic/kibana/issues/186983

Make `avg_number_global_data_tags_per_policy` optional as it can be undefined.

Filter out nulls or undefined values in `output_types`.