### PR TITLE
[Fleet] Allow preconfigured agent policy only with name and id

### DIFF
--- a/x-pack/plugins/fleet/server/types/models/preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/types/models/preconfiguration.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { PreconfiguredOutputsSchema } from './preconfiguration';
+import { PreconfiguredOutputsSchema, PreconfiguredAgentPoliciesSchema } from './preconfiguration';
 
 describe('Test preconfiguration schema', () => {
   describe('PreconfiguredOutputsSchema', () => {
@@ -142,6 +142,19 @@ describe('Test preconfiguration schema', () => {
             secrets: {
               service_token: 'myservicetoken',
             },
+          },
+        ]);
+      }).not.toThrowError();
+    });
+  });
+
+  describe('PreconfiguredAgentPoliciesSchema', () => {
+    it('should allow basic agent policy only with id and name', () => {
+      expect(() => {
+        PreconfiguredAgentPoliciesSchema.validate([
+          {
+            id: 'agent-default-policy',
+            name: 'test agent policy',
           },
         ]);
       }).not.toThrowError();

--- a/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
@@ -142,51 +142,53 @@ export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
     has_fleet_server: schema.maybe(schema.boolean()),
     data_output_id: schema.maybe(schema.string()),
     monitoring_output_id: schema.maybe(schema.string()),
-    package_policies: schema.arrayOf(
-      schema.oneOf([
-        schema.object({
-          id: schema.maybe(schema.oneOf([schema.string(), schema.number()])),
-          name: schema.string(),
-          package: schema.object({
-            name: schema.string({
-              validate: (value) => {
-                if (value === 'synthetics') {
-                  return i18n.translate('xpack.fleet.config.disableSynthetics', {
-                    defaultMessage:
-                      'Synthetics package is not supported via kibana.yml config. Please use Synthetics App to create monitors in private locations. https://www.elastic.co/guide/en/observability/current/synthetics-private-location.html',
-                  });
-                }
-              },
+    package_policies: schema.maybe(
+      schema.arrayOf(
+        schema.oneOf([
+          schema.object({
+            id: schema.maybe(schema.oneOf([schema.string(), schema.number()])),
+            name: schema.string(),
+            package: schema.object({
+              name: schema.string({
+                validate: (value) => {
+                  if (value === 'synthetics') {
+                    return i18n.translate('xpack.fleet.config.disableSynthetics', {
+                      defaultMessage:
+                        'Synthetics package is not supported via kibana.yml config. Please use Synthetics App to create monitors in private locations. https://www.elastic.co/guide/en/observability/current/synthetics-private-location.html',
+                    });
+                  }
+                },
+              }),
             }),
+            description: schema.maybe(schema.string()),
+            namespace: schema.maybe(PackagePolicyNamespaceSchema),
+            inputs: schema.maybe(
+              schema.arrayOf(
+                schema.object({
+                  type: schema.string(),
+                  enabled: schema.maybe(schema.boolean()),
+                  keep_enabled: schema.maybe(schema.boolean()),
+                  vars: varsSchema,
+                  streams: schema.maybe(
+                    schema.arrayOf(
+                      schema.object({
+                        data_stream: schema.object({
+                          type: schema.maybe(schema.string()),
+                          dataset: schema.string(),
+                        }),
+                        enabled: schema.maybe(schema.boolean()),
+                        keep_enabled: schema.maybe(schema.boolean()),
+                        vars: varsSchema,
+                      })
+                    )
+                  ),
+                })
+              )
+            ),
           }),
-          description: schema.maybe(schema.string()),
-          namespace: schema.maybe(PackagePolicyNamespaceSchema),
-          inputs: schema.maybe(
-            schema.arrayOf(
-              schema.object({
-                type: schema.string(),
-                enabled: schema.maybe(schema.boolean()),
-                keep_enabled: schema.maybe(schema.boolean()),
-                vars: varsSchema,
-                streams: schema.maybe(
-                  schema.arrayOf(
-                    schema.object({
-                      data_stream: schema.object({
-                        type: schema.maybe(schema.string()),
-                        dataset: schema.string(),
-                      }),
-                      enabled: schema.maybe(schema.boolean()),
-                      keep_enabled: schema.maybe(schema.boolean()),
-                      vars: varsSchema,
-                    })
-                  )
-                ),
-              })
-            )
-          ),
-        }),
-        SimplifiedPackagePolicyPreconfiguredSchema,
-      ])
+          SimplifiedPackagePolicyPreconfiguredSchema,
+        ])
+      )
     ),
   }),
   {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/182213

## Summary
Allow creating a preconfigured agent policy only with `name` and `id`. Previously this way Fleet wouldn't start.
Note that this was already defined this way in the docs, but the schema wasn't respecting it.

### Testing

- Create a preconfigured fleet policy with just the id and name:
```
xpack.fleet.agentPolicies:
  - name: agent-policy
    id: agent-default-policy
```
- Verify that Fleet starts correctly


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
