### PR TITLE
[ResponseOps][Cases]Add the `no template selected` option

### DIFF
--- a/x-pack/plugins/cases/public/components/create/form_fields.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_fields.tsx
@@ -45,6 +45,8 @@ const transformTemplateCaseFieldsToCaseFormFields = (
   return getInitialCaseValue({ owner, ...caseFields });
 };
 
+const DEFAULT_EMPTY_TEMPLATE_KEY = 'defaultEmptyTemplateKey';
+
 export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.memo(
   ({ configuration, connectors, isLoading, withSteps, draftStorageKey }) => {
     const { reset, updateFieldValues, isSubmitting, setFieldValue } = useFormContext();
@@ -60,6 +62,18 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
     useEffect(() => {
       setFieldValue('connectorId', configuration.connector.id);
     }, [configuration.connector.id, setFieldValue]);
+
+    const defaultTemplate = useMemo(
+      () => ({
+        key: DEFAULT_EMPTY_TEMPLATE_KEY,
+        name: i18n.DEFAULT_EMPTY_TEMPLATE_NAME,
+        caseFields: getInitialCaseValue({
+          owner: configurationOwner,
+          connector: configuration.connector,
+        }),
+      }),
+      [configurationOwner, configuration.connector]
+    );
 
     const onTemplateChange = useCallback(
       (caseFields: CasesConfigurationUITemplate['caseFields']) => {
@@ -83,12 +97,12 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
         children: (
           <TemplateSelector
             isLoading={isSubmitting || isLoading}
-            templates={configuration.templates}
+            templates={[defaultTemplate, ...configuration.templates]}
             onTemplateChange={onTemplateChange}
           />
         ),
       }),
-      [configuration.templates, isLoading, isSubmitting, onTemplateChange]
+      [configuration.templates, defaultTemplate, isLoading, isSubmitting, onTemplateChange]
     );
 
     const secondStep = useMemo(

--- a/x-pack/plugins/cases/public/components/create/templates.tsx
+++ b/x-pack/plugins/cases/public/components/create/templates.tsx
@@ -57,7 +57,6 @@ export const TemplateSelectorComponent: React.FC<Props> = ({
         isLoading={isLoading}
         data-test-subj="create-case-template-select"
         fullWidth
-        hasNoInitialSelection
         value={selectedTemplate}
       />
     </EuiFormRow>

--- a/x-pack/plugins/cases/public/components/create/translations.ts
+++ b/x-pack/plugins/cases/public/components/create/translations.ts
@@ -61,3 +61,10 @@ export const TEMPLATE_HELP_TEXT = i18n.translate('xpack.cases.create.templateHel
 export const SOLUTION_SELECTOR_LABEL = i18n.translate('xpack.cases.create.solutionSelectorLabel', {
   defaultMessage: 'Create case under:',
 });
+
+export const DEFAULT_EMPTY_TEMPLATE_NAME = i18n.translate(
+  'xpack.cases.create.defaultEmptyTemplateName',
+  {
+    defaultMessage: 'No template selected',
+  }
+);


### PR DESCRIPTION
## Summary

This PR adds a "No template selected" option in the Template Selection component in the Case Creation Page