### PR TITLE
[OAS] Example of Zod usage for API validation

### DIFF
--- a/packages/kbn-server-route-repository/src/typings.ts
+++ b/packages/kbn-server-route-repository/src/typings.ts
@@ -56,6 +56,7 @@ export type ServerRoute<
   ? {
       endpoint: TEndpoint;
       params?: TRouteParamsRT;
+      validation?: any;
       handler: ({}: TRouteHandlerResources &
         (TRouteParamsRT extends RouteParamsRT
           ? DecodedRequestParamsOfType<TRouteParamsRT>

--- a/x-pack/packages/kbn-slo-schema/src/rest_specs/routes/delete.ts
+++ b/x-pack/packages/kbn-slo-schema/src/rest_specs/routes/delete.ts
@@ -4,7 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import * as t from 'io-ts';
+import { z } from '@kbn/zod';
 import { sloIdSchema } from '../../schema/slo';
 
 const deleteSLOParamsSchema = t.type({
@@ -13,4 +15,12 @@ const deleteSLOParamsSchema = t.type({
   }),
 });
 
-export { deleteSLOParamsSchema };
+const deleteSLOParamsSchemaZod = {
+  params: z.object({
+    id: z.string({
+      description: 'An identifier for the slo.',
+    }),
+  }),
+};
+
+export { deleteSLOParamsSchema, deleteSLOParamsSchemaZod };

--- a/x-pack/plugins/observability_solution/slo/server/routes/register_routes.ts
+++ b/x-pack/plugins/observability_solution/slo/server/routes/register_routes.ts
@@ -53,13 +53,13 @@ export function registerRoutes({ config, repository, core, logger, dependencies 
   const router = core.http.createRouter();
 
   routes.forEach((route) => {
-    const { endpoint, options, handler, params } = route;
+    const { endpoint, options, handler, params, validation } = route;
     const { pathname, method } = parseEndpoint(endpoint);
 
     (router[method] as RouteRegistrar<typeof method, SloRequestHandlerContext>)(
       {
         path: pathname,
-        validate: routeValidationObject,
+        validate: validation ?? routeValidationObject,
         options,
       },
       async (context, request, response) => {

--- a/x-pack/plugins/observability_solution/slo/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability_solution/slo/server/routes/slo/route.ts
@@ -11,6 +11,7 @@ import {
   createSLOParamsSchema,
   deleteSLOInstancesParamsSchema,
   deleteSLOParamsSchema,
+  deleteSLOParamsSchemaZod,
   fetchHistoricalSummaryParamsSchema,
   fetchHistoricalSummaryResponseSchema,
   fetchSLOHealthParamsSchema,
@@ -29,6 +30,7 @@ import {
   updateSLOParamsSchema,
 } from '@kbn/slo-schema';
 import { getOverviewParamsSchema } from '@kbn/slo-schema/src/rest_specs/routes/get_overview';
+import { z } from '@kbn/zod';
 import { GetSLOsOverview } from '../../services/get_slos_overview';
 import type { IndicatorTypes } from '../../domain/models';
 import {
@@ -238,8 +240,59 @@ const deleteSLORoute = createSloServerRoute({
   options: {
     tags: ['access:slo_write'],
     access: 'public',
+    summary: 'Delete an SLO',
+    description:
+      'You must have the `write` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.\n',
   },
   params: deleteSLOParamsSchema,
+  validation: {
+    request: deleteSLOParamsSchemaZod,
+    response: {
+      204: {
+        // description: 'Successful request',
+        body: () => {},
+      },
+      400: {
+        // description: 'Bad request',
+        body: () =>
+          z.object({
+            statusCode: z.number(),
+            error: z.string(),
+            message: z.string(),
+          }),
+      },
+      // 401: {
+      //   description: 'Unauthorized response',
+      //   content: {
+      //     'application/json': {
+      //       schema: {
+      //         $ref: '#/components/schemas/401_response',
+      //       },
+      //     },
+      //   },
+      // },
+      // 403: {
+      //   description: 'Unauthorized response',
+      //   content: {
+      //     'application/json': {
+      //       schema: {
+      //         $ref: '#/components/schemas/403_response',
+      //       },
+      //     },
+      //   },
+      // },
+      // 404: {
+      //   description: 'Not found response',
+      //   content: {
+      //     'application/json': {
+      //       schema: {
+      //         $ref: '#/components/schemas/404_response',
+      //       },
+      //     },
+      //   },
+      // },
+    },
+  },
   handler: async ({ request, context, params, logger, dependencies }) => {
     await assertPlatinumLicense(context);
 

--- a/x-pack/plugins/observability_solution/slo/server/routes/types.ts
+++ b/x-pack/plugins/observability_solution/slo/server/routes/types.ts
@@ -22,10 +22,13 @@ export interface SloRouteHandlerResources {
   config: SloConfig;
 }
 
+// TODO Extend RouteConfigOptions or VersionedRouteConfig here
 export interface SloRouteCreateOptions {
   options: {
     tags: string[];
     access?: 'public' | 'internal';
+    summary?: string;
+    description?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

This is an example of how we can use Zod. This PR uses Zod in SLO delete API. (Related to [[OAS] zod support](https://github.com/elastic/kibana/pull/186190))

Here is how you can check the generated OAS for your API:

1. Start ES
2. Add `server.oas.enabled: true` to kibana.dev.yml
3. Start Kibana yarn start --no-base-path
4. Use one of these options to get the generated OAS for your new API
    - Using pluginId: http://localhost:5601/api/oas?pluginId=@kbn/slo-plugin
    - Using pathStartsWith: http://localhost:5601/api/oas?pathStartsWith=/api/observability/slos