### PR TITLE
[ML] Transform: Fixes transform stats API call in the transform health alerting rule 

### DIFF
--- a/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.test.ts
+++ b/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.test.ts
@@ -117,6 +117,7 @@ describe('transformHealthServiceProvider', () => {
     expect(esClient.transform.getTransformStats).toHaveBeenCalledTimes(1);
     expect(esClient.transform.getTransformStats).toHaveBeenNthCalledWith(1, {
       basic: true,
+      transform_id: '_all',
     });
 
     const notStarted = result[0];

--- a/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.ts
+++ b/x-pack/plugins/transform/server/lib/alerting/transform_health_rule_type/transform_health_service.ts
@@ -122,6 +122,7 @@ export function transformHealthServiceProvider({
             await esClient.transform.getTransformStats({
               // @ts-expect-error `basic` query option not yet in @elastic/elasticsearch
               basic: true,
+              transform_id: '_all',
             })
           ).transforms as TransformStats[]
         ).filter((t) => transformIds.has(t.id));


### PR DESCRIPTION
## Summary

In rare cases when the list of continuous transform exceeds the allowed URL length, we fetch stats for all transforms. 

The elasticsearch client has `transform-id` param as optional, but we actually have to pass `_all` or `*`. This PR sets the `transform_id` param explicitly in this case. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->