### PR TITLE
[8.15] fix(NA): eslint error at packages/kbn-test/src/mocha/junit_report_generation.js

### DIFF
--- a/packages/kbn-test/src/mocha/junit_report_generation.js
+++ b/packages/kbn-test/src/mocha/junit_report_generation.js
@@ -94,7 +94,12 @@ export function setupJUnitReportGeneration(runner, options = {}) {
       .map((node) => ({ skipped: true, node }));
 
     // cache codeowners for quicker lookup
-    const reversedCodeowners = getPathsWithOwnersReversed();
+    let reversedCodeowners = [];
+    try {
+      reversedCodeowners = getPathsWithOwnersReversed();
+    } catch {
+      /* no-op */
+    }
 
     const commandLine = prettifyCommandLine(process.argv);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - fix(NA): eslint error at packages/kbn-test/src/mocha/junit_report_generation.js (d3d3cb4d)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2024-07-04T19:34:32Z","message":"fix(NA): eslint error at packages/kbn-test/src/mocha/junit_report_generation.js","sha":"d3d3cb4d43daf9f596d841fd957310c0df335157"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->