### PR TITLE
[8.15] fix(NA): unhandled exception for junit report generation when no codeowners (#187597)

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -54,7 +54,7 @@ it('builds a generated plugin into a viable archive', async () => {
   };
 
   expect(filterLogs(generateProc.all)).toMatchInlineSnapshot(`
-    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider
+    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/8.15/production.html#openssl-legacy-provider
      succ 🎉
 
           Your plugin has been created in plugins/foo_test_plugin
@@ -74,7 +74,7 @@ it('builds a generated plugin into a viable archive', async () => {
   );
 
   expect(filterLogs(buildProc.all)).toMatchInlineSnapshot(`
-    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider
+    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/8.15/production.html#openssl-legacy-provider
      info deleting the build and target directories
      info run bazel and build required artifacts for the optimizer
      succ bazel run successfully and artifacts were created

--- a/packages/kbn-test/src/mocha/junit_report_generation.js
+++ b/packages/kbn-test/src/mocha/junit_report_generation.js
@@ -97,7 +97,9 @@ export function setupJUnitReportGeneration(runner, options = {}) {
     let reversedCodeowners = [];
     try {
       reversedCodeowners = getPathsWithOwnersReversed();
-    } catch {}
+    } catch {
+      /* no-op */
+    }
 
     const commandLine = prettifyCommandLine(process.argv);
 

--- a/packages/kbn-test/src/mocha/junit_report_generation.js
+++ b/packages/kbn-test/src/mocha/junit_report_generation.js
@@ -94,7 +94,10 @@ export function setupJUnitReportGeneration(runner, options = {}) {
       .map((node) => ({ skipped: true, node }));
 
     // cache codeowners for quicker lookup
-    const reversedCodeowners = getPathsWithOwnersReversed();
+    let reversedCodeowners = [];
+    try {
+      reversedCodeowners = getPathsWithOwnersReversed();
+    } catch {}
 
     const commandLine = prettifyCommandLine(process.argv);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [fix(NA): unhandled exception for junit report generation when no codeowners (#187597)](https://github.com/elastic/kibana/pull/187597)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2024-07-04T19:11:37Z","message":"fix(NA): unhandled exception for junit report generation when no codeowners (#187597)\n\nThis PR fixes what was brought on at\r\nhttps://github.com/elastic/kibana/pull/181711 .\r\n\r\nWhat was proposed won't work as we don't have codeowners files on\r\nbranches other than main.","sha":"228a6ffb0ff39bfdb5862071ee8cf559bb53e36a","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:prev-minor","v8.15.0","v8.16.0"],"number":187597,"url":"https://github.com/elastic/kibana/pull/187597","mergeCommit":{"message":"fix(NA): unhandled exception for junit report generation when no codeowners (#187597)\n\nThis PR fixes what was brought on at\r\nhttps://github.com/elastic/kibana/pull/181711 .\r\n\r\nWhat was proposed won't work as we don't have codeowners files on\r\nbranches other than main.","sha":"228a6ffb0ff39bfdb5862071ee8cf559bb53e36a"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/187597","number":187597,"mergeCommit":{"message":"fix(NA): unhandled exception for junit report generation when no codeowners (#187597)\n\nThis PR fixes what was brought on at\r\nhttps://github.com/elastic/kibana/pull/181711 .\r\n\r\nWhat was proposed won't work as we don't have codeowners files on\r\nbranches other than main.","sha":"228a6ffb0ff39bfdb5862071ee8cf559bb53e36a"}}]}] BACKPORT-->