### PR TITLE
Fix "Elastic did not load properly" message color when system in dark mode

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/bootstrap/__snapshots__/render_template.test.ts.snap
+++ b/packages/core/rendering/core-rendering-server-internal/src/bootstrap/__snapshots__/render_template.test.ts.snap
@@ -64,10 +64,12 @@ if (window.__kbnStrictCsp__ && window.__kbnCspNotEnforced__) {
       var errorTitleEl = document.createElement('h1');
       errorTitleEl.innerText = errorTitle;
       errorTitleEl.style.margin = '20px';
+      errorTitleEl.style.color = '#1a1c21';
 
       var errorTextEl = document.createElement('p');
       errorTextEl.innerText = errorText;
       errorTextEl.style.margin = '20px';
+      errorTextEl.style.color = '#343741';
 
       var errorReloadEl = document.createElement('button');
       errorReloadEl.innerText = errorReload;

--- a/packages/core/rendering/core-rendering-server-internal/src/bootstrap/render_template.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/bootstrap/render_template.ts
@@ -80,10 +80,12 @@ if (window.__kbnStrictCsp__ && window.__kbnCspNotEnforced__) {
       var errorTitleEl = document.createElement('h1');
       errorTitleEl.innerText = errorTitle;
       errorTitleEl.style.margin = '20px';
+      errorTitleEl.style.color = '#1a1c21';
 
       var errorTextEl = document.createElement('p');
       errorTextEl.innerText = errorText;
       errorTextEl.style.margin = '20px';
+      errorTextEl.style.color = '#343741';
 
       var errorReloadEl = document.createElement('button');
       errorReloadEl.innerText = errorReload;


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/187570

The problem was that when the system/browser was in dark mode, the default text color became white, but the background was forced to a specific bright color, so the text became unreadable. A quick fix is to also force the text color (I used EUI text colors)


<img width="858" alt="Screenshot 2024-07-05 at 12 44 11" src="https://github.com/elastic/kibana/assets/7784120/9ccefc04-60f6-46e3-a649-4e47cad043ac">



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->