### PR TITLE
[ES|QL] Fixes the console error that appears in places where the editor exists

### DIFF
--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -4469,13 +4469,14 @@ The following boolean operators are supported:
             'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.castOperator.markdown',
             {
               defaultMessage: `### CAST (\`::\`)
-The \`::\` operator provides a convenient alternative syntax to the \`TO_<type>\` type conversion functions.
 
-Example:
+The \`::\` operator provides a convenient alternative syntax to the \`TO_<type>\` type conversion functions.
+Example: 
 \`\`\`
-ROW ver = CONCAT(("0"::INT + 1)::STRING, ".2.3")::VERSION
+ROW ver = CONCAT((“0”::INT + 1)::STRING, “.2.3")::VERSION
 \`\`\`
               `,
+              ignoreTag: true,
               description:
                 'Text is in markdown. Do not translate function names, special characters, or field names like sum(bytes)',
             }


### PR DESCRIPTION
The new i18n upgrade requires the `ignoreTag` in some places as also parses html tags and makes sure they are formatted correctly. This one is not an html tag so we safely add the ignoreTag flag.
