### PR TITLE
[Usage Counters] enhancements

### DIFF
--- a/packages/kbn-check-mappings-update-cli/current_fields.json
+++ b/packages/kbn-check-mappings-update-cli/current_fields.json
@@ -1030,6 +1030,7 @@
     "slug"
   ],
   "usage-counter": [
+    "count",
     "counterName",
     "counterType",
     "domainId",

--- a/packages/kbn-check-mappings-update-cli/current_mappings.json
+++ b/packages/kbn-check-mappings-update-cli/current_mappings.json
@@ -3410,6 +3410,9 @@
   "usage-counter": {
     "dynamic": false,
     "properties": {
+      "count": {
+        "type": "integer"
+      },
       "counterName": {
         "type": "keyword"
       },

--- a/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
@@ -168,7 +168,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "uptime-dynamic-settings": "b6756ff71d6b5258971b1c8fd433d167affbde52",
         "uptime-synthetics-api-key": "7ae976a461248f9dbd8442af14a179bdbc229eca",
         "url": "c923a4a5002a09c0080c9095e958f07d518e6704",
-        "usage-counter": "3a104db0c9867da2d0436e20604a11dc5d0bb59e",
+        "usage-counter": "1690e9b642393c467e560fd14dd317dea24a14ee",
         "usage-counters": "48782b3bcb6b5a23ba6f2bfe3a380d835e68890a",
         "visualization": "93a3e73994ad836fe2b1dccbe208238f41f63da0",
         "workplace_search_telemetry": "52b32b47ee576f554ac77cb1d5896dfbcfe9a1fb",

--- a/src/plugins/kibana_usage_collection/server/collectors/usage_counters/integration_tests/rollups.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/usage_counters/integration_tests/rollups.test.ts
@@ -137,6 +137,7 @@ describe('usage-counters', () => {
 
 async function createTestCounters(internalRepository: ISavedObjectsRepository) {
   await createCounters(internalRepository, OLD_ISO, [
+    // domainId, counterName, counterType, source, count, namespace?
     ['domain1', 'a', 'count', 'server', 28],
     ['domain1', 'b', 'count', 'server', 29, 'one'],
     ['domain1', 'b', 'count', 'server', 30, 'two'],
@@ -144,6 +145,7 @@ async function createTestCounters(internalRepository: ISavedObjectsRepository) {
   ]);
 
   await createCounters(internalRepository, RECENT_ISO, [
+    // domainId, counterName, counterType, source, count, namespace?
     ['domain1', 'a', 'count', 'server', 32],
     ['domain1', 'b', 'count', 'server', 33, 'one'],
     ['domain1', 'b', 'count', 'server', 34, 'two'],
@@ -191,7 +193,6 @@ function createCounter(
     type: USAGE_COUNTERS_SAVED_OBJECT_TYPE,
     id,
     ...(namespace && { namespaces: [namespace] }),
-    // updated_at: date // illustrative purpose only, overriden by SOR
     attributes: {
       domainId,
       counterName,

--- a/src/plugins/usage_collection/server/usage_counters/saved_objects.ts
+++ b/src/plugins/usage_collection/server/usage_counters/saved_objects.ts
@@ -54,6 +54,7 @@ export const registerUsageCountersSavedObjectTypes = (
         counterName: { type: 'keyword' },
         counterType: { type: 'keyword' },
         source: { type: 'keyword' },
+        count: { type: 'integer' },
       },
     },
   });


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/187064

* Improves the `rollups.test.ts` integration test.
* Adds the `count` field to the mappings, so that it can be aggregated.