### PR TITLE
[EEM][POC] Use runtime field to join identity field values

### DIFF
--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.ts
@@ -107,6 +107,8 @@ export function generateHistoryProcessors(definition: EntityDefinition) {
 
             // Assign the slo.instanceId
           ctx["entity"]["id"] = entityId.length() > 0 ? entityId.substring(0, entityId.length() - 1) : "unknown";
+        } else {
+          ctx["entity"]["id"] = ctx["bucket_key"];
         }
        `,
       },

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_history_transform.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_history_transform.ts
@@ -42,6 +42,15 @@ export function generateHistoryTransform(
           },
         },
       }),
+      runtime_mappings: {
+        bucket_key: {
+          type: 'keyword',
+          script: {
+            source:
+              "if(doc.containsKey('a')) { emit(doc['a'].value)} else if (doc.containsKey('b')) { emit(doc['b'].value) }",
+          },
+        },
+      },
     },
     dest: {
       index: `${ENTITY_HISTORY_BASE_PREFIX}.noop`,
@@ -60,15 +69,18 @@ export function generateHistoryTransform(
     },
     pivot: {
       group_by: {
-        ...definition.identityFields.reduce(
-          (acc, id) => ({
-            ...acc,
-            [`entity.identityFields.${id.field}`]: {
-              terms: { field: id.field, missing_bucket: id.optional },
-            },
-          }),
-          {}
-        ),
+        // ...definition.identityFields.reduce(
+        //   (acc, id) => ({
+        //     ...acc,
+        //     [`entity.identityFields.${id.field}`]: {
+        //       terms: { field: id.field, missing_bucket: id.optional },
+        //     },
+        //   }),
+        //   {}
+        // ),
+        bucket_key: {
+          terms: { field: 'bucket_key' },
+        },
         ['@timestamp']: {
           date_histogram: {
             field: definition.history.timestampField,

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
@@ -25,6 +25,15 @@ export function generateLatestTransform(
     defer_validation: true,
     source: {
       index: `${generateHistoryIndexName(definition)}.*`,
+      // runtime_mappings: {
+      //   bucket_key: {
+      //     type: 'keyword',
+      //     script: {
+      //       source:
+      //         "if(doc.containsKey('a')) { emit(doc['a'].value)} else if (doc.containsKey('b')) { emit(doc['b'].value) }",
+      //     },
+      //   },
+      // },
     },
     dest: {
       index: generateLatestIndexName(definition),
@@ -49,15 +58,18 @@ export function generateLatestTransform(
         ['entity.displayName']: {
           terms: { field: 'entity.displayName.keyword' },
         },
-        ...definition.identityFields.reduce(
-          (acc, id) => ({
-            ...acc,
-            [`entity.identityFields.${id.field}`]: {
-              terms: { field: `entity.identityFields.${id.field}`, missing_bucket: id.optional },
-            },
-          }),
-          {}
-        ),
+        // bucket_key: {
+        //   terms: { field: 'bucket_key' },
+        // },
+        // ...definition.identityFields.reduce(
+        //   (acc, id) => ({
+        //     ...acc,
+        //     [`entity.identityFields.${id.field}`]: {
+        //       terms: { field: `entity.identityFields.${id.field}`, missing_bucket: id.optional },
+        //     },
+        //   }),
+        //   {}
+        // ),
       },
       aggs: {
         ...generateLatestMetricAggregations(definition),


### PR DESCRIPTION
This little PoC shows how we could pass a runtime field to the transform to join the **value** found in the `identifyFields`, making it so that we can use this runtime field in the `group_by` to join entities at ingest time.

### How to test
Source data:
```
PUT index_a
{
  "mappings": {
    "properties": {
      "a": {
        "type": "keyword"
      },
      "@timestamp": {
        "type": "date"
      }
    }
  }
}

PUT index_b
{
  "mappings": {
    "properties": {
      "b": {
        "type": "keyword"
      },
      "@timestamp": {
        "type": "date"
      }
    }
  }
}

POST index_a/_doc
{
  "a": "same",
  "@timestamp": "2024-07-05T12:33:06.162Z"
}

POST index_b/_doc
{
  "b": "same",
  "@timestamp": "2024-07-05T12:33:06.162Z"
}
```

Entity definition:
```
POST kbn:/internal/api/entities/definition
{
  "id": "bucket_key",
  "name": "Bucket key",
  "type": "service",
  "indexPatterns": [
    "index_*"
  ],
  "timestampField": "@timestamp",
  "lookback": "5m",
  "identityFields": [
    {
      "field": "a",
      "optional": true
    },
    {
      "field": "b",
      "optional": true
    }
  ],
  "displayNameTemplate": "{{a}}{{b}}",
  "history": {
    "timestampField": "@timestamp",
    "interval": "5m"
  }
}
```