### PR TITLE
[8.14] [Security Solution][Alert table] Fix alert table refresh with bulk action (#183674)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_bulk_actions.tsx
@@ -10,7 +10,7 @@ import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/type
 import type { SerializableRecord } from '@kbn/utility-types';
 import { isEqual } from 'lodash';
 import type { Filter } from '@kbn/es-query';
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import type { TableId } from '@kbn/securitysolution-data-table';
 import { useBulkAlertAssigneesItems } from '../../../common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items';
 import { useBulkAlertTagsItems } from '../../../common/components/toolbar/bulk_actions/use_bulk_alert_tags_items';
@@ -18,6 +18,9 @@ import { SourcererScopeName } from '../../../common/store/sourcerer/model';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useAddBulkToTimelineAction } from '../../components/alerts_table/timeline_actions/use_add_bulk_to_timeline';
 import { useBulkAlertActionItems } from './use_alert_actions';
+import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
+import type { inputsModel } from '../../../common/store';
+import { inputsSelectors } from '../../../common/store';
 
 // check to see if the query is a known "empty" shape
 export function isKnownEmptyQuery(query: QueryDslQueryContainer) {
@@ -82,6 +85,14 @@ export const getBulkActionHook =
       };
     }, [filters, from, to]);
 
+    const getGlobalQueriesSelector = useMemo(() => inputsSelectors.globalQuery(), []);
+    const globalQueries = useDeepEqualSelector(getGlobalQueriesSelector);
+
+    const refetch = useCallback(() => {
+      refresh();
+      globalQueries.forEach((q) => q.refetch && (q.refetch as inputsModel.Refetch)());
+    }, [globalQueries, refresh]);
+
     const alertActionParams = useMemo(() => {
       return {
         scopeId: SourcererScopeName.detections,
@@ -89,9 +100,9 @@ export const getBulkActionHook =
         from,
         to,
         tableId,
-        refetch: refresh,
+        refetch,
       };
-    }, [from, to, filters, refresh]);
+    }, [from, to, filters, refetch]);
 
     const bulkAlertTagParams = useMemo(() => {
       return {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Security Solution][Alert table] Fix alert table refresh with bulk action (#183674)](https://github.com/elastic/kibana/pull/183674)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-05-29T18:43:24Z","message":"[Security Solution][Alert table] Fix alert table refresh with bulk action (#183674)\n\n## Summary\r\n\r\nCurrently components outside of alert table do not refresh after\r\nchanging status with bulk action. This PR adds global query refresh in\r\nbulk actions\r\n\r\n- https://github.com/elastic/kibana/issues/183025\r\n\r\nNo grouping\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/18648970/0490187d-9f3e-49d0-80b3-4cd75e8fdbf8\r\n\r\n\r\n\r\nGrouping\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/18648970/80e55fda-2f89-4c8d-a882-2df413cb3560","sha":"993903bb6177666b1dfd4b8ebf7fa4fa0ad4aed5","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","backport:prev-minor","v8.15.0","v8.14.3"],"number":183674,"url":"https://github.com/elastic/kibana/pull/183674","mergeCommit":{"message":"[Security Solution][Alert table] Fix alert table refresh with bulk action (#183674)\n\n## Summary\r\n\r\nCurrently components outside of alert table do not refresh after\r\nchanging status with bulk action. This PR adds global query refresh in\r\nbulk actions\r\n\r\n- https://github.com/elastic/kibana/issues/183025\r\n\r\nNo grouping\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/18648970/0490187d-9f3e-49d0-80b3-4cd75e8fdbf8\r\n\r\n\r\n\r\nGrouping\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/18648970/80e55fda-2f89-4c8d-a882-2df413cb3560","sha":"993903bb6177666b1dfd4b8ebf7fa4fa0ad4aed5"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183674","number":183674,"mergeCommit":{"message":"[Security Solution][Alert table] Fix alert table refresh with bulk action (#183674)\n\n## Summary\r\n\r\nCurrently components outside of alert table do not refresh after\r\nchanging status with bulk action. This PR adds global query refresh in\r\nbulk actions\r\n\r\n- https://github.com/elastic/kibana/issues/183025\r\n\r\nNo grouping\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/18648970/0490187d-9f3e-49d0-80b3-4cd75e8fdbf8\r\n\r\n\r\n\r\nGrouping\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/18648970/80e55fda-2f89-4c8d-a882-2df413cb3560","sha":"993903bb6177666b1dfd4b8ebf7fa4fa0ad4aed5"}},{"branch":"8.14","label":"v8.14.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->