### PR TITLE
Fix issue with no values been displayed in new agg based visualization filterbox

### DIFF
--- a/src/plugins/visualizations/public/actions/add_agg_vis_action.test.ts
+++ b/src/plugins/visualizations/public/actions/add_agg_vis_action.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  AddAggVisualizationPanelAction,
+  ADD_AGG_VIS_ACTION_ID,
+  type AddAggVisualizationPanelActionApi,
+} from './add_agg_vis_action';
+import type { BaseVisType } from '../vis_types/base_vis_type';
+import { VisGroups } from '../vis_types/vis_groups_enum';
+import { TypesService, type TypesStart } from '../vis_types/types_service';
+
+const mockCompatibleEmbeddableAPI: AddAggVisualizationPanelActionApi = {
+  type: ADD_AGG_VIS_ACTION_ID,
+  addNewPanel: jest.fn(),
+  getAppContext: jest.fn(),
+};
+
+describe('AddAggVisualizationPanelAction', () => {
+  let typeServiceStart: TypesStart;
+
+  beforeEach(() => {
+    const typeService = new TypesService();
+
+    typeServiceStart = typeService.start();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('invoking the compatibility function returns false when initialized with types that are not grouped as agg visualizations', async () => {
+    jest.spyOn(typeServiceStart, 'all').mockReturnValue([]);
+
+    const addAggVisualizationPanelAction = new AddAggVisualizationPanelAction(typeServiceStart);
+
+    expect(
+      await addAggVisualizationPanelAction.isCompatible({ embeddable: mockCompatibleEmbeddableAPI })
+    ).toBe(false);
+  });
+
+  test('invoking the compatibility function returns true when the registered agg visualizations type does not have creation disabled', async () => {
+    jest.spyOn(typeServiceStart, 'all').mockReturnValue([
+      {
+        group: VisGroups.AGGBASED,
+        disableCreate: false,
+        name: 'test visualization',
+      } as BaseVisType,
+    ]);
+
+    const addAggVisualizationPanelAction = new AddAggVisualizationPanelAction(typeServiceStart);
+
+    expect(
+      await addAggVisualizationPanelAction.isCompatible({ embeddable: mockCompatibleEmbeddableAPI })
+    ).toBe(true);
+  });
+});

--- a/src/plugins/visualizations/public/actions/add_agg_vis_action.ts
+++ b/src/plugins/visualizations/public/actions/add_agg_vis_action.ts
@@ -18,12 +18,12 @@ import { Action, IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
 import { apiHasType } from '@kbn/presentation-publishing';
 import { apiCanAddNewPanel, CanAddNewPanel } from '@kbn/presentation-containers';
 import { VisGroups } from '../vis_types/vis_groups_enum';
-import { TypesService } from '../vis_types/types_service';
+import type { TypesStart } from '../vis_types/types_service';
 import { showNewVisModal } from '../wizard/show_new_vis';
 
-const ADD_AGG_VIS_ACTION_ID = 'ADD_AGG_VIS';
+export const ADD_AGG_VIS_ACTION_ID = 'ADD_AGG_VIS';
 
-type AddAggVisualizationPanelActionApi = HasType & CanAddNewPanel & HasAppContext;
+export type AddAggVisualizationPanelActionApi = HasType & CanAddNewPanel & HasAppContext;
 
 const isApiCompatible = (api: unknown | null): api is AddAggVisualizationPanelActionApi => {
   return apiHasType(api) && apiCanAddNewPanel(api) && apiHasAppContext(api);
@@ -37,7 +37,7 @@ export class AddAggVisualizationPanelAction implements Action<EmbeddableApiConte
 
   public readonly order = 20;
 
-  constructor(visTypes: ReturnType<TypesService['start']>) {
+  constructor(visTypes: TypesStart) {
     this.aggVisualizationCreationEnabled =
       visTypes.all().filter((type) => {
         return !type.disableCreate && type.group === VisGroups.AGGBASED;

--- a/src/plugins/visualizations/public/actions/add_agg_vis_action.ts
+++ b/src/plugins/visualizations/public/actions/add_agg_vis_action.ts
@@ -38,10 +38,9 @@ export class AddAggVisualizationPanelAction implements Action<EmbeddableApiConte
   public readonly order = 20;
 
   constructor(visTypes: TypesStart) {
-    this.aggVisualizationCreationEnabled =
-      visTypes.all().filter((type) => {
-        return !type.disableCreate && type.group === VisGroups.AGGBASED;
-      }).length > 0;
+    this.aggVisualizationCreationEnabled = visTypes.all().some((type) => {
+      return !type.disableCreate && type.group === VisGroups.AGGBASED;
+    });
   }
 
   public getIconType() {

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -400,8 +400,6 @@ export class VisualizationsPlugin
     uiActions.registerTrigger(dashboardVisualizationPanelTrigger);
     const editInLensAction = new EditInLensAction(data.query.timefilter.timefilter);
     uiActions.addTriggerAction(CONTEXT_MENU_TRIGGER, editInLensAction);
-    const addAggVisAction = new AddAggVisualizationPanelAction();
-    uiActions.addTriggerAction(ADD_PANEL_TRIGGER, addAggVisAction);
     const embeddableFactory = new VisualizeEmbeddableFactory({ start });
     embeddable.registerEmbeddableFactory(VISUALIZE_EMBEDDABLE_TYPE, embeddableFactory);
 
@@ -498,6 +496,9 @@ export class VisualizationsPlugin
     if (savedObjectsTaggingOss) {
       setSavedObjectTagging(savedObjectsTaggingOss);
     }
+
+    const addAggVisAction = new AddAggVisualizationPanelAction(types);
+    uiActions.addTriggerAction(ADD_PANEL_TRIGGER, addAggVisAction);
 
     return {
       ...types,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/187710

The issue results for configuration that makes such that in certain cases agg based visualisations aren't enabled for creation relates to  https://github.com/elastic/kibana/pull/157920  see https://github.com/elastic/kibana/pull/157920/files#diff-062b952861b34b71d7bb79ee2409352ccc6c82ab99a47233ed8b9686aab95c38R78-R79 for more details, as such this PR introduces consideration for the possibility of this so that in the case where there isn't any agg based visualization that can be created, the option to create one is not provided.


How to test;
- Navigating to dashboards in stateful kibana, one should be presented with the aggregation based visualization option when the add panel button is clicked.
- Navigating to dashboards in serverless kibana, if the aggregation based visualization option is available there  **must** an option presented when the selection is rendered.

<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->