### PR TITLE
[eem] fix metadata fields painless script

### DIFF
--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/built_in/services.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/built_in/services.ts
@@ -24,6 +24,7 @@ export const builtInServicesEntityDefinition: EntityDefinition = entityDefinitio
   identityFields: ['service.name', { field: 'service.environment', optional: true }],
   displayNameTemplate: '{{service.name}}{{#service.environment}}:{{.}}{{/service.environment}}',
   metadata: [
+    { source: '_index', destination: 'sourceIndex' },
     'data_stream.type',
     'service.instance.id',
     'service.namespace',

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/helpers/fixtures/entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/helpers/fixtures/entity_definition.ts
@@ -17,7 +17,7 @@ export const entityDefinition = entityDefinitionSchema.parse({
   },
   identityFields: ['log.logger', { field: 'event.category', optional: true }],
   displayNameTemplate: '{{log.logger}}{{#event.category}}:{{.}}{{/event.category}}',
-  metadata: ['tags', 'host.name', 'host.os.name'],
+  metadata: ['tags', 'host.name', 'host.os.name', { source: '_index', destination: 'sourceIndex' }],
   metrics: [
     {
       name: 'logRate',

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_history_processors.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_history_processors.test.ts.snap
@@ -91,6 +91,9 @@ if (ctx.entity?.metadata?.host?.os?.name != null) {
  if(ctx.host.os == null)  ctx[\\"host\\"][\\"os\\"] = new HashMap();
   ctx[\\"host\\"][\\"os\\"][\\"name\\"] = ctx.entity.metadata.host.os.name.keySet();
 }
+if (ctx.entity?.metadata?.sourceIndex != null) {
+  ctx[\\"sourceIndex\\"] = ctx.entity.metadata.sourceIndex.keySet();
+}
 ",
     },
   },

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
@@ -34,6 +34,9 @@ if (ctx.entity?.metadata?.host?.os?.name.data != null) {
  if(ctx.host.os == null)  ctx[\\"host\\"][\\"os\\"] = new HashMap();
   ctx[\\"host\\"][\\"os\\"][\\"name\\"] = ctx.entity.metadata.host.os.name.data.keySet();
 }
+if (ctx.entity?.metadata?.sourceIndex.data != null) {
+  ctx[\\"sourceIndex\\"] = ctx.entity.metadata.sourceIndex.data.keySet();
+}
 ",
     },
   },

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.ts
@@ -14,13 +14,13 @@ function createIdTemplate(definition: EntityDefinition) {
   }, definition.displayNameTemplate);
 }
 
-function mapDestinationToPainless(destination: string, source: string) {
+function mapDestinationToPainless(destination: string) {
   const fieldParts = destination.split('.');
   return fieldParts.reduce((acc, _part, currentIndex, parts) => {
     if (currentIndex + 1 === parts.length) {
       return `${acc}\n  ctx${parts
         .map((s) => `["${s}"]`)
-        .join('')} = ctx.entity.metadata.${source}.keySet();`;
+        .join('')} = ctx.entity.metadata.${destination}.keySet();`;
     }
     return `${acc}\n if(ctx.${parts.slice(0, currentIndex + 1).join('.')} == null)  ctx${parts
       .slice(0, currentIndex + 1)
@@ -34,12 +34,11 @@ function createMetadataPainlessScript(definition: EntityDefinition) {
     return '';
   }
   return definition.metadata.reduce((script, def) => {
-    const source = def.source;
     const destination = def.destination || def.source;
-    return `${script}if (ctx.entity?.metadata?.${source.replaceAll(
+    return `${script}if (ctx.entity?.metadata?.${destination.replaceAll(
       '.',
       '?.'
-    )} != null) {${mapDestinationToPainless(destination, source)}\n}\n`;
+    )} != null) {${mapDestinationToPainless(destination)}\n}\n`;
   }, '');
 }
 

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
@@ -8,13 +8,13 @@
 import { EntityDefinition } from '@kbn/entities-schema';
 import { generateLatestIndexName } from '../helpers/generate_component_id';
 
-function mapDestinationToPainless(destination: string, source: string) {
+function mapDestinationToPainless(destination: string) {
   const fieldParts = destination.split('.');
   return fieldParts.reduce((acc, _part, currentIndex, parts) => {
     if (currentIndex + 1 === parts.length) {
       return `${acc}\n  ctx${parts
         .map((s) => `["${s}"]`)
-        .join('')} = ctx.entity.metadata.${source}.data.keySet();`;
+        .join('')} = ctx.entity.metadata.${destination}.data.keySet();`;
     }
     return `${acc}\n if(ctx.${parts.slice(0, currentIndex + 1).join('.')} == null)  ctx${parts
       .slice(0, currentIndex + 1)
@@ -28,12 +28,11 @@ function createMetadataPainlessScript(definition: EntityDefinition) {
     return '';
   }
   return definition.metadata.reduce((script, def) => {
-    const source = def.source;
     const destination = def.destination || def.source;
-    return `${script}if (ctx.entity?.metadata?.${source.replaceAll(
+    return `${script}if (ctx.entity?.metadata?.${destination.replaceAll(
       '.',
       '?.'
-    )}.data != null) {${mapDestinationToPainless(destination, source)}\n}\n`;
+    )}.data != null) {${mapDestinationToPainless(destination)}\n}\n`;
   }, '');
 }
 

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/__snapshots__/generate_history_transform.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/__snapshots__/generate_history_transform.test.ts.snap
@@ -55,6 +55,12 @@ Object {
           "size": 1000,
         },
       },
+      "entity.metadata.sourceIndex": Object {
+        "terms": Object {
+          "field": "_index",
+          "size": 1000,
+        },
+      },
       "entity.metadata.tags": Object {
         "terms": Object {
           "field": "tags",

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/__snapshots__/generate_latest_transform.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/transform/__snapshots__/generate_latest_transform.test.ts.snap
@@ -82,6 +82,23 @@ Object {
           },
         },
       },
+      "entity.metadata.sourceIndex": Object {
+        "aggs": Object {
+          "data": Object {
+            "terms": Object {
+              "field": "sourceIndex",
+              "size": 1000,
+            },
+          },
+        },
+        "filter": Object {
+          "range": Object {
+            "event.ingested": Object {
+              "gte": "now-1m",
+            },
+          },
+        },
+      },
       "entity.metadata.tags": Object {
         "aggs": Object {
           "data": Object {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/186873

The ingest pipeline painless scripts for metadata fields were not looking at the right context fields. This was not a problem until now because our the fields we collect had the same name in the entity document (`source field == destination field`), but for collecting _index we need a different destination to avoid breaking elasticsearch internals