### PR TITLE
[Console] Update Es client for fetching autocomplete metadata

### DIFF
--- a/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
+++ b/src/plugins/console/server/routes/api/console/autocomplete_entities/index.ts
@@ -16,7 +16,7 @@ const MAX_RESPONSE_SIZE = 10 * 1024 * 1024; // 10MB
 
 const getMappings = async (settings: SettingsToRetrieve, esClient: IScopedClusterClient) => {
   if (settings.fields && settings.fieldsIndices) {
-    const mappings = await esClient.asInternalUser.indices.getMapping(
+    const mappings = await esClient.asCurrentUser.indices.getMapping(
       {
         index: settings.fieldsIndices,
       },
@@ -33,7 +33,7 @@ const getMappings = async (settings: SettingsToRetrieve, esClient: IScopedCluste
 
 const getAliases = async (settings: SettingsToRetrieve, esClient: IScopedClusterClient) => {
   if (settings.indices) {
-    const aliases = await esClient.asInternalUser.indices.getAlias();
+    const aliases = await esClient.asCurrentUser.indices.getAlias();
     return aliases;
   }
   // If the user doesn't want autocomplete suggestions, then clear any that exist.
@@ -42,7 +42,7 @@ const getAliases = async (settings: SettingsToRetrieve, esClient: IScopedCluster
 
 const getDataStreams = async (settings: SettingsToRetrieve, esClient: IScopedClusterClient) => {
   if (settings.dataStreams) {
-    const dataStreams = await esClient.asInternalUser.indices.getDataStream();
+    const dataStreams = await esClient.asCurrentUser.indices.getDataStream();
     return dataStreams;
   }
   // If the user doesn't want autocomplete suggestions, then clear any that exist.
@@ -51,7 +51,7 @@ const getDataStreams = async (settings: SettingsToRetrieve, esClient: IScopedClu
 
 const getLegacyTemplates = async (settings: SettingsToRetrieve, esClient: IScopedClusterClient) => {
   if (settings.templates) {
-    const legacyTemplates = await esClient.asInternalUser.indices.getTemplate();
+    const legacyTemplates = await esClient.asCurrentUser.indices.getTemplate();
     return legacyTemplates;
   }
   // If the user doesn't want autocomplete suggestions, then clear any that exist.
@@ -60,7 +60,7 @@ const getLegacyTemplates = async (settings: SettingsToRetrieve, esClient: IScope
 
 const getIndexTemplates = async (settings: SettingsToRetrieve, esClient: IScopedClusterClient) => {
   if (settings.templates) {
-    const indexTemplates = await esClient.asInternalUser.indices.getIndexTemplate();
+    const indexTemplates = await esClient.asCurrentUser.indices.getIndexTemplate();
     return indexTemplates;
   }
   // If the user doesn't want autocomplete suggestions, then clear any that exist.
@@ -72,7 +72,7 @@ const getComponentTemplates = async (
   esClient: IScopedClusterClient
 ) => {
   if (settings.templates) {
-    const componentTemplates = await esClient.asInternalUser.cluster.getComponentTemplate();
+    const componentTemplates = await esClient.asCurrentUser.cluster.getComponentTemplate();
     return componentTemplates;
   }
   // If the user doesn't want autocomplete suggestions, then clear any that exist.


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/186896 

## Summary

This PR changes the Es client used for fetching autocomplete data from `asInternalUser` to `asCurrentUser`. This will exposing only suggestions for indices/data streams/templates/etc. which the current user has access to.

How to test:
1. Start Es and Kibana
2. Create a new index
3. Create a new role:
 - Cluster privileges: `all` 
 - Run As privileges: `elastic`
 - Index privileges: add only the index created from the previous step and add `all` privileges for it
 - Kibana privileges: All privileges for all spaces and all features
4. Create a user that has the created role from the previous step
5. Log in with the new user
6. Go to Console and start typing `GET ` and verify that only the created test index is suggested. Typing `GET .` shouldn't suggest anything as the current user doesn't have access to the hidden indices.
