### PR TITLE
[Fleet] Always use a SNAPSHOT version when running elastic-agent docker image

### DIFF
--- a/x-pack/test/fleet_cypress/artifact_manager.ts
+++ b/x-pack/test/fleet_cypress/artifact_manager.ts
@@ -15,6 +15,10 @@ export async function getLatestVersion(): Promise<string> {
   return pRetry(() => axios('https://artifacts-api.elastic.co/v1/versions'), {
     maxRetryTime: 60 * 1000, // 1 minute
   })
-    .then((response) => last(response.data.versions as string[]) || DEFAULT_VERSION)
+    .then(
+      (response) =>
+        last((response.data.versions as string[]).filter((v) => v.includes('-SNAPSHOT'))) ||
+        DEFAULT_VERSION
+    )
     .catch(() => DEFAULT_VERSION);
 }


### PR DESCRIPTION
Resolve https://github.com/elastic/kibana/issues/184681

## Summary

Test are failing when the latest version is not yet available we should probably use the latest `SNAPSHOT` instead.

Should fix the following error:
```
Error response from daemon: manifest for docker.elastic.co/beats/elastic-agent:8.15.0 not found: manifest unknown: manifest unknown
```

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->