### PR TITLE
[Observability Onboarding] Add missing translation on OTel quickstart title

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -770,7 +770,12 @@ rm ./otel.yml && cp ./otel_samples/platformlogs_hostmetrics.yml ./otel.yml && mk
                 ),
               },
               {
-                title: 'Visualize your data',
+                title: i18n.translate(
+                  'xpack.observability_onboarding.otelLogsPanel.steps.visualize',
+                  {
+                    defaultMessage: 'Visualize your data',
+                  }
+                ),
                 children: (
                   <>
                     <EuiText>


### PR DESCRIPTION
## Summary

Adds a missing translation call to one of the titles on the OTel collector quickstart in onboarding.



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->