### PR TITLE
[Security solution] Add model parameter to token telemetry

### DIFF
--- a/x-pack/plugins/actions/server/lib/action_executor.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.ts
@@ -603,6 +603,7 @@ export class ActionExecutor {
                   ...(actionTypeId === '.gen-ai' && config?.apiProvider != null
                     ? { provider: config?.apiProvider }
                     : {}),
+                  ...(config?.defaultModel != null ? { model: config?.defaultModel } : {}),
                 });
               }
             })

--- a/x-pack/plugins/actions/server/lib/event_based_telemetry.ts
+++ b/x-pack/plugins/actions/server/lib/event_based_telemetry.ts
@@ -13,6 +13,7 @@ export const GEN_AI_TOKEN_COUNT_EVENT: EventTypeOpts<{
   prompt_tokens: number;
   completion_tokens: number;
   provider?: string;
+  model?: string;
 }> = {
   eventType: 'gen_ai_token_count',
   schema: {
@@ -48,6 +49,13 @@ export const GEN_AI_TOKEN_COUNT_EVENT: EventTypeOpts<{
       type: 'keyword',
       _meta: {
         description: 'OpenAI provider',
+        optional: true,
+      },
+    },
+    model: {
+      type: 'keyword',
+      _meta: {
+        description: 'LLM model',
         optional: true,
       },
     },


### PR DESCRIPTION
## Summary

Adds the `model` parameter to GenAI token tracking telemetry events if `defaultModel` is a property on the connector `config`

<img width="427" alt="Screenshot 2024-07-08 at 11 28 38 AM" src="https://github.com/elastic/kibana/assets/6935300/eba0309d-dc18-467d-bbfc-22f6475b9513">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->