### PR TITLE
[ML] Functional tests: unskip anomaly detection results forecast flaky test 

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/forecasts.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/forecasts.ts
@@ -39,8 +39,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const ml = getService('ml');
 
-  // Failing: See https://github.com/elastic/kibana/issues/164381
-  describe.skip('forecasts', function () {
+  describe('forecasts', function () {
     this.tags(['ml']);
 
     describe('with single metric job', function () {


### PR DESCRIPTION
## Summary

Unskip skipped test due to flakiness: https://github.com/elastic/kibana/issues/164381
Initial investigation appears to indicate something in the testing environment - likely the chrome version. That has been updated since so letting the CI run to confirm.

Flaky test runner build: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6494

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



<!--ONMERGE {"backportTargets":["7.17","8.14","8.15"]} ONMERGE-->