### PR TITLE
[CI] Fix auto approve backport permissions

### DIFF
--- a/.github/workflows/auto-approve-api-docs.yml
+++ b/.github/workflows/auto-approve-api-docs.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:

--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     branches-ignore:
       - main
     types:


### PR DESCRIPTION
## Summary

In #187246 this workflow was changed to `pull_request` instead of `pull_request_target` and has been failing on forks. When running with `pull_request` the workflow is in the context of the fork and doesn't have secrets from the Kibana repo.

[Action logs](https://github.com/elastic/kibana/actions/workflows/auto-approve-backports.yml)
[Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories)

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->