### PR TITLE
[FIPS / Build] Move OpenSSL compile to builder step

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -153,6 +153,7 @@ RUN fc-cache -v
 {{/serverless}}
 WORKDIR /usr/share/kibana
 {{#fips}}
+
 # Enable FIPS for Kibana only. In the future we can override OS wide with ENV OPENSSL_CONF
 RUN /usr/bin/echo -e '\n--enable-fips' >> config/node.options
 RUN /usr/bin/echo '--openssl-config=/usr/share/kibana/config/nodejs.cnf' >> config/node.options

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -39,14 +39,11 @@ RUN tar \
   -zxf /tmp/kibana.tar.gz
 
 {{#fips}}
-# OpenSSL requires specific versions that are FIPS certified. Further, the FIPS modules
-# need to be compiled on the machine to pass its own self validation on startup.
+# OpenSSL requires specific versions that are FIPS certified.
 #
 # See:
 # https://github.com/openssl/openssl/blob/openssl-3.0/README-FIPS.md
 # https://www.openssl.org/docs/man3.0/man7/fips_module.html
-
-# Ideally we would handle this in the builder step, but OpenSSL requires linking of many submodules.
 RUN set -e ; \
  OPENSSL_VERSION='3.0.8'; \
  OPENSSL_PATH=/usr/share/kibana/openssl ; \

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -12,7 +12,7 @@
 FROM {{{baseImageName}}} AS builder
 
 {{#ubi}}
-RUN microdnf install -y findutils tar gzip
+RUN microdnf install -y findutils tar gzip{{#fips}} perl make gcc{{/fips}}
 {{/ubi}}
 {{#ubuntu}}
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
@@ -37,6 +37,33 @@ WORKDIR /usr/share/kibana
 RUN tar \
   --strip-components=1 \
   -zxf /tmp/kibana.tar.gz
+
+{{#fips}}
+# OpenSSL requires specific versions that are FIPS certified. Further, the FIPS modules
+# need to be compiled on the machine to pass its own self validation on startup.
+#
+# See:
+# https://github.com/openssl/openssl/blob/openssl-3.0/README-FIPS.md
+# https://www.openssl.org/docs/man3.0/man7/fips_module.html
+
+# Ideally we would handle this in the builder step, but OpenSSL requires linking of many submodules.
+RUN set -e ; \
+ OPENSSL_VERSION='3.0.8'; \
+ OPENSSL_PATH=/usr/share/kibana/openssl ; \
+ mkdir "${OPENSSL_PATH}"; \
+ curl --retry 8 -S -L -O "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" ; \
+ curl --retry 8 -S -L -O "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256" ; \
+ echo "$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256) openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c ; \
+ tar -zxf "openssl-${OPENSSL_VERSION}.tar.gz" ; \
+ rm -rf openssl-${OPENSSL_VERSION}.tar* ; \
+ cd "/usr/share/kibana/openssl-${OPENSSL_VERSION}" ; \
+ ./Configure --prefix="${OPENSSL_PATH}" --openssldir="${OPENSSL_PATH}/ssl" --libdir="${OPENSSL_PATH}/lib" enable-fips; \
+ make -j $(nproc) > /dev/null ; \
+ make install > /dev/null ; \
+ rm -rf  "/usr/share/kibana/openssl-${OPENSSL_VERSION}" ; \
+ chown -R 1000:0 "${OPENSSL_PATH}";
+ 
+{{/fips}}
 # Ensure that group permissions are the same as user permissions.
 # This will help when relying on GID-0 to run Kibana, rather than UID-1000.
 # OpenShift does this, for example.
@@ -90,7 +117,7 @@ EXPOSE 5601
 RUN for iter in {1..10}; do \
       microdnf update --setopt=tsflags=nodocs -y && \
       microdnf install --setopt=tsflags=nodocs -y \
-        fontconfig freetype shadow-utils nss findutils {{#fips}}perl make gcc tar {{/fips}}&& \
+        fontconfig freetype shadow-utils nss findutils && \
       microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && \
       sleep 10; \
     done; \
@@ -126,31 +153,6 @@ RUN fc-cache -v
 {{/serverless}}
 WORKDIR /usr/share/kibana
 {{#fips}}
-
-# OpenSSL requires specific versions that are FIPS certified. Further, the FIPS modules
-# need to be compiled on the machine to pass its own self validation on startup.
-#
-# See:
-# https://github.com/openssl/openssl/blob/openssl-3.0/README-FIPS.md
-# https://www.openssl.org/docs/man3.0/man7/fips_module.html
-
-# Ideally we would handle this in the builder step, but OpenSSL requires linking of many submodules.
-RUN set -e ; \
- OPENSSL_VERSION='3.0.8'; \
- OPENSSL_PATH=/usr/share/kibana/openssl ; \
- mkdir "${OPENSSL_PATH}"; \
- curl --retry 8 -S -L -O "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" ; \
- curl --retry 8 -S -L -O "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256" ; \
- echo "$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256) openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c ; \
- tar -zxf "openssl-${OPENSSL_VERSION}.tar.gz" ; \
- rm -rf openssl-${OPENSSL_VERSION}.tar* ; \
- cd "/usr/share/kibana/openssl-${OPENSSL_VERSION}" ; \
- ./Configure --prefix="${OPENSSL_PATH}" --openssldir="${OPENSSL_PATH}/ssl" --libdir="${OPENSSL_PATH}/lib" enable-fips; \
- make -j $(nproc) > /dev/null ; \
- make install > /dev/null ; \
- rm -rf  "/usr/share/kibana/openssl-${OPENSSL_VERSION}" ; \
- chown -R 1000:0 "${OPENSSL_PATH}";
-
 # Enable FIPS for Kibana only. In the future we can override OS wide with ENV OPENSSL_CONF
 RUN /usr/bin/echo -e '\n--enable-fips' >> config/node.options
 RUN /usr/bin/echo '--openssl-config=/usr/share/kibana/config/nodejs.cnf' >> config/node.options


### PR DESCRIPTION
## Summary

This moves the OpenSSL compilation and it's dependencies into the builder step for the FIPS Docker image. This reduces the FIPS image from 582MB to 445MB, making it ~15MB larger than the Kibana UBI image.

### Testing
1. `docker pull docker.elastic.co/kibana-ci/kibana-ubi-fips:8.16.0-SNAPSHOT-5d7290bf1c8af263aedd6d617279ff15cef7de03`
2. `docker run --rm -it -p 5601:5601/tcp docker.elastic.co/kibana-ci/kibana-ubi-fips:8.16.0-SNAPSHOT-5d7290bf1c8af263aedd6d617279ff15cef7de03`
3. `docker exec -it <container ID or name> bash`
4. `node/glibc-217/bin/node --enable-fips --openssl-config="$HOME/config/nodejs.cnf" -p 'crypto.getFips()'`
5. Output should be `1` indicating FIPS is working successfully.