### PR TITLE
[Fleet] Small UI tweaks for reusable integration policies

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -192,7 +192,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 <h3>
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyFormGroupTitle"
-                    defaultMessage="Agent policy"
+                    defaultMessage="Agent policies"
                   />
                 </h3>
               </EuiTitle>
@@ -215,7 +215,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                   <EuiFlexItem>
                     <FormattedMessage
                       id="xpack.fleet.createPackagePolicy.StepSelectPolicy.agentPolicyLabel"
-                      defaultMessage="Agent policy"
+                      defaultMessage="Agent policies"
                     />
                   </EuiFlexItem>
                 </EuiFlexGroup>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -113,7 +113,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
         sortable: true,
         truncateText: true,
         name: i18n.translate('xpack.fleet.policyDetails.packagePoliciesTable.nameColumnTitle', {
-          defaultMessage: 'Name',
+          defaultMessage: 'Integration policy',
         }),
         render: (value: string, packagePolicy: InMemoryPackagePolicy) => (
           <EuiFlexGroup gutterSize="s" alignItems="center">

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/policies/package_policies.tsx
@@ -230,7 +230,7 @@ export const PackagePoliciesPage = ({ name, version }: PackagePoliciesPanelProps
       {
         field: 'packagePolicy.policy_ids',
         name: i18n.translate('xpack.fleet.epm.packageDetails.integrationList.agentPolicy', {
-          defaultMessage: 'Agent policy',
+          defaultMessage: 'Agent policies',
         }),
         truncateText: true,
         render(id, { agentPolicies, packagePolicy }) {


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/kibana/issues/75867

Change to `Agent policy` to `Agent policies` in a few places.

<img width="1154" alt="image" src="https://github.com/elastic/kibana/assets/90178898/52ea19ea-6302-44b8-88b2-54abd6a4ec37">
<img width="1405" alt="image" src="https://github.com/elastic/kibana/assets/90178898/503844c5-d9ec-4bdf-a2d3-aeb4e9100764">
<img width="1409" alt="image" src="https://github.com/elastic/kibana/assets/90178898/9149bf6f-c9fa-4535-ab7b-c4ff4df35dca">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
