### PR TITLE
[Skip on MKI] Switch from skipSvlSec to failsOnMKI

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/datastreams.ts
@@ -23,7 +23,7 @@ export default function ({ getService }: FtrProviderContext) {
 
   describe('Data streams', function () {
     // see details: https://github.com/elastic/kibana/issues/187372
-    this.tags(['skipSvlSec']);
+    this.tags(['failsOnMKI']);
     before(async () => {
       roleAuthc = await svlUserManager.createApiKeyForRole('admin');
       internalReqHeader = svlCommonApi.getInternalRequestHeader();


### PR DESCRIPTION
## Summary

Due to the `skipSvlSec` tag being ignored (for now), switch the tag so it actually does not run on mki, at all.