### PR TITLE
[8.15] [Integration-Assistant] Fix categorization ECS types and categories (#187516)

### DIFF
--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/constants.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/constants.ts
@@ -123,13 +123,13 @@ export type EventCategories =
   | 'iam'
   | 'intrusion_detection'
   | 'library'
+  | 'malware'
   | 'network'
   | 'package'
   | 'process'
   | 'registry'
   | 'session'
   | 'threat'
-  | 'user'
   | 'vulnerability'
   | 'web';
 
@@ -153,21 +153,21 @@ export const ECS_EVENT_TYPES_PER_CATEGORY: {
   configuration: ['access', 'change', 'creation', 'deletion', 'info'],
   database: ['access', 'change', 'info', 'error'],
   driver: ['change', 'end', 'info', 'start'],
-  email: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  file: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  host: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  iam: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  intrusion_detection: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  library: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  network: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  package: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  process: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  registry: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  session: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  threat: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  user: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  vulnerability: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
-  web: ['access', 'change', 'creation', 'deletion', 'info', 'start'],
+  email: ['info'],
+  file: ['access', 'change', 'creation', 'deletion', 'info'],
+  host: ['access', 'change', 'end', 'info', 'start'],
+  iam: ['admin', 'change', 'creation', 'deletion', 'group', 'info', 'user'],
+  intrusion_detection: ['allowed', 'denied', 'info'],
+  library: ['start'],
+  malware: ['info'],
+  network: ['access', 'allowed', 'connection', 'denied', 'end', 'info', 'protocol', 'start'],
+  package: ['access', 'change', 'deletion', 'info', 'installation', 'start'],
+  process: ['access', 'change', 'end', 'info', 'start'],
+  registry: ['access', 'change', 'creation', 'deletion'],
+  session: ['start', 'end', 'info'],
+  threat: ['indicator'],
+  vulnerability: ['info'],
+  web: ['access', 'error', 'info'],
 };
 
 export const CATEGORIZATION_EXAMPLE_PROCESSORS = `


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Integration-Assistant] Fix categorization ECS types and categories (#187516)](https://github.com/elastic/kibana/pull/187516)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kylie Meli","email":"kylie.geller@elastic.co"},"sourceCommit":{"committedDate":"2024-07-04T05:47:54Z","message":"[Integration-Assistant] Fix categorization ECS types and categories (#187516)\n\n## Summary\r\n\r\nThis PR corrects the ECS type and categories constants used in the\r\ncategorization chain.\r\n\r\nI double checked everything against the ECS docs for\r\n[categories](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-category.html)\r\nand\r\n[types](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-type.html).","sha":"27d280893cf4a1f27af8dc89fdb799918850d808","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Security Generative AI","v8.15.0","v8.16.0"],"number":187516,"url":"https://github.com/elastic/kibana/pull/187516","mergeCommit":{"message":"[Integration-Assistant] Fix categorization ECS types and categories (#187516)\n\n## Summary\r\n\r\nThis PR corrects the ECS type and categories constants used in the\r\ncategorization chain.\r\n\r\nI double checked everything against the ECS docs for\r\n[categories](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-category.html)\r\nand\r\n[types](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-type.html).","sha":"27d280893cf4a1f27af8dc89fdb799918850d808"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/187516","number":187516,"mergeCommit":{"message":"[Integration-Assistant] Fix categorization ECS types and categories (#187516)\n\n## Summary\r\n\r\nThis PR corrects the ECS type and categories constants used in the\r\ncategorization chain.\r\n\r\nI double checked everything against the ECS docs for\r\n[categories](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-category.html)\r\nand\r\n[types](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-type.html).","sha":"27d280893cf4a1f27af8dc89fdb799918850d808"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->