### PR TITLE
[Unified Fieldlist] unskip the flaky test

### DIFF
--- a/packages/kbn-unified-field-list/src/components/field_list_filters/field_name_search.test.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_list_filters/field_name_search.test.tsx
@@ -8,12 +8,18 @@
 
 import React, { useState } from 'react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { FieldNameSearch, type FieldNameSearchProps } from './field_name_search';
-import { render, screen, waitFor } from '@testing-library/react';
 
-// Flaky: https://github.com/elastic/kibana/issues/187714
-describe.skip('UnifiedFieldList <FieldNameSearch />', () => {
-  it('should render correctly', async () => {
+describe('UnifiedFieldList <FieldNameSearch />', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should render correctly', () => {
     const props: FieldNameSearchProps = {
       nameFilter: '',
       onChange: jest.fn(),
@@ -24,11 +30,12 @@ describe.skip('UnifiedFieldList <FieldNameSearch />', () => {
     const input = screen.getByRole('searchbox', { name: 'Search field names' });
     expect(input).toHaveAttribute('aria-describedby', 'htmlId');
     userEvent.type(input, 'hey');
-    await waitFor(() => expect(props.onChange).toHaveBeenCalledWith('hey'), { timeout: 256 });
+    jest.advanceTimersByTime(256);
+    expect(props.onChange).toHaveBeenCalledWith('hey');
     expect(props.onChange).toBeCalledTimes(1);
   });
 
-  it('should accept the updates from the top', async () => {
+  it('should accept the updates from the top', () => {
     const FieldNameSearchWithWrapper = ({ defaultNameFilter = '' }) => {
       const [nameFilter, setNameFilter] = useState(defaultNameFilter);
       const props: FieldNameSearchProps = {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/187714

I could reproduce the flakiness on my local machine. It doesn't happen anymore with this PR.

Tested by running 100 times like this;
before:
```
  test.each(Array(100).fill(null))('should render correctly', async () => {
    const props: FieldNameSearchProps = {
      nameFilter: '',
      onChange: jest.fn(),
      screenReaderDescriptionId: 'htmlId',
      'data-test-subj': 'searchInput',
    };
    render(<FieldNameSearch {...props} />);
    const input = screen.getByRole('searchbox', { name: 'Search field names' });
    expect(input).toHaveAttribute('aria-describedby', 'htmlId');
    userEvent.type(input, 'hey');
    await waitFor(() => expect(props.onChange).toHaveBeenCalledWith('hey'), { timeout: 256 });
    expect(props.onChange).toBeCalledTimes(1);
  });
```

<img width="453" alt="Screenshot 2024-07-09 at 14 56 49" src="https://github.com/elastic/kibana/assets/4283304/25f37d1d-3a1e-4d09-8751-978673246483">

after:
```
  test.each(Array(100).fill(null))('should render correctly', () => {
    const props: FieldNameSearchProps = {
      nameFilter: '',
      onChange: jest.fn(),
      screenReaderDescriptionId: 'htmlId',
      'data-test-subj': 'searchInput',
    };
    render(<FieldNameSearch {...props} />);
    const input = screen.getByRole('searchbox', { name: 'Search field names' });
    expect(input).toHaveAttribute('aria-describedby', 'htmlId');
    userEvent.type(input, 'hey');
    jest.advanceTimersByTime(256);
    expect(props.onChange).toHaveBeenCalledWith('hey');

    expect(props.onChange).toBeCalledTimes(1);
  });
```
<img width="339" alt="Screenshot 2024-07-09 at 14 57 56" src="https://github.com/elastic/kibana/assets/4283304/ac2228b4-5d0e-446a-b99b-399e288d637b">


