### PR TITLE
[ResponseOps][Cases] Make custom fields and the cases webhook GA

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -281,7 +281,6 @@ paths:
                             - elastic
                     customFields:
                       type: array
-                      x-technical-preview: true
                       description: Custom fields configuration details.
                       items:
                         type: object
@@ -478,7 +477,6 @@ paths:
                           - elastic
                   customFields:
                     type: array
-                    x-technical-preview: true
                     description: Custom fields configuration details.
                     items:
                       type: object
@@ -677,7 +675,6 @@ paths:
                           - elastic
                   customFields:
                     type: array
-                    x-technical-preview: true
                     description: Custom fields configuration details.
                     items:
                       type: object
@@ -1548,7 +1545,6 @@ paths:
                             - elastic
                     customFields:
                       type: array
-                      x-technical-preview: true
                       description: Custom fields configuration details.
                       items:
                         type: object
@@ -1746,7 +1742,6 @@ paths:
                           - elastic
                   customFields:
                     type: array
-                    x-technical-preview: true
                     description: Custom fields configuration details.
                     items:
                       type: object
@@ -1946,7 +1941,6 @@ paths:
                           - elastic
                   customFields:
                     type: array
-                    x-technical-preview: true
                     description: Custom fields configuration details.
                     items:
                       type: object
@@ -3305,7 +3299,6 @@ components:
           type: array
           description: |
             Custom field values for a case. Any optional custom fields that are not specified in the request are set to null.
-          x-technical-preview: true
           minItems: 0
           maxItems: 10
           items:
@@ -3804,7 +3797,6 @@ components:
         customFields:
           type: array
           description: Custom field values for the case.
-          x-technical-preview: true
           items:
             type: object
             properties:
@@ -3933,7 +3925,6 @@ components:
                 type: array
                 description: |
                   Custom field values for a case. Any optional custom fields that are not specified in the request are set to null.
-                x-technical-preview: true
                 minItems: 0
                 maxItems: 10
                 items:
@@ -4053,7 +4044,6 @@ components:
                     $ref: '#/components/schemas/connector_types'
               customFields:
                 type: array
-                x-technical-preview: true
                 description: Custom field values in the template.
                 items:
                   type: object
@@ -4135,7 +4125,6 @@ components:
         customFields:
           type: array
           description: Custom fields case configuration.
-          x-technical-preview: true
           minItems: 0
           maxItems: 10
           items:
@@ -4216,7 +4205,6 @@ components:
         customFields:
           type: array
           description: Custom fields case configuration.
-          x-technical-preview: true
           items:
             type: object
             required:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/case_configure_response_properties.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/case_configure_response_properties.yaml
@@ -1,6 +1,6 @@
 closure_type:
   $ref: 'closure_types.yaml'
-connector: 
+connector:
   type: object
   properties:
     $ref: 'case_configure_connector_properties.yaml'
@@ -12,14 +12,13 @@ created_at:
 created_by:
   type: object
   required:
-      - email
-      - full_name
-      - username
+    - email
+    - full_name
+    - username
   properties:
     $ref: 'user_properties.yaml'
 customFields:
   type: array
-  x-technical-preview: true
   description: Custom fields configuration details.
   items:
     type: object
@@ -27,8 +26,8 @@ customFields:
       $ref: 'case_configure_customfields.yaml'
 error:
   type:
-    - "string"
-    - "null"
+    - 'string'
+    - 'null'
   examples:
     - null
 id:
@@ -58,19 +57,19 @@ templates:
   $ref: 'templates.yaml'
 updated_at:
   type:
-    - "string"
-    - "null"
+    - 'string'
+    - 'null'
   format: date-time
   examples:
     - 2022-06-01T19:58:48.169Z
 updated_by:
   type:
-    - "object"
-    - "null"
+    - 'object'
+    - 'null'
   required:
-      - email
-      - full_name
-      - username
+    - email
+    - full_name
+    - username
   properties:
     $ref: 'user_properties.yaml'
 version:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/case_response_properties.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/case_response_properties.yaml
@@ -27,13 +27,13 @@ properties:
     $ref: 'assignees.yaml'
   category:
     type:
-      - "string"
-      - "null"
+      - 'string'
+      - 'null'
     description: The case category.
   closed_at:
     type:
-      - "string"
-      - "null"
+      - 'string'
+      - 'null'
     format: date-time
   closed_by:
     $ref: 'case_response_closed_by_properties.yaml'
@@ -81,7 +81,6 @@ properties:
   customFields:
     type: array
     description: Custom field values for the case.
-    x-technical-preview: true
     items:
       type: object
       properties:
@@ -92,8 +91,8 @@ properties:
       - A case description.
   duration:
     type:
-      - "integer"
-      - "null"
+      - 'integer'
+      - 'null'
     description: >
       The elapsed time from the creation of the case to its closure (in seconds).
       If the case has not been closed, the duration is set to null. If the case
@@ -135,8 +134,8 @@ properties:
       - 0
   updated_at:
     type:
-      - "string"
-      - "null"
+      - 'string'
+      - 'null'
     format: date-time
   updated_by:
     $ref: 'case_response_updated_by_properties.yaml'

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/create_case_request.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/create_case_request.yaml
@@ -40,7 +40,6 @@ properties:
     description: >
       Custom field values for a case.
       Any optional custom fields that are not specified in the request are set to null.
-    x-technical-preview: true
     minItems: 0
     maxItems: 10
     items:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/set_case_configuration_request.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/set_case_configuration_request.yaml
@@ -21,7 +21,6 @@ properties:
   customFields:
     type: array
     description: Custom fields case configuration.
-    x-technical-preview: true
     minItems: 0
     maxItems: 10
     items:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/update_case_configuration_request.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/update_case_configuration_request.yaml
@@ -2,7 +2,7 @@ title: Update case configuration request
 description: >
   You can update settings such as the closure type, custom fields, templates, and the default connector for cases.
 type: object
-required: 
+required:
   - version
 properties:
   closure_type:
@@ -20,7 +20,6 @@ properties:
   customFields:
     type: array
     description: Custom fields case configuration.
-    x-technical-preview: true
     items:
       type: object
       required:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/update_case_request.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/update_case_request.yaml
@@ -34,7 +34,6 @@ properties:
           description: >
             Custom field values for a case.
             Any optional custom fields that are not specified in the request are set to null.
-          x-technical-preview: true
           minItems: 0
           maxItems: 10
           items:

--- a/x-pack/plugins/cases/public/components/custom_fields/index.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/index.tsx
@@ -21,7 +21,6 @@ import { useCasesContext } from '../cases_context/use_cases_context';
 import type { CustomFieldsConfiguration } from '../../../common/types/domain';
 import { MAX_CUSTOM_FIELDS_PER_CASE } from '../../../common/constants';
 import { CustomFieldsList } from './custom_fields_list';
-import { ExperimentalBadge } from '../experimental_badge/experimental_badge';
 
 export interface Props {
   customFields: CustomFieldsConfiguration;
@@ -68,14 +67,7 @@ const CustomFieldsComponent: React.FC<Props> = ({
   return canAddCustomFields ? (
     <EuiDescribedFormGroup
       fullWidth
-      title={
-        <EuiFlexGroup alignItems="center" gutterSize="none">
-          <EuiFlexItem grow={false}>{i18n.TITLE}</EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <ExperimentalBadge />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
+      title={<h3>{i18n.TITLE}</h3>}
       description={<p>{i18n.DESCRIPTION}</p>}
       data-test-subj="custom-fields-form-group"
     >

--- a/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/webhook.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/cases_webhook/webhook.tsx
@@ -27,7 +27,6 @@ export function getConnectorType(): ConnectorTypeModel<
         defaultMessage: 'Send a request to a Case Management web service.',
       }
     ),
-    isExperimental: true,
     actionTypeTitle: i18n.translate(
       'xpack.stackConnectors.components.casesWebhookxpack.stackConnectors.components.casesWebhook.connectorTypeTitle',
       {


### PR DESCRIPTION
## Summary

This PR makes the custom fields and the cases web hook GA.

<img width="1213" alt="Screenshot 2024-07-09 at 6 51 24 PM" src="https://github.com/elastic/kibana/assets/7871006/a47789a0-e238-4fcb-88cb-edd2531c4046">

<img width="1275" alt="Screenshot 2024-07-09 at 6 51 15 PM" src="https://github.com/elastic/kibana/assets/7871006/a0bb5904-2ed5-4d65-9e08-74ce193559c4">

## Release notes
Cases custom fields and the cases webhook are now GA.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->