### PR TITLE
Remove use of beats_stats.metrics.apm-server.server.response.errors.concurrency

### DIFF
--- a/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
+++ b/x-pack/plugins/monitoring/server/lib/metrics/__snapshots__/metrics.test.js.snap
@@ -1409,60 +1409,6 @@ Object {
     "usageField": undefined,
     "uuidField": "cluster_uuid",
   },
-  "apm_responses_errors_concurrency": ApmEventsRateClusterMetric {
-    "aggs": Object {
-      "beats_uuids": Object {
-        "aggs": Object {
-          "event_rate_per_beat": Object {
-            "max": Object {
-              "field": "beats_stats.metrics.apm-server.server.response.errors.concurrency",
-            },
-          },
-        },
-        "terms": Object {
-          "field": "beats_stats.beat.uuid",
-          "size": 10000,
-        },
-      },
-      "event_rate": Object {
-        "sum_bucket": Object {
-          "buckets_path": "beats_uuids>event_rate_per_beat",
-          "gap_policy": "skip",
-        },
-      },
-      "metric_deriv": Object {
-        "derivative": Object {
-          "buckets_path": "event_rate",
-          "gap_policy": "skip",
-          "unit": "1s",
-        },
-      },
-    },
-    "app": "apm",
-    "calculation": undefined,
-    "dateHistogramSubAggs": undefined,
-    "derivative": true,
-    "derivativeNormalizedUnits": true,
-    "description": "HTTP Requests rejected due to overall concurrency limit breach",
-    "docType": undefined,
-    "field": "beats_stats.metrics.apm-server.server.response.errors.concurrency",
-    "fieldSource": undefined,
-    "format": "0,0.[00]",
-    "getDateHistogramSubAggs": undefined,
-    "isNotSupportedInInternalCollection": undefined,
-    "label": "Concurrency",
-    "legendFormat": undefined,
-    "mbField": undefined,
-    "metricAgg": "max",
-    "periodsField": undefined,
-    "quotaField": undefined,
-    "technicalPreview": undefined,
-    "timestampField": "beats_stats.timestamp",
-    "title": "Concurrency",
-    "units": "/s",
-    "usageField": undefined,
-    "uuidField": "cluster_uuid",
-  },
   "apm_responses_errors_decode": ApmEventsRateClusterMetric {
     "aggs": Object {
       "beats_uuids": Object {

--- a/x-pack/plugins/monitoring/server/lib/metrics/apm/metrics.ts
+++ b/x-pack/plugins/monitoring/server/lib/metrics/apm/metrics.ts
@@ -318,21 +318,6 @@ export const metrics = {
       }
     ),
   }),
-  apm_responses_errors_concurrency: new ApmEventsRateClusterMetric({
-    field: 'beats_stats.metrics.apm-server.server.response.errors.concurrency',
-    title: i18n.translate('xpack.monitoring.metrics.apm.responseErrors.concurrencyTitle', {
-      defaultMessage: 'Concurrency',
-    }),
-    label: i18n.translate('xpack.monitoring.metrics.apm.responseErrors.concurrencyLabel', {
-      defaultMessage: 'Concurrency',
-    }),
-    description: i18n.translate(
-      'xpack.monitoring.metrics.apm.responseErrors.concurrencyDescription',
-      {
-        defaultMessage: 'HTTP Requests rejected due to overall concurrency limit breach',
-      }
-    ),
-  }),
   apm_responses_errors_closed: new ApmEventsRateClusterMetric({
     field: 'beats_stats.metrics.apm-server.server.response.errors.closed',
     title: i18n.translate('xpack.monitoring.metrics.apm.responseErrors.closedTitle', {

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_instance.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_instance.ts
@@ -47,7 +47,6 @@ export const metricSet: NamedMetricDescriptor[] = [
       'apm_responses_errors_queue',
       'apm_responses_errors_decode',
       'apm_responses_errors_forbidden',
-      'apm_responses_errors_concurrency',
       'apm_responses_errors_closed',
       'apm_responses_errors_internal',
     ],

--- a/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_overview.ts
+++ b/x-pack/plugins/monitoring/server/routes/api/v1/apm/metric_set_overview.ts
@@ -47,7 +47,6 @@ export const metricSet: NamedMetricDescriptor[] = [
       'apm_responses_errors_queue',
       'apm_responses_errors_decode',
       'apm_responses_errors_forbidden',
-      'apm_responses_errors_concurrency',
       'apm_responses_errors_closed',
       'apm_responses_errors_internal',
     ],


### PR DESCRIPTION
## Summary

`beats_stats.metrics.apm-server.server.response.errors.concurrency` was never emitted by apm-server. Remove it from stack monitoring UI.

https://github.com/elastic/elasticsearch/pull/110568 contains a workaround for this.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
