### PR TITLE
[8.14] Sync auto approve actions with main

### DIFF
--- a/.github/workflows/auto-approve-api-docs.yml
+++ b/.github/workflows/auto-approve-api-docs.yml
@@ -1,16 +1,16 @@
 on:
   pull_request_target:
-    branches-ignore:
+    branches:
       - main
     types:
       - opened
 
 jobs:
   approve:
-    name: Auto-approve backport
+    name: Auto-approve API docs
     runs-on: ubuntu-latest
     if: |
-      startsWith(github.event.pull_request.head.ref, 'backport') &&
+      startsWith(github.event.pull_request.head.ref, 'api_docs') &&
       github.event.pull_request.user.login == 'kibanamachine'
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

Workflows are based on their state in the target branch, so this brings the two actions in sync with `main` so we can backport in the future if needed and the behavior is consistent.

[7.17 PR](https://github.com/elastic/kibana/pull/187919)