### PR TITLE
[7.17] Sync auto approve actions with main

### DIFF
--- a/.github/workflows/auto-approve-api-docs.yml
+++ b/.github/workflows/auto-approve-api-docs.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+
+jobs:
+  approve:
+    name: Auto-approve API docs
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'api_docs') &&
+      github.event.pull_request.user.login == 'kibanamachine'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 #4.0.0

--- a/.github/workflows/auto-approve-backports.yml
+++ b/.github/workflows/auto-approve-backports.yml
@@ -2,6 +2,8 @@ on:
   pull_request_target:
     branches-ignore:
       - main
+    types:
+      - opened
 
 jobs:
   approve:
@@ -13,4 +15,4 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: hmarr/auto-approve-action@v3
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 #4.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,8 @@ report.asciidoc
 *.tsbuildinfo
 
 # Ignore gihub folder to avoid pings on backports
-.github
+.github/*
+!.github/workflows/
 
 # Automatically generated and user-modifiable
 /tsconfig.refs.json
@@ -99,7 +100,7 @@ report.asciidoc
 # Exclude renovate config file (we only need it on master)
 renovate.json5
 
-# Exclude auto generated files from tooling 
+# Exclude auto generated files from tooling
 /packages/*/synthetic-packages.json
 /packages/*/package-map.json
 /packages/*/config-paths.json


### PR DESCRIPTION
## Summary

Workflows are based on their state in the target branch, so this brings the two actions in sync with `main` so we can backport in the future if needed and the behavior is consistent.

[8.14 PR](https://github.com/elastic/kibana/pull/187918)