### PR TITLE
[Security Solution][Notes] - fix notes management page search crash

### DIFF
--- a/x-pack/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/plugins/security_solution/public/notes/components/search_row.tsx
@@ -47,7 +47,7 @@ export const SearchRow = React.memo(() => {
     <SearchRowContainer>
       <SearchRowFlexGroup gutterSize="s">
         <EuiFlexItem>
-          <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery={''} />
+          <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery="" />
         </EuiFlexItem>
       </SearchRowFlexGroup>
     </SearchRowContainer>

--- a/x-pack/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/plugins/security_solution/public/notes/components/search_row.tsx
@@ -7,9 +7,9 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiSearchBar } from '@elastic/eui';
 import React, { useMemo, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
-import { userSearchedNotes, selectNotesTableSearch } from '..';
+import { userSearchedNotes } from '..';
 
 const SearchRowContainer = styled.div`
   &:not(:last-child) {
@@ -36,8 +36,6 @@ export const SearchRow = React.memo(() => {
     []
   );
 
-  const notesSearch = useSelector(selectNotesTableSearch);
-
   const onQueryChange = useCallback(
     ({ queryText }) => {
       dispatch(userSearchedNotes(queryText.trim()));
@@ -49,12 +47,7 @@ export const SearchRow = React.memo(() => {
     <SearchRowContainer>
       <SearchRowFlexGroup gutterSize="s">
         <EuiFlexItem>
-          <EuiSearchBar
-            box={searchBox}
-            onChange={onQueryChange}
-            query={notesSearch}
-            defaultQuery={''}
-          />
+          <EuiSearchBar box={searchBox} onChange={onQueryChange} defaultQuery={''} />
         </EuiFlexItem>
       </SearchRowFlexGroup>
     </SearchRowContainer>


### PR DESCRIPTION
## Summary

This PR fixes a crash happening on the new Notes Management page, when entering special characters to the search bar. According to [EUI docs](https://eui.elastic.co/#/forms/search-bar) for the `EuiSearchBar`, we shouldn't pass the `query` to the component unless it's controlled outside. In our case, it's only done via user input within the component.

Before

https://github.com/elastic/kibana/assets/17276605/8a46b2ec-78d8-4f1d-a099-d4f3d03d1c8c

After

https://github.com/elastic/kibana/assets/17276605/29543a99-11dd-4973-82bc-04aaff4c12a8

https://github.com/elastic/kibana/issues/187734


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->