### PR TITLE
[licensing] Log a warning when fetching a missing license

### DIFF
--- a/x-pack/plugins/licensing/server/license_fetcher.ts
+++ b/x-pack/plugins/licensing/server/license_fetcher.ts
@@ -45,6 +45,10 @@ export const getLicenseFetcher = ({
         ? normalizeFeatures(response.features)
         : undefined;
 
+      if (!normalizedLicense) {
+        logger.warn('License information fetched from Elasticsearch, but no license is available');
+      }
+
       const signature = sign({
         license: normalizedLicense,
         features: normalizedFeatures,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/101865
