### PR TITLE
[Synthetics] Allow ssl.certificate_authorities arrays

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/common/runtime_types/monitor_management/monitor_types.ts
+++ b/x-pack/plugins/observability_solution/synthetics/common/runtime_types/monitor_management/monitor_types.ts
@@ -40,7 +40,7 @@ const ScheduleCodec = t.interface({
 
 // TLSFields
 export const TLSFieldsCodec = t.partial({
-  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: t.string,
+  [ConfigKey.TLS_CERTIFICATE_AUTHORITIES]: t.union([t.string, t.array(t.string)]),
   [ConfigKey.TLS_CERTIFICATE]: t.string,
   [ConfigKey.TLS_VERIFICATION_MODE]: VerificationModeCodec,
   [ConfigKey.TLS_VERSION]: t.array(TLSVersionCodec),


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/183300 !!

Allows arrays of string for `ssl.certificate_authorities`

### test project monitor

heartbeat.monitors:
- type: http
  name: Todos Lightweight
  id: todos-lightweight
  enabled: true
  urls: "https://elastic.github.io/synthetics-demo/"
  schedule: '@every 3m'
  timeout: 16s
  ssl:
    certificate_authorities: ['/etc/ca.crt']