### PR TITLE
[Security Solution][Alert details] - do not show Notes tab for Rule creation preview alerts

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/index.tsx
@@ -32,7 +32,7 @@ export const LeftPanelNotesTab: LeftPanelPaths = 'notes';
 export const LeftPanel: FC<Partial<DocumentDetailsProps>> = memo(({ path }) => {
   const { telemetry } = useKibana().services;
   const { openLeftPanel } = useExpandableFlyoutApi();
-  const { eventId, indexName, scopeId, getFieldsData } = useDocumentDetailsContext();
+  const { eventId, indexName, scopeId, getFieldsData, isPreview } = useDocumentDetailsContext();
   const eventKind = getField(getFieldsData('event.kind'));
   const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
     'securitySolutionNotesEnabled'
@@ -43,11 +43,11 @@ export const LeftPanel: FC<Partial<DocumentDetailsProps>> = memo(({ path }) => {
       eventKind === EventKind.signal
         ? [tabs.insightsTab, tabs.investigationTab, tabs.responseTab]
         : [tabs.insightsTab];
-    if (securitySolutionNotesEnabled) {
+    if (securitySolutionNotesEnabled && !isPreview) {
       tabList.push(tabs.notesTab);
     }
     return tabList;
-  }, [eventKind, securitySolutionNotesEnabled]);
+  }, [eventKind, isPreview, securitySolutionNotesEnabled]);
 
   const selectedTabId = useMemo(() => {
     const defaultTab = tabsDisplayed[0].id;


### PR DESCRIPTION
## Summary

This PR fixes a small bug where the Notes tab of the alert details expandable flyout was appearing on the Rule creation page when visualizing previews of alerts. We shouldn't show the tab there, as we shouldn't allow users to create notes for preview alerts.

Before

https://github.com/elastic/kibana/assets/17276605/61708d39-da07-404b-9237-36db2165f729

After

https://github.com/elastic/kibana/assets/17276605/b430afc4-335a-47ae-9d2c-6b0781aa0f0f

https://github.com/elastic/kibana/issues/187959

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->