### PR TITLE
[Security Solution][Notes] - fix item per page wrong order in popover

### DIFF
--- a/x-pack/plugins/security_solution/public/notes/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/notes/components/translations.ts
@@ -60,13 +60,6 @@ export const DELETE_SINGLE_NOTE_DESCRIPTION = i18n.translate(
   }
 );
 
-export const NOTES_MANAGEMENT_TITLE = i18n.translate(
-  'xpack.securitySolution.notes.management.pageTitle',
-  {
-    defaultMessage: 'Notes management',
-  }
-);
-
 export const TABLE_ERROR = i18n.translate('xpack.securitySolution.notes.management.tableError', {
   defaultMessage: 'Unable to load notes',
 });

--- a/x-pack/plugins/security_solution/public/notes/pages/note_management_page.tsx
+++ b/x-pack/plugins/security_solution/public/notes/pages/note_management_page.tsx
@@ -73,7 +73,7 @@ const columns: (
   ];
 };
 
-const pageSizeOptions = [50, 25, 10, 0];
+const pageSizeOptions = [10, 25, 50, 100];
 
 /**
  * Allows user to search and delete notes.


### PR DESCRIPTION
## Summary

This PR fixes a small UI issue in the new Notes management page, where the item per page popover was displaying the values in descending order instead of ascending.

Also the PR removes the `0` value which translate into `Show all rows` in the UI. Main reasons for removing are:
- I haven't seen that option on other pages in Kibana
- the option actually does not work (when selecting it I do not get any results in the table)
- it's dangerous as we could get hundreds or thousands of records and the DOM could suffer from it

Finally I added one more option (`100`) to make the page more usable in case of many notes.

Before

![Screenshot 2024-07-10 at 2 32 37 PM](https://github.com/elastic/kibana/assets/17276605/bc8f3c80-4865-4f37-92c6-d3a83910554e)

After

![Screenshot 2024-07-10 at 2 35 51 PM](https://github.com/elastic/kibana/assets/17276605/a454e315-11ba-4022-a709-12c9b9d968fd)

https://github.com/elastic/kibana/issues/187954

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->