### PR TITLE
[Security Solution][Notes] - improve fetch notes on timeline tabs, events table and alerts

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -22,6 +22,7 @@ import {
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { fetchNotesByDocumentIds } from '../../../notes/store/notes.slice';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useLicense } from '../../../common/hooks/use_license';
@@ -266,12 +267,19 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
     };
   }, []);
 
+  const expandableFlyoutDisabled = useIsExperimentalFeatureEnabled('expandableFlyoutDisabled');
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
+
   const onLoaded = useCallback(
     (alerts: Alerts) => {
+      if (!securitySolutionNotesEnabled || expandableFlyoutDisabled || alerts.length === 0) return;
+
       const alertIds = alerts.map((alert: Alert) => alert._id);
       dispatch(fetchNotesByDocumentIds({ documentIds: alertIds }));
     },
-    [dispatch]
+    [dispatch, expandableFlyoutDisabled, securitySolutionNotesEnabled]
   );
 
   const alertStateProps: AlertsTableStateProps = useMemo(

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -17,7 +17,9 @@ import type { EuiDataGridControlColumn } from '@elastic/eui';
 
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import { useKibana } from '../../../../../common/lib/kibana';
+import { fetchNotesByDocumentIds } from '../../../../../notes';
 import {
   DocumentDetailsLeftPanelKey,
   DocumentDetailsRightPanelKey,
@@ -150,6 +152,13 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
     'securitySolutionNotesEnabled'
   );
+
+  useEffect(() => {
+    if (!securitySolutionNotesEnabled || expandableFlyoutDisabled || events.length === 0) return;
+
+    const eventIds = events.map((event: TimelineItem) => event._id);
+    dispatch(fetchNotesByDocumentIds({ documentIds: eventIds }));
+  }, [dispatch, events, expandableFlyoutDisabled, securitySolutionNotesEnabled]);
 
   const {
     associateNote,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -15,6 +15,7 @@ import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { fetchNotesByDocumentIds } from '../../../../../notes';
 import {
   DocumentDetailsLeftPanelKey,
   DocumentDetailsRightPanelKey,
@@ -26,7 +27,7 @@ import { useTimelineDataFilters } from '../../../../containers/use_timeline_data
 import { InputsModelId } from '../../../../../common/store/inputs/constants';
 import { useInvalidFilterQuery } from '../../../../../common/hooks/use_invalid_filter_query';
 import { timelineActions, timelineSelectors } from '../../../../store';
-import type { Direction } from '../../../../../../common/search_strategy';
+import type { Direction, TimelineItem } from '../../../../../../common/search_strategy';
 import type { ControlColumnProps } from '../../../../../../common/types';
 import { useTimelineEvents } from '../../../../containers';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -216,6 +217,13 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
     'securitySolutionNotesEnabled'
   );
+
+  useEffect(() => {
+    if (!securitySolutionNotesEnabled || expandableFlyoutDisabled || events.length === 0) return;
+
+    const eventIds = events.map((event: TimelineItem) => event._id);
+    dispatch(fetchNotesByDocumentIds({ documentIds: eventIds }));
+  }, [dispatch, events, expandableFlyoutDisabled, securitySolutionNotesEnabled]);
 
   const {
     associateNote,


### PR DESCRIPTION
## Summary

This PR makes sure that notes are being fetched on all the places we have notes icon.
- events table in the Explore pages
- timeline all tabs (pinned, eql and correlation)
- alerts table

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios