### PR TITLE
[Fleet] Reusable integration policies fixes

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
@@ -105,7 +105,7 @@ describe('step select agent policy', () => {
       const select = renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]');
       expect((select as any)?.value).toEqual('');
 
-      expect(renderResult.getByText('An agent policy is required.')).toBeVisible();
+      expect(renderResult.getByText('At least one agent policy is required.')).toBeVisible();
     });
   });
 
@@ -178,7 +178,7 @@ describe('step select agent policy', () => {
         );
         expect((select as any)?.value).toEqual(undefined);
 
-        expect(renderResult.getByText('An agent policy is required.')).toBeVisible();
+        expect(renderResult.getByText('At least one agent policy is required.')).toBeVisible();
       });
     });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.tsx
@@ -244,7 +244,7 @@ export const StepSelectAgentPolicy: React.FunctionComponent<{
                 selectedPolicyIds.length === 0 ? (
                   <FormattedMessage
                     id="xpack.fleet.createPackagePolicy.StepSelectPolicy.noPolicySelectedError"
-                    defaultMessage="An agent policy is required."
+                    defaultMessage="At least one agent policy is required."
                   />
                 ) : someNewAgentPoliciesHaveLimitedPackage ? (
                   <FormattedMessage

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
@@ -175,7 +175,7 @@ describe('StepSelectHosts', () => {
     });
 
     waitFor(() => {
-      expect(renderResult.getByText('An agent policy is required.')).toBeInTheDocument();
+      expect(renderResult.getByText('At least one agent policy is required.')).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/fleet/public/components/package_policy_delete_provider.tsx
+++ b/x-pack/plugins/fleet/public/components/package_policy_delete_provider.tsx
@@ -194,7 +194,7 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
             id="xpack.fleet.deletePackagePolicy.confirmModal.loadingAgentsCountMessage"
             defaultMessage="Checking affected agents…"
           />
-        ) : agentsCount && agentPolicies ? (
+        ) : agentsCount ? (
           <>
             {hasMultipleAgentPolicies && (
               <>
@@ -244,7 +244,7 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
                     ),
                   }}
                 />
-              ) : (
+              ) : agentPolicies && agentPolicies.length > 0 ? (
                 <FormattedMessage
                   id="xpack.fleet.deletePackagePolicy.confirmModal.affectedAgentsMessage"
                   defaultMessage="Fleet has detected that {agentPolicyName} is already in use by some of your agents."
@@ -252,7 +252,7 @@ export const PackagePolicyDeleteProvider: React.FunctionComponent<Props> = ({
                     agentPolicyName: <strong>{agentPolicies[0]?.name}</strong>,
                   }}
                 />
-              )}
+              ) : null}
             </EuiCallOut>
             <EuiSpacer size="l" />
           </>

--- a/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/handlers.ts
@@ -421,6 +421,10 @@ export const updatePackagePolicyHandler: FleetRequestHandler<
       throw new PackagePolicyRequestError(errorMessage);
     }
 
+    if (newData.policy_ids && newData.policy_ids.length === 0) {
+      throw new PackagePolicyRequestError('At least one agent policy id must be provided');
+    }
+
     const updatedPackagePolicy = await packagePolicyService.update(
       soClient,
       esClient,

--- a/x-pack/plugins/fleet/server/routes/package_policy/utils/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/utils/index.ts
@@ -8,7 +8,7 @@
 import type { TypeOf } from '@kbn/config-schema';
 
 import type { CreatePackagePolicyRequestSchema, PackagePolicyInput } from '../../../types';
-import { licenseService } from '../../../services';
+import { appContextService, licenseService } from '../../../services';
 import type { SimplifiedPackagePolicy } from '../../../../common/services/simplified_package_policy_helper';
 
 export function isSimplifiedCreatePackagePolicyRequest(
@@ -44,9 +44,12 @@ const LICENCE_FOR_MULTIPLE_AGENT_POLICIES = 'enterprise';
 
 export function canUseMultipleAgentPolicies() {
   const hasEnterpriseLicence = licenseService.hasAtLeast(LICENCE_FOR_MULTIPLE_AGENT_POLICIES);
+  const { enableReusableIntegrationPolicies } = appContextService.getExperimentalFeatures();
 
   return {
-    canUseReusablePolicies: hasEnterpriseLicence,
-    errorMessage: 'Reusable integration policies are only available with an Enterprise license',
+    canUseReusablePolicies: hasEnterpriseLicence && enableReusableIntegrationPolicies,
+    errorMessage: !hasEnterpriseLicence
+      ? 'Reusable integration policies are only available with an Enterprise license'
+      : 'Reusable integration policies are not supported',
   };
 }


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/ingest-dev/issues/3335
Fixing issues found during testing.

Updated validation message in Edit integration page:

<img width="953" alt="image" src="https://github.com/elastic/kibana/assets/90178898/d2004d8c-6f31-4438-bdd7-2afb35525e81">

API validation: at least one agent policy id must be provided when updating a package policy
```
PUT kbn:/api/fleet/package_policies/3e725032-66cf-47cb-af1a-261b3b92f260
{
 "policy_ids": [
    ]
}

{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "At least one agent policy id must be provided"
}
```

API validation: multiple `policy_ids` are not accepted if the feature flag is off
```
PUT kbn:/api/fleet/package_policies/3e725032-66cf-47cb-af1a-261b3b92f260
{
  "policy_ids": [
      "ca0cb008-d243-4f93-8bab-ac2f9a60683b",
      "397c47dd-8d58-459c-8171-1a81f95e9656"
    ]
}

{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Reusable integration policies are not supported"
}
```

Fixed modal to show shared warning when deleting integration policy from Agent policy / Integrations list:

<img width="1401" alt="image" src="https://github.com/elastic/kibana/assets/90178898/178ebd6c-76f6-4540-bfa3-02f25b0a2425">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
