### PR TITLE
[ES|QL] [Unified Histogram] Changes the ratio to be rectangle

### DIFF
--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { useEuiTheme, useResizeObserver } from '@elastic/eui';
+import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useState, useRef, useEffect } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/public';
@@ -116,17 +116,15 @@ export function Histogram({
     timeField: dataView.timeFieldName,
   });
   const chartRef = useRef<HTMLDivElement | null>(null);
-  const { height: containerHeight, width: containerWidth } = useResizeObserver(chartRef.current);
   const { attributes } = visContext;
 
   useEffect(() => {
     if (attributes.visualizationType === 'lnsMetric') {
-      const size = containerHeight < containerWidth ? containerHeight : containerWidth;
-      setChartSize(`${size}px`);
+      setChartSize('90%');
     } else {
       setChartSize('100%');
     }
-  }, [attributes, containerHeight, containerWidth]);
+  }, [attributes]);
 
   const onLoad = useStableCallback(
     (

--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -8,7 +8,7 @@
 
 import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { DefaultInspectorAdapters, Datatable } from '@kbn/expressions-plugin/common';
 import type { IKibanaSearchResponse } from '@kbn/search-types';
@@ -106,7 +106,6 @@ export function Histogram({
   abortController,
 }: HistogramProps) {
   const [bucketInterval, setBucketInterval] = useState<UnifiedHistogramBucketInterval>();
-  const [chartSize, setChartSize] = useState('100%');
   const { timeRangeText, timeRangeDisplay } = useTimeRange({
     uiSettings,
     bucketInterval,
@@ -115,16 +114,7 @@ export function Histogram({
     isPlainRecord,
     timeField: dataView.timeFieldName,
   });
-  const chartRef = useRef<HTMLDivElement | null>(null);
   const { attributes } = visContext;
-
-  useEffect(() => {
-    if (attributes.visualizationType === 'lnsMetric') {
-      setChartSize('90%');
-    } else {
-      setChartSize('100%');
-    }
-  }, [attributes]);
 
   const onLoad = useStableCallback(
     (
@@ -195,7 +185,7 @@ export function Histogram({
     }
 
     & .lnsExpressionRenderer {
-      width: ${chartSize};
+      width: ${attributes.visualizationType === 'lnsMetric' ? '90$' : '100%'};
       margin: auto;
       box-shadow: ${attributes.visualizationType === 'lnsMetric' ? boxShadow : 'none'};
     }
@@ -220,7 +210,6 @@ export function Histogram({
         data-request-data={requestData}
         data-suggestion-type={visContext.suggestionType}
         css={chartCss}
-        ref={chartRef}
       >
         <lens.EmbeddableComponent
           {...lensProps}


### PR DESCRIPTION
## Summary

<img width="1250" alt="image" src="https://github.com/elastic/kibana/assets/17003240/9a41566c-76b5-4c32-97c1-50a3b57a51f3">


We had a chat with @gvnmagni about the ratio of the metric in Discover. The square one is okeish but not for multi values.

We decided to change it in rectangle to be closer to how it will look in a dashboard