### PR TITLE
[Lens] Fix multi-value formatting for metric

### DIFF
--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.test.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.test.tsx
@@ -405,6 +405,61 @@ describe('MetricVisComponent', function () {
       expect(tileConfig.trend).toEqual(trends[DEFAULT_TRENDLINE_NAME]);
       expect(tileConfig.trendShape).toEqual('area');
     });
+
+    it('should display multi-values non-numeric values formatted and without quotes', () => {
+      const newTable: Datatable = {
+        ...table,
+        // change the format id for the columns
+        columns: table.columns.map((column) =>
+          [basePriceColumnId, minPriceColumnId].includes(column.id)
+            ? {
+                ...column,
+                meta: { ...column.meta, params: { id: 'text' } },
+              }
+            : column
+        ),
+        rows: table.rows.map((row) => ({
+          ...row,
+          [basePriceColumnId]: [String(row[basePriceColumnId]), String(100)],
+          [minPriceColumnId]: [String(row[minPriceColumnId]), String(10)],
+        })),
+      };
+      const component = shallow(<MetricVis config={config} data={newTable} {...defaultProps} />);
+
+      const [[visConfig]] = component.find(Metric).props().data!;
+
+      expect(visConfig!.value).toMatchInlineSnapshot(
+        `
+        Array [
+          "text-28.984375",
+          "text-100",
+        ]
+      `
+      );
+    });
+
+    it('should display multi-values numeric values formatted and without quotes', () => {
+      const newTable = {
+        ...table,
+        rows: table.rows.map((row) => ({
+          ...row,
+          [basePriceColumnId]: [row[basePriceColumnId], 100],
+          [minPriceColumnId]: [row[minPriceColumnId], 10],
+        })),
+      };
+      const component = shallow(<MetricVis config={config} data={newTable} {...defaultProps} />);
+
+      const [[visConfig]] = component.find(Metric).props().data!;
+
+      expect(visConfig!.value).toMatchInlineSnapshot(
+        `
+        Array [
+          "number-28.984375",
+          "number-100",
+        ]
+      `
+      );
+    });
   });
 
   describe('metric grid', () => {

--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -208,15 +208,16 @@ export const MetricVis = ({
     const subtitle = breakdownByColumn ? primaryMetricColumn.name : config.metric.subtitle;
 
     if (typeof value !== 'number') {
-      const nonNumericMetric: MetricWText = {
-        value: formatPrimaryMetric(value),
+      const nonNumericMetricBase: Omit<MetricWText, 'value'> = {
         title: String(title),
         subtitle,
         icon: config.metric?.icon ? getIcon(config.metric?.icon) : undefined,
         extra: renderSecondaryMetric(data.columns, row, config),
         color: config.metric.color ?? defaultColor,
       };
-      return nonNumericMetric;
+      return Array.isArray(value)
+        ? { ...nonNumericMetricBase, value: value.map((v) => formatPrimaryMetric(v)) }
+        : { ...nonNumericMetricBase, value: formatPrimaryMetric(value) };
     }
 
     const baseMetric: MetricWNumber = {


### PR DESCRIPTION
## Summary

Fixes #187968

It avoids the default JSON stringify behaviour around formatted values in multi-values scenarios for the new Metric chart type


<img width="1504" alt="Screenshot 2024-07-10 at 15 28 23" src="https://github.com/elastic/kibana/assets/924948/c52c5c5c-3004-4a3f-bdbf-612fdedd853a">

Added also a couple of unit tests to spot regressions in the area.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->