### PR TITLE
[Search] Notebooks Telemetry

### DIFF
--- a/x-pack/plugins/search_notebooks/kibana.jsonc
+++ b/x-pack/plugins/search_notebooks/kibana.jsonc
@@ -15,7 +15,9 @@
     "requiredPlugins": [
       "console"
     ],
-    "optionalPlugins": [],
+    "optionalPlugins": [
+      "usageCollection"
+    ],
     "requiredBundles": [
       "kibanaReact"
     ]

--- a/x-pack/plugins/search_notebooks/public/components/notebooks_view.tsx
+++ b/x-pack/plugins/search_notebooks/public/components/notebooks_view.tsx
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -11,24 +12,32 @@ import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { SearchNotebooks } from './search_notebooks';
-import { NotebookListValue } from '../types';
+import { AppMetricsTracker, NotebookListValue } from '../types';
 
 export interface SearchNotebooksViewProps {
   core: CoreStart;
   queryClient: QueryClient;
+  usageTracker: AppMetricsTracker;
   getNotebookList: () => NotebookListValue;
 }
 
 export const SearchNotebooksView = ({
   core,
   queryClient,
+  usageTracker,
   getNotebookList,
-}: SearchNotebooksViewProps) => (
-  <KibanaThemeProvider theme={core.theme}>
-    <KibanaContextProvider services={{ ...core, notebooks: { getNotebookList } }}>
-      <QueryClientProvider client={queryClient}>
-        <SearchNotebooks />
-      </QueryClientProvider>
-    </KibanaContextProvider>
-  </KibanaThemeProvider>
-);
+}: SearchNotebooksViewProps) => {
+  React.useEffect(() => {
+    usageTracker.load('opened_notebooks_view');
+  }, [usageTracker]);
+
+  return (
+    <KibanaThemeProvider theme={core.theme}>
+      <KibanaContextProvider services={{ ...core, notebooks: { getNotebookList }, usageTracker }}>
+        <QueryClientProvider client={queryClient}>
+          <SearchNotebooks />
+        </QueryClientProvider>
+      </KibanaContextProvider>
+    </KibanaThemeProvider>
+  );
+};

--- a/x-pack/plugins/search_notebooks/public/components/notebooks_view.tsx
+++ b/x-pack/plugins/search_notebooks/public/components/notebooks_view.tsx
@@ -28,7 +28,7 @@ export const SearchNotebooksView = ({
   getNotebookList,
 }: SearchNotebooksViewProps) => {
   React.useEffect(() => {
-    usageTracker.load('opened_notebooks_view');
+    usageTracker.count('opened_notebooks_view');
   }, [usageTracker]);
 
   return (

--- a/x-pack/plugins/search_notebooks/public/components/search_notebook.tsx
+++ b/x-pack/plugins/search_notebooks/public/components/search_notebook.tsx
@@ -20,7 +20,7 @@ export const SearchNotebook = ({ notebookId }: SearchNotebookProps) => {
   const usageTracker = useUsageTracker();
   const { data, isLoading, error } = useNotebook(notebookId);
   useEffect(() => {
-    usageTracker.load(`nb-${notebookId}`);
+    usageTracker.count(['view-notebook', `nb-${notebookId}`]);
   }, [usageTracker, notebookId]);
 
   if (isLoading) {

--- a/x-pack/plugins/search_notebooks/public/components/search_notebook.tsx
+++ b/x-pack/plugins/search_notebooks/public/components/search_notebook.tsx
@@ -4,48 +4,31 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import { EuiPanel, EuiEmptyPrompt, EuiCodeBlock } from '@elastic/eui';
+import React, { useEffect } from 'react';
+import { EuiPanel } from '@elastic/eui';
 import { NotebookRenderer } from '@kbn/ipynb';
-import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useNotebook } from '../hooks/use_notebook';
+import { useUsageTracker } from '../hooks/use_usage_tracker';
 import { LoadingPanel } from './loading_panel';
+import { SearchNotebookError } from './search_notebook_error';
 
 export interface SearchNotebookProps {
   notebookId: string;
 }
 export const SearchNotebook = ({ notebookId }: SearchNotebookProps) => {
+  const usageTracker = useUsageTracker();
   const { data, isLoading, error } = useNotebook(notebookId);
+  useEffect(() => {
+    usageTracker.load(`nb-${notebookId}`);
+  }, [usageTracker, notebookId]);
+
   if (isLoading) {
     return <LoadingPanel />;
   }
   if (!data || error) {
     return (
-      <EuiEmptyPrompt
-        iconType="warning"
-        iconColor="danger"
-        title={
-          <h2>
-            <FormattedMessage
-              id="xpack.searchNotebooks.notebook.fetchError.title"
-              defaultMessage="Error loading notebook"
-            />
-          </h2>
-        }
-        titleSize="l"
-        body={
-          <>
-            <p>
-              <FormattedMessage
-                id="xpack.searchNotebooks.notebook.fetchError.body"
-                defaultMessage="We can't fetch the notebook from Kibana due to the following error:"
-              />
-            </p>
-            <EuiCodeBlock css={{ textAlign: 'left' }}>{JSON.stringify(error)}</EuiCodeBlock>
-          </>
-        }
-      />
+      <SearchNotebookError notebookId={notebookId} usageTracker={usageTracker} error={error} />
     );
   }
   return (

--- a/x-pack/plugins/search_notebooks/public/components/search_notebook_error.tsx
+++ b/x-pack/plugins/search_notebooks/public/components/search_notebook_error.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiEmptyPrompt, EuiCodeBlock } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import type { AppMetricsTracker } from '../types';
+import { getErrorMessage } from '../utils/get_error_message';
+
+export interface SearchNotebookErrorProps {
+  error: unknown;
+  notebookId: string;
+  usageTracker: AppMetricsTracker;
+}
+
+export const SearchNotebookError = ({
+  error,
+  notebookId,
+  usageTracker,
+}: SearchNotebookErrorProps) => {
+  React.useEffect(() => {
+    usageTracker.count(['notebookViewError', `error-${notebookId}`]);
+  }, [usageTracker, notebookId]);
+
+  return (
+    <EuiEmptyPrompt
+      iconType="warning"
+      iconColor="danger"
+      title={
+        <h2>
+          <FormattedMessage
+            id="xpack.searchNotebooks.notebook.fetchError.title"
+            defaultMessage="Error loading notebook"
+          />
+        </h2>
+      }
+      titleSize="l"
+      body={
+        <>
+          <p>
+            <FormattedMessage
+              id="xpack.searchNotebooks.notebook.fetchError.body"
+              defaultMessage="We can't fetch the notebook from Kibana due to the following error:"
+            />
+          </p>
+          {error !== undefined && typeof error === 'object' ? (
+            <EuiCodeBlock css={{ textAlign: 'left' }}>{JSON.stringify(error)}</EuiCodeBlock>
+          ) : (
+            <p>
+              {getErrorMessage(
+                error,
+                i18n.translate('xpack.searchNotebooks.notebook.fetchError.unknownError', {
+                  defaultMessage: 'Unknown error fetching notebook',
+                })
+              )}
+            </p>
+          )}
+        </>
+      }
+    />
+  );
+};

--- a/x-pack/plugins/search_notebooks/public/console_view.tsx
+++ b/x-pack/plugins/search_notebooks/public/console_view.tsx
@@ -14,7 +14,7 @@ import type {
 import { dynamic } from '@kbn/shared-ux-utility';
 import { QueryClient } from '@tanstack/react-query';
 
-import { NotebookListValue } from './types';
+import { NotebookListValue, AppMetricsTracker } from './types';
 
 const SearchNotebooksButton = dynamic(async () => ({
   default: (await import('./components/notebooks_button')).SearchNotebooksButton,
@@ -26,6 +26,7 @@ const SearchNotebooksView = dynamic(async () => ({
 export const notebooksConsoleView = (
   core: CoreStart,
   queryClient: QueryClient,
+  usageTracker: AppMetricsTracker,
   clearNotebookList: () => void,
   getNotebookListValue: () => NotebookListValue
 ): EmbeddedConsoleView => {
@@ -37,6 +38,7 @@ export const notebooksConsoleView = (
       <SearchNotebooksView
         core={core}
         queryClient={queryClient}
+        usageTracker={usageTracker}
         getNotebookList={getNotebookListValue}
       />
     ),

--- a/x-pack/plugins/search_notebooks/public/hooks/use_kibana.ts
+++ b/x-pack/plugins/search_notebooks/public/hooks/use_kibana.ts
@@ -9,13 +9,14 @@ import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { CoreStart } from '@kbn/core/public';
 import { useKibana as useKibanaBase } from '@kbn/kibana-react-plugin/public';
 
-import { NotebookListValue } from '../types';
+import { NotebookListValue, AppMetricsTracker } from '../types';
 
 export interface SearchNotebooksContext {
   console: ConsolePluginStart;
   notebooks: {
     getNotebookList: () => NotebookListValue;
   };
+  usageTracker: AppMetricsTracker;
 }
 
 type ServerlessSearchKibanaContext = CoreStart & SearchNotebooksContext;

--- a/x-pack/plugins/search_notebooks/public/hooks/use_usage_tracker.ts
+++ b/x-pack/plugins/search_notebooks/public/hooks/use_usage_tracker.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibanaServices } from './use_kibana';
+import { AppMetricsTracker } from '../types';
+
+export const useUsageTracker = (): AppMetricsTracker => {
+  const { usageTracker } = useKibanaServices();
+
+  return usageTracker;
+};

--- a/x-pack/plugins/search_notebooks/public/plugin.ts
+++ b/x-pack/plugins/search_notebooks/public/plugin.ts
@@ -14,14 +14,17 @@ import {
   SearchNotebooksPluginStart,
   SearchNotebooksPluginStartDependencies,
   NotebookListValue,
+  AppMetricsTracker,
 } from './types';
 import { getErrorCode, getErrorMessage, isKibanaServerError } from './utils/get_error_message';
+import { createUsageTracker } from './utils/usage_tracker';
 
 export class SearchNotebooksPlugin
   implements Plugin<SearchNotebooksPluginSetup, SearchNotebooksPluginStart>
 {
   private notebooksList: NotebookListValue = null;
   private queryClient: QueryClient | undefined;
+  private usageTracker: AppMetricsTracker | undefined;
 
   public setup(core: CoreSetup): SearchNotebooksPluginSetup {
     this.queryClient = new QueryClient({
@@ -56,11 +59,13 @@ export class SearchNotebooksPlugin
     core: CoreStart,
     deps: SearchNotebooksPluginStartDependencies
   ): SearchNotebooksPluginStart {
+    this.usageTracker = createUsageTracker(deps.usageCollection);
     if (deps.console?.registerEmbeddedConsoleAlternateView) {
       deps.console.registerEmbeddedConsoleAlternateView(
         notebooksConsoleView(
           core,
           this.queryClient!,
+          this.usageTracker,
           this.clearNotebookList.bind(this),
           this.getNotebookList.bind(this)
         )

--- a/x-pack/plugins/search_notebooks/public/types.ts
+++ b/x-pack/plugins/search_notebooks/public/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchNotebooksPluginSetup {}
@@ -16,6 +17,13 @@ export interface SearchNotebooksPluginStart {
 
 export interface SearchNotebooksPluginStartDependencies {
   console: ConsolePluginStart;
+  usageCollection?: UsageCollectionStart;
 }
 
 export type NotebookListValue = string | null;
+
+export interface AppMetricsTracker {
+  click: (eventName: string | string[]) => void;
+  count: (eventName: string | string[]) => void;
+  load: (eventName: string | string[]) => void;
+}

--- a/x-pack/plugins/search_notebooks/public/utils/get_error_message.ts
+++ b/x-pack/plugins/search_notebooks/public/utils/get_error_message.ts
@@ -7,7 +7,7 @@
 
 import { KibanaServerError } from '@kbn/kibana-utils-plugin/common';
 
-export function getErrorMessage(error: unknown): string {
+export function getErrorMessage(error: unknown, defaultMessage?: string): string {
   if (typeof error === 'string') {
     return error;
   }
@@ -19,7 +19,7 @@ export function getErrorMessage(error: unknown): string {
     return (error as { name: string }).name;
   }
 
-  return '';
+  return defaultMessage ?? '';
 }
 
 export function getErrorCode(error: unknown): number | undefined {

--- a/x-pack/plugins/search_notebooks/public/utils/usage_tracker.ts
+++ b/x-pack/plugins/search_notebooks/public/utils/usage_tracker.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { METRIC_TYPE, UiCounterMetricType } from '@kbn/analytics';
+import type {
+  UsageCollectionSetup,
+  UsageCollectionStart,
+} from '@kbn/usage-collection-plugin/public';
+import { AppMetricsTracker } from '../types';
+
+const APP_TRACKER_NAME = 'searchNotebooks';
+
+export function createUsageTracker(
+  usageCollection?: UsageCollectionSetup | UsageCollectionStart
+): AppMetricsTracker {
+  const track = (type: UiCounterMetricType, name: string | string[]) =>
+    usageCollection?.reportUiCounter(APP_TRACKER_NAME, type, name);
+  return {
+    click: (eventName: string | string[]) => {
+      track(METRIC_TYPE.CLICK, eventName);
+    },
+    count: (eventName: string | string[]) => {
+      track(METRIC_TYPE.COUNT, eventName);
+    },
+    load: (eventName: string | string[]) => {
+      track(METRIC_TYPE.LOADED, eventName);
+    },
+  };
+}

--- a/x-pack/plugins/search_notebooks/tsconfig.json
+++ b/x-pack/plugins/search_notebooks/tsconfig.json
@@ -15,6 +15,7 @@
     "target/**/*"
   ],
   "kbn_references": [
+    "@kbn/analytics",
     "@kbn/config-schema",
     "@kbn/core",
     "@kbn/i18n",
@@ -26,5 +27,6 @@
     "@kbn/shared-ux-utility",
     "@kbn/kibana-utils-plugin",
     "@kbn/ipynb",
+    "@kbn/usage-collection-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

Added telemetry tracking with usageCollection for opening notebooks view, viewing a specific notebook and errors fetching notebooks.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->