### PR TITLE
[APM] Unskip get environment test

### DIFF
--- a/x-pack/test/apm_api_integration/tests/environment/generate_data.ts
+++ b/x-pack/test/apm_api_integration/tests/environment/generate_data.ts
@@ -63,5 +63,5 @@ export async function generateData({
       return [...loopGeneratedDocs, customDoc];
     });
 
-  await apmSynthtraceEsClient.index(docs);
+  return apmSynthtraceEsClient.index(docs);
 }

--- a/x-pack/test/apm_api_integration/tests/environment/get_environment.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/environment/get_environment.spec.ts
@@ -28,9 +28,7 @@ export default function environmentsAPITests({ getService }: FtrProviderContext)
       })
     );
 
-    after(async () => {
-      await apmSynthtraceEsClient.clean();
-    });
+    after(() => apmSynthtraceEsClient.clean());
 
     describe('get environments', () => {
       describe('when service name is not specified', () => {

--- a/x-pack/test/apm_api_integration/tests/environment/get_environment.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/environment/get_environment.spec.ts
@@ -19,17 +19,18 @@ export default function environmentsAPITests({ getService }: FtrProviderContext)
   const apmApiClient = getService('apmApiClient');
   const apmSynthtraceEsClient = getService('apmSynthtraceEsClient');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/177305
   registry.when('environments when data is loaded', { config: 'basic', archives: [] }, async () => {
-    before(async () => {
-      await generateData({
+    before(async () =>
+      generateData({
         apmSynthtraceEsClient,
         start: startNumber,
         end: endNumber,
-      });
-    });
+      })
+    );
 
-    after(() => apmSynthtraceEsClient.clean());
+    after(async () => {
+      await apmSynthtraceEsClient.clean();
+    });
 
     describe('get environments', () => {
       describe('when service name is not specified', () => {


### PR DESCRIPTION
Fixes [177305](https://github.com/elastic/kibana/issues/177305)

## Summary

Another problem related to synthtrace not completing the creation of docs before the test case execution

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6514


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->