### PR TITLE
[A11y][Observability] keyboard navigatable view details popover

### DIFF
--- a/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_text_stream/log_entry_context_menu.tsx
+++ b/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_text_stream/log_entry_context_menu.tsx
@@ -8,16 +8,12 @@
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
-  EuiButton,
-  EuiIcon,
   EuiPopover,
   EuiContextMenuPanel,
   EuiContextMenuItem,
   EuiContextMenuItemProps,
+  EuiButtonEmpty,
 } from '@elastic/eui';
-
-import { euiStyled } from '@kbn/kibana-react-plugin/common';
-import { LogEntryColumnContent } from './log_entry_column';
 
 export interface LogEntryContextMenuItem {
   label: string;
@@ -59,18 +55,14 @@ export const LogEntryContextMenu: React.FC<LogEntryContextMenuProps> = ({
   }, [onClose]);
 
   const button = (
-    <ButtonWrapper>
-      <EuiButton
-        data-test-subj="infraLogEntryContextMenuButton"
-        size="s"
-        fill
-        aria-label={ariaLabel || DEFAULT_MENU_LABEL}
-        onClick={isOpen ? onClose : onOpen}
-        minWidth="auto"
-      >
-        <EuiIcon type="boxesHorizontal" />
-      </EuiButton>
-    </ButtonWrapper>
+    <EuiButtonEmpty
+      css={{ transform: 'translate(-6px, -6px)' }}
+      data-test-subj="infraLogEntryContextMenuButton"
+      size="s"
+      aria-label={ariaLabel || DEFAULT_MENU_LABEL}
+      onClick={isOpen ? onClose : onOpen}
+      iconType="boxesHorizontal"
+    />
   );
 
   const wrappedItems = useMemo(() => {
@@ -92,34 +84,22 @@ export const LogEntryContextMenu: React.FC<LogEntryContextMenuProps> = ({
   }, [items, closeMenuAndCall, externalItems]);
 
   return (
-    <LogEntryContextMenuContent>
-      <AbsoluteWrapper>
-        <EuiPopover
-          panelPaddingSize="none"
-          closePopover={onClose}
-          isOpen={isOpen}
-          button={button}
-          ownFocus={true}
-        >
-          <EuiContextMenuPanel items={wrappedItems} />
-        </EuiPopover>
-      </AbsoluteWrapper>
-    </LogEntryContextMenuContent>
+    <EuiPopover
+      css={{
+        overflow: 'hidden',
+        userSelect: 'none',
+        position: 'absolute',
+      }}
+      panelPaddingSize="none"
+      closePopover={onClose}
+      isOpen={isOpen}
+      button={button}
+      ownFocus={true}
+    >
+      <EuiContextMenuPanel items={wrappedItems} />
+    </EuiPopover>
   );
 };
-
-const LogEntryContextMenuContent = euiStyled(LogEntryColumnContent)`
-  overflow: hidden;
-  user-select: none;
-`;
-
-const AbsoluteWrapper = euiStyled.div`
-  position: absolute;
-`;
-
-const ButtonWrapper = euiStyled.div`
-  transform: translate(-6px, -6px);
-`;
 
 // eslint-disable-next-line import/no-default-export
 export default LogEntryContextMenu;


### PR DESCRIPTION
## Summary

~~Closes https://github.com/elastic/kibana/issues/194952~~

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

