### PR TITLE
[Security Solution][Endpoint] Fix Response Console not displaying the platform icon for non-Windows hosts when opened from an alert

### DIFF
--- a/x-pack/plugins/security_solution/public/common/hooks/endpoint/use_alert_response_actions_support.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/endpoint/use_alert_response_actions_support.ts
@@ -184,7 +184,7 @@ export const useAlertResponseActionsSupport = (
       );
     }
 
-    return getAlertDetailsFieldValue({ category: 'host', field: 'host.os.family' }, eventData);
+    return getAlertDetailsFieldValue({ category: 'host', field: 'host.os.type' }, eventData);
   }, [agentType, eventData]);
 
   const unsupportedReason = useMemo(() => {

--- a/x-pack/plugins/security_solution/public/common/mock/endpoint/endpoint_alert_data_mock.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/endpoint/endpoint_alert_data_mock.ts
@@ -119,6 +119,13 @@ const generateEndpointAlertDetailsItemDataMock = (
     {
       category: 'host',
       field: 'host.os.family',
+      values: ['Windows Server'],
+      originalValue: ['Windows Server'],
+      isObjectArray: false,
+    },
+    {
+      category: 'host',
+      field: 'host.os.type',
       values: ['windows'],
       originalValue: ['windows'],
       isObjectArray: false,
@@ -189,13 +196,6 @@ const generateCrowdStrikeAlertDetailsItemDataMock = (
       field: RESPONSE_ACTIONS_ALERT_AGENT_ID_FIELD.crowdstrike,
       values: ['abfe4a35-d5b4-42a0-a539-bd054c791769'],
       originalValue: ['abfe4a35-d5b4-42a0-a539-bd054c791769'],
-      isObjectArray: false,
-    },
-    {
-      category: 'host',
-      field: 'host.os.type',
-      values: ['windows'],
-      originalValue: ['windows'],
       isObjectArray: false,
     },
     {


### PR DESCRIPTION
## Summary

- Fixes `useAlertResponseActionsSupport()` hook so that the OS platform is retrieved from the alert's `host.os.type`
    - Note: tests already exist to validate this, however, the mocks were also incorrectly typed. Those are now corrected as well.





<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->