### PR TITLE
[Discover] Fix chart getting stuck on loading when switching from ES|QL

### DIFF
--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -247,6 +247,7 @@ export const useDiscoverHistogram = ({
   useEffect(() => {
     if (!isEsqlMode) {
       setIsSuggestionLoading(false);
+      return;
     }
 
     const fetchStart = stateContainer.dataState.fetch$.subscribe(() => {

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -246,7 +246,7 @@ export const useDiscoverHistogram = ({
 
   useEffect(() => {
     if (!isEsqlMode) {
-      return;
+      setIsSuggestionLoading(false);
     }
 
     const fetchStart = stateContainer.dataState.fetch$.subscribe(() => {


### PR DESCRIPTION
## Summary

This PR fixes an issue I noticed where the Discover chart can get stuck on loading when switching from ES|QL to data view mode due to a race condition:

https://github.com/elastic/kibana/assets/25592674/811448c6-0256-4fe4-a362-bc966d8d9ffd

Really this shouldn't happen, and there's likely an underlying race condition with the state management causing it which this PR doesn't address, but it prevents the UX issue of the chart getting stuck in a visible loading state to users.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->