### PR TITLE
[Cloud Security] Broken UI fix

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -74,8 +74,11 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
         <h2>
           <FormattedMessage
             id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.promptTitle"
-            defaultMessage="Detect vulnerabilities in your <br/> cloud assets"
+            defaultMessage="Detect vulnerabilities in your {lineBreak} cloud assets"
             ignoreTag
+            values={{
+              lineBreak: <br />,
+            }}
           />
         </h2>
       }

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -333,8 +333,13 @@ const CurrentPageOfTotal = ({
           <EuiText size="xs" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
             <FormattedMessage
               id="xpack.csp.rules.rulesTable.showingPageOfTotalLabel"
-              defaultMessage="Showing {pageSize} of {total, plural, one {# rule} other {# rules}} \u2000|\u2000 Selected {selectedRulesAmount, plural, one {# rule} other {# rules}}"
-              values={{ pageSize, total, selectedRulesAmount: selectedRules.length || 0 }}
+              defaultMessage="Showing {pageSize} of {total, plural, one {# rule} other {# rules}} {pipe} Selected {selectedRulesAmount, plural, one {# rule} other {# rules}}"
+              values={{
+                pageSize,
+                total,
+                selectedRulesAmount: selectedRules.length || 0,
+                pipe: '\u2000|\u2000',
+              }}
             />
           </EuiText>
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Fix for line break tag showing up as text instead of actual line break 
Fix for Pipe symbol not showing properly

**BEFORE**
![341360105-1705fa0f-fc9c-4068-b1bc-ae578d14b7c5](https://github.com/elastic/kibana/assets/8703149/05b5f568-70b4-44b2-9c2f-eb566d446f2a)
<img width="801" alt="Screenshot 2024-07-10 at 4 53 21 PM" src="https://github.com/elastic/kibana/assets/8703149/b581814f-35e2-40e6-8718-76a21659e9fe">


**AFTER**
<img width="1399" alt="Screenshot 2024-07-10 at 3 34 03 PM" src="https://github.com/elastic/kibana/assets/8703149/a1b49202-2e01-49fb-9cb0-8bf3234e778b">
<img width="641" alt="Screenshot 2024-07-10 at 4 50 50 PM" src="https://github.com/elastic/kibana/assets/8703149/b95b0036-9ac1-40a6-ad96-36a7ccf70b0a">






<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->