### PR TITLE
[APM] Unskip ml jobs test

### DIFF
--- a/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/anomaly_detection/write_user.ts
@@ -53,7 +53,7 @@ export default function apiTest({ getService }: FtrProviderContext) {
       });
 
       // FAILING ES FORWARD COMPATIBILITY: https://github.com/elastic/kibana/issues/179168
-      describe.skip('when calling create endpoint', () => {
+      describe('when calling create endpoint', () => {
         it('creates two jobs', async () => {
           await createJobs(['production', 'staging']);
 


### PR DESCRIPTION
closes [#179168](https://github.com/elastic/kibana/issues/179168)
## Summary

I ran this test against 8.14.0, 8.14.1, 8.14.2, and 8.14.3 and got no errors.

### How to test

`ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/ES_VERSION/manifest-latest-verified.json" yarn test:ftr:server --config x-pack/test/apm_api_integration/trial/config.ts`

`yarn test:ftr:runner --es-version=ESVERSION --config=x-pack/test/apm_api_integration/trial/config.ts --grep="ML jobs"`

