### PR TITLE
fix: [Obs Synthetics > Monitor Detail][SCREEN READER] Icons and repeated controls need unique accessible labels: 0013

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/components/view_document.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/components/view_document.tsx
@@ -20,6 +20,7 @@ export const ViewDocument = ({ ping }: { ping: Ping }) => {
 
   const dataView = useSyntheticsDataView();
   const formatter = useDateFormat();
+  const formattedTimestamp = formatter(ping.timestamp);
 
   const [, hit] = useEsDocSearch({ id: ping.docId, index: SYNTHETICS_INDEX_PATTERN, dataView });
 
@@ -28,7 +29,7 @@ export const ViewDocument = ({ ping }: { ping: Ping }) => {
       <EuiButtonIcon
         data-test-subj="syntheticsViewDocumentButton"
         iconType="inspect"
-        title={INSPECT_DOCUMENT}
+        title={INSPECT_DOCUMENT(formattedTimestamp)}
         onClick={(evt: MouseEvent<HTMLButtonElement>) => {
           evt.stopPropagation();
           setIsFlyoutVisible(true);
@@ -46,7 +47,7 @@ export const ViewDocument = ({ ping }: { ping: Ping }) => {
           <EuiFlyoutHeader>
             <EuiTitle size="m">
               <h4>
-                {INDEXED_AT} {formatter(ping.timestamp)}
+                {INDEXED_AT} {formattedTimestamp}
               </h4>
             </EuiTitle>
           </EuiFlyoutHeader>
@@ -67,9 +68,8 @@ const INDEXED_AT = i18n.translate('xpack.synthetics.monitorDetails.summary.index
   defaultMessage: 'Indexed at',
 });
 
-export const INSPECT_DOCUMENT = i18n.translate(
-  'xpack.synthetics.monitorDetails.action.inspectDocument',
-  {
-    defaultMessage: 'Inspect document',
-  }
-);
+export const INSPECT_DOCUMENT = (timestamp: string) =>
+  i18n.translate('xpack.synthetics.monitorDetails.action.inspectDocument', {
+    defaultMessage: 'Inspect document timestamped {timestamp}',
+    values: { timestamp },
+  });

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
@@ -31,6 +31,7 @@ export const StepDetailsLinkIcon = ({
 }) => {
   const { basePath } = useSyntheticsSettingsContext();
   const selectedLocation = useSelectedLocation();
+  const title = VIEW_DETAILS(stepIndex);
 
   const stepDetailsLink = `${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}`;
 
@@ -52,8 +53,8 @@ export const StepDetailsLinkIcon = ({
     <EuiButtonIcon
       data-test-subj="syntheticsStepDetailsLinkIconButton"
       {...commonProps}
-      aria-label={VIEW_DETAILS}
-      title={VIEW_DETAILS}
+      aria-label={title}
+      title={title}
       size="s"
       href={stepDetailsLink}
       target={target}
@@ -62,6 +63,10 @@ export const StepDetailsLinkIcon = ({
   );
 };
 
-const VIEW_DETAILS = i18n.translate('xpack.synthetics.monitor.step.viewStepDetails', {
-  defaultMessage: 'View step details',
-});
+const VIEW_DETAILS = (stepIndex: number) =>
+  i18n.translate('xpack.synthetics.monitor.step.viewStepDetails', {
+    defaultMessage: 'View step {stepIndex} details',
+    values: {
+      stepIndex,
+    },
+  });

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/common/links/step_details_link.tsx
@@ -31,7 +31,6 @@ export const StepDetailsLinkIcon = ({
 }) => {
   const { basePath } = useSyntheticsSettingsContext();
   const selectedLocation = useSelectedLocation();
-  const title = VIEW_DETAILS(stepIndex);
 
   const stepDetailsLink = `${basePath}/app/synthetics/monitor/${configId}/test-run/${checkGroup}/step/${stepIndex}?locationId=${selectedLocation?.id}`;
 
@@ -53,8 +52,7 @@ export const StepDetailsLinkIcon = ({
     <EuiButtonIcon
       data-test-subj="syntheticsStepDetailsLinkIconButton"
       {...commonProps}
-      aria-label={title}
-      title={title}
+      title={VIEW_DETAILS(stepIndex)}
       size="s"
       href={stepDetailsLink}
       target={target}
@@ -63,7 +61,7 @@ export const StepDetailsLinkIcon = ({
   );
 };
 
-const VIEW_DETAILS = (stepIndex: number) =>
+const VIEW_DETAILS = (stepIndex: number = 1) =>
   i18n.translate('xpack.synthetics.monitor.step.viewStepDetails', {
     defaultMessage: 'View step {stepIndex} details',
     values: {


### PR DESCRIPTION
Closes: https://github.com/elastic/observability-dev/issues/3651

# Description 

Observability has a lot of icons that are used for controls and table row actions. These icons often have the same aria-label repeated across rows. While this meets the letter of SC 1.3.1: Info and Relationships, the repeated generic labels do not usually answer question what users are editing, or what users are deleting. We want to provide clear labels for each row to make the implicit relationships sighted users depend on, explicit for screen reader users.

# Steps to repeat
1. Open the Inventory view
2. Turn on a screen reader
3. Traverse through the tables in screenshots
4. Verify the buttons do not describe what test run or document you're taking action on

# What was changed?: 
1. `title`, `arial-label` attributes were updated for `EuiButtonIcon`'s

# Screen:
 
<img width="1546" alt="image" src="https://github.com/elastic/kibana/assets/20072247/fedc7756-d077-4a6e-bd80-af49b69b541c">



<img width="1546" alt="image" src="https://github.com/elastic/kibana/assets/20072247/ec0364c8-8fe5-448d-9a4d-c5f2b19a171d">