### PR TITLE
Enable manual rule run in 8.15 branch

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -257,7 +257,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the manual rule run
    */
-  manualRuleRunEnabled: false,
+  manualRuleRunEnabled: true,
 
   /**
    * Adds a new option to filter descendants of a process for Management / Event Filters


### PR DESCRIPTION
## Enable manual rule run in 8.15 (this PR target in 8.15, not main)

As we want to enable manual rule run in 8.15, but we can't yet do it in main, as docs not ready.
We want to enable in 8.15 to be able test in BC

