### PR TITLE
[Infra] Limit the number of metrics accepted by Snapshot API

### DIFF
--- a/x-pack/plugins/observability_solution/infra/common/constants.ts
+++ b/x-pack/plugins/observability_solution/infra/common/constants.ts
@@ -42,3 +42,5 @@ export const DEFAULT_METRICS_VIEW_ATTRIBUTES = {
   name: 'Metrics View',
   timeFieldName: TIMESTAMP_FIELD,
 };
+
+export const SNAPSHOT_API_MAX_METRICS = 20;

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/custom_metric_form.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/custom_metric_form.tsx
@@ -198,6 +198,7 @@ export const CustomMetricForm = withTheme(({ theme, onCancel, onChange, metric }
                   options={fieldOptions}
                   onChange={handleFieldChange}
                   isClearable={false}
+                  data-test-subj="infraCustomMetricFieldSelect"
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/index.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/index.tsx
@@ -9,6 +9,7 @@ import { EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useState, useCallback } from 'react';
 import { SnapshotMetricType } from '@kbn/metrics-data-access-plugin/common';
+import { SNAPSHOT_API_MAX_METRICS } from '../../../../../../../common/constants';
 import { getCustomMetricLabel } from '../../../../../../../common/formatters/get_custom_metric_label';
 import {
   SnapshotMetricInput,
@@ -132,10 +133,13 @@ export const WaffleMetricControls = ({
     return null;
   }
 
+  const canAdd = options.length + customMetrics.length < SNAPSHOT_API_MAX_METRICS;
+
   const button = (
     <DropdownButton
       onClick={handleToggle}
       label={i18n.translate('xpack.infra.waffle.metriclabel', { defaultMessage: 'Metric' })}
+      data-test-subj="infraInventoryMetricDropdown"
     >
       {currentLabel}
     </DropdownButton>
@@ -190,6 +194,7 @@ export const WaffleMetricControls = ({
           mode={mode}
           onSave={handleSaveEdit}
           customMetrics={customMetrics}
+          disableAdd={!canAdd}
         />
       </EuiPopover>
     </>

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/metrics_context_menu.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/metrics_context_menu.tsx
@@ -70,5 +70,11 @@ export const MetricsContextMenu = ({
     },
   ];
 
-  return <EuiContextMenu initialPanelId={0} panels={panels} />;
+  return (
+    <EuiContextMenu
+      initialPanelId={0}
+      panels={panels}
+      data-test-subj="infraInventoryMetricsContextMenu"
+    />
+  );
 };

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/mode_switcher.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/mode_switcher.tsx
@@ -5,98 +5,123 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButton } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButton, EuiToolTip } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiTheme, withTheme } from '@kbn/kibana-react-plugin/common';
+import {} from '@elastic/eui';
+import { useEuiTheme } from '@elastic/eui';
+import { SNAPSHOT_API_MAX_METRICS } from '../../../../../../../common/constants';
 import { CustomMetricMode } from './types';
 import { SnapshotCustomMetricInput } from '../../../../../../../common/http_api/snapshot_api';
 
 interface Props {
-  theme: EuiTheme | undefined;
   onEdit: () => void;
   onAdd: () => void;
   onSave: () => void;
   onEditCancel: () => void;
   mode: CustomMetricMode;
   customMetrics: SnapshotCustomMetricInput[];
+  disableAdd?: boolean;
 }
 
-export const ModeSwitcher = withTheme(
-  ({ onSave, onEditCancel, onEdit, onAdd, mode, customMetrics, theme }: Props) => {
-    if (['editMetric', 'addMetric'].includes(mode)) {
-      return null;
-    }
-    return (
-      <div
-        style={{
-          borderTop: `${theme?.eui.euiBorderWidthThin} solid ${theme?.eui.euiBorderColor}`,
-          padding: 12,
-        }}
-      >
-        <EuiFlexGroup justifyContent="spaceBetween">
-          {mode === 'edit' ? (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  data-test-subj="infraModeSwitcherCancelButton"
-                  size="s"
-                  flush="left"
-                  onClick={onEditCancel}
-                  aria-label={i18n.translate(
-                    'xpack.infra.waffle.customMetrics.modeSwitcher.cancelAriaLabel',
-                    { defaultMessage: 'Cancel edit mode' }
-                  )}
-                >
-                  <FormattedMessage
-                    id="xpack.infra.waffle.customMetrics.modeSwitcher.cancel"
-                    defaultMessage="Cancel"
-                  />
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  data-test-subj="infraModeSwitcherSaveButton"
-                  onClick={onSave}
-                  size="s"
-                  fill
-                  aria-label={i18n.translate(
-                    'xpack.infra.waffle.customMetrics.modeSwitcher.saveButtonAriaLabel',
-                    { defaultMessage: 'Save changes to custom metrics' }
-                  )}
-                >
-                  <FormattedMessage
-                    id="xpack.infra.waffle.customMetrics.modeSwitcher.saveButton"
-                    defaultMessage="Save"
-                  />
-                </EuiButton>
-              </EuiFlexItem>
-            </>
-          ) : (
-            <>
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  data-test-subj="infraModeSwitcherEditButton"
-                  size="s"
-                  flush="left"
-                  onClick={onEdit}
-                  disabled={customMetrics.length === 0}
-                  aria-label={i18n.translate(
-                    'xpack.infra.waffle.customMetrics.modeSwitcher.editAriaLabel',
-                    { defaultMessage: 'Edit custom metrics' }
-                  )}
-                >
-                  <FormattedMessage
-                    id="xpack.infra.waffle.customMetrics.modeSwitcher.edit"
-                    defaultMessage="Edit"
-                  />
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
+export const ModeSwitcher = ({
+  onSave,
+  onEditCancel,
+  onEdit,
+  onAdd,
+  mode,
+  customMetrics,
+  disableAdd = false,
+}: Props) => {
+  const { euiTheme } = useEuiTheme();
+
+  if (['editMetric', 'addMetric'].includes(mode)) {
+    return null;
+  }
+  return (
+    <div
+      style={{
+        borderTop: `${euiTheme.border.thin} solid ${euiTheme.border.color}`,
+        padding: 12,
+      }}
+    >
+      <EuiFlexGroup justifyContent="spaceBetween">
+        {mode === 'edit' ? (
+          <>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                data-test-subj="infraModeSwitcherCancelButton"
+                size="s"
+                flush="left"
+                onClick={onEditCancel}
+                aria-label={i18n.translate(
+                  'xpack.infra.waffle.customMetrics.modeSwitcher.cancelAriaLabel',
+                  { defaultMessage: 'Cancel edit mode' }
+                )}
+              >
+                <FormattedMessage
+                  id="xpack.infra.waffle.customMetrics.modeSwitcher.cancel"
+                  defaultMessage="Cancel"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                data-test-subj="infraModeSwitcherSaveButton"
+                onClick={onSave}
+                size="s"
+                fill
+                aria-label={i18n.translate(
+                  'xpack.infra.waffle.customMetrics.modeSwitcher.saveButtonAriaLabel',
+                  { defaultMessage: 'Save changes to custom metrics' }
+                )}
+              >
+                <FormattedMessage
+                  id="xpack.infra.waffle.customMetrics.modeSwitcher.saveButton"
+                  defaultMessage="Save"
+                />
+              </EuiButton>
+            </EuiFlexItem>
+          </>
+        ) : (
+          <>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                data-test-subj="infraModeSwitcherEditButton"
+                size="s"
+                flush="left"
+                onClick={onEdit}
+                disabled={customMetrics.length === 0}
+                aria-label={i18n.translate(
+                  'xpack.infra.waffle.customMetrics.modeSwitcher.editAriaLabel',
+                  { defaultMessage: 'Edit custom metrics' }
+                )}
+              >
+                <FormattedMessage
+                  id="xpack.infra.waffle.customMetrics.modeSwitcher.edit"
+                  defaultMessage="Edit"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                content={
+                  disableAdd
+                    ? i18n.translate(
+                        'xpack.infra.waffle.customMetrics.modeSwitcher.addDisabledTooltip',
+                        {
+                          defaultMessage: 'Maximum number of {maxMetrics} metrics reached.',
+                          values: { maxMetrics: SNAPSHOT_API_MAX_METRICS },
+                        }
+                      )
+                    : undefined
+                }
+              >
                 <EuiButtonEmpty
                   data-test-subj="infraModeSwitcherAddMetricButton"
                   onClick={onAdd}
+                  disabled={disableAdd}
                   size="s"
                   flush="right"
                   aria-label={i18n.translate(
@@ -109,11 +134,11 @@ export const ModeSwitcher = withTheme(
                     defaultMessage="Add metric"
                   />
                 </EuiButtonEmpty>
-              </EuiFlexItem>
-            </>
-          )}
-        </EuiFlexGroup>
-      </div>
-    );
-  }
-);
+              </EuiToolTip>
+            </EuiFlexItem>
+          </>
+        )}
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/mode_switcher.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/inventory_view/components/waffle/metric_control/mode_switcher.tsx
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiButton, EuiToolTip } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  EuiButton,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import {} from '@elastic/eui';
-import { useEuiTheme } from '@elastic/eui';
 import { SNAPSHOT_API_MAX_METRICS } from '../../../../../../../common/constants';
 import { CustomMetricMode } from './types';
 import { SnapshotCustomMetricInput } from '../../../../../../../common/http_api/snapshot_api';

--- a/x-pack/test/api_integration/apis/metrics_ui/snapshot.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/snapshot.ts
@@ -622,5 +622,26 @@ export default function ({ getService }: FtrProviderContext) {
         }
       });
     });
+
+    describe('request validation', () => {
+      it('should return 400 when requesting more than 20 metrics', async () => {
+        const { min, max } = DATES['8.0.0'].logs_and_metrics;
+        await fetchSnapshot(
+          {
+            sourceId: 'default',
+            timerange: {
+              to: max,
+              from: min,
+              interval: '1m',
+            },
+            metrics: Array(21).fill({ type: 'cpu' }),
+            nodeType: 'host',
+            groupBy: [{ field: 'service.type' }],
+            includeTimeseries: true,
+          },
+          400
+        );
+      });
+    });
   });
 }

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -555,6 +555,39 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           });
         });
       });
+
+      it('should not allow adding more than 20 custom metrics', async () => {
+        // open
+        await pageObjects.infraHome.clickCustomMetricDropdown();
+
+        const fields = [
+          'process.cpu.pct',
+          'process.memory.pct',
+          'system.core.total.pct',
+          'system.core.user.pct',
+          'system.core.nice.pct',
+          'system.core.idle.pct',
+          'system.core.iowait.pct',
+          'system.core.irq.pct',
+          'system.core.softirq.pct',
+          'system.core.steal.pct',
+          'system.cpu.nice.pct',
+          'system.cpu.idle.pct',
+          'system.cpu.iowait.pct',
+          'system.cpu.irq.pct',
+        ];
+
+        for (const field of fields) {
+          await pageObjects.infraHome.addCustomMetric(field);
+        }
+        const metricsCount = await pageObjects.infraHome.getMetricsContextMenuItemsCount();
+        // there are 6 default metrics in the context menu for hosts
+        expect(metricsCount).to.eql(20);
+
+        await pageObjects.infraHome.ensureCustomMetricAddButtonIsDisabled();
+        // close
+        await pageObjects.infraHome.clickCustomMetricDropdown();
+      });
     });
 
     describe('alerts flyouts', () => {

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -482,5 +482,27 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
     async clickCloseFlyoutButton() {
       return testSubjects.click('euiFlyoutCloseButton');
     },
+
+    async clickCustomMetricDropdown() {
+      await testSubjects.click('infraInventoryMetricDropdown');
+    },
+
+    async addCustomMetric(field: string) {
+      await testSubjects.click('infraModeSwitcherAddMetricButton');
+      const groupByCustomField = await testSubjects.find('infraCustomMetricFieldSelect');
+      await comboBox.setElement(groupByCustomField, field);
+      await testSubjects.click('infraCustomMetricFormSaveButton');
+    },
+
+    async getMetricsContextMenuItemsCount() {
+      const contextMenu = await testSubjects.find('infraInventoryMetricsContextMenu');
+      const menuItems = await contextMenu.findAllByCssSelector('button.euiContextMenuItem');
+      return menuItems.length;
+    },
+
+    async ensureCustomMetricAddButtonIsDisabled() {
+      const button = await testSubjects.find('infraModeSwitcherAddMetricButton');
+      expect(await button.getAttribute('disabled')).to.be('true');
+    },
   };
 }


### PR DESCRIPTION
part of [3628](https://github.com/elastic/observability-dev/issues/3628) - private


## Summary

After adding 20 items, users can no longer add more metrics and will see the "Add metric" button disabled with a tooltip 

<img width="1713" alt="image" src="https://github.com/user-attachments/assets/c784b08b-e118-4491-b53d-46bfde898216">


### How to test

- Start a local Kibana instance pointing to an oblt cluster
- Navigate to Infrastructure
- Try to add more than 20 metrics in the Metrics dropdown.



<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->