### PR TITLE
[FTR] Fix for env variables read

### DIFF
--- a/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
+++ b/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
@@ -32,26 +32,34 @@ import { preventParallelCalls } from './prevent_parallel_calls';
 import { Browsers } from './browsers';
 import { NetworkProfile, NETWORK_PROFILES } from './network_profiles';
 
-const throttleOption: string = process.env.TEST_THROTTLE_NETWORK as string;
-const headlessBrowser: string = process.env.TEST_BROWSER_HEADLESS as string;
-const browserBinaryPath: string = process.env.TEST_BROWSER_BINARY_PATH as string;
-const remoteDebug: string = process.env.TEST_REMOTE_DEBUG as string;
-const certValidation: string = process.env.NODE_TLS_REJECT_UNAUTHORIZED as string;
-const noCache: string = process.env.TEST_DISABLE_CACHE as string;
+const now = Date.now();
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 const NO_QUEUE_COMMANDS = ['getLog', 'getStatus', 'newSession', 'quit'];
 const downloadDir = resolve(REPO_ROOT, 'target/functional-tests/downloads');
-const chromiumUserPrefs = {
-  'download.default_directory': downloadDir,
-  'download.prompt_for_download': false,
-  'profile.content_settings.exceptions.clipboard': {
-    '[*.],*': {
-      last_modified: Date.now(),
-      setting: 1,
+
+// ENV variables may be injected dynamically by the test runner CLI script
+// so do not read on module load, rather read on demand.
+function getConfiguration() {
+  return {
+    throttleOption: process.env.TEST_THROTTLE_NETWORK as string,
+    headlessBrowser: process.env.TEST_BROWSER_HEADLESS as string,
+    browserBinaryPath: process.env.TEST_BROWSER_BINARY_PATH as string,
+    remoteDebug: process.env.TEST_REMOTE_DEBUG as string,
+    certValidation: process.env.NODE_TLS_REJECT_UNAUTHORIZED as string,
+    noCache: process.env.TEST_DISABLE_CACHE as string,
+    chromiumUserPrefs: {
+      'download.default_directory': downloadDir,
+      'download.prompt_for_download': false,
+      'profile.content_settings.exceptions.clipboard': {
+        '[*.],*': {
+          last_modified: now,
+          setting: 1,
+        },
+      },
     },
-  },
-};
+  };
+}
 
 const sleep$ = (ms: number) => Rx.timer(ms).pipe(ignoreElements());
 
@@ -75,6 +83,14 @@ export interface BrowserConfig {
 
 function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean) {
   const options = browserType === Browsers.Chrome ? new chrome.Options() : new edge.Options();
+  const {
+    headlessBrowser,
+    certValidation,
+    remoteDebug,
+    browserBinaryPath,
+    noCache,
+    chromiumUserPrefs,
+  } = getConfiguration();
 
   options.addArguments(
     // Disables the sandbox for all process types that are normally sandboxed.
@@ -162,6 +178,7 @@ async function attemptToCreateCommand(
   const attemptId = ++attemptCounter;
   log.debug('[webdriver] Creating session');
   const remoteSessionUrl = process.env.REMOTE_SESSION_URL;
+  const { headlessBrowser, throttleOption, noCache } = getConfiguration();
 
   const buildDriverInstance = async () => {
     switch (browserType) {


### PR DESCRIPTION
## Summary

Fix #174752

env variables were read on module load, so before the CLI script could change them based on user flag inputs.
This PR fixes making it lazily read the variable when required picking up always the fresh value after the CLI set it.

After a first read of the value, it avoids to re-read env variables again, preventing other scripts to poison it.
