### PR TITLE
[Security Solution][Notes] - fix attach to active timeline behavior

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/add_note.tsx
@@ -93,7 +93,8 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
 
   // if the flyout is open from a timeline and that timeline is saved, we automatically check the checkbox to associate the note to it
   const isTimelineFlyout = useIsTimelineFlyoutOpen();
-  const [checked, setChecked] = useState(isTimelineFlyout && activeTimeline.savedObjectId != null);
+
+  const [checked, setChecked] = useState<boolean>(true);
   const onCheckboxChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => setChecked(e.target.checked),
     []
@@ -130,6 +131,11 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
   const buttonDisabled = useMemo(
     () => editorValue.trim().length === 0 || isMarkdownInvalid,
     [editorValue, isMarkdownInvalid]
+  );
+
+  const initialCheckboxChecked = useMemo(
+    () => isTimelineFlyout && activeTimeline.savedObjectId != null,
+    [activeTimeline?.savedObjectId, isTimelineFlyout]
   );
 
   const checkBoxDisabled = useMemo(
@@ -171,7 +177,7 @@ export const AddNote = memo(({ eventId }: AddNewNoteProps) => {
                 </>
               }
               disabled={checkBoxDisabled}
-              checked={checked}
+              checked={initialCheckboxChecked && checked}
               onChange={(e) => onCheckboxChange(e)}
             />
           </>

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_is_timeline_flyout_open.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_is_timeline_flyout_open.test.ts
@@ -30,6 +30,13 @@ describe('useInvestigationGuide', () => {
     expect(hookResult.result.current).toEqual(false);
   });
 
+  it('should return false when timeline flyout is in url but params are empty preview', () => {
+    window.location.search =
+      'http://app/security/alerts&flyout=(right:(id:document-details-right))&timelineFlyout=(preview:!())';
+    const hookResult = renderHook(() => useIsTimelineFlyoutOpen());
+    expect(hookResult.result.current).toEqual(false);
+  });
+
   it('should return true when timeline flyout is open', () => {
     window.location.search =
       'http://app/security/alerts&flyout=(right:(id:document-details-right))&timelineFlyout=(right:(id:document-details-right,params:(id:id,indexName:index,scopeId:scope)))';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_is_timeline_flyout_open.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_is_timeline_flyout_open.ts
@@ -14,7 +14,10 @@ import { URL_PARAM_KEY } from '../../../../common/hooks/use_url_state';
  */
 export const useIsTimelineFlyoutOpen = (): boolean => {
   const query = new URLSearchParams(window.location.search);
-  return (
-    query.has(URL_PARAM_KEY.timelineFlyout) && query.get(URL_PARAM_KEY.timelineFlyout) !== '()'
-  );
+  const queryHasTimelineFlyout = query.has(URL_PARAM_KEY.timelineFlyout);
+  const timelineFlyoutHasValue =
+    query.get(URL_PARAM_KEY.timelineFlyout) !== '()' &&
+    query.get(URL_PARAM_KEY.timelineFlyout) !== '(preview:!())';
+
+  return queryHasTimelineFlyout && timelineFlyoutHasValue;
 };


### PR DESCRIPTION
## Summary

This PR fixes the behavior of the `Attach to active timeline` checkbox in the new Notes tab of the expandable flyout.

The expected behavior is as follows:
- checkbox should be disabled and unchecked if the user opens the flyout from a non-timeline location (like the alerts table on the alerts page, of the events table on the explore pages)
- checkbox should be disabled and unchecked if the user opens the flyout from a non-saved timeline
- checkbox should be enabled and checked when the user opens the flyout from a saved timeline

#### Opening from the alerts table on the alerts page (with no timeline)

https://github.com/user-attachments/assets/a3999d2b-0f5d-4583-ae6b-b7d81e04c1bc

#### Opening from an unsaved timeline

https://github.com/user-attachments/assets/433a9364-414e-4f99-8a5c-8df3b8b2b2a8

#### Opening from a saved timeline


https://github.com/user-attachments/assets/8f6bd9fa-5b8c-4bd6-a616-c4968b5379ac

#### Opening from the alerts table on the alerts page (with saved timeline)

https://github.com/user-attachments/assets/d7f4bcce-5e3f-4f30-acd5-f998769123d6


### Notes

The PR also updated the `useIsTimelineFlyoutOpen` hook to handle the situation where the url has the following value `(preview:!())`. This behavior was introduced I believe in [this PR](https://github.com/elastic/kibana/pull/186130).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->