### PR TITLE
[POC] Discover filter icons

### DIFF
--- a/packages/kbn-unified-data-table/src/components/default_cell_actions.tsx
+++ b/packages/kbn-unified-data-table/src/components/default_cell_actions.tsx
@@ -46,7 +46,7 @@ export const FilterInBtn = (
       onClick={() => {
         onFilterCell(context, rowIndex, columnId, '+', field);
       }}
-      iconType="plusInCircle"
+      iconType="filterInclude"
       aria-label={buttonTitle}
       title={buttonTitle}
       data-test-subj="filterForButton"
@@ -73,7 +73,7 @@ export const FilterOutBtn = (
       onClick={() => {
         onFilterCell(context, rowIndex, columnId, '-', field);
       }}
-      iconType="minusInCircle"
+      iconType="filterExclude"
       aria-label={buttonTitle}
       title={buttonTitle}
       data-test-subj="filterOutButton"

--- a/packages/kbn-unified-field-list/src/components/field_stats/field_top_values_bucket.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_stats/field_top_values_bucket.tsx
@@ -153,8 +153,8 @@ const FieldTopValuesBucket: React.FC<FieldTopValuesBucketProps> = ({
           ) : (
             <div>
               <EuiButtonIcon
-                iconSize="s"
-                iconType="plusInCircle"
+                iconSize="m"
+                iconType="filterInclude"
                 onClick={() => onAddFilter(field, fieldValue, '+')}
                 aria-label={i18n.translate(
                   'unifiedFieldList.fieldStats.filterValueButtonAriaLabel',
@@ -174,8 +174,8 @@ const FieldTopValuesBucket: React.FC<FieldTopValuesBucketProps> = ({
                 }}
               />
               <EuiButtonIcon
-                iconSize="s"
-                iconType="minusInCircle"
+                iconSize="m"
+                iconType="filterExclude"
                 onClick={() => onAddFilter(field, fieldValue, '-')}
                 aria-label={i18n.translate(
                   'unifiedFieldList.fieldStats.filterOutValueButtonAriaLabel',

--- a/src/plugins/discover/public/components/data_types/logs/filter_in_button.tsx
+++ b/src/plugins/discover/public/components/data_types/logs/filter_in_button.tsx
@@ -29,7 +29,7 @@ export const FilterInButton = ({ property, value }: { property: string; value: s
     <EuiFlexItem key="addToFilterAction">
       <EuiButtonEmpty
         size="s"
-        iconType="plusInCircle"
+        iconType="filterInclude"
         aria-label={ariaFilterForText}
         onClick={onFilterForAction}
         data-test-subj={`dataTableCellAction_addToFilterAction_${property}`}

--- a/src/plugins/discover/public/components/data_types/logs/filter_out_button.tsx
+++ b/src/plugins/discover/public/components/data_types/logs/filter_out_button.tsx
@@ -29,7 +29,7 @@ export const FilterOutButton = ({ property, value }: { property: string; value: 
     <EuiFlexItem key="removeFromFilterAction">
       <EuiButtonEmpty
         size="s"
-        iconType="minusInCircle"
+        iconType="filterExclude"
         aria-label={ariaFilterOutText}
         onClick={onFilterOutAction}
         data-test-subj={`dataTableCellAction_removeFromFilterAction_${property}`}

--- a/src/plugins/discover/public/components/doc_table/components/table_row/__snapshots__/table_cell.test.tsx.snap
+++ b/src/plugins/discover/public/components/doc_table/components/table_row/__snapshots__/table_cell.test.tsx.snap
@@ -77,14 +77,14 @@ exports[`Doc table cell component renders a cell with filter buttons if it is fi
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock{display:inline-block;}
                         </style>
                         <style
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock *[disabled]{pointer-events:none;}
                         </style>
                       </head>,
@@ -99,14 +99,14 @@ exports[`Doc table cell component renders a cell with filter buttons if it is fi
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock{display:inline-block;}
                         </style>,
                         <style
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock *[disabled]{pointer-events:none;}
                         </style>,
                       ],
@@ -141,11 +141,11 @@ exports[`Doc table cell component renders a cell with filter buttons if it is fi
                   <EuiIcon
                     color="primary"
                     size="s"
-                    type="plusInCircle"
+                    type="filterInclude"
                   >
                     <span
                       color="primary"
-                      data-euiicon-type="plusInCircle"
+                      data-euiicon-type="filterInclude"
                       size="s"
                     />
                   </EuiIcon>
@@ -204,14 +204,14 @@ exports[`Doc table cell component renders a cell with filter buttons if it is fi
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock{display:inline-block;}
                         </style>
                         <style
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock *[disabled]{pointer-events:none;}
                         </style>
                       </head>,
@@ -226,14 +226,14 @@ exports[`Doc table cell component renders a cell with filter buttons if it is fi
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock{display:inline-block;}
                         </style>,
                         <style
                           data-emotion="css"
                           data-s=""
                         >
-                          
+
                           .emotion-euiToolTipAnchor-inlineBlock *[disabled]{pointer-events:none;}
                         </style>,
                       ],
@@ -268,11 +268,11 @@ exports[`Doc table cell component renders a cell with filter buttons if it is fi
                   <EuiIcon
                     color="primary"
                     size="s"
-                    type="minusInCircle"
+                    type="filterExclude"
                   >
                     <span
                       color="primary"
-                      data-euiicon-type="minusInCircle"
+                      data-euiicon-type="filterExclude"
                       size="s"
                     />
                   </EuiIcon>

--- a/src/plugins/discover/public/components/doc_table/components/table_row/table_cell_actions.tsx
+++ b/src/plugins/discover/public/components/doc_table/components/table_row/table_cell_actions.tsx
@@ -33,7 +33,7 @@ export const TableCellActions = ({ handleFilterFor, handleFilterOut }: TableCell
           })}
           onClick={handleFilterFor}
         >
-          <EuiIcon type="plusInCircle" size="s" color="primary" />
+          <EuiIcon type="filterInclude" size="s" color="primary" />
         </button>
       </EuiToolTip>
 
@@ -52,7 +52,7 @@ export const TableCellActions = ({ handleFilterFor, handleFilterOut }: TableCell
           })}
           onClick={handleFilterOut}
         >
-          <EuiIcon type="minusInCircle" size="s" color="primary" />
+          <EuiIcon type="filterExclude" size="s" color="primary" />
         </button>
       </EuiToolTip>
     </span>


### PR DESCRIPTION
## Summary

Working on replacing the icons of the filters in Discover, for hands on experience
![Bildschirmfoto 2024-07-17 um 09 59 20](https://github.com/user-attachments/assets/4ac122af-5a47-4da3-94b6-e00c9fb604c0)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
