### PR TITLE
[Onboarding] Change k8s troubleshooting doc URL

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/kubernetes/command_snippet.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/kubernetes/command_snippet.tsx
@@ -17,6 +17,7 @@ interface Props {
   onboardingId: string;
   elasticsearchUrl: string;
   elasticAgentVersion: string;
+  isCopyPrimaryAction: boolean;
 }
 
 export function CommandSnippet({
@@ -24,6 +25,7 @@ export function CommandSnippet({
   onboardingId,
   elasticsearchUrl,
   elasticAgentVersion,
+  isCopyPrimaryAction,
 }: Props) {
   const command = buildKubectlCommand({
     encodedApiKey,
@@ -66,7 +68,7 @@ export function CommandSnippet({
 
       <EuiSpacer />
 
-      <CopyToClipboardButton textToCopy={command} fill />
+      <CopyToClipboardButton textToCopy={command} fill={isCopyPrimaryAction} />
     </>
   );
 }

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/kubernetes/data_ingest_status.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/kubernetes/data_ingest_status.tsx
@@ -93,7 +93,7 @@ export function DataIngestStatus({ onboardingId }: Props) {
                 troubleshootingLink: (
                   <EuiLink
                     data-test-subj="observabilityOnboardingDataIngestStatusTroubleshootingLink"
-                    href="https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html#agent-oom-k8s"
+                    href="https://www.elastic.co/guide/en/fleet/current/fleet-troubleshooting.html"
                     external
                     target="_blank"
                   >

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
@@ -53,6 +53,7 @@ export const KubernetesPanel: React.FC = () => {
               onboardingId={data.onboardingId}
               elasticsearchUrl={data.elasticsearchUrl}
               elasticAgentVersion={data.elasticAgentVersion}
+              isCopyPrimaryAction={!isMonitoringStepActive}
             />
           )}
         </>


### PR DESCRIPTION
Two minor fixes for the k8s onboarding:

- Make the troubleshooting link point to the whole page instead of the Kubernetes section which is for now is not very relevant
- Remove `fill` from the copy button after we start monitoring data