### PR TITLE
[8.14] [Telemetry][Security Solution] Use the proper index to query builtin alerts (#187859) 

### DIFF
--- a/x-pack/plugins/security_solution/server/integration_tests/__mocks__/alerts-detections-request.json
+++ b/x-pack/plugins/security_solution/server/integration_tests/__mocks__/alerts-detections-request.json
@@ -1,0 +1,185 @@
+{
+  "@timestamp": "2024-07-09T12:07:22.061Z",
+  "kibana.alert.ancestors": [
+    {
+      "id": "yEVhkpABheYIwp45uyhA",
+      "type": "event",
+      "index": ".ds-logs-endpoint.alerts-default-2024.07.08-000001",
+      "depth": 0
+    }
+  ],
+  "kibana.alert.depth": 1,
+  "kibana.alert.original_event.action": "rule_detection",
+  "kibana.alert.original_event.category": "behavior",
+  "kibana.alert.original_event.dataset": "endpoint.diagnostic.collection",
+  "kibana.alert.original_event.kind": "alert",
+  "kibana.alert.original_event.module": "endpoint",
+  "kibana.alert.original_event.type": "info",
+  "kibana.alert.original_time": "2024-07-08T12:46:42.856Z",
+  "kibana.alert.risk_score": 47,
+  "kibana.alert.rule.actions": [],
+  "kibana.alert.rule.category": "Custom Query Rule",
+  "kibana.alert.rule.consumer": "siem",
+  "kibana.alert.rule.created_at": "2024-07-08T12:00:22.100Z",
+  "kibana.alert.rule.enabled": true,
+  "kibana.alert.rule.exceptions_list": [
+    {
+      "id": "endpoint_list",
+      "list_id": "endpoint_list",
+      "type": "endpoint",
+      "namespace_type": "agnostic"
+    }
+  ],
+  "kibana.alert.rule.execution.uuid": "740f5acd-6dfa-4b71-878a-2dcbf615f0d2",
+  "kibana.alert.rule.false_positives": [],
+  "kibana.alert.rule.from": "now-10m",
+  "kibana.alert.rule.immutable": true,
+  "kibana.alert.rule.interval": "5m",
+  "kibana.alert.rule.name": "Endpoint Security",
+  "kibana.alert.rule.producer": "siem",
+  "kibana.alert.rule.references": [],
+  "kibana.alert.rule.risk_score_mapping": [
+    {
+      "field": "event.risk_score",
+      "operator": "equals",
+      "value": ""
+    }
+  ],
+  "kibana.alert.rule.rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+  "kibana.alert.rule.rule_type_id": "siem.queryRule",
+  "kibana.alert.rule.severity": "medium",
+  "kibana.alert.rule.severity_mapping": [
+    {
+      "field": "event.severity",
+      "operator": "equals",
+      "severity": "low",
+      "value": "21"
+    },
+    {
+      "field": "event.severity",
+      "operator": "equals",
+      "severity": "medium",
+      "value": "47"
+    },
+    {
+      "field": "event.severity",
+      "operator": "equals",
+      "severity": "high",
+      "value": "73"
+    },
+    {
+      "field": "event.severity",
+      "operator": "equals",
+      "severity": "critical",
+      "value": "99"
+    }
+  ],
+  "kibana.alert.rule.tags": ["Data Source: Elastic Defend"],
+  "kibana.alert.rule.threat": [],
+  "kibana.alert.rule.timestamp_override": "event.ingested",
+  "kibana.alert.rule.type": "query",
+  "kibana.alert.rule.updated_at": "2024-07-08T12:00:22.100Z",
+  "kibana.alert.rule.uuid": "5623aff4-d3f2-41c8-9542-ef7e6515ce40",
+  "kibana.alert.rule.version": 103,
+  "kibana.alert.severity": "medium",
+  "kibana.alert.status": "active",
+  "kibana.alert.uuid": "76713cff0f7c8e81bd7462f94c5fc6df4d3b52d9737ccc35a38c5efa42f47c26",
+  "kibana.alert.workflow_status": "open",
+  "kibana.space_ids": ["default"],
+  "kibana.version": "8.14.2",
+  "event.ingested": "2024-07-08T12:46:36Z",
+  "event.kind": "signal",
+  "event.action": "rule_detection",
+  "event.id": "87f78f3b-5f84-434a-ac37-6c9e414c4df9",
+  "event.type": "info",
+  "event.category": "behavior",
+  "event.dataset": "endpoint.diagnostic.collection",
+  "event.module": "endpoint",
+  "agent": {
+    "id": "9e6f8f6a-6913-47a1-8a38-2a9ba87f8894"
+  },
+  "destination": {
+    "port": 443,
+    "ip": "10.102.118.219"
+  },
+  "dll": [
+    {
+      "code_signature": {
+        "subject_name": "Cybereason Inc",
+        "trusted": true
+      },
+      "path": "",
+      "hash": {
+        "sha256": "8ad40c90a611d36eb8f9eb24fa04f7dbca713db383ff55a03aa0f382e92061a2"
+      }
+    }
+  ],
+  "host": {
+    "os": {
+      "Ext": {
+        "variant": "Windows Server Release 2"
+      },
+      "name": "Windows",
+      "family": "windows",
+      "version": "6.3",
+      "platform": "Windows",
+      "full": "Windows Server 2012R2"
+    }
+  },
+  "network": {
+    "transport": "tcp",
+    "type": "ipv4",
+    "direction": "outgoing"
+  },
+  "process": {
+    "code_signature": {
+      "status": "trusted",
+      "subject_name": "Microsoft Windows"
+    },
+    "entity_id": "5hdvz461o6",
+    "entry_leader": {
+      "name": "fake entry",
+      "pid": 376,
+      "entity_id": "jpd1z6lsu6"
+    },
+    "executable": "C:/fake_behavior/notepad.exe",
+    "Ext": {
+      "token": {
+        "integrity_level_name": "high"
+      }
+    },
+    "name": "notepad.exe",
+    "parent": {
+      "entity_id": "iv54turo1i",
+      "pid": 1
+    },
+    "pid": 2,
+    "session_leader": {
+      "name": "fake session",
+      "pid": 891,
+      "entity_id": "jpd1z6lsu6"
+    }
+  },
+  "registry": {
+    "data": {
+      "strings": "C:/fake_behavior/notepad.exe"
+    },
+    "path": "",
+    "value": "notepad.exe"
+  },
+  "source": {
+    "port": 59406,
+    "ip": "10.43.68.40"
+  },
+  "user": {
+    "domain": "qbf98z0au1"
+  },
+  "file": {
+    "name": "fake_behavior.exe",
+    "path": "C:/fake_behavior.exe"
+  },
+  "licence_id": "b7d16098-16fc-42fb-ab0f-40e2394c2375",
+  "cluster_uuid": "BldID7FMTb66oQgpvC5Uyg",
+  "cluster_name": "es-test-cluster",
+  "task_version": "1.2.0"
+}

--- a/x-pack/plugins/security_solution/server/integration_tests/__mocks__/prebuilt-rules-events.json
+++ b/x-pack/plugins/security_solution/server/integration_tests/__mocks__/prebuilt-rules-events.json
@@ -1,0 +1,734 @@
+[
+  {
+    "kibana.alert.start": "2024-07-08T12:50:55.123Z",
+    "kibana.alert.last_detected": "2024-07-08T12:50:55.123Z",
+    "kibana.version": "8.14.2",
+    "kibana.alert.rule.parameters": {
+      "description": "Generates a detection alert each time an Elastic Endpoint Security alert is received. Enabling this rule allows you to immediately begin investigating your Endpoint alerts.",
+      "risk_score": 47,
+      "severity": "medium",
+      "license": "Elastic License v2",
+      "rule_name_override": "message",
+      "timestamp_override": "event.ingested",
+      "author": ["Elastic"],
+      "false_positives": [],
+      "from": "now-10m",
+      "rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+      "max_signals": 10000,
+      "risk_score_mapping": [
+        {
+          "field": "event.risk_score",
+          "operator": "equals",
+          "value": ""
+        }
+      ],
+      "severity_mapping": [
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "low",
+          "value": "21"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "medium",
+          "value": "47"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "high",
+          "value": "73"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "critical",
+          "value": "99"
+        }
+      ],
+      "threat": [],
+      "to": "now",
+      "references": [],
+      "version": 103,
+      "exceptions_list": [
+        {
+          "id": "endpoint_list",
+          "list_id": "endpoint_list",
+          "type": "endpoint",
+          "namespace_type": "agnostic"
+        }
+      ],
+      "immutable": true,
+      "related_integrations": [
+        {
+          "package": "endpoint",
+          "version": "^8.2.0"
+        }
+      ],
+      "required_fields": [
+        {
+          "name": "event.kind",
+          "type": "keyword",
+          "ecs": true
+        },
+        {
+          "name": "event.module",
+          "type": "keyword",
+          "ecs": true
+        }
+      ],
+      "setup": ""
+    },
+    "kibana.alert.rule.category": "Custom Query Rule",
+    "kibana.alert.rule.consumer": "siem",
+    "kibana.alert.rule.execution.uuid": "740f5acd-6dfa-4b71-878a-2dcbf615f0d2",
+    "kibana.alert.rule.name": "Endpoint Security",
+    "kibana.alert.rule.producer": "siem",
+    "kibana.alert.rule.revision": 0,
+    "kibana.alert.rule.rule_type_id": "siem.queryRule",
+    "kibana.alert.rule.uuid": "5623aff4-d3f2-41c8-9542-ef7e6515ce40",
+    "kibana.space_ids": ["default"],
+    "kibana.alert.rule.tags": ["Data Source: Elastic Defend"],
+    "@timestamp": "2024-07-08T12:50:55.085Z",
+    "registry": {
+      "path": "",
+      "data": {
+        "strings": "C:/fake_behavior/notepad.exe"
+      },
+      "value": "notepad.exe"
+    },
+    "agent": {
+      "id": "9e6f8f6a-6913-47a1-8a38-2a9ba87f8894",
+      "type": "endpoint",
+      "version": "8.14.2"
+    },
+    "process": {
+      "Ext": {
+        "ancestry": ["iv54turo1i", "dac98d002m"],
+        "code_signature": [
+          {
+            "trusted": false,
+            "subject_name": "bad signer"
+          }
+        ],
+        "user": "SYSTEM",
+        "token": {
+          "integrity_level_name": "high",
+          "elevation_level": "full"
+        }
+      },
+      "parent": {
+        "pid": 1,
+        "entity_id": "iv54turo1i"
+      },
+      "group_leader": {
+        "name": "fake leader",
+        "pid": 687,
+        "entity_id": "jpd1z6lsu6"
+      },
+      "session_leader": {
+        "name": "fake session",
+        "pid": 891,
+        "entity_id": "jpd1z6lsu6"
+      },
+      "code_signature": {
+        "subject_name": "Microsoft Windows",
+        "status": "trusted"
+      },
+      "entry_leader": {
+        "name": "fake entry",
+        "pid": 376,
+        "entity_id": "jpd1z6lsu6"
+      },
+      "name": "notepad.exe",
+      "pid": 2,
+      "entity_id": "5hdvz461o6",
+      "executable": "C:/fake_behavior/notepad.exe"
+    },
+    "dll": [
+      {
+        "Ext": {
+          "compile_time": 1534424710,
+          "malware_classification": {
+            "identifier": "Whitelisted",
+            "score": 0,
+            "threshold": 0,
+            "version": "3.0.0"
+          },
+          "mapped_address": 5362483200,
+          "mapped_size": 0
+        },
+        "path": "",
+        "code_signature": {
+          "trusted": true,
+          "subject_name": "Cybereason Inc"
+        },
+        "pe": {
+          "architecture": "x64"
+        },
+        "hash": {
+          "sha1": "ca85243c0af6a6471bdaa560685c51eefd6dbc0d",
+          "sha256": "8ad40c90a611d36eb8f9eb24fa04f7dbca713db383ff55a03aa0f382e92061a2",
+          "md5": "1f2d082566b0fc5f2c238a5180db7451"
+        }
+      }
+    ],
+    "destination": {
+      "port": 443,
+      "ip": "10.102.118.219"
+    },
+    "rule": {
+      "description": "Behavior rule description",
+      "id": "ee2b68fd-a8b4-42cb-82e3-018dd54e0d68"
+    },
+    "source": {
+      "port": 59406,
+      "ip": "10.43.68.40"
+    },
+    "network": {
+      "transport": "tcp",
+      "type": "ipv4",
+      "direction": "outgoing"
+    },
+    "file": {
+      "path": "C:/fake_behavior.exe",
+      "name": "fake_behavior.exe"
+    },
+    "Endpoint": {
+      "capabilities": [
+        "isolation",
+        "kill_process",
+        "suspend_process",
+        "running_processes",
+        "get_file",
+        "execute",
+        "upload_file"
+      ],
+      "configuration": {
+        "isolation": true
+      },
+      "state": {
+        "isolation": true
+      },
+      "status": "enrolled",
+      "policy": {
+        "applied": {
+          "name": "With Eventing",
+          "id": "C2A9093E-E289-4C0A-AA44-8C32A414FA7A",
+          "endpoint_policy_version": 3,
+          "version": 5,
+          "status": "success"
+        }
+      }
+    },
+    "ecs": {
+      "version": "1.6.0"
+    },
+    "data_stream": {
+      "namespace": "default",
+      "type": "logs",
+      "dataset": "endpoint.alerts"
+    },
+    "elastic": {
+      "agent": {
+        "id": "9e6f8f6a-6913-47a1-8a38-2a9ba87f8894"
+      }
+    },
+    "host": {
+      "hostname": "Host-o0zw8cq8rq",
+      "os": {
+        "Ext": {
+          "variant": "Windows Server Release 2"
+        },
+        "name": "Windows",
+        "family": "windows",
+        "version": "6.3",
+        "platform": "Windows",
+        "full": "Windows Server 2012R2"
+      },
+      "ip": ["10.254.97.183"],
+      "name": "Host-o0zw8cq8rq",
+      "id": "a5977222-3dfe-4f74-9719-9347c3b01857",
+      "mac": ["33-e1-de-eb-d3-2e"],
+      "architecture": "2ok2s7qnf3"
+    },
+    "user": {
+      "domain": "qbf98z0au1",
+      "name": "2q8d3pq1j8"
+    },
+    "event.agent_id_status": "auth_metadata_missing",
+    "event.sequence": 15,
+    "event.ingested": "2024-07-08T12:46:36Z",
+    "event.code": "behavior",
+    "event.kind": "signal",
+    "event.module": "endpoint",
+    "event.action": "rule_detection",
+    "event.id": "87f78f3b-5f84-434a-ac37-6c9e414c4df9",
+    "event.category": "behavior",
+    "event.type": "info",
+    "event.dataset": "endpoint.diagnostic.collection",
+    "kibana.alert.original_time": "2024-07-08T12:46:42.856Z",
+    "kibana.alert.ancestors": [
+      {
+        "id": "yEVhkpABheYIwp45uyhA",
+        "type": "event",
+        "index": ".ds-logs-endpoint.alerts-default-2024.07.08-000001",
+        "depth": 0
+      }
+    ],
+    "kibana.alert.status": "active",
+    "kibana.alert.workflow_status": "open",
+    "kibana.alert.depth": 1,
+    "kibana.alert.reason": "behavior event with process notepad.exe, file fake_behavior.exe, source 10.43.68.40:59406, destination 10.102.118.219:443, by 2q8d3pq1j8 on Host-o0zw8cq8rq created medium alert Endpoint Security.",
+    "kibana.alert.severity": "medium",
+    "kibana.alert.risk_score": 47,
+    "kibana.alert.rule.actions": [],
+    "kibana.alert.rule.author": ["Elastic"],
+    "kibana.alert.rule.created_at": "2024-07-08T12:00:22.100Z",
+    "kibana.alert.rule.created_by": "elastic",
+    "kibana.alert.rule.description": "Generates a detection alert each time an Elastic Endpoint Security alert is received. Enabling this rule allows you to immediately begin investigating your Endpoint alerts.",
+    "kibana.alert.rule.enabled": true,
+    "kibana.alert.rule.exceptions_list": [
+      {
+        "id": "endpoint_list",
+        "list_id": "endpoint_list",
+        "type": "endpoint",
+        "namespace_type": "agnostic"
+      }
+    ],
+    "kibana.alert.rule.false_positives": [],
+    "kibana.alert.rule.from": "now-10m",
+    "kibana.alert.rule.immutable": true,
+    "kibana.alert.rule.interval": "5m",
+    "kibana.alert.rule.indices": ["logs-endpoint.alerts-*"],
+    "kibana.alert.rule.license": "Elastic License v2",
+    "kibana.alert.rule.max_signals": 10000,
+    "kibana.alert.rule.references": [],
+    "kibana.alert.rule.risk_score_mapping": [
+      {
+        "field": "event.risk_score",
+        "operator": "equals",
+        "value": ""
+      }
+    ],
+    "kibana.alert.rule.rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+    "kibana.alert.rule.rule_name_override": "message",
+    "kibana.alert.rule.severity_mapping": [
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "low",
+        "value": "21"
+      },
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "medium",
+        "value": "47"
+      },
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "high",
+        "value": "73"
+      },
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "critical",
+        "value": "99"
+      }
+    ],
+    "kibana.alert.rule.threat": [],
+    "kibana.alert.rule.timestamp_override": "event.ingested",
+    "kibana.alert.rule.to": "now",
+    "kibana.alert.rule.type": "query",
+    "kibana.alert.rule.updated_at": "2024-07-08T12:00:22.100Z",
+    "kibana.alert.rule.updated_by": "elastic",
+    "kibana.alert.rule.version": 103,
+    "kibana.alert.uuid": "76713cff0f7c8e81bd7462f94c5fc6df4d3b52d9737ccc35a38c5efa42f47c26",
+    "kibana.alert.workflow_tags": [],
+    "kibana.alert.workflow_assignee_ids": [],
+    "kibana.alert.rule.risk_score": 47,
+    "kibana.alert.rule.severity": "medium",
+    "kibana.alert.original_event.agent_id_status": "auth_metadata_missing",
+    "kibana.alert.original_event.sequence": 15,
+    "kibana.alert.original_event.ingested": "2024-07-08T12:46:36Z",
+    "kibana.alert.original_event.code": "behavior",
+    "kibana.alert.original_event.kind": "alert",
+    "kibana.alert.original_event.module": "endpoint",
+    "kibana.alert.original_event.action": "rule_detection",
+    "kibana.alert.original_event.id": "87f78f3b-5f84-434a-ac37-6c9e414c4df9",
+    "kibana.alert.original_event.category": "behavior",
+    "kibana.alert.original_event.type": "info",
+    "kibana.alert.original_event.dataset": "endpoint.diagnostic.collection"
+  },
+  {
+    "kibana.alert.start": "2024-07-08T12:50:55.123Z",
+    "kibana.alert.last_detected": "2024-07-08T12:50:55.123Z",
+    "kibana.version": "8.14.2",
+    "kibana.alert.rule.parameters": {
+      "description": "Generates a detection alert each time an Elastic Endpoint Security alert is received. Enabling this rule allows you to immediately begin investigating your Endpoint alerts.",
+      "risk_score": 47,
+      "severity": "medium",
+      "license": "Elastic License v2",
+      "rule_name_override": "message",
+      "timestamp_override": "event.ingested",
+      "author": ["Elastic"],
+      "false_positives": [],
+      "from": "now-10m",
+      "rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+      "max_signals": 10000,
+      "risk_score_mapping": [
+        {
+          "field": "event.risk_score",
+          "operator": "equals",
+          "value": ""
+        }
+      ],
+      "severity_mapping": [
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "low",
+          "value": "21"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "medium",
+          "value": "47"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "high",
+          "value": "73"
+        },
+        {
+          "field": "event.severity",
+          "operator": "equals",
+          "severity": "critical",
+          "value": "99"
+        }
+      ],
+      "threat": [],
+      "to": "now",
+      "references": [],
+      "version": 103,
+      "exceptions_list": [
+        {
+          "id": "endpoint_list",
+          "list_id": "endpoint_list",
+          "type": "endpoint",
+          "namespace_type": "agnostic"
+        }
+      ],
+      "immutable": true,
+      "related_integrations": [
+        {
+          "package": "endpoint",
+          "version": "^8.2.0"
+        }
+      ],
+      "required_fields": [
+        {
+          "name": "event.kind",
+          "type": "keyword",
+          "ecs": true
+        },
+        {
+          "name": "event.module",
+          "type": "keyword",
+          "ecs": true
+        }
+      ],
+      "setup": ""
+    },
+    "kibana.alert.rule.category": "Custom Query Rule",
+    "kibana.alert.rule.consumer": "siem",
+    "kibana.alert.rule.execution.uuid": "740f5acd-6dfa-4b71-878a-2dcbf615f0d2",
+    "kibana.alert.rule.name": "Endpoint Security",
+    "kibana.alert.rule.producer": "siem",
+    "kibana.alert.rule.revision": 0,
+    "kibana.alert.rule.rule_type_id": "siem.queryRule",
+    "kibana.alert.rule.uuid": "5623aff4-d3f2-41c8-9542-ef7e6515ce40",
+    "kibana.space_ids": ["default"],
+    "kibana.alert.rule.tags": ["Data Source: Elastic Defend"],
+    "@timestamp": "2024-07-08T12:50:55.087Z",
+    "registry": {
+      "path": "",
+      "data": {
+        "strings": "C:/fake_behavior/explorer.exe"
+      },
+      "value": "explorer.exe"
+    },
+    "agent": {
+      "id": "9e6f8f6a-6913-47a1-8a38-2a9ba87f8894",
+      "type": "endpoint",
+      "version": "8.14.2"
+    },
+    "process": {
+      "Ext": {
+        "ancestry": ["dac98d002m", "jpd1z6lsu6"],
+        "code_signature": [
+          {
+            "trusted": false,
+            "subject_name": "bad signer"
+          }
+        ],
+        "user": "SYSTEM",
+        "token": {
+          "integrity_level_name": "high",
+          "elevation_level": "full"
+        }
+      },
+      "parent": {
+        "pid": 1,
+        "entity_id": "dac98d002m"
+      },
+      "group_leader": {
+        "name": "fake leader",
+        "pid": 471,
+        "entity_id": "jpd1z6lsu6"
+      },
+      "session_leader": {
+        "name": "fake session",
+        "pid": 775,
+        "entity_id": "jpd1z6lsu6"
+      },
+      "code_signature": {
+        "subject_name": "Microsoft Windows",
+        "status": "trusted"
+      },
+      "entry_leader": {
+        "name": "fake entry",
+        "pid": 722,
+        "entity_id": "jpd1z6lsu6"
+      },
+      "name": "explorer.exe",
+      "pid": 2,
+      "entity_id": "iv54turo1i",
+      "executable": "C:/fake_behavior/explorer.exe"
+    },
+    "dll": [
+      {
+        "Ext": {
+          "compile_time": 1534424710,
+          "malware_classification": {
+            "identifier": "Whitelisted",
+            "score": 0,
+            "threshold": 0,
+            "version": "3.0.0"
+          },
+          "mapped_address": 5362483200,
+          "mapped_size": 0
+        },
+        "path": "",
+        "code_signature": {
+          "trusted": true,
+          "subject_name": "Cybereason Inc"
+        },
+        "pe": {
+          "architecture": "x64"
+        },
+        "hash": {
+          "sha1": "ca85243c0af6a6471bdaa560685c51eefd6dbc0d",
+          "sha256": "8ad40c90a611d36eb8f9eb24fa04f7dbca713db383ff55a03aa0f382e92061a2",
+          "md5": "1f2d082566b0fc5f2c238a5180db7451"
+        }
+      }
+    ],
+    "destination": {
+      "port": 443,
+      "ip": "10.183.30.139"
+    },
+    "rule": {
+      "description": "Behavior rule description",
+      "id": "cc1892b8-e6ee-4a1e-bef9-3e1f1f62370e"
+    },
+    "source": {
+      "port": 59406,
+      "ip": "10.3.18.122"
+    },
+    "network": {
+      "transport": "tcp",
+      "type": "ipv4",
+      "direction": "outgoing"
+    },
+    "file": {
+      "path": "C:/fake_behavior.exe",
+      "name": "fake_behavior.exe"
+    },
+    "Endpoint": {
+      "capabilities": [
+        "isolation",
+        "kill_process",
+        "suspend_process",
+        "running_processes",
+        "get_file",
+        "execute",
+        "upload_file"
+      ],
+      "configuration": {
+        "isolation": true
+      },
+      "state": {
+        "isolation": true
+      },
+      "status": "enrolled",
+      "policy": {
+        "applied": {
+          "name": "With Eventing",
+          "id": "C2A9093E-E289-4C0A-AA44-8C32A414FA7A",
+          "endpoint_policy_version": 3,
+          "version": 5,
+          "status": "success"
+        }
+      }
+    },
+    "ecs": {
+      "version": "1.6.0"
+    },
+    "data_stream": {
+      "namespace": "default",
+      "type": "logs",
+      "dataset": "endpoint.alerts"
+    },
+    "elastic": {
+      "agent": {
+        "id": "9e6f8f6a-6913-47a1-8a38-2a9ba87f8894"
+      }
+    },
+    "host": {
+      "hostname": "Host-o0zw8cq8rq",
+      "os": {
+        "Ext": {
+          "variant": "Windows Server Release 2"
+        },
+        "name": "Windows",
+        "family": "windows",
+        "version": "6.3",
+        "platform": "Windows",
+        "full": "Windows Server 2012R2"
+      },
+      "ip": ["10.254.97.183"],
+      "name": "Host-o0zw8cq8rq",
+      "id": "a5977222-3dfe-4f74-9719-9347c3b01857",
+      "mac": ["33-e1-de-eb-d3-2e"],
+      "architecture": "2ok2s7qnf3"
+    },
+    "user": {
+      "domain": "182cw5hsw7",
+      "name": "v0teoghxky"
+    },
+    "event.agent_id_status": "auth_metadata_missing",
+    "event.sequence": 11,
+    "event.ingested": "2024-07-08T12:46:36Z",
+    "event.code": "behavior",
+    "event.kind": "signal",
+    "event.module": "endpoint",
+    "event.action": "rule_detection",
+    "event.id": "374b28d3-152e-4b80-8f80-d8c9ed42a2ef",
+    "event.category": "behavior",
+    "event.type": "info",
+    "event.dataset": "endpoint.diagnostic.collection",
+    "kibana.alert.original_time": "2024-07-08T14:53:09.856Z",
+    "kibana.alert.ancestors": [
+      {
+        "id": "xEVhkpABheYIwp45uyhA",
+        "type": "event",
+        "index": ".ds-logs-endpoint.alerts-default-2024.07.08-000001",
+        "depth": 0
+      }
+    ],
+    "kibana.alert.status": "active",
+    "kibana.alert.workflow_status": "open",
+    "kibana.alert.depth": 1,
+    "kibana.alert.reason": "behavior event with process explorer.exe, file fake_behavior.exe, source 10.3.18.122:59406, destination 10.183.30.139:443, by v0teoghxky on Host-o0zw8cq8rq created medium alert Endpoint Security.",
+    "kibana.alert.severity": "medium",
+    "kibana.alert.risk_score": 47,
+    "kibana.alert.rule.actions": [],
+    "kibana.alert.rule.author": ["Elastic"],
+    "kibana.alert.rule.created_at": "2024-07-08T12:00:22.100Z",
+    "kibana.alert.rule.created_by": "elastic",
+    "kibana.alert.rule.description": "Generates a detection alert each time an Elastic Endpoint Security alert is received. Enabling this rule allows you to immediately begin investigating your Endpoint alerts.",
+    "kibana.alert.rule.enabled": true,
+    "kibana.alert.rule.exceptions_list": [
+      {
+        "id": "endpoint_list",
+        "list_id": "endpoint_list",
+        "type": "endpoint",
+        "namespace_type": "agnostic"
+      }
+    ],
+    "kibana.alert.rule.false_positives": [],
+    "kibana.alert.rule.from": "now-10m",
+    "kibana.alert.rule.immutable": true,
+    "kibana.alert.rule.interval": "5m",
+    "kibana.alert.rule.indices": ["logs-endpoint.alerts-*"],
+    "kibana.alert.rule.license": "Elastic License v2",
+    "kibana.alert.rule.max_signals": 10000,
+    "kibana.alert.rule.references": [],
+    "kibana.alert.rule.risk_score_mapping": [
+      {
+        "field": "event.risk_score",
+        "operator": "equals",
+        "value": ""
+      }
+    ],
+    "kibana.alert.rule.rule_id": "9a1a2dae-0b5f-4c3d-8305-a268d404c306",
+    "kibana.alert.rule.rule_name_override": "message",
+    "kibana.alert.rule.severity_mapping": [
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "low",
+        "value": "21"
+      },
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "medium",
+        "value": "47"
+      },
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "high",
+        "value": "73"
+      },
+      {
+        "field": "event.severity",
+        "operator": "equals",
+        "severity": "critical",
+        "value": "99"
+      }
+    ],
+    "kibana.alert.rule.threat": [],
+    "kibana.alert.rule.timestamp_override": "event.ingested",
+    "kibana.alert.rule.to": "now",
+    "kibana.alert.rule.type": "query",
+    "kibana.alert.rule.updated_at": "2024-07-08T12:00:22.100Z",
+    "kibana.alert.rule.updated_by": "elastic",
+    "kibana.alert.rule.version": 103,
+    "kibana.alert.uuid": "bda4832328607d81ebd65eef8abbef8f3c8b74614ea85e71a781fd7e2d79fbda",
+    "kibana.alert.workflow_tags": [],
+    "kibana.alert.workflow_assignee_ids": [],
+    "kibana.alert.rule.risk_score": 47,
+    "kibana.alert.rule.severity": "medium",
+    "kibana.alert.original_event.agent_id_status": "auth_metadata_missing",
+    "kibana.alert.original_event.sequence": 11,
+    "kibana.alert.original_event.ingested": "2024-07-08T12:46:36Z",
+    "kibana.alert.original_event.code": "behavior",
+    "kibana.alert.original_event.kind": "alert",
+    "kibana.alert.original_event.module": "endpoint",
+    "kibana.alert.original_event.action": "rule_detection",
+    "kibana.alert.original_event.id": "374b28d3-152e-4b80-8f80-d8c9ed42a2ef",
+    "kibana.alert.original_event.category": "behavior",
+    "kibana.alert.original_event.type": "info",
+    "kibana.alert.original_event.dataset": "endpoint.diagnostic.collection"
+  }
+]

--- a/x-pack/plugins/security_solution/server/integration_tests/lib/telemetry_helpers.ts
+++ b/x-pack/plugins/security_solution/server/integration_tests/lib/telemetry_helpers.ts
@@ -44,6 +44,7 @@ import mockEndpointAlert from '../__mocks__/endpoint-alert.json';
 import mockedRule from '../__mocks__/rule.json';
 import fleetAgents from '../__mocks__/fleet-agents.json';
 import endpointMetrics from '../__mocks__/endpoint-metrics.json';
+import prebuiltRulesEvents from '../__mocks__/prebuilt-rules-events.json';
 import endpointMetadata from '../__mocks__/endpoint-metadata.json';
 import endpointPolicy from '../__mocks__/endpoint-policy.json';
 
@@ -51,6 +52,7 @@ const fleetIndex = '.fleet-agents';
 const endpointMetricsIndex = '.ds-metrics-endpoint.metrics-1';
 const endpointMetricsMetadataIndex = '.ds-metrics-endpoint.metadata-1';
 const endpointMetricsPolicyIndex = '.ds-metrics-endpoint.policy-1';
+const prebuiltRulesIndex = '.alerts-security.alerts';
 
 export function getTelemetryTasks(
   spy: jest.SpyInstance<
@@ -180,6 +182,10 @@ export async function mockEndpointData(
   await bulkInsert(esClient, endpointMetricsIndex, updateTimestamps(endpointMetrics));
   await bulkInsert(esClient, endpointMetricsMetadataIndex, updateTimestamps(endpointMetadata));
   await bulkInsert(esClient, endpointMetricsPolicyIndex, updateTimestamps(endpointPolicy));
+}
+
+export async function mockPrebuiltRulesData(esClient: ElasticsearchClient) {
+  await bulkInsert(esClient, prebuiltRulesIndex, updateTimestamps(prebuiltRulesEvents));
 }
 
 export async function initEndpointIndices(esClient: ElasticsearchClient) {

--- a/x-pack/plugins/security_solution/server/integration_tests/telemetry.test.ts
+++ b/x-pack/plugins/security_solution/server/integration_tests/telemetry.test.ts
@@ -15,7 +15,10 @@ import type {
 } from '@kbn/securitysolution-io-ts-list-types';
 
 import { ENDPOINT_STAGING } from '@kbn/telemetry-plugin/common/constants';
-import { TELEMETRY_CHANNEL_ENDPOINT_META } from '../lib/telemetry/constants';
+import {
+  TELEMETRY_CHANNEL_DETECTION_ALERTS,
+  TELEMETRY_CHANNEL_ENDPOINT_META,
+} from '../lib/telemetry/constants';
 
 import { eventually, setupTestServers, removeFile } from './lib/helpers';
 import {
@@ -33,6 +36,7 @@ import {
   dropEndpointIndices,
   mockEndpointData,
   getTelemetryReceiver,
+  mockPrebuiltRulesData,
 } from './lib/telemetry_helpers';
 
 import {
@@ -45,9 +49,10 @@ import {
   type TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server/plugin';
 import type { SecurityTelemetryTask } from '../lib/telemetry/task';
-import { TelemetryChannel } from '../lib/telemetry/types';
+import { TelemetryChannel, type TelemetryEvent } from '../lib/telemetry/types';
 import type { AsyncTelemetryEventsSender } from '../lib/telemetry/async_sender';
 import endpointMetaTelemetryRequest from './__mocks__/endpoint-meta-telemetry-request.json';
+import alertsDetectionsRequest from './__mocks__/alerts-detections-request.json';
 import type { ITelemetryReceiver, TelemetryReceiver } from '../lib/telemetry/receiver';
 import type { TaskMetric } from '../lib/telemetry/task_metrics.types';
 import type { AgentPolicy } from '@kbn/fleet-plugin/common';
@@ -659,11 +664,81 @@ describe('telemetry tasks', () => {
     });
   });
 
+  describe('telemetry-prebuilt-rule-alerts', () => {
+    it('should execute when scheduled', async () => {
+      await mockAndSchedulePrebuiltRulesTask();
+
+      const alertsDetectionsRequests = await getAlertsDetectionsRequests();
+
+      expect(alertsDetectionsRequests.length).toBe(2);
+
+      const body = alertsDetectionsRequests[0];
+
+      expect(body.dll).toStrictEqual(alertsDetectionsRequest.dll);
+      expect(body.process).toStrictEqual(alertsDetectionsRequest.process);
+      expect(body.file).toStrictEqual(alertsDetectionsRequest.file);
+    });
+
+    it('should manage runtime errors searching endpoint metrics', async () => {
+      const errorMessage = 'Something went wront';
+
+      async function* mockedGenerator(
+        _index: string,
+        _executeFrom: string,
+        _executeTo: string
+      ): AsyncGenerator<TelemetryEvent[], void, unknown> {
+        throw Error(errorMessage);
+      }
+
+      const fetchEndpointMetricsAbstract = telemetryReceiver.fetchPrebuiltRuleAlertsBatch;
+      deferred.push(() => {
+        telemetryReceiver.fetchPrebuiltRuleAlertsBatch = fetchEndpointMetricsAbstract;
+      });
+
+      telemetryReceiver.fetchPrebuiltRuleAlertsBatch = mockedGenerator;
+
+      const task = await mockAndSchedulePrebuiltRulesTask();
+      const started = performance.now();
+
+      const requests = await getTaskMetricsRequests(task, started);
+
+      expect(requests.length).toBe(1);
+
+      const metric = requests[0];
+
+      expect(metric).not.toBeFalsy();
+      expect(metric.taskMetric.passed).toBe(false);
+      expect(metric.taskMetric.error_message).toBe(errorMessage);
+    });
+  });
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async function getEndpointMetaRequests(atLeast: number = 1): Promise<any[]> {
     return eventually(async () => {
       const found = mockedAxiosPost.mock.calls.filter(([url]) => {
         return url.startsWith(ENDPOINT_STAGING) && url.endsWith(TELEMETRY_CHANNEL_ENDPOINT_META);
+      });
+
+      expect(found).not.toBeFalsy();
+      expect(found.length).toBeGreaterThanOrEqual(atLeast);
+
+      return (found ?? []).flatMap((req) => {
+        const ndjson = req[1] as string;
+        return ndjson
+          .split('\n')
+          .filter((l) => l.trim().length > 0)
+          .map((l) => {
+            return JSON.parse(l);
+          });
+      });
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function getAlertsDetectionsRequests(atLeast: number = 1): Promise<any[]> {
+    return eventually(async () => {
+      const found = mockedAxiosPost.mock.calls.filter(([url]) => {
+        return url.startsWith(ENDPOINT_STAGING) && url.endsWith(TELEMETRY_CHANNEL_DETECTION_ALERTS);
       });
 
       expect(found).not.toBeFalsy();
@@ -708,6 +783,19 @@ describe('telemetry tasks', () => {
     const task = getTelemetryTask(tasks, 'security:endpoint-meta-telemetry');
 
     await mockEndpointData(esClient, kibanaServer.coreStart.savedObjects);
+
+    // schedule task to run ASAP
+    await eventually(async () => {
+      await taskManagerPlugin.runSoon(task.getTaskId());
+    });
+
+    return task;
+  }
+
+  async function mockAndSchedulePrebuiltRulesTask(): Promise<SecurityTelemetryTask> {
+    const task = getTelemetryTask(tasks, 'security:telemetry-prebuilt-rule-alerts');
+
+    await mockPrebuiltRulesData(esClient);
 
     // schedule task to run ASAP
     await eventually(async () => {

--- a/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -203,6 +203,7 @@ export interface ITelemetryReceiver {
   }>;
 
   fetchPrebuiltRuleAlertsBatch(
+    index: string,
     executeFrom: string,
     executeTo: string
   ): AsyncGenerator<TelemetryEvent[], void, unknown>;
@@ -744,13 +745,17 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     };
   }
 
-  public async *fetchPrebuiltRuleAlertsBatch(executeFrom: string, executeTo: string) {
+  public async *fetchPrebuiltRuleAlertsBatch(
+    index: string,
+    executeFrom: string,
+    executeTo: string
+  ) {
     this.logger.l('Searching prebuilt rule alerts from', {
       executeFrom,
       executeTo,
     });
 
-    let pitId = await this.openPointInTime(DEFAULT_DIAGNOSTIC_INDEX);
+    let pitId = await this.openPointInTime(index);
     let fetchMore = true;
     let searchAfter: SortResults | undefined;
 

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/prebuilt_rule_alerts.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/prebuilt_rule_alerts.ts
@@ -67,6 +67,7 @@ export function createTelemetryPrebuiltRuleAlertsTaskConfig(maxTelemetryBatch: n
         }
 
         for await (const alerts of receiver.fetchPrebuiltRuleAlertsBatch(
+          index,
           taskExecutionPeriod.last ?? 'now-1h',
           taskExecutionPeriod.current
         )) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Telemetry][Security Solution] Use the proper index to query builtin alerts (#187859)](https://github.com/elastic/kibana/pull/187859)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2024-07-12T13:17:43Z","message":"[Telemetry][Security Solution] Use the proper index to query builtin alerts (#187859)\n\n## Summary\r\n\r\nhttps://github.com/elastic/kibana/pull/177263 changed the way\r\n`telemetry-prebuilt-rule-alerts` get data from elastic, but it changed\r\nthe index used to run the queries. This PR fixes it using the proper\r\nindex.","sha":"a120c510b9738aab0fb5f9296515a82f6f0792a6","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","v8.14.0","v8.15.0","v8.16.0"],"title":"[Telemetry][Security Solution] Use the proper index to query builtin alerts","number":187859,"url":"https://github.com/elastic/kibana/pull/187859","mergeCommit":{"message":"[Telemetry][Security Solution] Use the proper index to query builtin alerts (#187859)\n\n## Summary\r\n\r\nhttps://github.com/elastic/kibana/pull/177263 changed the way\r\n`telemetry-prebuilt-rule-alerts` get data from elastic, but it changed\r\nthe index used to run the queries. This PR fixes it using the proper\r\nindex.","sha":"a120c510b9738aab0fb5f9296515a82f6f0792a6"}},"sourceBranch":"main","suggestedTargetBranches":["8.14","8.15"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.15","label":"v8.15.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","branchLabelMappingKey":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/187859","number":187859,"mergeCommit":{"message":"[Telemetry][Security Solution] Use the proper index to query builtin alerts (#187859)\n\n## Summary\r\n\r\nhttps://github.com/elastic/kibana/pull/177263 changed the way\r\n`telemetry-prebuilt-rule-alerts` get data from elastic, but it changed\r\nthe index used to run the queries. This PR fixes it using the proper\r\nindex.","sha":"a120c510b9738aab0fb5f9296515a82f6f0792a6"}}]}] BACKPORT-->