### PR TITLE
fix dashboard scroll issue for when lens inline config is opened.

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -856,7 +856,7 @@ export class Embeddable
     this.updateInput({ attributes: attrs, savedObjectId });
   }
 
-  async openConfingPanel(
+  async openConfigPanel(
     startDependencies: LensPluginStartDependencies,
     isNewPanel?: boolean,
     deletePanel?: () => void

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action.test.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action.test.tsx
@@ -95,7 +95,7 @@ describe('open config panel action', () => {
           };
         },
         getIsEditable: () => true,
-        openConfingPanel: jest.fn().mockResolvedValue(<span>Lens Config Panel Component</span>),
+        openConfigPanel: jest.fn().mockResolvedValue(<span>Lens Config Panel Component</span>),
         getRoot: () => {
           return {
             openOverlay: jest.fn(),

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action_helpers.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action_helpers.ts
@@ -6,9 +6,10 @@
  */
 import React from 'react';
 import './helpers.scss';
-import { tracksOverlays } from '@kbn/presentation-containers';
-import { IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
+import { tracksOverlays } from '@kbn/presentation-containers';
+import type { IEmbeddable } from '@kbn/embeddable-plugin/public';
+import { ViewMode } from '@kbn/embeddable-plugin/common';
 import { IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
 import { isLensEmbeddable } from '../utils';
 import type { LensPluginStartDependencies } from '../../plugin';
@@ -24,9 +25,59 @@ interface Context extends StartServices {
 export async function isEditActionCompatible(embeddable: IEmbeddable) {
   if (!embeddable?.getInput) return false;
   // display the action only if dashboard is on editable mode
-  const inDashboardEditMode = embeddable.getInput().viewMode === 'edit';
+  const inDashboardEditMode = embeddable.getInput().viewMode === ViewMode.EDIT;
   return Boolean(isLensEmbeddable(embeddable) && embeddable.getIsEditable() && inDashboardEditMode);
 }
+
+type PanelConfigElement<T = {}> = React.ReactElement<T & { closeFlyout: () => void }>;
+
+const openInlineLensConfigEditor = (
+  startServices: StartServices,
+  embeddable: IEmbeddable,
+  EmbeddableInlineConfigEditor: PanelConfigElement
+) => {
+  const rootEmbeddable = embeddable.getRoot();
+  const overlayTracker = tracksOverlays(rootEmbeddable) ? rootEmbeddable : undefined;
+
+  const handle = startServices.overlays.openFlyout(
+    toMountPoint(
+      React.createElement(function InlineLensConfigEditor() {
+        React.useEffect(() => {
+          document.body.style.overflowY = 'hidden';
+
+          return () => {
+            document.body.style.overflowY = 'initial';
+          };
+        }, []);
+
+        return React.cloneElement(EmbeddableInlineConfigEditor, {
+          closeFlyout: () => {
+            overlayTracker?.clearOverlays();
+            handle.close();
+          },
+        });
+      }),
+      startServices
+    ),
+    {
+      size: 's',
+      type: 'push',
+      paddingSize: 'm',
+      'data-test-subj': 'customizeLens',
+      className: 'lnsConfigPanel__overlay',
+      hideCloseButton: true,
+      onClose: (overlayRef) => {
+        overlayTracker?.clearOverlays();
+        overlayRef.close();
+      },
+      outsideClickCloses: true,
+    }
+  );
+
+  overlayTracker?.openOverlay(handle, {
+    focusedPanelId: embeddable.id,
+  });
+};
 
 export async function executeEditAction({
   embeddable,
@@ -39,35 +90,10 @@ export async function executeEditAction({
   if (!isCompatibleAction || !isLensEmbeddable(embeddable)) {
     throw new IncompatibleActionError();
   }
-  const rootEmbeddable = embeddable.getRoot();
-  const overlayTracker = tracksOverlays(rootEmbeddable) ? rootEmbeddable : undefined;
-  const ConfigPanel = await embeddable.openConfingPanel(startDependencies, isNewPanel, deletePanel);
+
+  const ConfigPanel = await embeddable.openConfigPanel(startDependencies, isNewPanel, deletePanel);
 
   if (ConfigPanel) {
-    const handle = startServices.overlays.openFlyout(
-      toMountPoint(
-        React.cloneElement(ConfigPanel, {
-          closeFlyout: () => {
-            if (overlayTracker) overlayTracker.clearOverlays();
-            handle.close();
-          },
-        }),
-        startServices
-      ),
-      {
-        className: 'lnsConfigPanel__overlay',
-        size: 's',
-        'data-test-subj': 'customizeLens',
-        type: 'push',
-        paddingSize: 'm',
-        hideCloseButton: true,
-        onClose: (overlayRef) => {
-          if (overlayTracker) overlayTracker.clearOverlays();
-          overlayRef.close();
-        },
-        outsideClickCloses: true,
-      }
-    );
-    overlayTracker?.openOverlay(handle, { focusedPanelId: embeddable.id });
+    openInlineLensConfigEditor(startServices, embeddable, ConfigPanel);
   }
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/185895

This PR adds a side effect to opening the inline config editor to disable scroll on the document body, this way the user's scroll interaction if any remains within the open inline lens config editor, whilst keeping ~on~ the panel whose configuration is being modified in focus.

#### Previously:

![ScreenRecording2024-07-12at15 23 35-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/1ed0823f-24f4-4b05-a17e-04a5b1218763)

#### After

![ScreenRecording2024-07-12at16 20 27-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d6e136ca-778b-4216-8beb-1a9f2e2aa6e5)


<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->