### PR TITLE
[Security Solution] [Attack discovery] Fixes loading icon when zero connectors are configured

### DIFF
--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_states/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_states/index.test.tsx
@@ -143,6 +143,52 @@ describe('EmptyStates', () => {
     });
   });
 
+  describe('when the Failure prompt should NOT be shown, because loading is true', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      const aiConnectorsCount = 1;
+      const alertsContextCount = 10;
+      const alertsCount = 10;
+      const attackDiscoveriesCount = 10;
+      const connectorId = 'test-connector-id';
+      const failureReason = 'this failure should NOT be displayed, because we are loading'; // <-- failureReason is provided
+      const isLoading = true; // <-- loading data
+      const onGenerate = jest.fn();
+
+      render(
+        <TestProviders>
+          <EmptyStates
+            aiConnectorsCount={aiConnectorsCount}
+            alertsContextCount={alertsContextCount}
+            alertsCount={alertsCount}
+            attackDiscoveriesCount={attackDiscoveriesCount}
+            connectorId={connectorId}
+            failureReason={failureReason}
+            isLoading={isLoading}
+            onGenerate={onGenerate}
+          />
+        </TestProviders>
+      );
+    });
+
+    it('does NOT render the Welcome prompt', () => {
+      expect(screen.queryByTestId('welcome')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the Failure prompt', () => {
+      expect(screen.queryByTestId('failure')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the No Alerts prompt', () => {
+      expect(screen.queryByTestId('noAlerts')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the Empty prompt', () => {
+      expect(screen.queryByTestId('emptyPrompt')).not.toBeInTheDocument();
+    });
+  });
+
   describe('when the Empty prompt should be shown', () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -185,6 +231,51 @@ describe('EmptyStates', () => {
 
     it('renders the Empty prompt', () => {
       expect(screen.getByTestId('emptyPrompt')).toBeInTheDocument();
+    });
+  });
+
+  describe('when the Empty prompt should NOT be shown, because aiConnectorsCount is null (no connectors are configured)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      const aiConnectorsCount = null; // <-- no connectors configured
+      const alertsContextCount = 20; // <-- alerts were sent as context to be analyzed
+      const alertsCount = 0;
+      const attackDiscoveriesCount = 0;
+      const connectorId = undefined;
+      const isLoading = false;
+      const onGenerate = jest.fn();
+
+      render(
+        <TestProviders>
+          <EmptyStates
+            aiConnectorsCount={aiConnectorsCount}
+            alertsContextCount={alertsContextCount}
+            alertsCount={alertsCount}
+            attackDiscoveriesCount={attackDiscoveriesCount}
+            connectorId={connectorId}
+            failureReason={null}
+            isLoading={isLoading}
+            onGenerate={onGenerate}
+          />
+        </TestProviders>
+      );
+    });
+
+    it('does NOT render the Welcome prompt', () => {
+      expect(screen.queryByTestId('welcome')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the Failure prompt', () => {
+      expect(screen.queryByTestId('failure')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the No Alerts prompt', () => {
+      expect(screen.queryByTestId('noAlerts')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the Empty prompt', () => {
+      expect(screen.queryByTestId('emptyPrompt')).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_states/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/empty_states/index.tsx
@@ -36,11 +36,11 @@ const EmptyStatesComponent: React.FC<Props> = ({
 }) => {
   if (showWelcomePrompt({ aiConnectorsCount, isLoading })) {
     return <Welcome />;
-  } else if (failureReason !== null) {
+  } else if (!isLoading && failureReason != null) {
     return <Failure failureReason={failureReason} />;
   } else if (showNoAlertsPrompt({ alertsContextCount, isLoading })) {
     return <NoAlerts />;
-  } else if (showEmptyPrompt({ attackDiscoveriesCount, isLoading })) {
+  } else if (showEmptyPrompt({ aiConnectorsCount, attackDiscoveriesCount, isLoading })) {
     return (
       <EmptyPrompt
         alertsCount={alertsCount}

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/helpers.test.ts
@@ -87,6 +87,7 @@ describe('helpers', () => {
   describe('showEmptyPrompt', () => {
     it('returns true when isLoading is false and attackDiscoveriesCount is 0', () => {
       const result = showEmptyPrompt({
+        aiConnectorsCount: 1,
         attackDiscoveriesCount: 0,
         isLoading: false,
       });
@@ -94,8 +95,29 @@ describe('helpers', () => {
       expect(result).toBe(true);
     });
 
+    it('returns false when isLoading is false and attackDiscoveriesCount is 0 and aiConnectorsCount is null', () => {
+      const result = showEmptyPrompt({
+        aiConnectorsCount: null,
+        attackDiscoveriesCount: 0,
+        isLoading: false,
+      });
+
+      expect(result).toBe(false);
+    });
+
     it('returns false when isLoading is true', () => {
       const result = showEmptyPrompt({
+        aiConnectorsCount: 1,
+        attackDiscoveriesCount: 0,
+        isLoading: true,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when isLoading is true and aiConnectorsCount is null', () => {
+      const result = showEmptyPrompt({
+        aiConnectorsCount: null,
         attackDiscoveriesCount: 0,
         isLoading: true,
       });
@@ -105,6 +127,17 @@ describe('helpers', () => {
 
     it('returns false when attackDiscoveriesCount is greater than 0', () => {
       const result = showEmptyPrompt({
+        aiConnectorsCount: 1,
+        attackDiscoveriesCount: 4,
+        isLoading: false,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when attackDiscoveriesCount is greater than 0 and aiConnectorsCount is null', () => {
+      const result = showEmptyPrompt({
+        aiConnectorsCount: null,
         attackDiscoveriesCount: 4,
         isLoading: false,
       });

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/helpers.ts
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/helpers.ts
@@ -90,12 +90,14 @@ export const showWelcomePrompt = ({
 }): boolean => !isLoading && aiConnectorsCount != null && aiConnectorsCount === 0;
 
 export const showEmptyPrompt = ({
+  aiConnectorsCount,
   attackDiscoveriesCount,
   isLoading,
 }: {
+  aiConnectorsCount: number | null;
   attackDiscoveriesCount: number;
   isLoading: boolean;
-}): boolean => !isLoading && attackDiscoveriesCount === 0;
+}): boolean => !isLoading && aiConnectorsCount != null && attackDiscoveriesCount === 0;
 
 export const showLoading = ({
   connectorId,

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
@@ -14,6 +14,7 @@ import { UpsellingService } from '@kbn/security-solution-upselling/service';
 import { Router } from '@kbn/shared-ux-router';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { useLocalStorage } from 'react-use';
 
 import { TestProviders } from '../../common/mock';
 import { MockAssistantProvider } from '../../common/mock/mock_assistant_provider';
@@ -31,12 +32,20 @@ import { ATTACK_DISCOVERY_PAGE_TITLE } from './page_title/translations';
 import { useAttackDiscovery } from '../use_attack_discovery';
 import { useLoadConnectors } from '@kbn/elastic-assistant/impl/connectorland/use_load_connectors';
 
+const mockConnectors: unknown[] = [
+  {
+    id: 'test-id',
+    name: 'OpenAI connector',
+    actionTypeId: '.gen-ai',
+  },
+];
+
 jest.mock('react-use', () => {
   const actual = jest.requireActual('react-use');
 
   return {
     ...actual,
-    useLocalStorage: jest.fn().mockReturnValue([undefined, jest.fn()]),
+    useLocalStorage: jest.fn().mockReturnValue(['test-id', jest.fn()]),
     useSessionStorage: jest.fn().mockReturnValue([undefined, jest.fn()]),
   };
 });
@@ -47,14 +56,6 @@ jest.mock(
     useFetchAnonymizationFields: jest.fn(() => mockFindAnonymizationFieldsResponse),
   })
 );
-
-const mockConnectors: unknown[] = [
-  {
-    id: 'test-id',
-    name: 'OpenAI connector',
-    actionTypeId: '.gen-ai',
-  },
-];
 
 jest.mock('@kbn/elastic-assistant/impl/connectorland/use_load_connectors', () => ({
   useLoadConnectors: jest.fn(() => ({
@@ -209,6 +210,13 @@ const historyMock = {
 describe('AttackDiscovery', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    (useLoadConnectors as jest.Mock).mockReturnValue({
+      isFetched: true,
+      data: mockConnectors,
+    });
+
+    (useLocalStorage as jest.Mock).mockReturnValue(['test-id', jest.fn()]);
   });
 
   describe('page layout', () => {
@@ -314,6 +322,81 @@ describe('AttackDiscovery', () => {
 
     it('does NOT render the empty prompt', () => {
       expect(screen.queryByTestId('emptyPrompt')).toBeNull();
+    });
+
+    it('does NOT render attack discoveries', () => {
+      expect(screen.queryAllByTestId('attackDiscovery')).toHaveLength(0);
+    });
+
+    it('does NOT render the upgrade call to action', () => {
+      expect(screen.queryByTestId('upgrade')).toBeNull();
+    });
+  });
+
+  describe('when connectors are configured, connectorId is undefined, and didInitialFetch is false', () => {
+    // At least two connectors are required for this scenario,
+    // because a single connector will be automatically selected,
+    // which will set connectorId to a non-undefined value:
+    const multipleMockConnectors: unknown[] = [
+      {
+        id: 'mock-connector-1',
+        name: 'OpenAI connector 1',
+        actionTypeId: '.gen-ai',
+      },
+      {
+        id: 'mock-connector-2',
+        name: 'OpenAI connector 2',
+        actionTypeId: '.gen-ai',
+      },
+    ];
+
+    beforeEach(() => {
+      (useLoadConnectors as jest.Mock).mockReturnValue({
+        isFetched: true,
+        data: multipleMockConnectors, // <-- multiple connectors, so none are auto-selected
+      });
+
+      (useLocalStorage as jest.Mock).mockReturnValue([undefined, jest.fn()]); // <-- connectorId is undefined
+
+      (useAttackDiscovery as jest.Mock).mockReturnValue({
+        approximateFutureTime: null,
+        attackDiscoveries: [],
+        cachedAttackDiscoveries: {},
+        didInitialFetch: false, // <-- didInitialFetch is false
+        fetchAttackDiscoveries: jest.fn(),
+        failureReason: null,
+        generationIntervals: undefined,
+        isLoading: false,
+        isLoadingPost: false,
+        lastUpdated: null,
+        replacements: {},
+      });
+
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <UpsellingProvider upsellingService={mockUpselling}>
+              <AttackDiscoveryPage />
+            </UpsellingProvider>
+          </Router>
+        </TestProviders>
+      );
+    });
+
+    it('does NOT render the animated logo, because connectorId is undefined', () => {
+      expect(screen.queryByTestId('animatedLogo')).toBeNull();
+    });
+
+    it('does NOT render the summary', () => {
+      expect(screen.queryByTestId('summary')).toBeNull();
+    });
+
+    it('does NOT render the loading callout', () => {
+      expect(screen.queryByTestId('loadingCallout')).toBeNull();
+    });
+
+    it('renders the empty prompt', () => {
+      expect(screen.getByTestId('emptyPrompt')).toBeInTheDocument();
     });
 
     it('does NOT render attack discoveries', () => {

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/index.test.tsx
@@ -29,6 +29,7 @@ import {
 } from '../mock/mock_use_attack_discovery';
 import { ATTACK_DISCOVERY_PAGE_TITLE } from './page_title/translations';
 import { useAttackDiscovery } from '../use_attack_discovery';
+import { useLoadConnectors } from '@kbn/elastic-assistant/impl/connectorland/use_load_connectors';
 
 jest.mock('react-use', () => {
   const actual = jest.requireActual('react-use');
@@ -44,6 +45,28 @@ jest.mock(
   '@kbn/elastic-assistant/impl/assistant/api/anonymization_fields/use_fetch_anonymization_fields',
   () => ({
     useFetchAnonymizationFields: jest.fn(() => mockFindAnonymizationFieldsResponse),
+  })
+);
+
+const mockConnectors: unknown[] = [
+  {
+    id: 'test-id',
+    name: 'OpenAI connector',
+    actionTypeId: '.gen-ai',
+  },
+];
+
+jest.mock('@kbn/elastic-assistant/impl/connectorland/use_load_connectors', () => ({
+  useLoadConnectors: jest.fn(() => ({
+    isFetched: true,
+    data: mockConnectors,
+  })),
+}));
+
+jest.mock(
+  '@kbn/elastic-assistant/impl/connectorland/connector_selector_inline/connector_selector_inline',
+  () => ({
+    ConnectorSelectorInline: () => null,
   })
 );
 
@@ -225,6 +248,10 @@ describe('AttackDiscovery', () => {
       );
     });
 
+    it('does NOT render the animated logo', () => {
+      expect(screen.queryByTestId('animatedLogo')).toBeNull();
+    });
+
     it('does NOT render the summary', () => {
       expect(screen.queryByTestId('summary')).toBeNull();
     });
@@ -235,6 +262,115 @@ describe('AttackDiscovery', () => {
 
     it('renders the empty prompt', () => {
       expect(screen.getByTestId('emptyPrompt')).toBeInTheDocument();
+    });
+
+    it('does NOT render attack discoveries', () => {
+      expect(screen.queryAllByTestId('attackDiscovery')).toHaveLength(0);
+    });
+
+    it('does NOT render the upgrade call to action', () => {
+      expect(screen.queryByTestId('upgrade')).toBeNull();
+    });
+  });
+
+  describe('when connectors are configured and didInitialFetch is false', () => {
+    beforeEach(() => {
+      (useAttackDiscovery as jest.Mock).mockReturnValue({
+        approximateFutureTime: null,
+        attackDiscoveries: [],
+        cachedAttackDiscoveries: {},
+        didInitialFetch: false, // <-- didInitialFetch is false
+        fetchAttackDiscoveries: jest.fn(),
+        failureReason: null,
+        generationIntervals: undefined,
+        isLoading: false,
+        isLoadingPost: false,
+        lastUpdated: null,
+        replacements: {},
+      });
+
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <UpsellingProvider upsellingService={mockUpselling}>
+              <AttackDiscoveryPage />
+            </UpsellingProvider>
+          </Router>
+        </TestProviders>
+      );
+    });
+
+    it('renders the animated logo, because connectors are configured and the initial fetch is pending', () => {
+      expect(screen.getByTestId('animatedLogo')).toBeInTheDocument();
+    });
+
+    it('does NOT render the summary', () => {
+      expect(screen.queryByTestId('summary')).toBeNull();
+    });
+
+    it('does NOT render the loading callout', () => {
+      expect(screen.queryByTestId('loadingCallout')).toBeNull();
+    });
+
+    it('does NOT render the empty prompt', () => {
+      expect(screen.queryByTestId('emptyPrompt')).toBeNull();
+    });
+
+    it('does NOT render attack discoveries', () => {
+      expect(screen.queryAllByTestId('attackDiscovery')).toHaveLength(0);
+    });
+
+    it('does NOT render the upgrade call to action', () => {
+      expect(screen.queryByTestId('upgrade')).toBeNull();
+    });
+  });
+
+  describe('when connectors are NOT configured and didInitialFetch is false', () => {
+    beforeEach(() => {
+      (useLoadConnectors as jest.Mock).mockReturnValue({
+        isFetched: true,
+        data: [], // <-- connectors are NOT configured
+      });
+
+      (useAttackDiscovery as jest.Mock).mockReturnValue({
+        approximateFutureTime: null,
+        attackDiscoveries: [],
+        cachedAttackDiscoveries: {},
+        didInitialFetch: false, // <-- didInitialFetch is false
+        fetchAttackDiscoveries: jest.fn(),
+        failureReason: null,
+        generationIntervals: undefined,
+        isLoading: false,
+        isLoadingPost: false,
+        lastUpdated: null,
+        replacements: {},
+      });
+
+      render(
+        <TestProviders>
+          <Router history={historyMock}>
+            <UpsellingProvider upsellingService={mockUpselling}>
+              <AttackDiscoveryPage />
+            </UpsellingProvider>
+          </Router>
+        </TestProviders>
+      );
+    });
+
+    it('does NOT render the animated logo, because connectors are NOT configured', () => {
+      expect(screen.queryByTestId('animatedLogo')).toBeNull();
+    });
+
+    it('does NOT render the summary', () => {
+      expect(screen.queryByTestId('summary')).toBeNull();
+    });
+
+    it('does NOT render the loading callout', () => {
+      expect(screen.queryByTestId('loadingCallout')).toBeNull();
+    });
+
+    it('does NOT render the empty prompt', () => {
+      expect(screen.queryByTestId('emptyPrompt')).toBeNull();
     });
 
     it('does NOT render attack discoveries', () => {
@@ -264,6 +400,10 @@ describe('AttackDiscovery', () => {
           </Router>
         </TestProviders>
       );
+    });
+
+    it('does NOT render the animated logo', () => {
+      expect(screen.queryByTestId('animatedLogo')).toBeNull();
     });
 
     it('renders the summary', () => {
@@ -302,6 +442,10 @@ describe('AttackDiscovery', () => {
           </Router>
         </TestProviders>
       );
+    });
+
+    it('does NOT render the animated logo, because didInitialFetch is true', () => {
+      expect(screen.queryByTestId('animatedLogo')).toBeNull();
     });
 
     it('does NOT render the summary', () => {
@@ -346,6 +490,10 @@ describe('AttackDiscovery', () => {
           </Router>
         </TestProviders>
       );
+    });
+
+    it('does NOT render the animated logo', () => {
+      expect(screen.queryByTestId('animatedLogo')).toBeNull();
     });
 
     it('does NOT render the header', () => {

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -136,8 +136,12 @@ const AttackDiscoveryPageComponent: React.FC = () => {
     // If there is only one connector, set it as the selected connector
     if (aiConnectors != null && aiConnectors.length === 1) {
       setConnectorId(aiConnectors[0].id);
+    } else if (aiConnectors != null && aiConnectors.length === 0) {
+      // connectors have been removed, reset the connectorId and cached Attack discoveries
+      setConnectorId(undefined);
+      setSelectedConnectorAttackDiscoveries([]);
     }
-  }, [aiConnectors, setConnectorId]);
+  }, [aiConnectors]);
 
   const animatedLogo = useMemo(() => <EuiLoadingLogo logo="logoSecurity" size="xl" />, []);
   const connectorsAreConfigured = aiConnectors != null && aiConnectors.length > 0;

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -183,7 +183,7 @@ const AttackDiscoveryPageComponent: React.FC = () => {
           />
           <EuiSpacer size="m" />
         </HeaderPage>
-        {connectorsAreConfigured && !didInitialFetch ? (
+        {connectorsAreConfigured && connectorId != null && !didInitialFetch ? (
           <EuiEmptyPrompt data-test-subj="animatedLogo" icon={animatedLogo} />
         ) : (
           <>

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/index.tsx
@@ -139,6 +139,8 @@ const AttackDiscoveryPageComponent: React.FC = () => {
     }
   }, [aiConnectors, setConnectorId]);
 
+  const animatedLogo = useMemo(() => <EuiLoadingLogo logo="logoSecurity" size="xl" />, []);
+  const connectorsAreConfigured = aiConnectors != null && aiConnectors.length > 0;
   const attackDiscoveriesCount = selectedConnectorAttackDiscoveries.length;
 
   if (!isAssistantEnabled) {
@@ -166,7 +168,7 @@ const AttackDiscoveryPageComponent: React.FC = () => {
         <HeaderPage border title={pageTitle}>
           <Header
             connectorId={connectorId}
-            connectorsAreConfigured={aiConnectors != null && aiConnectors.length > 0}
+            connectorsAreConfigured={connectorsAreConfigured}
             isLoading={isLoading}
             // disable header actions before post request has completed
             isDisabledActions={isLoadingPost}
@@ -177,8 +179,8 @@ const AttackDiscoveryPageComponent: React.FC = () => {
           />
           <EuiSpacer size="m" />
         </HeaderPage>
-        {!didInitialFetch ? (
-          <EuiEmptyPrompt icon={<EuiLoadingLogo logo="logoSecurity" size="xl" />} />
+        {connectorsAreConfigured && !didInitialFetch ? (
+          <EuiEmptyPrompt data-test-subj="animatedLogo" icon={animatedLogo} />
         ) : (
           <>
             {showSummary({


### PR DESCRIPTION
## [Security Solution] [Attack discovery] Fixes loading icon when zero connectors are configured

### Summary

This PR fixes an issue where a persistent loading icon is displayed in Attack discovery when zero connectors are configured.

#### After

![after](https://github.com/user-attachments/assets/978bf641-a86f-4db5-8bf8-a3178ae350d8)

#### Before

![before](https://github.com/user-attachments/assets/27b24715-51ca-46bb-891e-c4e36e046f3f)

### Desk testing

Reproduction steps in `main`, (before the fix):

1) Clear local storage for Kibana (e.g. `http://localhost:5601`) in your browser, then close all Kibana tabs

2) If your local Kibana development environment has pre-configured connectors in `kibana.dev.yml`, comment them out.

3) Start a fresh local (development) deployment of Elasticsearch:

```sh
yarn es snapshot -E path.data=/example/path/to/data/data-2024-07-12a
```

4) Start a local instance of Kibana:

```sh
yarn start --no-base-path
```

5) In a terminal, navigate to `$KIBANA_HOME/x-pack/plugins/security_solution`:

```sh
cd $KIBANA_HOME/x-pack/plugins/security_solution
```

6) Generate some test data:

```sh
yarn test:generate
```

7) In a browser, login to Kibana as the `elastic` user

8) Navigate to Security > Attack discovery

9) Click `Manage license`

10) Click `Start trial`

11) In the `Start your free 30-day trial` modal, click `Start my trial`

12) Once again, navigate to Security > Attack discovery

**Expected result**

- The "Welcome to Attack Discovery" empty prompt appears, as illustrated by the animated gif below:

![after](https://github.com/user-attachments/assets/978bf641-a86f-4db5-8bf8-a3178ae350d8)

**Actual result**

- An animated shield loading icon continuously hovers, as illustrated by the animated gif below:

![before](https://github.com/user-attachments/assets/27b24715-51ca-46bb-891e-c4e36e046f3f)

**STOP HERE IF YOU ARE REPRODUCING THE ISSUE IN `MAIN`, CONTINUE IF YOU ARE TESTING THE FIX**

13) Click a connector, e.g. `OpenAI` to create a new connector

14) Configure the connector, then click `Save`

**Expected result**

- The `Up to 20 alerts will be analyzed` empty prompt is displayed
- The newly-added connector is selected
- The Generate button is enabled

15) Click `Generate`

**Expected results**

- The `Attack discovery in progress` loader appears
- When loading completes, the `No alerts to analyze` empty prompt appears

16) Navigate to Security > Alerts

17) Click the `Manage rules` button

18) Click `Add Elastic rules`

19) Click `Install all`

20) Click `Go back to installed Elastic rules`

21) Once again, generate some test data:

```sh
yarn test:generate
```

22) On the rules page, toggle the `Endpoint Security` rule `off`, then back `on` again

23) Navigate to Security > Alerts

24) Select `Last 24 hours` from the date picker

25) Click `Refresh`

**Expected results**

- Alerts in the Last 24 hours are displayed in the visualizations and table

26) Navigate to Security > Attack discovery

27) Click `Generate`

**Expected results**

- The `Attack discovery in progress` loader appears
- When the loader completes, attack discoveries are displayed

28) Navigate to Stack Management > Connectors

29) Delete the connector

30) Once again, navigate to Security > Attack discovery

**Expected results**

- The `Generate` button is disabled
- The previous Attack discovery results are NOT displayed
- The `Welcome to Attack Discovery!` prompt is displayed


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->