### PR TITLE
[Security GenAI] Make langsmith UI settings take precedence over env vars.

### DIFF
--- a/x-pack/packages/kbn-langchain/server/tracers/langsmith/langsmith_tracer.ts
+++ b/x-pack/packages/kbn-langchain/server/tracers/langsmith/langsmith_tracer.ts
@@ -32,7 +32,7 @@ export const getLangSmithTracer = ({
   logger: Logger | ToolingLog;
 }): LangChainTracer[] => {
   try {
-    if (!isLangSmithEnabled() || apiKey == null) {
+    if (!apiKey) {
       return [];
     }
     const lcTracer = new LangChainTracer({


### PR DESCRIPTION
## Summary

Fixes LangSmith tracing when there are no environment variables defined. The order of precedence will work as follows:

- **Only AI setting defined**: Uses AI settings
- **Only environment vars defined**: Uses env vars
- **With both AI setting and Env vars defined**: Uses AI settings
- **Without AI setting nor Env vars**: No tracing

The tracing feature is still in preview under a feature flag:
```
xpack.securitySolution.enableExperimental: ['assistantModelEvaluation']

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->