### PR TITLE
`yarn kbn reset` will clean data/ as well to avoid stale state

### DIFF
--- a/kbn_pm/src/commands/reset_command.mjs
+++ b/kbn_pm/src/commands/reset_command.mjs
@@ -36,6 +36,7 @@ export const command = {
     await cleanPaths(log, [
       Path.resolve(REPO_ROOT, 'node_modules'),
       Path.resolve(REPO_ROOT, 'x-pack/node_modules'),
+      Path.resolve(REPO_ROOT, 'data'),
       ...readCleanPatterns(REPO_ROOT),
       ...(await findPluginCleanPaths(log)),
     ]);


### PR DESCRIPTION
## Summary
In some cases, the `data/` folder sticking around is causing developers' environments to be corrupted. None of the current reset/clean methods clean that folder. This PR adds this small adjustment.

Closes: https://github.com/elastic/kibana/issues/187914

<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->