### PR TITLE
[Search] Allow users to save mappings with errors

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.helpers.ts
@@ -107,6 +107,7 @@ export interface IndexDetailsPageTestBed extends TestBed {
       getDataStreamDetailsContent: () => string;
       reloadDataStreamDetails: () => Promise<void>;
       addDocCodeBlockExists: () => boolean;
+      indexErrorCalloutExists: () => boolean;
     };
   };
 }
@@ -195,6 +196,9 @@ export const setup = async ({
     },
     addDocCodeBlockExists: () => {
       return exists('codeBlockControlsPanel');
+    },
+    indexErrorCalloutExists: () => {
+      return exists('indexErrorCallout');
     },
   };
 

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
@@ -103,8 +103,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('resends a request when reload button is clicked', async () => {
-      // already sent 2 requests while setting up the component
-      const numberOfRequests = 2;
+      // already sent 4 requests while setting up the component
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
       await testBed.actions.errorSection.clickReloadButton();
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -112,7 +112,7 @@ describe('<IndexDetailsPage />', () => {
 
     it('renders an error section when no index name is provided', async () => {
       // already sent 2 requests while setting up the component
-      const numberOfRequests = 2;
+      const numberOfRequests = 4;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
       await act(async () => {
         testBed = await setup({ httpSetup, initialEntry: '/indices/index_details' });
@@ -209,8 +209,8 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('resends a request when reload button is clicked', async () => {
-        // already sent 3 requests while setting up the component
-        const numberOfRequests = 3;
+        // already sent 7 requests while setting up the component
+        const numberOfRequests = 7;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.stats.clickErrorReloadButton();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -219,7 +219,7 @@ describe('<IndexDetailsPage />', () => {
   });
 
   it('loads index details from the API', async () => {
-    expect(httpSetup.get).toHaveBeenLastCalledWith(
+    expect(httpSetup.get).toHaveBeenCalledWith(
       `${INTERNAL_API_BASE_PATH}/indices/${testIndexName}`,
       requestOptions
     );
@@ -382,8 +382,8 @@ describe('<IndexDetailsPage />', () => {
           `Data streamUnable to load data stream detailsReloadLast update`
         );
 
-        // already sent 3 requests while setting up the component
-        const numberOfRequests = 3;
+        // already sent 7 requests while setting up the component
+        const numberOfRequests = 7;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.overview.reloadDataStreamDetails();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -612,7 +612,7 @@ describe('<IndexDetailsPage />', () => {
           body: '{"name":{"type":"text"}}',
         });
 
-        expect(httpSetup.get).toHaveBeenCalledTimes(5);
+        expect(httpSetup.get).toHaveBeenCalledTimes(9);
         expect(httpSetup.get).toHaveBeenLastCalledWith(
           `${API_BASE_PATH}/mapping/${testIndexName}`,
           requestOptions
@@ -792,8 +792,8 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('resends a request when reload button is clicked', async () => {
-        // already sent 4 requests while setting up the component
-        const numberOfRequests = 4;
+        // already sent 8 requests while setting up the component
+        const numberOfRequests = 8;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.mappings.clickErrorReloadButton();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -890,8 +890,8 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('resends a request when reload button is clicked', async () => {
-        // already sent 3 requests while setting up the component
-        const numberOfRequests = 3;
+        // already sent 7 requests while setting up the component
+        const numberOfRequests = 7;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         await testBed.actions.settings.clickErrorReloadButton();
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests + 1);
@@ -942,7 +942,7 @@ describe('<IndexDetailsPage />', () => {
       });
 
       it('reloads the settings after an update', async () => {
-        const numberOfRequests = 2;
+        const numberOfRequests = 4;
         expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
         const updatedSettings = { ...testIndexEditableSettingsAll, 'index.priority': '2' };
         await testBed.actions.settings.updateCodeEditorContent(JSON.stringify(updatedSettings));
@@ -1004,8 +1004,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('closes an index', async () => {
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 1;
+      // already sent 3 requests while setting up the component
+      const numberOfRequests = 3;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1027,8 +1027,8 @@ describe('<IndexDetailsPage />', () => {
       });
       testBed.component.update();
 
-      // already sent 2 requests while setting up the component
-      const numberOfRequests = 2;
+      // already sent 6 requests while setting up the component
+      const numberOfRequests = 6;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1040,8 +1040,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('forcemerges an index', async () => {
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 1;
+      // already sent 3 request while setting up the component
+      const numberOfRequests = 3;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1054,8 +1054,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it('refreshes an index', async () => {
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 1;
+      // already sent 3 request while setting up the component
+      const numberOfRequests = 3;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1067,8 +1067,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it(`clears an index's cache`, async () => {
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 1;
+      // already sent 3 request while setting up the component
+      const numberOfRequests = 3;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1080,8 +1080,8 @@ describe('<IndexDetailsPage />', () => {
     });
 
     it(`flushes an index`, async () => {
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 1;
+      // already sent 3 requests while setting up the component
+      const numberOfRequests = 3;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1095,7 +1095,7 @@ describe('<IndexDetailsPage />', () => {
     it(`deletes an index`, async () => {
       jest.spyOn(testBed.routerMock.history, 'push');
       // already sent 1 request while setting up the component
-      const numberOfRequests = 1;
+      const numberOfRequests = 3;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1120,8 +1120,8 @@ describe('<IndexDetailsPage />', () => {
       });
       testBed.component.update();
 
-      // already sent 1 request while setting up the component
-      const numberOfRequests = 2;
+      // already sent 6 requests while setting up the component
+      const numberOfRequests = 6;
       expect(httpSetup.get).toHaveBeenCalledTimes(numberOfRequests);
 
       await testBed.actions.contextMenu.clickManageIndexButton();
@@ -1154,7 +1154,7 @@ describe('<IndexDetailsPage />', () => {
       testBed.component.update();
     });
     it('loads the index details with the encoded index name', () => {
-      expect(httpSetup.get).toHaveBeenLastCalledWith(
+      expect(httpSetup.get).toHaveBeenCalledWith(
         `${INTERNAL_API_BASE_PATH}/indices/${encodeURIComponent(percentSignName)}`,
         requestOptions
       );

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/mocks.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/mocks.ts
@@ -42,6 +42,22 @@ export const testIndexMappings = {
   },
 };
 
+export const testIndexMappingsWithSemanticText = {
+  mappings: {
+    dynamic: 'false',
+    dynamic_templates: [],
+    properties: {
+      '@timestamp': {
+        type: 'date',
+      },
+      semantic_text: {
+        type: 'semantic_text',
+        inference_id: 'inference_id',
+      },
+    },
+  },
+};
+
 // Mocking partial index settings response
 export const testIndexSettings = {
   settings: {

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/trained_models_deployment_modal.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/trained_models_deployment_modal.test.tsx
@@ -107,7 +107,8 @@ const defaultState = {
 } as any;
 
 const setErrorsInTrainedModelDeployment = jest.fn().mockReturnValue(undefined);
-const fetchData = jest.fn().mockReturnValue(undefined);
+const saveMappings = jest.fn().mockReturnValue(undefined);
+const forceSaveMappings = jest.fn().mockReturnValue(undefined);
 
 describe('When semantic_text is enabled', () => {
   const setup = (defaultProps: Partial<TrainedModelsDeploymentModalProps>) =>
@@ -124,7 +125,8 @@ describe('When semantic_text is enabled', () => {
     mappingsContextMocked.useMappingsState.mockReturnValue(defaultState);
     const { exists } = setup({
       errorsInTrainedModelDeployment: {},
-      fetchData,
+      saveMappings,
+      forceSaveMappings,
       setErrorsInTrainedModelDeployment: () => undefined,
     });
 
@@ -156,7 +158,8 @@ describe('When semantic_text is enabled', () => {
     } as any);
     const { exists, find } = setup({
       errorsInTrainedModelDeployment: {},
-      fetchData,
+      forceSaveMappings,
+      saveMappings,
       setErrorsInTrainedModelDeployment,
     });
 
@@ -170,11 +173,25 @@ describe('When semantic_text is enabled', () => {
       );
     });
 
-    it('should call fetch data if refresh button is pressed', async () => {
+    it('should call saveMappings if refresh button is pressed', async () => {
       await act(async () => {
-        find('confirmModalConfirmButton').simulate('click');
+        find('tryAgainModalButton').simulate('click');
       });
-      expect(fetchData.mock.calls).toHaveLength(1);
+      expect(saveMappings.mock.calls).toHaveLength(1);
+    });
+    it('should disable the force save mappings button if checkbox is not checked', async () => {
+      expect(find('forceSaveMappingsButton').props().disabled).toBe(true);
+    });
+    it('checking checkbox should enable force save mappings button', async () => {
+      find('allowForceSaveMappingsCheckbox')
+        .simulate('change', { target: { checked: true } })
+        .update();
+      expect(find('forceSaveMappingsButton').props().disabled).toBe(false);
+      await act(async () => {
+        find('forceSaveMappingsButton').simulate('click');
+      });
+
+      expect(forceSaveMappings.mock.calls).toHaveLength(1);
     });
   });
 
@@ -200,8 +217,9 @@ describe('When semantic_text is enabled', () => {
       },
     } as any);
     const { find } = setup({
-      fetchData,
       errorsInTrainedModelDeployment: { '.elser_model_2': 'Error' },
+      saveMappings,
+      forceSaveMappings,
       setErrorsInTrainedModelDeployment,
     });
 
@@ -216,15 +234,9 @@ describe('When semantic_text is enabled', () => {
 
     it("should call refresh method if 'Try again' button is pressed", async () => {
       await act(async () => {
-        find('confirmModalConfirmButton').simulate('click');
+        find('tryAgainModalButton').simulate('click');
       });
-      expect(fetchData.mock.calls).toHaveLength(1);
-    });
-
-    it('should call setIsVisibleForErrorModal method if cancel button is pressed', async () => {
-      await act(async () => {
-        find('confirmModalCancelButton').simulate('click');
-      });
+      expect(saveMappings.mock.calls).toHaveLength(1);
     });
   });
 });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/type_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/type_parameter.tsx
@@ -30,7 +30,7 @@ export const TypeParameter = ({
   isMultiField,
   isRootLevelField,
   showDocLink = false,
-  isSemanticTextEnabled = false,
+  isSemanticTextEnabled = true,
 }: Props) => {
   const fieldTypeOptions = useMemo(() => {
     let options = isMultiField

--- a/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts
+++ b/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { Index } from '@kbn/index-management';
+import { MlPluginStart } from '@kbn/ml-plugin/public';
+import { useState, useEffect } from 'react';
+import { normalize } from '../components/mappings_editor/lib';
+import { isLocalModel } from '../components/mappings_editor/lib/utils';
+import { NormalizedField } from '../components/mappings_editor/types';
+import { useLoadIndexMappings, useLoadInferenceEndpoints } from '../services';
+import { parseMappings } from '../shared/parse_mappings';
+
+export const useIndexErrors = (
+  index: Index,
+  ml: MlPluginStart | undefined,
+  canGetTrainedModels: boolean
+) => {
+  const { data } = useLoadIndexMappings(index.name);
+  const { data: endpoints } = useLoadInferenceEndpoints();
+  const [errors, setErrors] = useState<Array<{ field: NormalizedField; error: string }>>([]);
+  useEffect(() => {
+    const mappings = data;
+    if (!mappings || !canGetTrainedModels || !endpoints || !ml) {
+      return;
+    }
+
+    const parsedMappings = parseMappings(mappings);
+    const normalizedFields = normalize(parsedMappings.parsedDefaultValue?.fields);
+    const semanticTextFields = Object.values(normalizedFields.byId).filter(
+      (field) => field.source.type === 'semantic_text'
+    );
+    const fetchErrors = async () => {
+      const trainedModelStats = await ml.mlApi?.trainedModels.getTrainedModelStats();
+
+      const semanticTextFieldsWithErrors = semanticTextFields
+        .map((field) => {
+          const model = endpoints.find(
+            (endpoint) => endpoint.model_id === field.source.inference_id
+          );
+          if (!model) {
+            return {
+              field,
+              error: i18n.translate('xpack.idxMgmt.indexOverview.indexErrors.missingModelError', {
+                defaultMessage: 'Model not found for inference endpoint {inferenceId}',
+                values: {
+                  inferenceId: field.source.inference_id as string,
+                  fieldName: field.path.join('.'),
+                },
+              }),
+            };
+          }
+          if (isLocalModel(model)) {
+            const modelId = model.service_settings.model_id;
+            const modelStats = trainedModelStats?.trained_model_stats.find(
+              (value) => value.model_id === modelId
+            );
+            if (!modelStats || modelStats.deployment_stats?.state !== 'started') {
+              return {
+                field,
+                error: i18n.translate(
+                  'xpack.idxMgmt.indexOverview.indexErrors.modelNotStartedError',
+                  {
+                    defaultMessage:
+                      'Model {modelId} for inference endpoint {inferenceId} in field {fieldName} has not been started',
+                    values: {
+                      inferenceId: field.source.inference_id as string,
+                      fieldName: field.path.join('.'),
+                      modelId,
+                    },
+                  }
+                ),
+              };
+            }
+          }
+          return { field, error: '' };
+        })
+        .filter((value) => !!value.error);
+      setErrors(semanticTextFieldsWithErrors);
+    };
+
+    if (semanticTextFields.length) {
+      fetchErrors();
+    }
+  }, [data, canGetTrainedModels, endpoints, ml, ml?.mlApi?.trainedModels]);
+  return errors;
+};

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
@@ -18,6 +18,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { RouteComponentProps } from 'react-router-dom';
 
+import { useIndexErrors } from '../../../../hooks/use_index_errors';
 import { resetIndexUrlParams } from './reset_index_url_params';
 import { renderBadges } from '../../../../lib/render_badges';
 import { Index } from '../../../../../../common';
@@ -36,6 +37,7 @@ import { DetailsPageMappings } from './details_page_mappings';
 import { DetailsPageSettings } from './details_page_settings';
 import { DetailsPageStats } from './details_page_stats';
 import { DetailsPageTab } from './details_page_tab';
+import { IndexErrorCallout } from './index_error_callout';
 
 const defaultTabs: IndexDetailsTab[] = [
   {
@@ -92,10 +94,16 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
   navigateToIndicesList,
 }) => {
   const {
+    core: {
+      application: { capabilities },
+    },
     config: { enableIndexStats },
-    plugins: { console: consolePlugin },
+    plugins: { console: consolePlugin, ml },
     services: { extensionsService },
   } = useAppContext();
+  const hasMLPermissions = capabilities?.ml?.canGetTrainedModels ? true : false;
+
+  const indexErrors = useIndexErrors(index, ml, hasMLPermissions);
 
   const tabs = useMemo(() => {
     const sortedTabs = [...defaultTabs];
@@ -171,7 +179,9 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
         }}
         responsive="reverse"
         tabs={headerTabs}
-      />
+      >
+        {indexErrors.length > 0 ? <IndexErrorCallout errors={indexErrors} /> : null}
+      </EuiPageHeader>
       <EuiSpacer size="l" />
       <div
         data-test-subj={`indexDetailsContent`}

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -211,64 +211,53 @@ export const DetailsPageMappingsContent: FunctionComponent<{
 
     fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isSemanticTextEnabled, hasMLPermissions]);
 
-  const fetchInferenceData = useCallback(async () => {
-    try {
-      if (!isSemanticTextEnabled) {
-        return;
-      }
-
-      if (!hasMLPermissions) {
-        return;
-      }
-
-      await fetchInferenceToModelIdMap();
-    } catch (exception) {
-      setSaveMappingError(exception.message);
-    }
-  }, [fetchInferenceToModelIdMap, isSemanticTextEnabled, hasMLPermissions]);
-
-  const updateMappings = useCallback(async () => {
-    const hasSemanticText = hasSemanticTextField(state.fields);
-    try {
-      if (isSemanticTextEnabled && hasMLPermissions && hasSemanticText) {
-        await fetchInferenceToModelIdMap();
-      }
-
-      const fields = hasSemanticText ? getStateWithCopyToFields(state).fields : state.fields;
-
-      const denormalizedFields = deNormalize(fields);
-
-      const inferenceIdsInPendingList = Object.values(deNormalize(fields))
-        .filter(isSemanticTextField)
-        .map((field) => field.inference_id)
-        .filter(
-          (inferenceId: string) =>
-            state.inferenceToModelIdMap?.[inferenceId] &&
-            !state.inferenceToModelIdMap?.[inferenceId].isDeployed
-        );
-      setHasSavedFields(true);
-      if (inferenceIdsInPendingList.length === 0) {
-        const { error } = await updateIndexMappings(indexName, denormalizedFields);
-
-        if (!error) {
-          notificationService.showSuccessToast(
-            i18n.translate('xpack.idxMgmt.indexDetails.mappings.successfullyUpdatedIndexMappings', {
-              defaultMessage: 'Updated index mapping',
-            })
-          );
-          refetchMapping();
-          setHasSavedFields(false);
-        } else {
-          setSaveMappingError(error.message);
+  const updateMappings = useCallback(
+    async (forceSaveMappings?: boolean) => {
+      const hasSemanticText = hasSemanticTextField(state.fields);
+      try {
+        if (isSemanticTextEnabled && hasMLPermissions && hasSemanticText && !forceSaveMappings) {
+          await fetchInferenceToModelIdMap();
         }
+        const fields = hasSemanticText ? getStateWithCopyToFields(state).fields : state.fields;
+        const denormalizedFields = deNormalize(fields);
+        const inferenceIdsInPendingList = forceSaveMappings
+          ? []
+          : Object.values(denormalizedFields)
+              .filter(isSemanticTextField)
+              .map((field) => field.inference_id)
+              .filter(
+                (inferenceId: string) =>
+                  state.inferenceToModelIdMap?.[inferenceId] &&
+                  !state.inferenceToModelIdMap?.[inferenceId].isDeployed
+              );
+        setHasSavedFields(true);
+        if (inferenceIdsInPendingList.length === 0) {
+          const { error } = await updateIndexMappings(indexName, denormalizedFields);
+
+          if (!error) {
+            notificationService.showSuccessToast(
+              i18n.translate(
+                'xpack.idxMgmt.indexDetails.mappings.successfullyUpdatedIndexMappings',
+                {
+                  defaultMessage: 'Updated index mapping',
+                }
+              )
+            );
+            refetchMapping();
+            setHasSavedFields(false);
+          } else {
+            setSaveMappingError(error.message);
+          }
+        }
+      } catch (exception) {
+        setSaveMappingError(exception.message);
       }
-    } catch (exception) {
-      setSaveMappingError(exception.message);
-    }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.fields]);
+    [state.fields]
+  );
 
   const onSearchChange = useCallback(
     (value: string) => {
@@ -496,7 +485,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
                   </EuiButton>
                 ) : (
                   <EuiButton
-                    onClick={updateMappings}
+                    onClick={() => updateMappings()}
                     color="success"
                     fill
                     disabled={newFieldsLength === 0}
@@ -613,8 +602,9 @@ export const DetailsPageMappingsContent: FunctionComponent<{
       </EuiFlexGroup>
       {isSemanticTextEnabled && isAddingFields && hasSavedFields && (
         <TrainedModelsDeploymentModal
-          fetchData={fetchInferenceData}
           errorsInTrainedModelDeployment={errorsInTrainedModelDeployment}
+          forceSaveMappings={() => updateMappings(true)}
+          saveMappings={() => updateMappings()}
           setErrorsInTrainedModelDeployment={setErrorsInTrainedModelDeployment}
         />
       )}

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -155,6 +155,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
   );
 
   const [hasSavedFields, setHasSavedFields] = useState<boolean>(false);
+  const [isUpdatingMappings, setIsUpdatingMappings] = useState<boolean>(false);
 
   useMappingsStateListener({ value: parsedDefaultValue, status: 'disabled' });
   const { fetchInferenceToModelIdMap } = useDetailsPageMappingsModelManagement();
@@ -216,6 +217,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
   const updateMappings = useCallback(
     async (forceSaveMappings?: boolean) => {
       const hasSemanticText = hasSemanticTextField(state.fields);
+      setIsUpdatingMappings(true);
       try {
         if (isSemanticTextEnabled && hasMLPermissions && hasSemanticText && !forceSaveMappings) {
           await fetchInferenceToModelIdMap();
@@ -254,6 +256,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
       } catch (exception) {
         setSaveMappingError(exception.message);
       }
+      setIsUpdatingMappings(false);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state.fields]
@@ -605,6 +608,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
           errorsInTrainedModelDeployment={errorsInTrainedModelDeployment}
           forceSaveMappings={() => updateMappings(true)}
           saveMappings={() => updateMappings()}
+          saveMappingsLoading={isUpdatingMappings}
           setErrorsInTrainedModelDeployment={setErrorsInTrainedModelDeployment}
         />
       )}

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_error_callout.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/index_error_callout.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiButton, EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { NormalizedField } from '../../../../components/mappings_editor/types';
+
+interface IndexErrorCalloutProps {
+  errors: Array<{
+    field: NormalizedField;
+    error: string;
+  }>;
+}
+
+export const IndexErrorCallout = ({ errors }: IndexErrorCalloutProps) => {
+  const [showErrors, setShowErrors] = useState(false);
+  return (
+    <EuiCallOut
+      data-test-subj="indexErrorCallout"
+      color="danger"
+      iconType="error"
+      title={i18n.translate('xpack.idxMgmt.indexOverview.indexErrors.title', {
+        defaultMessage: 'Index has errors',
+      })}
+    >
+      {showErrors && (
+        <>
+          <p>
+            {i18n.translate('xpack.idxMgmt.indexOverview.indexErrors.body', {
+              defaultMessage: 'Found errors in the following fields:',
+            })}
+            {errors.map(({ field, error }) => (
+              <li key={field.path.join('.')}>
+                <strong>{field.path.join('.')}</strong>: {error}
+              </li>
+            ))}
+          </p>
+          <EuiButton color="danger" onClick={() => setShowErrors(false)}>
+            {i18n.translate('xpack.idxMgmt.indexOverview.indexErrors.hideErrorsLabel', {
+              defaultMessage: 'Hide full error',
+            })}
+          </EuiButton>
+        </>
+      )}
+      {!showErrors && (
+        <EuiButton color="danger" onClick={() => setShowErrors(true)}>
+          {i18n.translate('xpack.idxMgmt.indexOverview.indexErrors.showErrorsLabel', {
+            defaultMessage: 'Show full error',
+          })}
+        </EuiButton>
+      )}
+    </EuiCallOut>
+  );
+};

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
@@ -210,6 +210,7 @@ export function TrainedModelsDeploymentModal({
 
           <EuiSpacer size="s" />
           <EuiCheckbox
+            data-test-subj="allowForceSaveMappingsCheckbox"
             id="allowForceSaveMappings"
             checked={allowForceSaveMappings}
             onChange={() => setAllowForceSaveMappings(!allowForceSaveMappings)}
@@ -249,7 +250,12 @@ export function TrainedModelsDeploymentModal({
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={forceSaveMappings} disabled={!allowForceSaveMappings}>
+            <EuiButton
+              fill
+              onClick={forceSaveMappings}
+              disabled={!allowForceSaveMappings}
+              data-test-subj="forceSaveMappingsButton"
+            >
               {i18n.translate(
                 'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.forceSaveMappingsLabel',
                 {

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
@@ -4,7 +4,23 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiConfirmModal, useGeneratedHtmlId, EuiHealth } from '@elastic/eui';
+import {
+  EuiHealth,
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiCheckbox,
+  EuiButtonEmpty,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  useGeneratedHtmlId,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiBadge,
+} from '@elastic/eui';
 import React from 'react';
 
 import { EuiLink } from '@elastic/eui';
@@ -17,8 +33,9 @@ import { useMappingsState } from '../../../../components/mappings_editor/mapping
 import { useAppContext } from '../../../../app_context';
 
 export interface TrainedModelsDeploymentModalProps {
-  fetchData: () => void;
   errorsInTrainedModelDeployment: Record<string, string | undefined>;
+  forceSaveMappings: () => void;
+  saveMappings: () => void;
   setErrorsInTrainedModelDeployment: React.Dispatch<
     React.SetStateAction<Record<string, string | undefined>>
   >;
@@ -29,18 +46,20 @@ const TRAINED_MODELS_MANAGE = 'trained_models';
 
 export function TrainedModelsDeploymentModal({
   errorsInTrainedModelDeployment = {},
-  fetchData,
+  forceSaveMappings,
+  saveMappings,
   setErrorsInTrainedModelDeployment,
 }: TrainedModelsDeploymentModalProps) {
+  const modalTitleId = useGeneratedHtmlId();
   const { fields, inferenceToModelIdMap } = useMappingsState();
   const {
     plugins: { ml },
     url,
   } = useAppContext();
-  const modalTitleId = useGeneratedHtmlId();
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const closeModal = () => setIsModalVisible(false);
   const [mlManagementPageUrl, setMlManagementPageUrl] = useState<string>('');
+  const [allowForceSaveMappings, setAllowForceSaveMappings] = useState<boolean>(false);
   const { showErrorToasts } = useMLModelNotificationToasts();
 
   useEffect(() => {
@@ -109,74 +128,132 @@ export function TrainedModelsDeploymentModal({
     }
   }, [erroredDeployments.length, pendingDeployments.length]);
   return isModalVisible ? (
-    <EuiConfirmModal
-      aria-labelledby={modalTitleId}
+    <EuiModal
       style={{ width: 600 }}
-      title={
-        erroredDeployments.length > 0
-          ? i18n.translate(
-              'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.deploymentErrorTitle',
-              {
-                defaultMessage: 'Models could not be deployed',
-              }
-            )
-          : i18n.translate('xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.titleLabel', {
-              defaultMessage: 'Models still deploying',
-            })
-      }
-      titleProps={{ id: modalTitleId }}
-      onCancel={closeModal}
-      onConfirm={fetchData}
-      cancelButtonText={i18n.translate(
-        'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.closeButtonLabel',
-        {
-          defaultMessage: 'Close',
-        }
-      )}
-      confirmButtonText={i18n.translate(
-        'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.refreshButtonLabel',
-        {
-          defaultMessage: 'Refresh',
-        }
-      )}
-      defaultFocusedButton="confirm"
+      aria-labelledby={modalTitleId}
+      onClose={closeModal}
       data-test-subj="trainedModelsDeploymentModal"
+      initialFocus="[data-test-subj=tryAgainModalButton]"
     >
-      <p data-test-subj="trainedModelsDeploymentModalText">
-        {erroredDeployments.length > 0
-          ? i18n.translate(
-              'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.deploymentErrorText',
-              {
-                defaultMessage: 'There was an error when trying to deploy the following models.',
-              }
+      <EuiModalHeader>
+        <EuiModalHeaderTitle title={modalTitleId}>
+          {erroredDeployments.length > 0
+            ? i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.deploymentErrorTitle',
+                {
+                  defaultMessage: 'Models could not be deployed',
+                }
+              )
+            : i18n.translate('xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.titleLabel', {
+                defaultMessage: 'Models still deploying',
+              })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <p data-test-subj="trainedModelsDeploymentModalText">
+          {erroredDeployments.length > 0
+            ? i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.deploymentErrorText',
+                {
+                  defaultMessage: 'There was an error when trying to deploy the following models.',
+                }
+              )
+            : i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.textAboutDeploymentsNotCompleted',
+                {
+                  defaultMessage:
+                    'Some fields are referencing models that have not yet completed deployment. Deployment may take a few minutes to complete.',
+                }
+              )}
+        </p>
+        <EuiSpacer size="s" />
+        <EuiLink href={mlManagementPageUrl} target="_blank">
+          {i18n.translate(
+            'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.textTrainedModelManagementLink',
+            {
+              defaultMessage: 'Go to Trained Model Management',
+            }
+          )}
+        </EuiLink>
+        <EuiSpacer />
+        <ul style={{ listStyleType: 'none' }}>
+          {(erroredDeployments.length > 0 ? erroredDeployments : pendingDeployments).map(
+            (deployment) => (
+              <li key={deployment}>
+                <EuiBadge color="hollow">
+                  <EuiHealth color="danger">{deployment}</EuiHealth>
+                </EuiBadge>
+              </li>
             )
-          : i18n.translate(
-              'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.textAboutDeploymentsNotCompleted',
+          )}
+        </ul>
+        <EuiSpacer />
+        <EuiCallOut
+          iconType="warning"
+          color="warning"
+          title={i18n.translate(
+            'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.forceSaveMappingsConfirmLabel',
+            {
+              defaultMessage: 'Saving mappings without a deployed model may cause errors',
+            }
+          )}
+        >
+          {i18n.translate(
+            'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.forceSaveMappingsDescription',
+            {
+              defaultMessage:
+                'Saving a semantic text field referencing a model that is not running will break ingesting documents and searching over documents using or referencing that field.',
+            }
+          )}
+
+          <EuiSpacer size="s" />
+          <EuiCheckbox
+            id="allowForceSaveMappings"
+            checked={allowForceSaveMappings}
+            onChange={() => setAllowForceSaveMappings(!allowForceSaveMappings)}
+            label={i18n.translate(
+              'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.allowForceSaveMappingsLabel',
               {
-                defaultMessage:
-                  'Some fields are referencing models that have not yet completed deployment. Deployment may take a few minutes to complete.',
+                defaultMessage: 'Allow semantic text mapping updates without a deployed model',
               }
             )}
-      </p>
-      <ul style={{ listStyleType: 'none' }}>
-        {(erroredDeployments.length > 0 ? erroredDeployments : pendingDeployments).map(
-          (deployment) => (
-            <li key={deployment}>
-              <EuiHealth textSize="xs" color="danger">
-                {deployment}
-              </EuiHealth>
-            </li>
-          )
-        )}
-      </ul>
-      <EuiLink href={mlManagementPageUrl} target="_blank">
-        {i18n.translate(
-          'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.textTrainedModelManagementLink',
-          {
-            defaultMessage: 'Go to Trained Model Management',
-          }
-        )}
-      </EuiLink>
-    </EuiConfirmModal>
+          />
+        </EuiCallOut>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={closeModal}>
+              {i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.cancelButtonLabel',
+                {
+                  defaultMessage: 'Cancel',
+                }
+              )}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={saveMappings} data-test-subj="tryAgainModalButton" id="">
+              {i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.tryAgainButtonLabel',
+                {
+                  defaultMessage: 'Try again',
+                }
+              )}
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton fill onClick={forceSaveMappings} disabled={!allowForceSaveMappings}>
+              {i18n.translate(
+                'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.forceSaveMappingsLabel',
+                {
+                  defaultMessage: 'Force save mappings',
+                }
+              )}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalFooter>
+    </EuiModal>
   ) : null;
 }

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
@@ -36,6 +36,7 @@ export interface TrainedModelsDeploymentModalProps {
   errorsInTrainedModelDeployment: Record<string, string | undefined>;
   forceSaveMappings: () => void;
   saveMappings: () => void;
+  saveMappingsLoading: boolean;
   setErrorsInTrainedModelDeployment: React.Dispatch<
     React.SetStateAction<Record<string, string | undefined>>
   >;
@@ -48,6 +49,7 @@ export function TrainedModelsDeploymentModal({
   errorsInTrainedModelDeployment = {},
   forceSaveMappings,
   saveMappings,
+  saveMappingsLoading,
   setErrorsInTrainedModelDeployment,
 }: TrainedModelsDeploymentModalProps) {
   const modalTitleId = useGeneratedHtmlId();
@@ -233,7 +235,11 @@ export function TrainedModelsDeploymentModal({
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={saveMappings} data-test-subj="tryAgainModalButton" id="">
+            <EuiButton
+              onClick={saveMappings}
+              data-test-subj="tryAgainModalButton"
+              isLoading={saveMappingsLoading}
+            >
               {i18n.translate(
                 'xpack.idxMgmt.indexDetails.trainedModelsDeploymentModal.tryAgainButtonLabel',
                 {

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/trained_models_deployment_modal.tsx
@@ -254,6 +254,7 @@ export function TrainedModelsDeploymentModal({
               fill
               onClick={forceSaveMappings}
               disabled={!allowForceSaveMappings}
+              isLoading={saveMappingsLoading}
               data-test-subj="forceSaveMappingsButton"
             >
               {i18n.translate(

--- a/x-pack/plugins/index_management/public/application/services/api.ts
+++ b/x-pack/plugins/index_management/public/application/services/api.ts
@@ -9,6 +9,7 @@ import { METRIC_TYPE } from '@kbn/analytics';
 import type { SerializedEnrichPolicy } from '@kbn/index-management';
 import { IndicesStatsResponse } from '@elastic/elasticsearch/lib/api/types';
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+import { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   API_BASE_PATH,
   INTERNAL_API_BASE_PATH,
@@ -405,7 +406,7 @@ export function loadIndex(indexName: string) {
 }
 
 export function useLoadIndexMappings(indexName: string) {
-  return useRequest({
+  return useRequest<MappingTypeMapping>({
     path: `${API_BASE_PATH}/mapping/${encodeURIComponent(indexName)}`,
     method: 'get',
   });

--- a/x-pack/plugins/index_management/public/application/services/api.ts
+++ b/x-pack/plugins/index_management/public/application/services/api.ts
@@ -255,7 +255,7 @@ export async function loadIndexStats(indexName: string) {
 }
 
 export async function loadIndexMapping(indexName: string) {
-  const response = await httpService.httpClient.get(
+  const response = await httpService.httpClient.get<MappingTypeMapping>(
     `${API_BASE_PATH}/mapping/${encodeURIComponent(indexName)}`
   );
   return response;

--- a/x-pack/plugins/index_management/public/hooks/use_details_page_mappings_model_management.ts
+++ b/x-pack/plugins/index_management/public/hooks/use_details_page_mappings_model_management.ts
@@ -10,8 +10,6 @@ import { ModelDownloadState, TrainedModelStat } from '@kbn/ml-plugin/common/type
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import {
   LATEST_ELSER_VERSION,
-  InferenceServiceSettings,
-  LocalInferenceServiceSettings,
   LATEST_ELSER_MODEL_ID,
   LATEST_E5_MODEL_ID,
   ElserVersion,
@@ -19,13 +17,10 @@ import {
 import { useCallback } from 'react';
 import { AppDependencies, useAppContext } from '../application/app_context';
 import { InferenceToModelIdMap } from '../application/components/mappings_editor/components/document_fields/fields';
+import { isLocalModel } from '../application/components/mappings_editor/lib/utils';
 import { useDispatch } from '../application/components/mappings_editor/mappings_state_context';
 import { DefaultInferenceModels } from '../application/components/mappings_editor/types';
 import { getInferenceEndpoints } from '../application/services/api';
-
-function isLocalModel(model: InferenceServiceSettings): model is LocalInferenceServiceSettings {
-  return Boolean((model as LocalInferenceServiceSettings).service_settings.model_id);
-}
 
 const getCustomInferenceIdMap = (
   models: InferenceAPIConfigResponse[],


### PR DESCRIPTION
## Summary

This adds a callout to the index overview page if there's an error with the semantic text mappings. It also allows users to force saving when facing errors deploying a model associated with an inference endpoint, and has minor bugfix for referencing a text field with child fields in a semantic text field.
<img width="1058" alt="Screenshot 2024-07-15 at 18 19 15" src="https://github.com/user-attachments/assets/903878ef-45bf-4a50-9760-9ae62842853b">

<img width="659" alt="Screenshot 2024-07-15 at 18 29 13" src="https://github.com/user-attachments/assets/5ca50fa1-dbdd-406e-9b48-7ffeb4cd0315">
<img width="752" alt="Screenshot 2024-07-15 at 18 29 07" src="https://github.com/user-attachments/assets/dfd18199-f0d8-4f13-ac44-e9b91a8ef492">

Testing:

- Create an index
- Add a text field and semantic text field referencing an existing inference endpoint (eg: elser_model_2) using the UI
- Save mappings
- Now delete the endpoint using the dev console or UI (`DELETE /_inference/sparse_embeddings/elser_model_2`) for elser_model_2.
- Go to that index's overview page (or refresh)
- You should see a callout telling you that there are errors in this index


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->