### PR TITLE
[build] Fix ci:build-all-platforms

### DIFF
--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -45,7 +45,7 @@ fi
 
 echo "--- Archive Kibana Distribution"
 version="$(jq -r '.version' package.json)"
-linuxBuild="$KIBANA_DIR/target/kibana-$version-linux-x86_64.tar.gz"
+linuxBuild="$KIBANA_DIR/target/kibana-$version-SNAPSHOT-linux-x86_64.tar.gz"
 installDir="$KIBANA_DIR/install/kibana"
 mkdir -p "$installDir"
 tar -xzf "$linuxBuild" -C "$installDir" --strip=1

--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -45,7 +45,7 @@ fi
 
 echo "--- Archive Kibana Distribution"
 version="$(jq -r '.version' package.json)"
-linuxBuild="$(find "$KIBANA_DIR/target" -name "kibana-$version-linux-x86_64.tar.gz")"
+linuxBuild="$KIBANA_DIR/target/kibana-$version-linux-x86_64.tar.gz"
 installDir="$KIBANA_DIR/install/kibana"
 mkdir -p "$installDir"
 tar -xzf "$linuxBuild" -C "$installDir" --strip=1

--- a/.buildkite/scripts/build_kibana.sh
+++ b/.buildkite/scripts/build_kibana.sh
@@ -44,7 +44,8 @@ EOF
 fi
 
 echo "--- Archive Kibana Distribution"
-linuxBuild="$(find "$KIBANA_DIR/target" -name 'kibana-*-linux-x86_64.tar.gz')"
+version="$(jq -r '.version' package.json)"
+linuxBuild="$(find "$KIBANA_DIR/target" -name "kibana-$version-linux-x86_64.tar.gz")"
 installDir="$KIBANA_DIR/install/kibana"
 mkdir -p "$installDir"
 tar -xzf "$linuxBuild" -C "$installDir" --strip=1

--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -19,8 +19,8 @@ fi
 
 echo "--- Upload Build Artifacts"
 # Moving to `target/` first will keep `buildkite-agent` from including directories in the artifact name
-cd "$KIBANA_DIR/target"
 version="$(jq -r '.version' package.json)"
+cd "$KIBANA_DIR/target"
 cp "kibana-$version-SNAPSHOT-linux-x86_64.tar.gz" kibana-default.tar.gz
 buildkite-agent artifact upload "./*.tar.gz;./*.zip;./*.deb;./*.rpm"
 cd -

--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -21,6 +21,6 @@ echo "--- Upload Build Artifacts"
 # Moving to `target/` first will keep `buildkite-agent` from including directories in the artifact name
 cd "$KIBANA_DIR/target"
 version="$(jq -r '.version' package.json)"
-cp "kibana-$version-linux-x86_64.tar.gz" kibana-default.tar.gz
+cp "kibana-$version-SNAPSHOT-linux-x86_64.tar.gz" kibana-default.tar.gz
 buildkite-agent artifact upload "./*.tar.gz;./*.zip;./*.deb;./*.rpm"
 cd -

--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -20,6 +20,7 @@ fi
 echo "--- Upload Build Artifacts"
 # Moving to `target/` first will keep `buildkite-agent` from including directories in the artifact name
 cd "$KIBANA_DIR/target"
-cp kibana-*-linux-x86_64.tar.gz kibana-default.tar.gz
+version="$(jq -r '.version' package.json)"
+cp "kibana-$version-linux-x86_64.tar.gz" kibana-default.tar.gz
 buildkite-agent artifact upload "./*.tar.gz;./*.zip;./*.deb;./*.rpm"
 cd -


### PR DESCRIPTION
The upload build artifacts step matches on a glob, which now resolves to two distributions, breaking future commands.  This swaps find for the specific distribution.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->