### PR TITLE
[Security Solution][Alert Details] Remove investigate in timeline action in suppressed alert in rule creation

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/correlations_details.tsx
@@ -66,6 +66,7 @@ export const CorrelationsDetails: React.FC = () => {
               <SuppressedAlerts
                 alertSuppressionCount={alertSuppressionCount}
                 dataAsNestedObject={dataAsNestedObject}
+                isPreview={isPreview}
               />
             </EuiFlexItem>
           )}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/suppressed_alerts.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/suppressed_alerts.test.tsx
@@ -43,13 +43,14 @@ const TITLE_TEXT = EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(
 );
 const INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID = `${CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID}InvestigateInTimeline`;
 
-const renderSuppressedAlerts = (alertSuppressionCount: number) =>
+const renderSuppressedAlerts = (alertSuppressionCount: number, isPreview: boolean = false) =>
   render(
     <TestProviders>
       <DocumentDetailsContext.Provider value={mockContextValue}>
         <SuppressedAlerts
           alertSuppressionCount={alertSuppressionCount}
           dataAsNestedObject={mockDataAsNestedObject}
+          isPreview={isPreview}
         />
       </DocumentDetailsContext.Provider>
     </TestProviders>
@@ -93,5 +94,14 @@ describe('<SuppressedAlerts />', () => {
     expect(
       queryByTestId(SUPPRESSED_ALERTS_SECTION_TECHNICAL_PREVIEW_TEST_ID)
     ).not.toBeInTheDocument();
+  });
+
+  it('should not render investigate in timeline if in rule creation alert preview', () => {
+    const { getByTestId, queryByTestId } = renderSuppressedAlerts(5, true);
+
+    expect(getByTestId(TITLE_ICON)).toBeInTheDocument();
+    expect(getByTestId(TITLE_TEXT)).toHaveTextContent('5 suppressed alert');
+    expect(queryByTestId(INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(TOGGLE_ICON)).not.toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/suppressed_alerts.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/suppressed_alerts.tsx
@@ -29,6 +29,10 @@ export interface SuppressedAlertsProps {
    * Value of the kibana.alert.suppression.doc_count field
    */
   alertSuppressionCount: number;
+  /**
+   * Indicate whether suppressed alert is shown in alert preview (rule creation)
+   */
+  isPreview: boolean;
 }
 
 /**
@@ -37,6 +41,7 @@ export interface SuppressedAlertsProps {
 export const SuppressedAlerts: React.FC<SuppressedAlertsProps> = ({
   dataAsNestedObject,
   alertSuppressionCount,
+  isPreview,
 }) => {
   const ruleType = get(dataAsNestedObject, ALERT_RULE_TYPE)?.[0];
 
@@ -62,7 +67,7 @@ export const SuppressedAlerts: React.FC<SuppressedAlertsProps> = ({
     </EuiFlexGroup>
   );
 
-  const headerContent = alertSuppressionCount > 0 && (
+  const headerContent = alertSuppressionCount > 0 && !isPreview && (
     <div
       data-test-subj={`${CORRELATIONS_DETAILS_SUPPRESSED_ALERTS_SECTION_TEST_ID}InvestigateInTimeline`}
     >


### PR DESCRIPTION
## Summary

This PR removed the `investigate in timeline` button for suppressed alerts in rule creation. Uncreated suppressed alerts do not exist and hence generated an error when clicking investigate in timeline. 

Related: https://github.com/elastic/kibana/issues/188188

![image](https://github.com/user-attachments/assets/6ddfc333-090c-429b-bbf2-d01cd8fe81db)

How to test:
- Have premium+ license
- Generate some alert data
- Create a rule, and add a field to suppressed alerts (i.e. host.name)
- Go to alert preview table, pick an alert
- Go to expanded panel, Insights, Correlations, suppressed alerts. investigate in timeline button should not be present

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->