### PR TITLE
[Security Solution][Notes] - ensures that notes are always sorted from newest to oldest in expandable flyout notes tab

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -37,7 +37,7 @@ import {
   selectDeleteNotesStatus,
   selectFetchNotesByDocumentIdsError,
   selectFetchNotesByDocumentIdsStatus,
-  selectNotesByDocumentId,
+  selectSortedNotesByDocumentId,
 } from '../../../../notes/store/notes.slice';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
@@ -90,7 +90,12 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
   const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdsStatus(state));
   const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdsError(state));
 
-  const notes: Note[] = useSelector((state: State) => selectNotesByDocumentId(state, eventId));
+  const notes: Note[] = useSelector((state: State) =>
+    selectSortedNotesByDocumentId(state, {
+      documentId: eventId,
+      sort: { field: 'created', direction: 'desc' },
+    })
+  );
 
   const createStatus = useSelector((state: State) => selectCreateNoteStatus(state));
 

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
@@ -41,6 +41,7 @@ import {
   userSelectedRow,
   userSelectedRowForDeletion,
   userSortedNotes,
+  selectSortedNotesByDocumentId,
 } from './notes.slice';
 import type { NotesState } from './notes.slice';
 import { mockGlobalState } from '../../common/mock';
@@ -513,6 +514,63 @@ describe('notesSlice', () => {
 
     it('should return no notes if document id does not exist', () => {
       expect(selectNotesByDocumentId(mockGlobalState, 'wrong-document-id')).toHaveLength(0);
+    });
+
+    it('should return all notes sorted dor an existing document id', () => {
+      const oldestNote = {
+        eventId: '1', // should be a valid id based on mockTimelineData
+        noteId: '1',
+        note: 'note-1',
+        timelineId: 'timeline-1',
+        created: 1663882629000,
+        createdBy: 'elastic',
+        updated: 1663882629000,
+        updatedBy: 'elastic',
+        version: 'version',
+      };
+      const newestNote = {
+        ...oldestNote,
+        noteId: '2',
+        created: 1663882689000,
+      };
+
+      const state = {
+        ...mockGlobalState,
+        notes: {
+          ...mockGlobalState.notes,
+          entities: {
+            '1': oldestNote,
+            '2': newestNote,
+          },
+          ids: ['1', '2'],
+        },
+      };
+
+      const ascResult = selectSortedNotesByDocumentId(state, {
+        documentId: '1',
+        sort: { field: 'created', direction: 'asc' },
+      });
+      expect(ascResult[0]).toEqual(oldestNote);
+      expect(ascResult[1]).toEqual(newestNote);
+
+      const descResult = selectSortedNotesByDocumentId(state, {
+        documentId: '1',
+        sort: { field: 'created', direction: 'desc' },
+      });
+      expect(descResult[0]).toEqual(newestNote);
+      expect(descResult[1]).toEqual(oldestNote);
+    });
+
+    it('should also return no notes if document id does not exist', () => {
+      expect(
+        selectSortedNotesByDocumentId(mockGlobalState, {
+          documentId: 'wrong-document-id',
+          sort: {
+            field: 'created',
+            direction: 'desc',
+          },
+        })
+      ).toHaveLength(0);
     });
 
     it('should select notes pagination', () => {

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.ts
@@ -276,8 +276,30 @@ export const selectFetchNotesError = (state: State) => state.notes.error.fetchNo
 export const selectFetchNotesStatus = (state: State) => state.notes.status.fetchNotes;
 
 export const selectNotesByDocumentId = createSelector(
-  [selectAllNotes, (state, documentId) => documentId],
+  [selectAllNotes, (state: State, documentId: string) => documentId],
   (notes, documentId) => notes.filter((note) => note.eventId === documentId)
+);
+
+export const selectSortedNotesByDocumentId = createSelector(
+  [
+    selectAllNotes,
+    (
+      state: State,
+      {
+        documentId,
+        sort,
+      }: { documentId: string; sort: { field: keyof Note; direction: 'asc' | 'desc' } }
+    ) => ({ documentId, sort }),
+  ],
+  (notes, { documentId, sort }) => {
+    const { field, direction } = sort;
+    return notes
+      .filter((note: Note) => note.eventId === documentId)
+      .sort((a: Note, b: Note) =>
+        // @ts-ignore Object is possibly null or undefined
+        direction === 'asc' ? (a[field] > b[field] ? 1 : -1) : a[field] > b[field] ? -1 : 1
+      );
+  }
 );
 
 export const {

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.ts
@@ -295,10 +295,13 @@ export const selectSortedNotesByDocumentId = createSelector(
     const { field, direction } = sort;
     return notes
       .filter((note: Note) => note.eventId === documentId)
-      .sort((a: Note, b: Note) =>
-        // @ts-ignore Object is possibly null or undefined
-        direction === 'asc' ? (a[field] > b[field] ? 1 : -1) : a[field] > b[field] ? -1 : 1
-      );
+      .sort((first: Note, second: Note) => {
+        const a = first[field];
+        const b = second[field];
+        if (a == null) return 1;
+        if (b == null) return -1;
+        return direction === 'asc' ? (a > b ? 1 : -1) : a > b ? -1 : 1;
+      });
   }
 );
 


### PR DESCRIPTION
## Summary

This PR fixes an issue in the expandable flyout new Notes tab, where the notes were not always sorted from newest notes at the top to oldest notes at the bottom.

The issue came from the fact that the redux slice of state for notes is shared between the notes displayed throughout Security Solution tables and flyouts as well as the notes management page. When the notes management page fetches notes sorted by a field and a direction, the result comes back sorted from the server, and is saved as is in redux. If a user visited a flyout after having been to the notes management page, there was a chance the notes wouldn't be sorted correctly.

The PR adds a new selector that allows developers to fetch notes by document id, sorted by field and direction.

![Screenshot 2024-07-16 at 10 11 14 AM](https://github.com/user-attachments/assets/0ed6d63e-245d-4fdb-8f03-d954dcecf916)


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

https://github.com/elastic/security-team/issues/9942

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->