### PR TITLE
[Metric threshold] Set missing group to false by default and show checkbox value in disable mode

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/alerting/metric_threshold/components/expression.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/metric_threshold/components/expression.tsx
@@ -245,7 +245,7 @@ export const Expressions: React.FC<Props> = (props) => {
       setRuleParams('alertOnNoData', true);
     }
     if (typeof ruleParams.alertOnGroupDisappear === 'undefined') {
-      setRuleParams('alertOnGroupDisappear', true);
+      setRuleParams('alertOnGroupDisappear', false);
     }
   }, [metadata, source]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -462,7 +462,7 @@ export const Expressions: React.FC<Props> = (props) => {
           </>
         }
         disabled={!hasGroupBy}
-        checked={Boolean(hasGroupBy && ruleParams.alertOnGroupDisappear)}
+        checked={Boolean(ruleParams.alertOnGroupDisappear)}
         onChange={(e) => setRuleParams('alertOnGroupDisappear', e.target.checked)}
       />
       <EuiSpacer size="m" />


### PR DESCRIPTION
Fixes #183921

## Summary

- Set the missing group value by default to false
- Match the checkbox value to what is shown in the UI in the disable mode

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/9525cb78-9a07-4d40-bcc1-9e6a0b04beb3)|![image](https://github.com/user-attachments/assets/79b196be-31c3-4cd2-a1a8-29cb0c867b65)|
