### PR TITLE
[APM] Update APM side nav to Applications

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/apm/public/plugin.ts
@@ -145,6 +145,10 @@ export interface ApmPluginStartDeps {
   entityManager: EntityManagerPublicPluginSetup;
 }
 
+const applicationsTitle = i18n.translate('xpack.apm.navigation.rootTitle', {
+  defaultMessage: 'Applications',
+});
+
 const servicesTitle = i18n.translate('xpack.apm.navigation.servicesTitle', {
   defaultMessage: 'Services',
 });
@@ -205,7 +209,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
             return [
               // APM navigation
               {
-                label: 'Applications',
+                label: applicationsTitle,
                 sortKey: 400,
                 entries: [
                   {

--- a/x-pack/plugins/observability_solution/apm/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/apm/public/plugin.ts
@@ -205,7 +205,7 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
             return [
               // APM navigation
               {
-                label: 'APM',
+                label: 'Applications',
                 sortKey: 400,
                 entries: [
                   {


### PR DESCRIPTION
closes https://github.com/elastic/observability-dev/issues/3719
## Summary

### Before

![image](https://github.com/user-attachments/assets/7c445870-2940-4f86-94a4-6ae917075193)


### After

![image](https://github.com/user-attachments/assets/7096ec75-9922-475f-8919-c2ab2bf04f37)


### Notes
- The PR updates only the label, the app id remains **apm**
- I checked global search in serverless and it still uses APM 