### PR TITLE
fix: [ES Serverless home] 'Documentation' links are ambiguous

### DIFF
--- a/packages/kbn-search-api-panels/components/github_link.tsx
+++ b/packages/kbn-search-api-panels/components/github_link.tsx
@@ -14,7 +14,8 @@ export const GithubLink: React.FC<{
   assetBasePath: string;
   label: string;
   href: string;
-}> = ({ assetBasePath, label, href }) => {
+  'aria-label'?: string;
+}> = ({ assetBasePath, label, href, 'aria-label': ariaLabel }) => {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="xs" justifyContent="flexEnd">
       <EuiFlexItem grow={false}>
@@ -22,7 +23,7 @@ export const GithubLink: React.FC<{
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiText size="s">
-          <EuiLink target="_blank" href={href}>
+          <EuiLink target="_blank" href={href} aria-label={ariaLabel}>
             {label}
           </EuiLink>
         </EuiText>

--- a/packages/kbn-search-api-panels/components/ingestions_panel.tsx
+++ b/packages/kbn-search-api-panels/components/ingestions_panel.tsx
@@ -41,6 +41,12 @@ export const IngestionsPanel: React.FC<IngestionPanelProps> = ({
       links: [
         {
           href: docLinks.logstash,
+          ariaLabel: i18n.translate(
+            'searchApiPanels.welcomeBanner.ingestData.alternativeOptions.logstashDocumentation.ariaLabel',
+            {
+              defaultMessage: 'Logstash documentation',
+            }
+          ),
           label: i18n.translate(
             'searchApiPanels.welcomeBanner.ingestData.alternativeOptions.logstashDocumentationLabel',
             {
@@ -72,6 +78,12 @@ export const IngestionsPanel: React.FC<IngestionPanelProps> = ({
       links: [
         {
           href: docLinks.beats,
+          ariaLabel: i18n.translate(
+            'searchApiPanels.welcomeBanner.ingestData.alternativeOptions.beatsDocumentation.ariaLabel',
+            {
+              defaultMessage: 'Beats documentation',
+            }
+          ),
           label: i18n.translate(
             'searchApiPanels.welcomeBanner.ingestData.alternativeOptions.beatsDocumentationLabel',
             {
@@ -109,12 +121,17 @@ export const IngestionsPanel: React.FC<IngestionPanelProps> = ({
           {links && links.length > 0 && (
             <>
               <EuiFlexGroup direction="row" justifyContent="flexStart" alignItems="center">
-                {links.map(({ label, href, isGithubLink }, linksIndex) => (
+                {links.map(({ label, href, isGithubLink, ariaLabel }, linksIndex) => (
                   <EuiFlexItem grow={false} key={linksIndex}>
                     {isGithubLink ? (
-                      <GithubLink assetBasePath={assetBasePath} label={label} href={href} />
+                      <GithubLink
+                        href={href}
+                        label={label}
+                        assetBasePath={assetBasePath}
+                        aria-label={ariaLabel}
+                      />
                     ) : (
-                      <EuiLink href={href} target="_blank">
+                      <EuiLink aria-label={ariaLabel} href={href} target="_blank">
                         {label}
                       </EuiLink>
                     )}


### PR DESCRIPTION
Closes: https://github.com/elastic/search-team/issues/7626

## Description

Multiple 'Documentation' links are ambiguous and give no context to blind screen reader user. They are not programmatically associated to their respective topics.

## Steps to Reproduce
1. Open a Search `Serverless` project.
2. Navigate to the `Search` project homepage.

## What was changed?: 

1. Required `aria-label` attributes were added

## Screen: 

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/59486298-0653-4443-a2f7-d51bd9ae7057">

