### PR TITLE
[8.15] [Security Solution ] Unified Timeline - Enables unified components by default and inverts the feature flag.  (#187460)

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/timelines.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/timelines.cy.ts
@@ -8,6 +8,7 @@
 import { initializeDataViews } from '../../tasks/login';
 import { takeOsqueryActionWithParams } from '../../tasks/live_query';
 import { ServerlessRoleName } from '../../support/roles';
+import { disableNewFeaturesTours } from '../../tasks/navigation';
 
 describe('ALL - Timelines', { tags: ['@ess'] }, () => {
   before(() => {
@@ -18,7 +19,11 @@ describe('ALL - Timelines', { tags: ['@ess'] }, () => {
   });
 
   it('should substitute osquery parameter on non-alert event take action', () => {
-    cy.visit('/app/security/timelines');
+    cy.visit('/app/security/timelines', {
+      onBeforeLoad: (win) => {
+        disableNewFeaturesTours(win);
+      },
+    });
     cy.getBySel('timeline-bottom-bar').within(() => {
       cy.getBySel('timeline-bottom-bar-title-button').click();
     });
@@ -36,16 +41,7 @@ describe('ALL - Timelines', { tags: ['@ess'] }, () => {
     });
     cy.getBySel('sourcerer-save').click();
 
-    cy.getBySel('event-actions-container')
-      .first()
-      .within(() => {
-        cy.getBySel('expand-event')
-          .first()
-          .within(() => {
-            cy.get(`[data-is-loading="true"]`).should('not.exist');
-          })
-          .click();
-      });
+    cy.getBySel('docTableExpandToggleColumn').first().click();
     takeOsqueryActionWithParams();
   });
 });

--- a/x-pack/plugins/osquery/cypress/tasks/navigation.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/navigation.ts
@@ -35,3 +35,34 @@ export enum NAV_SEARCH_INPUT_OSQUERY_RESULTS {
   LOGS = '/app/integrations/detail/osquery/overview',
   MANAGER = '/app/integrations/detail/osquery_manager/overview',
 }
+
+/**
+ * Local storage keys we use to store the state of our new features tours we currently show in the app.
+ *
+ * NOTE: As soon as we want to show tours for new features in the upcoming release,
+ * we will need to update these constants with the corresponding version.
+ */
+export const NEW_FEATURES_TOUR_STORAGE_KEYS = {
+  RULE_MANAGEMENT_PAGE: 'securitySolution.rulesManagementPage.newFeaturesTour.v8.13',
+  TIMELINES: 'securitySolution.security.timelineFlyoutHeader.saveTimelineTour',
+  TIMELINE: 'securitySolution.timeline.newFeaturesTour.v8.12',
+  FLYOUT: 'securitySolution.documentDetails.newFeaturesTour.v8.14',
+  ATTACK_DISCOVERY: 'securitySolution.attackDiscovery.newFeaturesTour.v8.14',
+};
+
+/**
+ * For all the new features tours we show in the app, this method disables them
+ * by setting their configs in the local storage. It prevents the tours from appearing
+ * on the page during test runs and covering other UI elements.
+ * @param window - browser's window object
+ */
+export const disableNewFeaturesTours = (window: Window) => {
+  const tourStorageKeys = Object.values(NEW_FEATURES_TOUR_STORAGE_KEYS);
+  const tourConfig = {
+    isTourActive: false,
+  };
+
+  tourStorageKeys.forEach((key) => {
+    window.localStorage.setItem(key, JSON.stringify(tourConfig));
+  });
+};

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -198,9 +198,9 @@ export const allowedExperimentalValues = Object.freeze({
    */
   timelineEsqlTabDisabled: false,
   /*
-   * Enables Discover components, UnifiedFieldList and UnifiedDataTable in Timeline.
+   * Disables experimental Discover components, UnifiedFieldList and UnifiedDataTable in Timeline.
    */
-  unifiedComponentsInTimelineEnabled: false,
+  unifiedComponentsInTimelineDisabled: false,
 
   /*
    * Disables date pickers and sourcerer in analyzer if needed.

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -246,7 +246,7 @@ const ActionsComponent: React.FC<ActionProps> = ({
   }, [documentBasedNotes, timelineNoteIds, securitySolutionNotesEnabled, expandableFlyoutDisabled]);
 
   return (
-    <ActionsContainer>
+    <ActionsContainer data-test-subj="actions-container">
       <>
         {!disableExpandAction && (
           <GuidedOnboardingTourStep

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/header_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/header_actions.test.tsx
@@ -141,10 +141,10 @@ describe('HeaderActions', () => {
     });
   });
 
-  describe('conditional components based on unifiedComponentsInTimelineEnabled', () => {
-    describe('when unifiedComponentsInTimelineEnabled is true', () => {
+  describe('conditional components based on unifiedComponentsInTimelineDisabled', () => {
+    describe('when unifiedComponentsInTimelineDisabled is false', () => {
       beforeEach(() => {
-        (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+        (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
       });
       it('should not show the event renderer settings', () => {
         const result = render(
@@ -165,9 +165,9 @@ describe('HeaderActions', () => {
       });
     });
 
-    describe('when unifiedComponentsInTimelineEnabled is false', () => {
+    describe('when unifiedComponentsInTimelineDisabled is true', () => {
       beforeEach(() => {
-        (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+        (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
       });
       it('should show the event renderer settings', () => {
         const result = render(

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/header_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/header_actions.tsx
@@ -91,8 +91,8 @@ const HeaderActionsComponent: React.FC<HeaderActionProps> = memo(
     const { timelineFullScreen, setTimelineFullScreen } = useTimelineFullScreen();
     const dispatch = useDispatch();
 
-    const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-      'unifiedComponentsInTimelineEnabled'
+    const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+      'unifiedComponentsInTimelineDisabled'
     );
 
     const { defaultColumns } = useDeepEqualSelector((state) =>
@@ -215,7 +215,7 @@ const HeaderActionsComponent: React.FC<HeaderActionProps> = memo(
     });
 
     return (
-      <ActionsContainer>
+      <ActionsContainer data-test-subj="header-actions-container">
         {showSelectAllCheckbox && (
           <EventsTh role="checkbox">
             <EventsThContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
@@ -242,7 +242,7 @@ const HeaderActionsComponent: React.FC<HeaderActionProps> = memo(
           </EventsTh>
         )}
 
-        {!unifiedComponentsInTimelineEnabled && (
+        {unifiedComponentsInTimelineDisabled && (
           <EventsTh role="button">
             <StatefulRowRenderersBrowser timelineId={timelineId} />
           </EventsTh>
@@ -275,7 +275,7 @@ const HeaderActionsComponent: React.FC<HeaderActionProps> = memo(
             </EventsThContent>
           </EventsTh>
         )}
-        {tabType !== TimelineTabs.eql && !unifiedComponentsInTimelineEnabled && (
+        {tabType !== TimelineTabs.eql && unifiedComponentsInTimelineDisabled && (
           <EventsTh role="button" data-test-subj="timeline-sorting-fields">
             <EventsThContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
               <EuiToolTip content={i18n.SORT_FIELDS}>

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_init_timeline_url_param.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_init_timeline_url_param.ts
@@ -19,8 +19,8 @@ import { URL_PARAM_KEY } from '../use_url_state';
 import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
 
 export const useInitTimelineFromUrlParam = () => {
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const isEsqlTabDisabled = useIsExperimentalFeatureEnabled('timelineEsqlTabDisabled');
@@ -43,11 +43,11 @@ export const useInitTimelineFromUrlParam = () => {
           timelineId: initialState.id,
           openTimeline: initialState.isOpen,
           savedSearchId: initialState.savedSearchId,
-          unifiedComponentsInTimelineEnabled,
+          unifiedComponentsInTimelineDisabled,
         });
       }
     },
-    [isEsqlTabDisabled, queryTimelineById, unifiedComponentsInTimelineEnabled]
+    [isEsqlTabDisabled, queryTimelineById, unifiedComponentsInTimelineDisabled]
   );
 
   useEffect(() => {

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
@@ -42,8 +42,8 @@ export const useQueryTimelineByIdOnUrlChange = () => {
   const oldSearch = usePrevious(search);
   const timelineIdFromReduxStore = flyoutTimeline?.savedObjectId ?? '';
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const [previousTimeline, currentTimeline] = useMemo(() => {
@@ -74,7 +74,7 @@ export const useQueryTimelineByIdOnUrlChange = () => {
         graphEventId,
         timelineId: newId,
         openTimeline: true,
-        unifiedComponentsInTimelineEnabled,
+        unifiedComponentsInTimelineDisabled,
       });
     }
   }, [
@@ -84,7 +84,7 @@ export const useQueryTimelineByIdOnUrlChange = () => {
     activeTab,
     graphEventId,
     queryTimelineById,
-    unifiedComponentsInTimelineEnabled,
+    unifiedComponentsInTimelineDisabled,
   ]);
 };
 

--- a/x-pack/plugins/security_solution/public/common/mock/timeline_results.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/timeline_results.ts
@@ -2020,29 +2020,13 @@ export const mockTimelineResult = {
   stale: false,
 };
 
-const defaultTimelineColumns: CreateTimelineProps['timeline']['columns'] = [
-  {
-    columnHeaderType: 'not-filtered',
-    id: '@timestamp',
-    type: 'date',
-    esTypes: ['date'],
-    initialWidth: 190,
-  },
-  { columnHeaderType: 'not-filtered', id: 'message', initialWidth: 180 },
-  { columnHeaderType: 'not-filtered', id: 'event.category', initialWidth: 180 },
-  { columnHeaderType: 'not-filtered', id: 'event.action', initialWidth: 180 },
-  { columnHeaderType: 'not-filtered', id: 'host.name', initialWidth: 180 },
-  { columnHeaderType: 'not-filtered', id: 'source.ip', initialWidth: 180 },
-  { columnHeaderType: 'not-filtered', id: 'destination.ip', initialWidth: 180 },
-  { columnHeaderType: 'not-filtered', id: 'user.name', initialWidth: 180 },
-];
 export const defaultTimelineProps: CreateTimelineProps = {
   from: '2018-11-05T18:58:25.937Z',
   timeline: {
     activeTab: TimelineTabs.query,
     prevActiveTab: TimelineTabs.query,
-    columns: defaultTimelineColumns,
-    defaultColumns: defaultTimelineColumns,
+    columns: timelineDefaults.columns,
+    defaultColumns: timelineDefaults.defaultColumns,
     dataProviders: [
       {
         and: [],

--- a/x-pack/plugins/security_solution/public/common/utils/timeline/use_timeline_click.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/timeline/use_timeline_click.tsx
@@ -13,8 +13,8 @@ import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_fe
 export const useTimelineClick = () => {
   const queryTimelineById = useQueryTimelineById();
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const handleTimelineClick = useCallback(
@@ -23,10 +23,10 @@ export const useTimelineClick = () => {
         graphEventId,
         timelineId,
         onError,
-        unifiedComponentsInTimelineEnabled,
+        unifiedComponentsInTimelineDisabled,
       });
     },
-    [queryTimelineById, unifiedComponentsInTimelineEnabled]
+    [queryTimelineById, unifiedComponentsInTimelineDisabled]
   );
 
   return handleTimelineClick;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/actions.test.tsx
@@ -38,7 +38,6 @@ import { TimelineId, TimelineTabs } from '../../../../common/types/timeline';
 import type { ISearchStart } from '@kbn/data-plugin/public';
 import { searchServiceMock } from '@kbn/data-plugin/public/search/mocks';
 import { getTimelineTemplate } from '../../../timelines/containers/api';
-import { defaultHeaders } from '../../../timelines/components/timeline/body/column_headers/default_headers';
 import { KibanaServices } from '../../../common/lib/kibana';
 import {
   DEFAULT_FROM_MOMENT,
@@ -58,6 +57,7 @@ import {
 } from '@kbn/lists-plugin/common/constants.mock';
 import { of } from 'rxjs';
 import { timelineDefaults } from '../../../timelines/store/defaults';
+import { defaultUdtHeaders } from '../../../timelines/components/timeline/unified_components/default_headers';
 
 jest.mock('../../../timelines/containers/api', () => ({
   getTimelineTemplate: jest.fn(),
@@ -332,40 +332,35 @@ describe('alert actions', () => {
                 id: '@timestamp',
                 type: 'date',
                 esTypes: ['date'],
-                initialWidth: 190,
+                initialWidth: 215,
               },
               {
                 columnHeaderType: 'not-filtered',
                 id: 'message',
-                initialWidth: 180,
+                initialWidth: 360,
               },
               {
                 columnHeaderType: 'not-filtered',
                 id: 'event.category',
-                initialWidth: 180,
               },
               {
                 columnHeaderType: 'not-filtered',
                 id: 'host.name',
-                initialWidth: 180,
               },
               {
                 columnHeaderType: 'not-filtered',
                 id: 'source.ip',
-                initialWidth: 180,
               },
               {
                 columnHeaderType: 'not-filtered',
                 id: 'destination.ip',
-                initialWidth: 180,
               },
               {
                 columnHeaderType: 'not-filtered',
                 id: 'user.name',
-                initialWidth: 180,
               },
             ],
-            defaultColumns: defaultHeaders,
+            defaultColumns: defaultUdtHeaders,
             dataProviders: [],
             dataViewId: null,
             dateRange: {
@@ -896,6 +891,7 @@ describe('alert actions', () => {
           timeline: {
             ...defaultTimelineProps.timeline,
             columns: mockGetOneTimelineResult.columns,
+            defaultColumns: defaultUdtHeaders,
             dataProviders: [],
             dateRange: {
               start: expectedFrom,
@@ -1110,6 +1106,8 @@ describe('alert actions', () => {
           timeline: {
             ...defaultTimelineProps.timeline,
             dataProviders: [],
+            columns: defaultUdtHeaders,
+            defaultColumns: defaultUdtHeaders,
             dateRange: {
               start: expectedFrom,
               end: expectedTo,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.tsx
@@ -144,8 +144,8 @@ export const useInvestigateInTimeline = ({
     timelineType: TimelineType.default,
   });
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
   const updateTimeline = useUpdateTimeline();
 
@@ -160,10 +160,10 @@ export const useInvestigateInTimeline = ({
         notes: [],
         timeline: {
           ...timeline,
-          columns: unifiedComponentsInTimelineEnabled ? defaultUdtHeaders : defaultHeaders,
+          columns: !unifiedComponentsInTimelineDisabled ? defaultUdtHeaders : defaultHeaders,
           indexNames: timeline.indexNames ?? [],
           show: true,
-          excludedRowRendererIds: unifiedComponentsInTimelineEnabled
+          excludedRowRendererIds: !unifiedComponentsInTimelineDisabled
             ? timeline.excludedRowRendererIds
             : [],
         },
@@ -175,7 +175,7 @@ export const useInvestigateInTimeline = ({
       updateTimeline,
       updateTimelineIsLoading,
       clearActiveTimeline,
-      unifiedComponentsInTimelineEnabled,
+      unifiedComponentsInTimelineDisabled,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/rules/use_rule_from_timeline.tsx
@@ -48,8 +48,8 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
     SourcererScopeName.timeline
   );
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const isEql = useRef(false);
@@ -200,11 +200,11 @@ export const useRuleFromTimeline = (setRuleQuery: SetRuleQuery): RuleFromTimelin
         queryTimelineById({
           timelineId,
           onOpenTimeline,
-          unifiedComponentsInTimelineEnabled,
+          unifiedComponentsInTimelineDisabled,
         });
       }
     },
-    [onOpenTimeline, queryTimelineById, selectedTimeline, unifiedComponentsInTimelineEnabled]
+    [onOpenTimeline, queryTimelineById, selectedTimeline, unifiedComponentsInTimelineDisabled]
   );
 
   const [urlStateInitialized, setUrlStateInitialized] = useState(false);

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.test.tsx
@@ -250,7 +250,7 @@ describe('NotesList', () => {
       onOpenTimeline: undefined,
       timelineId: 'timeline-1',
       timelineType: undefined,
-      unifiedComponentsInTimelineEnabled: false,
+      unifiedComponentsInTimelineDisabled: false,
     });
   });
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -80,8 +80,8 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
   const dispatch = useDispatch();
   const { addError: addErrorToast } = useAppToasts();
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdsStatus(state));
@@ -111,9 +111,9 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
         onOpenTimeline: undefined,
         timelineId,
         timelineType: undefined,
-        unifiedComponentsInTimelineEnabled,
+        unifiedComponentsInTimelineDisabled,
       }),
-    [queryTimelineById, unifiedComponentsInTimelineEnabled]
+    [queryTimelineById, unifiedComponentsInTimelineDisabled]
   );
 
   // show a toast if the fetch notes call fails

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/alerts.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/alerts.ts
@@ -49,7 +49,7 @@ export const openAlertDetailsView = (rowIndex: number = 0): void => {
 
 export const openAlertDetailsViewFromTimeline = (rowIndex: number = 0): void => {
   cy.getByTestSubj('timeline-container').within(() => {
-    cy.getByTestSubj('expand-event').eq(rowIndex).click();
+    cy.getByTestSubj('docTableExpandToggleColumn').eq(rowIndex).click();
   });
   cy.getByTestSubj('take-action-dropdown-btn').click();
 };

--- a/x-pack/plugins/security_solution/public/overview/components/recent_timelines/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/recent_timelines/index.tsx
@@ -33,8 +33,8 @@ interface Props {
 const PAGE_SIZE = 3;
 
 const StatefulRecentTimelinesComponent: React.FC<Props> = ({ filterBy }) => {
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const { formatUrl } = useFormatUrl(SecurityPageName.timelines);
@@ -47,10 +47,10 @@ const StatefulRecentTimelinesComponent: React.FC<Props> = ({ filterBy }) => {
       queryTimelineById({
         duplicate,
         timelineId,
-        unifiedComponentsInTimelineEnabled,
+        unifiedComponentsInTimelineDisabled,
       });
     },
-    [queryTimelineById, unifiedComponentsInTimelineEnabled]
+    [queryTimelineById, unifiedComponentsInTimelineDisabled]
   );
 
   const goToTimelines = useCallback(

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/new_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/new_timeline_button.test.tsx
@@ -66,18 +66,18 @@ describe('NewTimelineButton', () => {
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
-        columns: defaultHeaders,
+        columns: defaultUdtHeaders,
         dataViewId,
         id: TimelineId.test,
         indexNames: selectedPatterns,
         show: true,
         timelineType: 'default',
         updated: undefined,
-        excludedRowRendererIds: [],
+        excludedRowRendererIds: [...Object.keys(RowRendererId)],
       });
     });
 
-    // enable unified components in timeline
+    // disable unified components in timeline
     (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
 
     getByTestId('timeline-modal-new-timeline-dropdown-button').click();
@@ -87,14 +87,14 @@ describe('NewTimelineButton', () => {
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
-        columns: defaultUdtHeaders,
+        columns: defaultHeaders,
         dataViewId,
         id: TimelineId.test,
         indexNames: selectedPatterns,
         show: true,
         timelineType: 'default',
         updated: undefined,
-        excludedRowRendererIds: [...Object.keys(RowRendererId)],
+        excludedRowRendererIds: [],
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/timelines/components/new_timeline/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/new_timeline/index.test.tsx
@@ -11,9 +11,9 @@ import { NewTimelineButton } from '.';
 import { TimelineId } from '../../../../common/types';
 import { timelineActions } from '../../store';
 import { useDiscoverInTimelineContext } from '../../../common/components/discover_in_timeline/use_discover_in_timeline_context';
-import { defaultHeaders } from '../timeline/body/column_headers/default_headers';
-import { TimelineType } from '../../../../common/api/timeline';
+import { RowRendererId, TimelineType } from '../../../../common/api/timeline';
 import { TestProviders } from '../../../common/mock';
+import { defaultUdtHeaders } from '../timeline/unified_components/default_headers';
 
 jest.mock('../../../common/components/discover_in_timeline/use_discover_in_timeline_context');
 jest.mock('../../../common/hooks/use_selector');
@@ -57,14 +57,14 @@ describe('NewTimelineButton', () => {
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
-        columns: defaultHeaders,
+        columns: defaultUdtHeaders,
         dataViewId,
         id: TimelineId.active,
         indexNames: selectedPatterns,
         show: true,
         timelineType: TimelineType.default,
         updated: undefined,
-        excludedRowRendererIds: [],
+        excludedRowRendererIds: [...Object.values(RowRendererId)],
       });
     });
   });
@@ -87,14 +87,14 @@ describe('NewTimelineButton', () => {
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
-        columns: defaultHeaders,
+        columns: defaultUdtHeaders,
         dataViewId,
         id: TimelineId.active,
         indexNames: selectedPatterns,
         show: true,
         timelineType: TimelineType.template,
         updated: undefined,
-        excludedRowRendererIds: [],
+        excludedRowRendererIds: [...Object.values(RowRendererId)],
       });
     });
   });

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.test.ts
@@ -31,6 +31,12 @@ import {
 } from './__mocks__';
 import { resolveTimeline } from '../../containers/api';
 import { defaultUdtHeaders } from '../timeline/unified_components/default_headers';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
+import type { ExperimentalFeatures } from '../../../../common';
+import { allowedExperimentalValues } from '../../../../common';
+
+jest.mock('../../../common/hooks/use_experimental_features');
+const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 jest.mock('react-redux', () => {
   const actual = jest.requireActual('react-redux');
@@ -135,6 +141,14 @@ describe('helpers', () => {
 
   beforeEach(() => {
     mockResults = cloneDeep(mockTimelineResults);
+
+    (useIsExperimentalFeatureEnabledMock as jest.Mock).mockImplementation(
+      (featureFlag: keyof ExperimentalFeatures) => {
+        return featureFlag === 'unifiedComponentsInTimelineDisabled'
+          ? false
+          : allowedExperimentalValues[featureFlag];
+      }
+    );
   });
 
   describe('#getPinnedEventCount', () => {
@@ -302,6 +316,7 @@ describe('helpers', () => {
       const newTimeline = defaultTimelineToTimelineModel(timeline, false);
       expect(newTimeline).toEqual({
         ...defaultTimeline,
+        columns: defaultUdtHeaders,
       });
     });
 
@@ -318,6 +333,7 @@ describe('helpers', () => {
       expect(newTimeline).toEqual({
         ...defaultTimeline,
         timelineType: TimelineType.template,
+        columns: defaultUdtHeaders,
       });
     });
 
@@ -333,6 +349,7 @@ describe('helpers', () => {
       const newTimeline = defaultTimelineToTimelineModel(timeline, false, TimelineType.default);
       expect(newTimeline).toEqual({
         ...defaultTimeline,
+        columns: defaultUdtHeaders,
       });
     });
 
@@ -346,6 +363,7 @@ describe('helpers', () => {
       const newTimeline = defaultTimelineToTimelineModel(timeline, false);
       expect(newTimeline).toEqual({
         ...defaultTimeline,
+        columns: defaultUdtHeaders,
       });
     });
 
@@ -469,13 +487,19 @@ describe('helpers', () => {
         timelineType: TimelineType.template,
       };
 
-      const newTimeline = defaultTimelineToTimelineModel(timeline, false, TimelineType.template);
+      const newTimeline = defaultTimelineToTimelineModel(
+        timeline,
+        false,
+        TimelineType.template,
+        false
+      );
       expect(newTimeline).toEqual({
         ...defaultTimeline,
         dateRange: { end: '2020-10-28T11:37:31.655Z', start: '2020-10-27T11:37:31.655Z' },
         status: TimelineStatus.immutable,
         timelineType: TimelineType.template,
         title: 'Awesome Timeline',
+        columns: defaultUdtHeaders,
       });
     });
 
@@ -488,16 +512,22 @@ describe('helpers', () => {
         timelineType: TimelineType.default,
       };
 
-      const newTimeline = defaultTimelineToTimelineModel(timeline, false, TimelineType.default);
+      const newTimeline = defaultTimelineToTimelineModel(
+        timeline,
+        false,
+        TimelineType.default,
+        false
+      );
       expect(newTimeline).toEqual({
         ...defaultTimeline,
         dateRange: { end: '2020-07-08T08:20:18.966Z', start: '2020-07-07T08:20:18.966Z' },
         status: TimelineStatus.active,
         title: 'Awesome Timeline',
+        columns: defaultUdtHeaders,
       });
     });
 
-    test('should produce correct model if unifiedComponentsInTimelineEnabled is true', () => {
+    test('should produce correct model if unifiedComponentsInTimelineDisabled is false', () => {
       const timeline = {
         savedObjectId: 'savedObject-1',
         title: 'Awesome Timeline',
@@ -510,7 +540,7 @@ describe('helpers', () => {
         timeline,
         false,
         TimelineType.default,
-        true
+        false
       );
       expect(newTimeline).toEqual({
         ...defaultTimeline,
@@ -523,7 +553,7 @@ describe('helpers', () => {
       });
     });
 
-    test('should produce correct model if unifiedComponentsInTimelineEnabled is true and custom set of columns is passed', () => {
+    test('should produce correct model if unifiedComponentsInTimelineDisabled is false and custom set of columns is passed', () => {
       const customColumns = defaultUdtHeaders.slice(0, 2);
       const timeline = {
         savedObjectId: 'savedObject-1',
@@ -538,7 +568,7 @@ describe('helpers', () => {
         timeline,
         false,
         TimelineType.default,
-        true
+        false
       );
       expect(newTimeline).toEqual({
         ...defaultTimeline,
@@ -773,7 +803,7 @@ describe('helpers', () => {
         });
       });
     });
-    describe('open a timeline when unifiedComponentsInTimelineEnabled is true', () => {
+    describe('open a timeline when unifiedComponentsInTimelineDisabled is false', () => {
       const untitledTimeline = { ...mockSelectedTimeline, title: '' };
       const onOpenTimeline = jest.fn();
       afterEach(() => {
@@ -788,7 +818,7 @@ describe('helpers', () => {
           timelineType: TimelineType.default,
           onOpenTimeline,
           openTimeline: true,
-          unifiedComponentsInTimelineEnabled: true,
+          unifiedComponentsInTimelineDisabled: false,
         };
         (resolveTimeline as jest.Mock).mockResolvedValue(untitledTimeline);
         renderHook(async () => {
@@ -824,7 +854,7 @@ describe('helpers', () => {
           timelineType: TimelineType.default,
           onOpenTimeline: undefined,
           openTimeline: true,
-          unifiedComponentsInTimelineEnabled: true,
+          unifiedComponentsInTimelineDisabled: false,
         };
 
         (resolveTimeline as jest.Mock).mockResolvedValue(mockSelectedTimeline);
@@ -863,7 +893,7 @@ describe('helpers', () => {
           timelineType: TimelineType.default,
           onOpenTimeline,
           openTimeline: true,
-          unifiedComponentsInTimelineEnabled: true,
+          unifiedComponentsInTimelineDisabled: false,
         };
 
         (resolveTimeline as jest.Mock).mockResolvedValue(mockSelectedTimeline);

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.ts
@@ -233,10 +233,10 @@ export const defaultTimelineToTimelineModel = (
   timeline: TimelineResult,
   duplicate: boolean,
   timelineType?: TimelineType,
-  unifiedComponentsInTimelineEnabled?: boolean
+  unifiedComponentsInTimelineDisabled?: boolean
 ): TimelineModel => {
   const isTemplate = timeline.timelineType === TimelineType.template;
-  const defaultHeadersValue = unifiedComponentsInTimelineEnabled
+  const defaultHeadersValue = !unifiedComponentsInTimelineDisabled
     ? defaultUdtHeaders
     : defaultHeaders;
 
@@ -288,7 +288,7 @@ export const formatTimelineResultToModel = (
   timelineToOpen: TimelineResult,
   duplicate: boolean = false,
   timelineType?: TimelineType,
-  unifiedComponentsInTimelineEnabled?: boolean
+  unifiedComponentsInTimelineDisabled?: boolean
 ): { notes: Note[] | null | undefined; timeline: TimelineModel } => {
   const { notes, ...timelineModel } = timelineToOpen;
   return {
@@ -297,7 +297,7 @@ export const formatTimelineResultToModel = (
       timelineModel,
       duplicate,
       timelineType,
-      unifiedComponentsInTimelineEnabled
+      unifiedComponentsInTimelineDisabled
     ),
   };
 };
@@ -316,7 +316,7 @@ export interface QueryTimelineById {
    * Below feature flag will be removed once
    * unified components have been fully migrated
    * */
-  unifiedComponentsInTimelineEnabled?: boolean;
+  unifiedComponentsInTimelineDisabled?: boolean;
 }
 
 export const useQueryTimelineById = () => {
@@ -340,7 +340,7 @@ export const useQueryTimelineById = () => {
     onOpenTimeline,
     openTimeline = true,
     savedSearchId,
-    unifiedComponentsInTimelineEnabled = false,
+    unifiedComponentsInTimelineDisabled = false,
   }: QueryTimelineById) => {
     updateIsLoading({ id: TimelineId.active, isLoading: true });
     if (timelineId == null) {
@@ -352,13 +352,13 @@ export const useQueryTimelineById = () => {
         to: DEFAULT_TO_MOMENT.toISOString(),
         timeline: {
           ...timelineDefaults,
-          columns: unifiedComponentsInTimelineEnabled ? defaultUdtHeaders : defaultHeaders,
+          columns: !unifiedComponentsInTimelineDisabled ? defaultUdtHeaders : defaultHeaders,
           id: TimelineId.active,
           activeTab: activeTimelineTab,
           show: openTimeline,
           initialized: true,
           savedSearchId: savedSearchId ?? null,
-          excludedRowRendererIds: unifiedComponentsInTimelineEnabled
+          excludedRowRendererIds: !unifiedComponentsInTimelineDisabled
             ? timelineDefaults.excludedRowRendererIds
             : [],
         },
@@ -377,7 +377,7 @@ export const useQueryTimelineById = () => {
             timelineToOpen,
             duplicate,
             timelineType,
-            unifiedComponentsInTimelineEnabled
+            unifiedComponentsInTimelineDisabled
           );
 
           if (onOpenTimeline != null) {

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -161,8 +161,8 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     );
 
     const { dataViewId, selectedPatterns } = useSourcererDataView(SourcererScopeName.timeline);
-    const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-      'unifiedComponentsInTimelineEnabled'
+    const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+      'unifiedComponentsInTimelineDisabled'
     );
 
     const {
@@ -252,11 +252,11 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
           dispatch(
             dispatchCreateNewTimeline({
               id: TimelineId.active,
-              columns: unifiedComponentsInTimelineEnabled ? defaultUdtHeaders : defaultHeaders,
+              columns: !unifiedComponentsInTimelineDisabled ? defaultUdtHeaders : defaultHeaders,
               dataViewId,
               indexNames: selectedPatterns,
               show: false,
-              excludedRowRendererIds: unifiedComponentsInTimelineEnabled
+              excludedRowRendererIds: !unifiedComponentsInTimelineDisabled
                 ? timelineDefaults.excludedRowRendererIds
                 : [],
             })
@@ -273,7 +273,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
         dispatch,
         dataViewId,
         selectedPatterns,
-        unifiedComponentsInTimelineEnabled,
+        unifiedComponentsInTimelineDisabled,
       ]
     );
 
@@ -375,7 +375,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
           onOpenTimeline,
           timelineId,
           timelineType: timelineTypeToOpen,
-          unifiedComponentsInTimelineEnabled,
+          unifiedComponentsInTimelineDisabled,
         });
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -75,8 +75,8 @@ const StatefulTimelineComponent: React.FC<Props> = ({
 }) => {
   const dispatch = useDispatch();
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const containerElement = useRef<HTMLDivElement | null>(null);
@@ -129,11 +129,11 @@ const StatefulTimelineComponent: React.FC<Props> = ({
       dispatch(
         timelineActions.createTimeline({
           id: timelineId,
-          columns: unifiedComponentsInTimelineEnabled ? defaultUdtHeaders : defaultHeaders,
+          columns: !unifiedComponentsInTimelineDisabled ? defaultUdtHeaders : defaultHeaders,
           dataViewId: selectedDataViewIdSourcerer,
           indexNames: selectedPatternsSourcerer,
           show: false,
-          excludedRowRendererIds: unifiedComponentsInTimelineEnabled
+          excludedRowRendererIds: !unifiedComponentsInTimelineDisabled
             ? timelineDefaults.excludedRowRendererIds
             : [],
         })

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -22,6 +22,9 @@ import { useTimelineEvents } from '../../../../containers';
 import { useTimelineEventsDetails } from '../../../../containers/details';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { mockSourcererScope } from '../../../../../sourcerer/containers/mocks';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import type { ExperimentalFeatures } from '../../../../../../common';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -40,6 +43,9 @@ jest.mock('../../../../../sourcerer/containers');
 jest.mock('../../../../../sourcerer/containers/use_signal_helpers', () => ({
   useSignalHelpers: () => ({ signalIndexNeedsInit: false }),
 }));
+
+jest.mock('../../../../../common/hooks/use_experimental_features');
+const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 const mockUseResizeObserver: jest.Mock = useResizeObserver as jest.Mock;
 jest.mock('use-resize-observer/polyfilled');
@@ -68,6 +74,15 @@ describe('Timeline', () => {
     (useTimelineEventsDetails as jest.Mock).mockReturnValue([false, {}]);
 
     (useSourcererDataView as jest.Mock).mockReturnValue(mockSourcererScope);
+
+    (useIsExperimentalFeatureEnabledMock as jest.Mock).mockImplementation(
+      (feature: keyof ExperimentalFeatures) => {
+        if (feature === 'unifiedComponentsInTimelineDisabled') {
+          return true;
+        }
+        return allowedExperimentalValues[feature];
+      }
+    );
 
     props = {
       activeTab: TimelineTabs.eql,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -102,8 +102,8 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   } = useSourcererDataView(SourcererScopeName.timeline);
   const { augmentedColumnHeaders, timelineQueryFieldsFromColumns } = useTimelineColumns(columns);
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const getManageTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
@@ -138,7 +138,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
     id: timelineId,
     indexNames: selectedPatterns,
     language: 'eql',
-    limit: unifiedComponentsInTimelineEnabled ? sampleSize : itemsPerPage,
+    limit: !unifiedComponentsInTimelineDisabled ? sampleSize : itemsPerPage,
     runtimeMappings,
     skip: !canQueryTimeline(),
     startDate: start,
@@ -279,10 +279,12 @@ export const EqlTabContentComponent: React.FC<Props> = ({
 
   return (
     <>
-      {unifiedComponentsInTimelineEnabled ? (
+      {!unifiedComponentsInTimelineDisabled ? (
         <>
           <InPortal node={eqlEventsCountPortalNode}>
-            {totalCount >= 0 ? <EventsCountBadge>{totalCount}</EventsCountBadge> : null}
+            {totalCount >= 0 ? (
+              <EventsCountBadge data-test-subj="eql-events-count">{totalCount}</EventsCountBadge>
+            ) : null}
           </InPortal>
           {NotesFlyoutMemo}
           <FullWidthFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.test.tsx
@@ -24,6 +24,9 @@ import type { Props as PinnedTabContentComponentProps } from '.';
 import { PinnedTabContentComponent } from '.';
 import { Direction } from '../../../../../../common/search_strategy';
 import { mockCasesContext } from '@kbn/cases-plugin/public/mocks/mock_cases_context';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import type { ExperimentalFeatures } from '../../../../../../common';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -39,6 +42,9 @@ jest.mock('../../body/events', () => ({
 }));
 
 jest.mock('../../../../../sourcerer/containers');
+
+jest.mock('../../../../../common/hooks/use_experimental_features');
+const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 const mockUseResizeObserver: jest.Mock = useResizeObserver as jest.Mock;
 jest.mock('use-resize-observer/polyfilled');
@@ -113,6 +119,15 @@ describe('PinnedTabContent', () => {
     (useTimelineEventsDetails as jest.Mock).mockReturnValue([false, {}]);
 
     (useSourcererDataView as jest.Mock).mockReturnValue(mockSourcererScope);
+
+    (useIsExperimentalFeatureEnabledMock as jest.Mock).mockImplementation(
+      (feature: keyof ExperimentalFeatures) => {
+        if (feature === 'unifiedComponentsInTimelineDisabled') {
+          return true;
+        }
+        return allowedExperimentalValues[feature];
+      }
+    );
 
     props = {
       columns: defaultHeaders,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -104,8 +104,8 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
     selectedPatterns,
   } = useSourcererDataView(SourcererScopeName.timeline);
   const { setTimelineFullScreen, timelineFullScreen } = useTimelineFullScreen();
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const filterQuery = useMemo(() => {
@@ -288,7 +288,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
     );
   }, [associateNote, closeNotesFlyout, isNotesFlyoutVisible, noteEventId, notes, timelineId]);
 
-  if (unifiedComponentsInTimelineEnabled) {
+  if (!unifiedComponentsInTimelineDisabled) {
     return (
       <>
         {NotesFlyoutMemo}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/header/index.tsx
@@ -67,8 +67,8 @@ const QueryTabHeaderComponent: React.FC<Props> = ({
   showEventsCountBadge,
   totalCount,
 }) => {
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
   const { portalNode: timelineEventsCountPortalNode } = useTimelineEventsCountPortal();
   const { setTimelineFullScreen, timelineFullScreen } = useTimelineFullScreen();
@@ -92,10 +92,12 @@ const QueryTabHeaderComponent: React.FC<Props> = ({
   return (
     <StyledEuiFlyoutHeader data-test-subj={`${activeTab}-tab-flyout-header`} hasBorder={false}>
       <InPortal node={timelineEventsCountPortalNode}>
-        {showEventsCountBadge ? <EventsCountBadge>{totalCount}</EventsCountBadge> : null}
+        {showEventsCountBadge ? (
+          <EventsCountBadge data-test-subj="query-events-count">{totalCount}</EventsCountBadge>
+        ) : null}
       </InPortal>
       <EuiFlexGroup gutterSize="s" direction="column">
-        {!unifiedComponentsInTimelineEnabled &&
+        {unifiedComponentsInTimelineDisabled &&
           timelineFullScreen &&
           setTimelineFullScreen != null && (
             <EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -28,6 +28,9 @@ import { mockSourcererScope } from '../../../../../sourcerer/containers/mocks';
 import { Direction } from '../../../../../../common/search_strategy';
 import * as helpers from '../../../../../common/lib/kuery';
 import { waitFor } from '@testing-library/react';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
+import type { ExperimentalFeatures } from '../../../../../../common';
+import { allowedExperimentalValues } from '../../../../../../common';
 
 jest.mock('../../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -60,6 +63,8 @@ jest.mock('../../../../containers/use_timeline_data_filters', () => ({
 }));
 
 jest.mock('../../../../../common/hooks/use_experimental_features');
+
+const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
 
 describe('Timeline', () => {
   let props = {} as QueryTabContentComponentProps;
@@ -94,6 +99,15 @@ describe('Timeline', () => {
     (useTimelineEventsDetails as jest.Mock).mockReturnValue([false, {}]);
 
     (useSourcererDataView as jest.Mock).mockReturnValue(mockSourcererScope);
+
+    (useIsExperimentalFeatureEnabledMock as jest.Mock).mockImplementation(
+      (feature: keyof ExperimentalFeatures) => {
+        if (feature === 'unifiedComponentsInTimelineDisabled') {
+          return true;
+        }
+        return allowedExperimentalValues[feature];
+      }
+    );
 
     props = {
       columns: defaultHeaders,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -121,8 +121,8 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     query: { filterManager: timelineFilterManager },
   } = timelineDataService;
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const getManageTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
@@ -203,7 +203,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     id: timelineId,
     indexNames: selectedPatterns,
     language: kqlQuery.language,
-    limit: unifiedComponentsInTimelineEnabled ? sampleSize : itemsPerPage,
+    limit: !unifiedComponentsInTimelineDisabled ? sampleSize : itemsPerPage,
     runtimeMappings,
     skip: !canQueryTimeline,
     sort: timelineQuerySortField,
@@ -361,7 +361,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     );
   }, [associateNote, closeNotesFlyout, isNotesFlyoutVisible, noteEventId, notes, timelineId]);
 
-  if (unifiedComponentsInTimelineEnabled) {
+  if (!unifiedComponentsInTimelineDisabled) {
     return (
       <>
         <TimelineRefetch

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/query_tab_unified_components.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/query_tab_unified_components.test.tsx
@@ -74,8 +74,8 @@ jest.mock('react-router-dom', () => ({
 const SPECIAL_TEST_TIMEOUT = 50000;
 
 const useIsExperimentalFeatureEnabledMock = jest.fn((feature: keyof ExperimentalFeatures) => {
-  if (feature === 'unifiedComponentsInTimelineEnabled') {
-    return true;
+  if (feature === 'unifiedComponentsInTimelineDisabled') {
+    return false;
   }
   return allowedExperimentalValues[feature];
 });
@@ -158,6 +158,14 @@ const { storage: storageMock } = createSecuritySolutionStorageMock();
 let useTimelineEventsMock = jest.fn();
 
 describe('query tab with unified timeline', () => {
+  beforeAll(() => {
+    // https://github.com/atlassian/react-beautiful-dnd/blob/4721a518356f72f1dac45b5fd4ee9d466aa2996b/docs/guides/setup-problem-detection-and-error-recovery.md#disable-logging
+    Object.defineProperty(window, '__@hello-pangea/dnd-disable-dev-warnings', {
+      get() {
+        return true;
+      },
+    });
+  });
   const kibanaServiceMock: StartServices = {
     ...createStartServicesMock(),
     storage: storageMock,
@@ -171,10 +179,6 @@ describe('query tab with unified timeline', () => {
   });
 
   beforeEach(() => {
-    Object.defineProperty(window, '__@hello-pangea/dnd-disable-dev-warnings', {
-      value: true,
-      writable: false,
-    });
     useTimelineEventsMock = jest.fn(() => [
       false,
       {
@@ -782,8 +786,8 @@ describe('query tab with unified timeline', () => {
       beforeEach(() => {
         (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
           jest.fn((feature: keyof ExperimentalFeatures) => {
-            if (feature === 'unifiedComponentsInTimelineEnabled') {
-              return true;
+            if (feature === 'unifiedComponentsInTimelineDisabled') {
+              return false;
             }
             if (feature === 'securitySolutionNotesEnabled') {
               return true;
@@ -797,7 +801,6 @@ describe('query tab with unified timeline', () => {
         'should have the notification dot & correct tooltip',
         async () => {
           renderTestComponents();
-
           expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
 
           expect(screen.getAllByTestId('timeline-notes-button-small')).toHaveLength(1);
@@ -840,8 +843,8 @@ describe('query tab with unified timeline', () => {
       beforeEach(() => {
         (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
           jest.fn((feature: keyof ExperimentalFeatures) => {
-            if (feature === 'unifiedComponentsInTimelineEnabled') {
-              return true;
+            if (feature === 'unifiedComponentsInTimelineDisabled') {
+              return false;
             }
             if (feature === 'securitySolutionNotesEnabled') {
               return false;
@@ -855,7 +858,6 @@ describe('query tab with unified timeline', () => {
         'should have the notification dot & correct tooltip',
         async () => {
           renderTestComponents();
-
           expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
 
           expect(screen.getAllByTestId('timeline-notes-button-small')).toHaveLength(1);
@@ -977,9 +979,6 @@ describe('query tab with unified timeline', () => {
       beforeEach(() => {
         (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
           jest.fn((feature: keyof ExperimentalFeatures) => {
-            if (feature === 'unifiedComponentsInTimelineEnabled') {
-              return true;
-            }
             if (feature === 'securitySolutionNotesEnabled') {
               return true;
             }
@@ -1022,9 +1021,6 @@ describe('query tab with unified timeline', () => {
       beforeEach(() => {
         (useIsExperimentalFeatureEnabled as jest.Mock).mockImplementation(
           jest.fn((feature: keyof ExperimentalFeatures) => {
-            if (feature === 'unifiedComponentsInTimelineEnabled') {
-              return true;
-            }
             if (feature === 'securitySolutionNotesEnabled') {
               return false;
             }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.test.ts
@@ -14,7 +14,7 @@ import { defaultHeaders } from '../../body/column_headers/default_headers';
 import type { ColumnHeaderOptions } from '../../../../../../common/types/timeline/columns';
 
 jest.mock('../../../../../common/hooks/use_experimental_features', () => ({
-  useIsExperimentalFeatureEnabled: jest.fn().mockReturnValue(false),
+  useIsExperimentalFeatureEnabled: jest.fn().mockReturnValue(true),
 }));
 
 const useIsExperimentalFeatureEnabledMock = useIsExperimentalFeatureEnabled as jest.Mock;
@@ -41,7 +41,7 @@ describe('useTimelineColumns', () => {
     });
 
     it('should return the default unified data table (udt) columns', () => {
-      useIsExperimentalFeatureEnabledMock.mockReturnValue(true);
+      useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
       const { result } = renderHook(() => useTimelineColumns([]), {
         wrapper: TestProviders,
       });
@@ -51,7 +51,7 @@ describe('useTimelineColumns', () => {
 
   describe('localColumns', () => {
     it('should return the default columns', () => {
-      useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
+      useIsExperimentalFeatureEnabledMock.mockReturnValue(true);
       const { result } = renderHook(() => useTimelineColumns([]), {
         wrapper: TestProviders,
       });
@@ -59,7 +59,7 @@ describe('useTimelineColumns', () => {
     });
 
     it('should return the default unified data table (udt) columns', () => {
-      useIsExperimentalFeatureEnabledMock.mockReturnValue(true);
+      useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
       const { result } = renderHook(() => useTimelineColumns([]), {
         wrapper: TestProviders,
       });
@@ -84,7 +84,7 @@ describe('useTimelineColumns', () => {
     });
 
     it('should return the default unified data table (udt) columns', () => {
-      useIsExperimentalFeatureEnabledMock.mockReturnValue(true);
+      useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
       const { result } = renderHook(() => useTimelineColumns([]), {
         wrapper: TestProviders,
       });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.tsx
@@ -18,13 +18,13 @@ import { memoizedGetTimelineColumnHeaders } from './utils';
 export const useTimelineColumns = (columns: ColumnHeaderOptions[]) => {
   const { browserFields } = useSourcererDataView(SourcererScopeName.timeline);
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const defaultColumns = useMemo(
-    () => (unifiedComponentsInTimelineEnabled ? defaultUdtHeaders : defaultHeaders),
-    [unifiedComponentsInTimelineEnabled]
+    () => (!unifiedComponentsInTimelineDisabled ? defaultUdtHeaders : defaultHeaders),
+    [unifiedComponentsInTimelineDisabled]
   );
 
   const localColumns = useMemo(() => columns ?? defaultColumns, [columns, defaultColumns]);

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.test.tsx
@@ -13,10 +13,6 @@ import type { ColumnHeaderOptions } from '../../../../../../common/types/timelin
 import { TimelineId } from '@kbn/timelines-plugin/public/store/timeline';
 import { TimelineTabs } from '../../../../../../common/types';
 
-jest.mock('../../../../../common/hooks/use_experimental_features', () => ({
-  useIsExperimentalFeatureEnabled: jest.fn().mockReturnValue(true),
-}));
-
 jest.mock('../../../../../common/hooks/use_license', () => ({
   useLicense: jest.fn().mockReturnValue({
     isEnterprise: () => true,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.tsx
@@ -51,8 +51,8 @@ export const useTimelineControlColumn = ({
 }: UseTimelineControlColumnArgs) => {
   const { browserFields } = useSourcererDataView(SourcererScopeName.timeline);
 
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
 
   const isEnterprisePlus = useLicense().isEnterprise();
@@ -62,7 +62,7 @@ export const useTimelineControlColumn = ({
   // We need one less when the unified components are enabled because the document expand is provided by the unified data table
   const UNIFIED_COMPONENTS_ACTION_BUTTON_COUNT = ACTION_BUTTON_COUNT - 1;
   return useMemo(() => {
-    if (unifiedComponentsInTimelineEnabled) {
+    if (!unifiedComponentsInTimelineDisabled) {
       return getDefaultControlColumn(UNIFIED_COMPONENTS_ACTION_BUTTON_COUNT).map((x) => ({
         ...x,
         headerCellRender: function HeaderCellRender(props: UnifiedActionProps) {
@@ -94,7 +94,7 @@ export const useTimelineControlColumn = ({
            * the number of rows in the table currently rendered.
            *
            * */
-          if (props.rowIndex >= events.length) return <></>;
+          if ('rowIndex' in props && props.rowIndex >= events.length) return <></>;
           props.setCellProps({
             className:
               props.expandedEventId === events[props.rowIndex]?._id
@@ -135,7 +135,7 @@ export const useTimelineControlColumn = ({
       })) as unknown as ColumnHeaderOptions[];
     }
   }, [
-    unifiedComponentsInTimelineEnabled,
+    unifiedComponentsInTimelineDisabled,
     UNIFIED_COMPONENTS_ACTION_BUTTON_COUNT,
     browserFields,
     localColumns,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
@@ -67,8 +67,8 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const useIsExperimentalFeatureEnabledMock = jest.fn((feature: keyof ExperimentalFeatures) => {
-  if (feature === 'unifiedComponentsInTimelineEnabled') {
-    return true;
+  if (feature === 'unifiedComponentsInTimelineDisabled') {
+    return false;
   }
   return allowedExperimentalValues[feature];
 });

--- a/x-pack/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
@@ -15,10 +15,10 @@ import { timelineActions } from '../store';
 import { inputsActions } from '../../common/store/inputs';
 import { sourcererActions } from '../../sourcerer/store';
 import { appActions } from '../../common/store/app';
-import { defaultHeaders } from '../components/timeline/body/column_headers/default_headers';
 import { SourcererScopeName } from '../../sourcerer/store/model';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import { TestProviders, mockGlobalState } from '../../common/mock';
+import { defaultUdtHeaders } from '../components/timeline/unified_components/default_headers';
 
 jest.mock('../../common/components/discover_in_timeline/use_discover_in_timeline_context');
 jest.mock('../../common/containers/use_global_time', () => {
@@ -68,7 +68,7 @@ describe('useCreateTimeline', () => {
     await hookResult.result.current();
     expect(createTimeline.mock.calls[0][0].id).toEqual(TimelineId.test);
     expect(createTimeline.mock.calls[0][0].timelineType).toEqual(TimelineType.default);
-    expect(createTimeline.mock.calls[0][0].columns).toEqual(defaultHeaders);
+    expect(createTimeline.mock.calls[0][0].columns).toEqual(defaultUdtHeaders);
     expect(createTimeline.mock.calls[0][0].dataViewId).toEqual(
       mockGlobalState.sourcerer.defaultDataView.id
     );

--- a/x-pack/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -50,8 +50,8 @@ export const useCreateTimeline = ({
   onClick,
 }: UseCreateTimelineParams): ((options?: { timeRange?: TimeRange }) => Promise<void>) => {
   const dispatch = useDispatch();
-  const unifiedComponentsInTimelineEnabled = useIsExperimentalFeatureEnabled(
-    'unifiedComponentsInTimelineEnabled'
+  const unifiedComponentsInTimelineDisabled = useIsExperimentalFeatureEnabled(
+    'unifiedComponentsInTimelineDisabled'
   );
   const { id: dataViewId, patternList: selectedPatterns } = useSelector(
     sourcererSelectors.defaultDataView
@@ -79,14 +79,14 @@ export const useCreateTimeline = ({
 
       dispatch(
         timelineActions.createTimeline({
-          columns: unifiedComponentsInTimelineEnabled ? defaultUdtHeaders : defaultHeaders,
+          columns: !unifiedComponentsInTimelineDisabled ? defaultUdtHeaders : defaultHeaders,
           dataViewId,
           id,
           indexNames: selectedPatterns,
           show,
           timelineType,
           updated: undefined,
-          excludedRowRendererIds: unifiedComponentsInTimelineEnabled
+          excludedRowRendererIds: !unifiedComponentsInTimelineDisabled
             ? timelineDefaults.excludedRowRendererIds
             : [],
         })
@@ -123,7 +123,7 @@ export const useCreateTimeline = ({
       setTimelineFullScreen,
       timelineFullScreen,
       timelineType,
-      unifiedComponentsInTimelineEnabled,
+      unifiedComponentsInTimelineDisabled,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/timelines/store/defaults.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/defaults.ts
@@ -11,6 +11,7 @@ import { TimelineType, TimelineStatus, RowRendererId } from '../../../common/api
 import { defaultHeaders } from '../components/timeline/body/column_headers/default_headers';
 import { normalizeTimeRange } from '../../common/utils/normalize_time_range';
 import type { SubsetTimelineModel, TimelineModel } from './model';
+import { defaultUdtHeaders } from '../components/timeline/unified_components/default_headers';
 
 // normalizeTimeRange uses getTimeRangeSettings which cannot be used outside Kibana context if the uiSettings is not false
 const { from: start, to: end } = normalizeTimeRange({ from: '', to: '' }, false);
@@ -19,9 +20,9 @@ export const timelineDefaults: SubsetTimelineModel &
   Pick<TimelineModel, 'eqlOptions' | 'resolveTimelineConfig' | 'sampleSize' | 'rowHeight'> = {
   activeTab: TimelineTabs.query,
   prevActiveTab: TimelineTabs.query,
-  columns: defaultHeaders,
+  columns: defaultUdtHeaders,
   documentType: '',
-  defaultColumns: defaultHeaders,
+  defaultColumns: defaultUdtHeaders,
   dataProviders: [],
   dataViewId: null,
   dateRange: { start, end },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/event_rendered_view.cy.ts
@@ -69,7 +69,7 @@ describe(`Event Rendered View`, { tags: ['@ess', '@serverless'] }, () => {
   });
 
   it('Sorting control is not visible', () => {
-    cy.get(DATA_GRID_FIELD_SORT_BTN).should('not.be.visible');
+    cy.get(DATA_GRID_FIELD_SORT_BTN).should('not.exist');
   });
 
   it('Column Order button is not visible', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_table_tab.cy.ts
@@ -97,11 +97,11 @@ describe(
 
       const timestampColumn = '@timestamp';
       cy.get(TIMESTAMP_COLUMN).should('be.visible');
-      cy.get(COLUMN_HEADER).should('contain.text', timestampColumn);
+      cy.get(COLUMN_HEADER).first().should('contain.text', timestampColumn);
       toggleColumnTableTabTable();
-      cy.get(COLUMN_HEADER).should('not.contain.text', timestampColumn);
+      cy.get(COLUMN_HEADER).first().should('not.contain.text', timestampColumn);
       toggleColumnTableTabTable();
-      cy.get(TIMESTAMP_COLUMN).should('be.visible');
+      cy.get(TIMESTAMP_COLUMN).first().should('be.visible');
       cy.get(COLUMN_HEADER).should('contain.text', timestampColumn);
     });
   }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/bulk_add_to_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/bulk_add_to_timeline.cy.ts
@@ -7,7 +7,7 @@
 
 import { getNewRule } from '../../../objects/rule';
 import { SELECTED_ALERTS } from '../../../screens/alerts';
-import { SERVER_SIDE_EVENT_COUNT } from '../../../screens/timeline';
+import { QUERY_EVENT_COUNT } from '../../../screens/timeline';
 import { selectAllAlerts, selectFirstPageAlerts } from '../../../tasks/alerts';
 import { deleteAlertsAndRules } from '../../../tasks/api_calls/common';
 import { createRule } from '../../../tasks/api_calls/rules';
@@ -51,7 +51,7 @@ describe('Bulk Investigate in Timeline', { tags: ['@ess', '@serverless'] }, () =
         const alertCount = alertCountText.split(' ')[1];
         bulkInvestigateSelectedEventsInTimeline();
         cy.get('body').should('contain.text', `${alertCount} event IDs`);
-        cy.get(SERVER_SIDE_EVENT_COUNT).should('contain.text', alertCount);
+        cy.get(QUERY_EVENT_COUNT).should('contain.text', alertCount);
       });
     });
 
@@ -62,7 +62,7 @@ describe('Bulk Investigate in Timeline', { tags: ['@ess', '@serverless'] }, () =
         const alertCount = alertCountText.split(' ')[1];
         bulkInvestigateSelectedEventsInTimeline();
         cy.get('body').should('contain.text', `${alertCount} event IDs`);
-        cy.get(SERVER_SIDE_EVENT_COUNT).should('contain.text', alertCount);
+        cy.get(QUERY_EVENT_COUNT).should('contain.text', alertCount);
       });
     });
   });
@@ -83,7 +83,7 @@ describe('Bulk Investigate in Timeline', { tags: ['@ess', '@serverless'] }, () =
         const alertCount = alertCountText.split(' ')[1];
         bulkInvestigateSelectedEventsInTimeline();
         cy.get('body').should('contain.text', `${alertCount} event IDs`);
-        cy.get(SERVER_SIDE_EVENT_COUNT).should('contain.text', alertCount);
+        cy.get(QUERY_EVENT_COUNT).should('contain.text', alertCount);
       });
     });
 
@@ -94,7 +94,7 @@ describe('Bulk Investigate in Timeline', { tags: ['@ess', '@serverless'] }, () =
         const alertCount = alertCountText.split(' ')[1];
         bulkInvestigateSelectedEventsInTimeline();
         cy.get('body').should('contain.text', `${alertCount} event IDs`);
-        cy.get(SERVER_SIDE_EVENT_COUNT).should('contain.text', alertCount);
+        cy.get(QUERY_EVENT_COUNT).should('contain.text', alertCount);
       });
     });
   });
@@ -115,7 +115,7 @@ describe('Bulk Investigate in Timeline', { tags: ['@ess', '@serverless'] }, () =
         const alertCount = alertCountText.split(' ')[1];
         bulkInvestigateSelectedEventsInTimeline();
         cy.get('body').should('contain.text', `${alertCount} event IDs`);
-        cy.get(SERVER_SIDE_EVENT_COUNT).should('contain.text', alertCount);
+        cy.get(QUERY_EVENT_COUNT).should('contain.text', alertCount);
       });
     });
 
@@ -126,7 +126,7 @@ describe('Bulk Investigate in Timeline', { tags: ['@ess', '@serverless'] }, () =
         const alertCount = alertCountText.split(' ')[1];
         bulkInvestigateSelectedEventsInTimeline();
         cy.get('body').should('contain.text', `${alertCount} event IDs`);
-        cy.get(SERVER_SIDE_EVENT_COUNT).should('contain.text', alertCount);
+        cy.get(QUERY_EVENT_COUNT).should('contain.text', alertCount);
       });
     });
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/correlation_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/correlation_tab.cy.ts
@@ -6,11 +6,7 @@
  */
 
 import { openTimeline } from '../../../tasks/timelines';
-import {
-  SERVER_SIDE_EVENT_COUNT,
-  TIMELINE_TAB_CONTENT_EQL,
-  TIMELINE_CORRELATION_INPUT,
-} from '../../../screens/timeline';
+import { TIMELINE_CORRELATION_INPUT, EQL_EVENT_COUNT } from '../../../screens/timeline';
 import { createTimeline } from '../../../tasks/api_calls/timelines';
 
 import { login } from '../../../tasks/login';
@@ -38,10 +34,7 @@ describe('Correlation tab', { tags: ['@ess', '@serverless'] }, () => {
   });
 
   it('should update timeline after adding eql', () => {
-    cy.get(`${TIMELINE_TAB_CONTENT_EQL} ${SERVER_SIDE_EVENT_COUNT}`)
-      .invoke('text')
-      .then(parseInt)
-      .should('be.gt', 0);
+    cy.get(`${EQL_EVENT_COUNT}`).invoke('text').then(parseInt).should('be.gt', 0);
   });
 
   it('should update timeline after removing eql', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/fields_browser.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/fields_browser.cy.ts
@@ -6,14 +6,10 @@
  */
 
 import {
-  FIELDS_BROWSER_CATEGORIES_COUNT,
-  FIELDS_BROWSER_FIELDS_COUNT,
   FIELDS_BROWSER_HOST_GEO_CITY_NAME_HEADER,
   FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER,
   FIELDS_BROWSER_MESSAGE_HEADER,
   FIELDS_BROWSER_FILTER_INPUT,
-  FIELDS_BROWSER_CATEGORIES_FILTER_CONTAINER,
-  FIELDS_BROWSER_CATEGORY_BADGE,
 } from '../../../screens/fields_browser';
 import { TIMELINE_FIELDS_BUTTON } from '../../../screens/timeline';
 
@@ -22,11 +18,8 @@ import {
   addsHostGeoContinentNameToTimeline,
   closeFieldsBrowser,
   filterFieldsBrowser,
-  toggleCategoryFilter,
   removesMessageField,
   resetFields,
-  toggleCategory,
-  activateViewSelected,
 } from '../../../tasks/fields_browser';
 import { login } from '../../../tasks/login';
 import { visitWithTimeRange } from '../../../tasks/navigation';
@@ -35,121 +28,81 @@ import { openTimelineFieldsBrowser } from '../../../tasks/timeline';
 
 import { hostsUrl } from '../../../urls/navigation';
 
-const defaultHeaders = [
-  { id: '@timestamp' },
-  { id: 'message' },
-  { id: 'event.category' },
-  { id: 'event.action' },
-  { id: 'host.name' },
-  { id: 'source.ip' },
-  { id: 'destination.ip' },
-  { id: 'user.name' },
-];
-
-describe('Fields Browser', { tags: ['@ess', '@serverless'] }, () => {
-  beforeEach(() => {
-    login();
-    visitWithTimeRange(hostsUrl('allHosts'));
-    openTimelineUsingToggle();
-    openTimelineFieldsBrowser();
-  });
-
-  // FLAKY: https://github.com/elastic/kibana/issues/178776
-  describe.skip('Fields Browser rendering', () => {
-    it('should display the expected count of categories and fields that match the filter input', () => {
-      const filterInput = 'host.mac';
-
-      filterFieldsBrowser(filterInput);
-
-      cy.get(FIELDS_BROWSER_CATEGORIES_COUNT).should('have.text', '2');
-      cy.get(FIELDS_BROWSER_FIELDS_COUNT).should('contain.text', '2');
+describe(
+  'Fields Browser',
+  {
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
+    env: {
+      ftrConfig: {
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'unifiedComponentsInTimelineDisabled',
+          ])}`,
+        ],
+      },
+    },
+  },
+  () => {
+    beforeEach(() => {
+      login();
+      visitWithTimeRange(hostsUrl('allHosts'));
+      openTimelineUsingToggle();
+      openTimelineFieldsBrowser();
     });
 
-    it('should display only the selected fields when "view selected" option is enabled', () => {
-      activateViewSelected();
-      cy.get(FIELDS_BROWSER_FIELDS_COUNT).should('contain.text', `${defaultHeaders.length}`);
-      defaultHeaders.forEach((header) => {
-        cy.get(`[data-test-subj="field-${header.id}-checkbox"]`).should('be.checked');
+    describe('Editing the timeline', () => {
+      it('should add/remove columns from the alerts table when the user checks/un-checks them', () => {
+        const filterInput = 'host.geo.c';
+
+        cy.log('removing the message column');
+
+        cy.get(FIELDS_BROWSER_MESSAGE_HEADER).should('exist');
+
+        removesMessageField();
+        closeFieldsBrowser();
+
+        cy.get(FIELDS_BROWSER_MESSAGE_HEADER).should('not.exist');
+
+        cy.log('add host.geo.city_name column');
+
+        cy.get(FIELDS_BROWSER_HOST_GEO_CITY_NAME_HEADER).should('not.exist');
+
+        openTimelineFieldsBrowser();
+        filterFieldsBrowser(filterInput);
+        addsHostGeoCityNameToTimeline();
+        closeFieldsBrowser();
+
+        cy.get(FIELDS_BROWSER_HOST_GEO_CITY_NAME_HEADER).should('exist');
+      });
+
+      it('should reset all fields in the timeline when `Reset Fields` is clicked', () => {
+        const filterInput = 'host.geo.c';
+
+        filterFieldsBrowser(filterInput);
+
+        cy.get(FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER).should('not.exist');
+
+        addsHostGeoContinentNameToTimeline();
+        closeFieldsBrowser();
+
+        cy.get(FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER).should('exist');
+
+        openTimelineFieldsBrowser();
+        resetFields();
+
+        cy.get(FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER).should('not.exist');
+
+        cy.log('restores focus to the Customize Columns button when `Reset Fields` is clicked');
+
+        cy.get(TIMELINE_FIELDS_BUTTON).should('have.focus');
+
+        cy.log('restores focus to the Customize Columns button when Esc is pressed');
+
+        openTimelineFieldsBrowser();
+
+        cy.get(FIELDS_BROWSER_FILTER_INPUT).type('{esc}');
+        cy.get(TIMELINE_FIELDS_BUTTON).should('have.focus');
       });
     });
-
-    it('should create the category badge when it is selected', () => {
-      const category = 'host';
-      const categoryCheck = 'event';
-
-      cy.get(FIELDS_BROWSER_CATEGORY_BADGE(category)).should('not.exist');
-
-      toggleCategory(category);
-
-      cy.get(FIELDS_BROWSER_CATEGORY_BADGE(category)).should('exist');
-
-      toggleCategory(category);
-
-      cy.log('the category filter should contain the filtered category');
-
-      filterFieldsBrowser(category);
-      toggleCategoryFilter();
-
-      cy.get(FIELDS_BROWSER_CATEGORIES_FILTER_CONTAINER).should('contain.text', category);
-
-      cy.log('non-matching categories should not be listed in the category filter');
-
-      cy.get(FIELDS_BROWSER_CATEGORIES_FILTER_CONTAINER).should('not.contain.text', categoryCheck);
-    });
-  });
-
-  describe('Editing the timeline', () => {
-    it('should add/remove columns from the alerts table when the user checks/un-checks them', () => {
-      const filterInput = 'host.geo.c';
-
-      cy.log('removing the message column');
-
-      cy.get(FIELDS_BROWSER_MESSAGE_HEADER).should('exist');
-
-      removesMessageField();
-      closeFieldsBrowser();
-
-      cy.get(FIELDS_BROWSER_MESSAGE_HEADER).should('not.exist');
-
-      cy.log('add host.geo.city_name column');
-
-      cy.get(FIELDS_BROWSER_HOST_GEO_CITY_NAME_HEADER).should('not.exist');
-
-      openTimelineFieldsBrowser();
-      filterFieldsBrowser(filterInput);
-      addsHostGeoCityNameToTimeline();
-      closeFieldsBrowser();
-
-      cy.get(FIELDS_BROWSER_HOST_GEO_CITY_NAME_HEADER).should('exist');
-    });
-
-    it('should reset all fields in the timeline when `Reset Fields` is clicked', () => {
-      const filterInput = 'host.geo.c';
-
-      filterFieldsBrowser(filterInput);
-
-      cy.get(FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER).should('not.exist');
-
-      addsHostGeoContinentNameToTimeline();
-      closeFieldsBrowser();
-
-      cy.get(FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER).should('exist');
-
-      openTimelineFieldsBrowser();
-      resetFields();
-
-      cy.get(FIELDS_BROWSER_HEADER_HOST_GEO_CONTINENT_NAME_HEADER).should('not.exist');
-
-      cy.log('restores focus to the Customize Columns button when `Reset Fields` is clicked');
-
-      cy.get(TIMELINE_FIELDS_BUTTON).should('have.focus');
-
-      cy.log('restores focus to the Customize Columns button when Esc is pressed');
-
-      openTimelineFieldsBrowser();
-
-      cy.get(FIELDS_BROWSER_FILTER_INPUT).type('{esc}');
-      cy.get(TIMELINE_FIELDS_BUTTON).should('have.focus');
-    });
-  });
-});
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/filters.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/filters.cy.ts
@@ -15,16 +15,15 @@ import {
 import { openTimelineUsingToggle } from '../../../tasks/security_main';
 import { ALERTS_URL } from '../../../urls/navigation';
 import { getTimeline } from '../../../objects/timeline';
+import { TIMELINE_EVENT, TIMELINE_FILTER_BADGE_ENABLED } from '../../../screens/timeline';
 import {
-  GET_TIMELINE_GRID_CELL,
-  TIMELINE_EVENT,
-  TIMELINE_FILTER_BADGE_ENABLED,
-  HOVER_ACTIONS,
-} from '../../../screens/timeline';
+  GET_UNIFIED_DATA_GRID_CELL,
+  UNIFIED_TABLE_HOVER_ACTIONS,
+} from '../../../screens/unified_timeline';
 
 const mockTimeline = getTimeline();
 describe(
-  `timleine cell actions`,
+  `timeline cell actions`,
   {
     tags: ['@ess'],
   },
@@ -38,14 +37,14 @@ describe(
       populateTimeline();
     });
     it('filter in', () => {
-      cy.get(GET_TIMELINE_GRID_CELL('event.category')).trigger('mouseover');
-      cy.get(HOVER_ACTIONS.FILTER_FOR).should('be.visible').click();
+      cy.get(GET_UNIFIED_DATA_GRID_CELL('event.category', 0)).realHover();
+      cy.get(UNIFIED_TABLE_HOVER_ACTIONS.FILTER_FOR).should('be.visible').click();
       cy.get(TIMELINE_FILTER_BADGE_ENABLED).should('be.visible');
     });
 
     it('filter out', () => {
-      cy.get(GET_TIMELINE_GRID_CELL('event.category')).trigger('mouseover');
-      cy.get(HOVER_ACTIONS.FILTER_OUT).should('be.visible').click();
+      cy.get(GET_UNIFIED_DATA_GRID_CELL('event.category', 0)).realHover();
+      cy.get(UNIFIED_TABLE_HOVER_ACTIONS.FILTER_OUT).should('be.visible').click();
       cy.get(TIMELINE_EVENT).should('not.exist');
     });
   }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/full_screen.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/full_screen.cy.ts
@@ -9,11 +9,8 @@ import { TIMELINE_HEADER, TIMELINE_TABS } from '../../../screens/timeline';
 
 import { login } from '../../../tasks/login';
 import { visitWithTimeRange } from '../../../tasks/navigation';
-import {
-  openTimelineUsingToggle,
-  enterFullScreenMode,
-  exitFullScreenMode,
-} from '../../../tasks/security_main';
+import { openTimelineUsingToggle } from '../../../tasks/security_main';
+import { executeTimelineSearch, toggleFullScreen } from '../../../tasks/timeline';
 
 import { hostsUrl } from '../../../urls/navigation';
 
@@ -22,18 +19,19 @@ describe('Toggle full screen', { tags: ['@ess', '@serverless'] }, () => {
     login();
     visitWithTimeRange(hostsUrl('allHosts'));
     openTimelineUsingToggle();
+    executeTimelineSearch('*');
   });
 
   it('Should hide timeline header and tab list area', () => {
-    enterFullScreenMode();
+    toggleFullScreen();
 
     cy.get(TIMELINE_TABS).should('not.exist');
     cy.get(TIMELINE_HEADER).should('not.be.visible');
   });
 
   it('Should show timeline header and tab list area', () => {
-    enterFullScreenMode();
-    exitFullScreenMode();
+    toggleFullScreen();
+    toggleFullScreen();
     cy.get(TIMELINE_TABS).should('exist');
     cy.get(TIMELINE_HEADER).should('be.visible');
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy.ts
@@ -25,39 +25,54 @@ import { hostsUrl } from '../../../urls/navigation';
 // Flaky on serverless
 const defaultPageSize = 25;
 
-describe('Timeline Pagination', { tags: ['@ess', '@serverless'] }, () => {
-  beforeEach(() => {
-    cy.task('esArchiverLoad', { archiveName: 'timeline' });
-    login();
-    visitWithTimeRange(hostsUrl('allHosts'));
-    openTimelineUsingToggle();
-    populateTimeline();
-  });
+describe(
+  'Timeline Pagination',
+  {
+    tags: ['@ess', '@serverless'],
+    env: {
+      ftrConfig: {
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'unifiedComponentsInTimelineDisabled',
+          ])}`,
+        ],
+      },
+    },
+  },
+  () => {
+    beforeEach(() => {
+      cy.task('esArchiverLoad', { archiveName: 'timeline' });
+      login();
+      visitWithTimeRange(hostsUrl('allHosts'));
+      openTimelineUsingToggle();
+      populateTimeline();
+    });
 
-  afterEach(() => {
-    cy.task('esArchiverUnload', { archiveName: 'timeline' });
-  });
+    afterEach(() => {
+      cy.task('esArchiverUnload', { archiveName: 'timeline' });
+    });
 
-  it(`should paginate records correctly`, () => {
-    // should have ${defaultPageSize} events in the page by default
-    cy.get(TIMELINE_EVENT).should('have.length', defaultPageSize);
+    it(`should paginate records correctly`, () => {
+      // should have ${defaultPageSize} events in the page by default
+      cy.get(TIMELINE_EVENT).should('have.length', defaultPageSize);
 
-    // should be able to go to next / previous page
-    cy.get(`${TIMELINE_FLYOUT} ${TIMELINE_EVENTS_COUNT_NEXT_PAGE}`).first().click();
-    cy.get(`${TIMELINE_FLYOUT} ${TIMELINE_EVENTS_COUNT_PREV_PAGE}`).first().click();
+      // should be able to go to next / previous page
+      cy.get(`${TIMELINE_FLYOUT} ${TIMELINE_EVENTS_COUNT_NEXT_PAGE}`).first().click();
+      cy.get(`${TIMELINE_FLYOUT} ${TIMELINE_EVENTS_COUNT_PREV_PAGE}`).first().click();
 
-    // should select ${defaultPageSize} items per page by default
-    cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE).should('contain.text', defaultPageSize);
+      // should select ${defaultPageSize} items per page by default
+      cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE).should('contain.text', defaultPageSize);
 
-    // should be able to change items count per page with the dropdown
-    const itemsPerPage = 100;
-    cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE_BTN).first().click();
-    cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE_OPTION(itemsPerPage)).click();
-    cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE).should('not.have.text', '0');
-    cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE)
-      .invoke('text')
-      .then((events) => {
-        cy.wrap(parseInt(events, 10)).should('be.gt', defaultPageSize);
-      });
-  });
-});
+      // should be able to change items count per page with the dropdown
+      const itemsPerPage = 100;
+      cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE_BTN).first().click();
+      cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE_OPTION(itemsPerPage)).click();
+      cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE).should('not.have.text', '0');
+      cy.get(TIMELINE_EVENTS_COUNT_PER_PAGE)
+        .invoke('text')
+        .then((events) => {
+          cy.wrap(parseInt(events, 10)).should('be.gt', defaultPageSize);
+        });
+    });
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/query_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/query_tab.cy.ts
@@ -31,40 +31,55 @@ import { TIMELINES_URL } from '../../../urls/navigation';
 
 const mockTimeline = getTimeline();
 
-describe('Timeline query tab', { tags: ['@ess', '@serverless'] }, () => {
-  beforeEach(() => {
-    login();
-    visit(TIMELINES_URL);
-    deleteTimelines();
-    createTimeline(mockTimeline)
-      .then((response) => response.body.data.persistTimeline.timeline.savedObjectId)
-      .then((timelineId: string) => {
-        cy.wrap(timelineId).as('timelineId');
-        addNoteToTimeline(mockTimeline.notes, timelineId);
-        openTimelineById(timelineId);
-        pinFirstEvent();
-        addFilter(mockTimeline.filter);
-      });
-  });
+describe(
+  'Timeline query tab',
+  {
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
+    env: {
+      ftrConfig: {
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'unifiedComponentsInTimelineDisabled',
+          ])}`,
+        ],
+      },
+    },
+  },
+  () => {
+    beforeEach(() => {
+      login();
+      visit(TIMELINES_URL);
+      deleteTimelines();
+      createTimeline(mockTimeline)
+        .then((response) => response.body.data.persistTimeline.timeline.savedObjectId)
+        .then((timelineId: string) => {
+          cy.wrap(timelineId).as('timelineId');
+          addNoteToTimeline(mockTimeline.notes, timelineId);
+          openTimelineById(timelineId);
+          pinFirstEvent();
+          addFilter(mockTimeline.filter);
+        });
+    });
 
-  it('should display the right query and filters', () => {
-    cy.get(TIMELINE_QUERY).should('have.text', `${mockTimeline.query}`);
-    cy.get(TIMELINE_FILTER(mockTimeline.filter)).should('exist');
-  });
+    it('should display the right query and filters', () => {
+      cy.get(TIMELINE_QUERY).should('have.text', `${mockTimeline.query}`);
+      cy.get(TIMELINE_FILTER(mockTimeline.filter)).should('exist');
+    });
 
-  it('should be able to add event note', () => {
-    const note = 'event note';
-    addNoteToFirstRowEvent(note);
-    cy.get(NOTE_CARD_CONTENT).should('contain', 'event note');
-  });
+    it('should be able to add event note', () => {
+      const note = 'event note';
+      addNoteToFirstRowEvent(note);
+      cy.get(NOTE_CARD_CONTENT).should('contain', 'event note');
+    });
 
-  it('should display pinned events', () => {
-    cy.get(PIN_EVENT)
-      .should('have.attr', 'aria-label')
-      .and('match', /Unpin the event in row 2/);
-  });
+    it('should display pinned events', () => {
+      cy.get(PIN_EVENT)
+        .should('have.attr', 'aria-label')
+        .and('match', /Unpin the event in row 2/);
+    });
 
-  it('should have an unlock icon', { tags: '@skipInServerless' }, () => {
-    cy.get(UNLOCKED_ICON).should('be.visible');
-  });
-});
+    it('should have an unlock icon', { tags: '@skipInServerless' }, () => {
+      cy.get(UNLOCKED_ICON).should('be.visible');
+    });
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/search_or_filter.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/search_or_filter.cy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ADD_FILTER, SERVER_SIDE_EVENT_COUNT } from '../../../screens/timeline';
+import { ADD_FILTER, QUERY_EVENT_COUNT } from '../../../screens/timeline';
 import { LOADING_INDICATOR } from '../../../screens/security_header';
 
 import { login } from '../../../tasks/login';
@@ -37,7 +37,7 @@ describe('Timeline search and filters', { tags: ['@ess', '@serverless'] }, () =>
       openTimelineUsingToggle();
       executeTimelineKQL(hostExistsQuery);
 
-      cy.get(SERVER_SIDE_EVENT_COUNT).should(($count) => expect(+$count.text()).to.be.gt(0));
+      cy.get(QUERY_EVENT_COUNT).should(($count) => expect(+$count.text()).to.be.gt(0));
     });
 
     it('should execute a Lucene query', () => {
@@ -46,7 +46,7 @@ describe('Timeline search and filters', { tags: ['@ess', '@serverless'] }, () =>
       changeTimelineQueryLanguage('lucene');
       executeTimelineSearch(messageProcessQuery);
 
-      cy.get(SERVER_SIDE_EVENT_COUNT).should(($count) => expect(+$count.text()).to.be.gt(0));
+      cy.get(QUERY_EVENT_COUNT).should(($count) => expect(+$count.text()).to.be.gt(0));
     });
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/table_row_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/table_row_actions.cy.ts
@@ -25,6 +25,15 @@ describe(
   'Timeline table Row Actions',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
+    env: {
+      ftrConfig: {
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'unifiedComponentsInTimelineDisabled',
+          ])}`,
+        ],
+      },
+    },
   },
   () => {
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/unified_components/query_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/unified_components/query_tab.cy.ts
@@ -40,15 +40,6 @@ describe(
   'Unsaved Timeline query tab',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'unifiedComponentsInTimelineEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/unified_components/table_row_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/unified_components/table_row_actions.cy.ts
@@ -25,15 +25,6 @@ describe(
   'Unified Timeline table Row Actions',
   {
     tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'unifiedComponentsInTimelineEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/screens/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/timeline.ts
@@ -110,6 +110,10 @@ export const ANALYZER_GRAPH_TAB_BUTTON = getDataTestSubjectSelector('timelineTab
 
 export const SERVER_SIDE_EVENT_COUNT = '[data-test-subj="server-side-event-count"]';
 
+export const EQL_EVENT_COUNT = '[data-test-subj="eql-events-count"]';
+
+export const QUERY_EVENT_COUNT = '[data-test-subj="query-events-count"]';
+
 export const ALERTS_TABLE_COUNT = `[data-test-subj="toolbar-alerts-count"]`;
 
 export const STAR_ICON = '[data-test-subj="timeline-favorite-empty-star"]';

--- a/x-pack/test/security_solution_cypress/cypress/screens/unified_timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/unified_timeline.ts
@@ -9,6 +9,8 @@ import { getDataTestSubjectSelector } from '../helpers/common';
 
 export const TIMELINE_DETAILS_FLYOUT_BTN = getDataTestSubjectSelector('docTableExpandToggleColumn');
 
+export const UNIFIED_TABLE = getDataTestSubjectSelector('discoverDocTable');
+
 export const HOST_DETAILS_LINK = getDataTestSubjectSelector('host-details-button');
 
 export const USER_DETAILS_LINK = getDataTestSubjectSelector('users-link-anchor');
@@ -48,4 +50,16 @@ export const GET_UNIFIED_DATA_GRID_CELL = (columnId: string, rowIndex: number) =
   return `${TIMELINE_UNIFIED_DATA_GRID} ${getDataTestSubjectSelector(
     'dataGridRowCell'
   )}[data-gridcell-column-id="${columnId}"][data-gridcell-row-index="${rowIndex}"] .unifiedDataTable__cellValue`;
+};
+
+export const GET_UNIFIED_FIELD_LIST_FIELD = (columnId: string) =>
+  `${getDataTestSubjectSelector(`field-${columnId}`)}`;
+
+export const UNIFIED_TABLE_HOVER_ACTIONS = {
+  ADD_TO_TIMELINE:
+    '[data-test-subj="dataGridColumnCellAction-security-default-cellActions-addToTimeline"]',
+  FILTER_FOR: '[data-test-subj="dataGridColumnCellAction-security-default-cellActions-filterIn"]',
+  FILTER_OUT: '[data-test-subj="dataGridColumnCellAction-security-default-cellActions-filterOut"]',
+  COPY: '[data-test-subj="dataGridColumnCellAction-security-default-cellActions-copyToClipboard"]',
+  SHOW_TOP: '[data-test-subj="dataGridColumnCellAction-security-default-cellActions-showTopN"]',
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -36,7 +36,6 @@ import {
   SAVE_FILTER_BTN,
   SEARCH_OR_FILTER_CONTAINER,
   SELECT_CASE,
-  SERVER_SIDE_EVENT_COUNT,
   STAR_ICON,
   TIMELINE_DESCRIPTION_INPUT,
   TIMELINE_FIELDS_BUTTON,
@@ -90,6 +89,8 @@ import {
   BOTTOM_BAR_CREATE_NEW_TIMELINE,
   BOTTOM_BAR_CREATE_NEW_TIMELINE_TEMPLATE,
   TIMELINE_FLYOUT,
+  TIMELINE_FULL_SCREEN_BUTTON,
+  QUERY_EVENT_COUNT,
 } from '../screens/timeline';
 
 import { REFRESH_BUTTON, TIMELINE, TIMELINES_TAB_TEMPLATE } from '../screens/timelines';
@@ -418,7 +419,7 @@ export const pinFirstEvent = (): Cypress.Chainable<JQuery<HTMLElement>> => {
 
 export const populateTimeline = () => {
   executeTimelineKQL(hostExistsQuery);
-  cy.get(SERVER_SIDE_EVENT_COUNT).should('not.have.text', '0');
+  cy.get(QUERY_EVENT_COUNT).should('not.have.text', '0');
 };
 
 const clickTimestampHoverActionOverflowButton = () => {
@@ -526,4 +527,8 @@ export const openTimelineEventContextMenu = (rowIndex: number = 0) => {
 
     togglePopover();
   });
+};
+
+export const toggleFullScreen = () => {
+  cy.get(TIMELINE_FULL_SCREEN_BUTTON).first().click();
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Security Solution ] Unified Timeline - Enables unified components by default and inverts the feature flag.  (#187460)](https://github.com/elastic/kibana/pull/187460)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2024-07-15T12:49:06Z","message":"[Security Solution ] Unified Timeline - Enables unified components by default and inverts the feature flag.  (#187460)\n\n## Summary\r\n\r\nThis PR inverts the feature flag from\r\n`unifiedComponentsInTimelineEnabled` to\r\n`unifiedComponentsInTimelineDisabled` with a defualt value of false.\r\n\r\n- This is done so that users have the option to turn off the **unified\r\ncomponents**.\r\n- This also adapts all relevant jest and cypress tests to assume that\r\n`unified components` are enabled.","sha":"7d6c18a08e34167187d5325516e5d0ae4b89e6fe","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:prev-minor","v8.15.0","v8.16.0"],"number":187460,"url":"https://github.com/elastic/kibana/pull/187460","mergeCommit":{"message":"[Security Solution ] Unified Timeline - Enables unified components by default and inverts the feature flag.  (#187460)\n\n## Summary\r\n\r\nThis PR inverts the feature flag from\r\n`unifiedComponentsInTimelineEnabled` to\r\n`unifiedComponentsInTimelineDisabled` with a defualt value of false.\r\n\r\n- This is done so that users have the option to turn off the **unified\r\ncomponents**.\r\n- This also adapts all relevant jest and cypress tests to assume that\r\n`unified components` are enabled.","sha":"7d6c18a08e34167187d5325516e5d0ae4b89e6fe"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/187460","number":187460,"mergeCommit":{"message":"[Security Solution ] Unified Timeline - Enables unified components by default and inverts the feature flag.  (#187460)\n\n## Summary\r\n\r\nThis PR inverts the feature flag from\r\n`unifiedComponentsInTimelineEnabled` to\r\n`unifiedComponentsInTimelineDisabled` with a defualt value of false.\r\n\r\n- This is done so that users have the option to turn off the **unified\r\ncomponents**.\r\n- This also adapts all relevant jest and cypress tests to assume that\r\n`unified components` are enabled.","sha":"7d6c18a08e34167187d5325516e5d0ae4b89e6fe"}}]}] BACKPORT-->