### PR TITLE
[8.15] [CI] Fix publish script (#188027)

### DIFF
--- a/.buildkite/scripts/steps/artifacts/publish.sh
+++ b/.buildkite/scripts/steps/artifacts/publish.sh
@@ -54,7 +54,7 @@ echo "--- Pull latest Release Manager CLI"
 docker pull docker.elastic.co/infra/release-manager:latest
 
 echo "--- Publish artifacts"
-if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]]; then
+if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]] || [[ "${DRY_RUN:-}" =~ ^(1|true)$ ]]; then
   export VAULT_ROLE_ID="$(get_vault_role_id)"
   export VAULT_SECRET_ID="$(get_vault_secret_id)"
   export VAULT_ADDR="https://secrets.elastic.co:8200"
@@ -62,29 +62,42 @@ if [[ "$BUILDKITE_BRANCH" == "$KIBANA_BASE_BRANCH" ]]; then
   download_artifact beats_manifest.json /tmp --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
   export BEATS_MANIFEST_URL=$(jq -r .manifest_url /tmp/beats_manifest.json)
 
-  PUBLISH_CMD=$(cat < EOF
-  docker run --rm \
-    --name release-manager \
-    -e VAULT_ADDR \
-    -e VAULT_ROLE_ID \
-    -e VAULT_SECRET_ID \
-    --mount type=bind,readonly=false,src="$PWD/target",target=/artifacts/target \
-    docker.elastic.co/infra/release-manager:latest \
-      cli collect \
-        --project kibana \
-        --branch "$KIBANA_BASE_BRANCH" \
-        --commit "$GIT_COMMIT" \
-        --workflow "$WORKFLOW" \
-        --version "$BASE_VERSION" \
-        --qualifier "$VERSION_QUALIFIER" \
-        --dependency "beats:$BEATS_MANIFEST_URL" \
-        --artifact-set main
-EOF)
-  if [[ "${DRY_RUN:-}" =~ ^(1|true)$ ]]; then
-    PUBLISH_CMD+=(" --dry-run")
+  if [[ "$DRY_RUN" =~ ^(1|true)$ ]]; then
+      docker run --rm \
+        --name release-manager \
+        -e VAULT_ADDR \
+        -e VAULT_ROLE_ID \
+        -e VAULT_SECRET_ID \
+        --mount type=bind,readonly=false,src="$PWD/target",target=/artifacts/target \
+        docker.elastic.co/infra/release-manager:latest \
+          cli collect \
+            --project kibana \
+            --branch "$KIBANA_BASE_BRANCH" \
+            --commit "$GIT_COMMIT" \
+            --workflow "$WORKFLOW" \
+            --version "$BASE_VERSION" \
+            --qualifier "$VERSION_QUALIFIER" \
+            --dependency "beats:$BEATS_MANIFEST_URL" \
+            --artifact-set main \
+            --dry-run
+  else
+      docker run --rm \
+        --name release-manager \
+        -e VAULT_ADDR \
+        -e VAULT_ROLE_ID \
+        -e VAULT_SECRET_ID \
+        --mount type=bind,readonly=false,src="$PWD/target",target=/artifacts/target \
+        docker.elastic.co/infra/release-manager:latest \
+          cli collect \
+            --project kibana \
+            --branch "$KIBANA_BASE_BRANCH" \
+            --commit "$GIT_COMMIT" \
+            --workflow "$WORKFLOW" \
+            --version "$BASE_VERSION" \
+            --qualifier "$VERSION_QUALIFIER" \
+            --dependency "beats:$BEATS_MANIFEST_URL" \
+            --artifact-set main
   fi
-
-  "${PUBLISH_CMD[@]}"
 
   KIBANA_SUMMARY=$(curl -s "$KIBANA_MANIFEST_LATEST" | jq -re '.summary_url')
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[CI] Fix publish script (#188027)](https://github.com/elastic/kibana/pull/188027)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2024-07-16T14:14:06Z","message":"[CI] Fix publish script (#188027)\n\n## Summary\r\nAnother attempt to fix the DRY_RUN-enhanced publish call - as it seems\r\nsimply emitting the script only works if there are no arguments.\r\n\r\nFixes:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4488#01909cf6-71a4-4608-a830-041af9d781d9\r\nTested here:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4490 (the\r\ndry-run is supposedly added? but it seems the artifacts were published\r\nnonetheless - at least there's no more syntax error)\r\n\r\nSuccesful run with the if-else:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4516","sha":"9d75f32f422c641fd6560a7e562303cb7935c98a","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","skip-ci","backport:prev-minor","v8.16.0"],"number":188027,"url":"https://github.com/elastic/kibana/pull/188027","mergeCommit":{"message":"[CI] Fix publish script (#188027)\n\n## Summary\r\nAnother attempt to fix the DRY_RUN-enhanced publish call - as it seems\r\nsimply emitting the script only works if there are no arguments.\r\n\r\nFixes:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4488#01909cf6-71a4-4608-a830-041af9d781d9\r\nTested here:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4490 (the\r\ndry-run is supposedly added? but it seems the artifacts were published\r\nnonetheless - at least there's no more syntax error)\r\n\r\nSuccesful run with the if-else:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4516","sha":"9d75f32f422c641fd6560a7e562303cb7935c98a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188027","number":188027,"mergeCommit":{"message":"[CI] Fix publish script (#188027)\n\n## Summary\r\nAnother attempt to fix the DRY_RUN-enhanced publish call - as it seems\r\nsimply emitting the script only works if there are no arguments.\r\n\r\nFixes:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4488#01909cf6-71a4-4608-a830-041af9d781d9\r\nTested here:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4490 (the\r\ndry-run is supposedly added? but it seems the artifacts were published\r\nnonetheless - at least there's no more syntax error)\r\n\r\nSuccesful run with the if-else:\r\nhttps://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4516","sha":"9d75f32f422c641fd6560a7e562303cb7935c98a"}}]}] BACKPORT-->