### PR TITLE
test: remove waitFor in slow toolbar tests

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/metric/toolbar/titles_and_text_popover.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/metric/toolbar/titles_and_text_popover.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { CustomPaletteParams, PaletteOutput } from '@kbn/coloring';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MetricVisualizationState } from '../types';
 import { TitlesAndTextPopover } from './titles_and_text_popover';
 import { EuiButtonGroupTestHarness } from '@kbn/test-eui-helpers';
@@ -57,7 +57,17 @@ describe('TitlesAndTextPopover', () => {
     };
   };
 
-  afterEach(() => mockSetState.mockClear());
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    mockSetState.mockClear();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('should set a subtitle', async () => {
     renderToolbarOptions({
@@ -71,11 +81,14 @@ describe('TitlesAndTextPopover', () => {
     const subtitleField = screen.getByDisplayValue('subtitle');
     // cannot use userEvent because the element cannot be clicked on
     fireEvent.change(subtitleField, { target: { value: newSubtitle + ' 1' } });
-    await waitFor(() => expect(mockSetState).toHaveBeenCalled());
+    jest.advanceTimersByTime(256);
+    expect(mockSetState).toHaveBeenCalled();
     fireEvent.change(subtitleField, { target: { value: newSubtitle + ' 2' } });
-    await waitFor(() => expect(mockSetState).toHaveBeenCalledTimes(2));
+    jest.advanceTimersByTime(256);
+    expect(mockSetState).toHaveBeenCalledTimes(2);
     fireEvent.change(subtitleField, { target: { value: newSubtitle + ' 3' } });
-    await waitFor(() => expect(mockSetState).toHaveBeenCalledTimes(3));
+    jest.advanceTimersByTime(256);
+    expect(mockSetState).toHaveBeenCalledTimes(3);
     expect(mockSetState.mock.calls.map(([state]) => state.subtitle)).toMatchInlineSnapshot(`
       Array [
         "new subtitle hey 1",


### PR DESCRIPTION
## Summary

Removes `waitFor` in favor of `useFakeTimers` and `advanceTimersByTime`. Per missed comment https://github.com/elastic/kibana/pull/187903#discussion_r1679166709