### PR TITLE
[Lens] [Inline editing] Flyout gets too big fix

### DIFF
--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/helpers.scss
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/helpers.scss
@@ -14,3 +14,9 @@
     }
   }
 }
+
+.lnsEditFlyoutBody {
+  .euiFlyoutBody__overflow {
+    transform: initial;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/188330 

Caused by eui upgrade: https://github.com/elastic/eui/commit/b1370afea85a7c5a7a4374132b64f8da757d2135

It's an ugly solution, but I couldn't find any other :( 

After the fix:

<img width="1258" alt="Screenshot 2024-07-16 at 17 09 44" src="https://github.com/user-attachments/assets/d0678e23-d7bd-4e18-b906-a0202c4aaadc">

