### PR TITLE
fix gemini connector card in icon style

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/gemini/logo.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/gemini/logo.tsx
@@ -9,7 +9,14 @@ import React from 'react';
 import { LogoProps } from '../types';
 
 const Logo = (props: LogoProps) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 16 16">
+  <svg
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    fill="none"
+    viewBox="0 0 16 16"
+  >
     <path
       d="M16 8.016A8.522 8.522 0 008.016 16h-.032A8.521 8.521 0 000 8.016v-.032A8.521 8.521 0 007.984 0h.032A8.522 8.522 0 0016 7.984v.032z"
       fill="#000000"


### PR DESCRIPTION
Gemini connector logo is missing some classes to give it the necessary styles and so it is misaligned:

(notice text is too high due to missing top margin in the icon)
<img width="1271" alt="Screenshot 2024-07-16 at 1 41 02 PM" src="https://github.com/user-attachments/assets/c1516b49-c491-49fc-ae30-120029277b17">

This PR will give the logo the top margin:
<img width="1251" alt="Screenshot 2024-07-16 at 1 40 34 PM" src="https://github.com/user-attachments/assets/ce385133-12a5-4168-9cb4-b1b9c49f789f">



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->