### PR TITLE
[Fleet] Fix image in readme for installed integration

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_links.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_links.tsx
@@ -43,7 +43,8 @@ export function useLinks() {
       version: string;
     }) => {
       const imagePath = removeRelativePath(path);
-      const filePath = `${epmRouteService.getInfoPath(packageName, version)}/${imagePath}`;
+
+      const filePath = `${epmRouteService.getInfoPath(packageName, version)}${imagePath}`;
       return http.basePath.prepend(filePath);
     },
   };

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.test.tsx
@@ -35,6 +35,6 @@ describe('Readme', () => {
     const img = result.getByAltText('Image');
 
     expect(img).toHaveStyle('max-width: 100%');
-    expect(img).toHaveAttribute('src', '/mock/api/fleet/epm/packages/test/1.0.0//img/image.png');
+    expect(img).toHaveAttribute('src', '/mock/api/fleet/epm/packages/test/1.0.0/img/image.png');
   });
 });

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.tsx
@@ -31,6 +31,7 @@ export function Readme({
     (uri: string) => {
       const isRelative =
         uri.indexOf('http://') === 0 || uri.indexOf('https://') === 0 ? false : true;
+
       const fullUri = isRelative ? toRelativeImage({ packageName, version, path: uri }) : uri;
       return fullUri;
     },


### PR DESCRIPTION
## Summary

Fix image in readme for installed integration

## Tests

Fixed the unit tests note the `//` in the test that was an error.

You can tests this by installing the aws package and check the image inside the readme is correclty rendered 

##### Before

<img width="600" alt="Screenshot 2024-07-16 at 2 05 48 PM" src="https://github.com/user-attachments/assets/40b1dd16-e4be-4e9b-a41c-cda253901608">

##### After

<img width="1265" alt="Screenshot 2024-07-16 at 2 25 05 PM" src="https://github.com/user-attachments/assets/d516f5af-3daa-4ea1-b54a-31c0beaa3423">

### Questions

Should we backport that? it seems safe to me but curious to have a second thought on that




<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->