### PR TITLE
[OAS] Test beta overlay

### DIFF
--- a/oas_docs/kibana.serverless.overlays.yaml
+++ b/oas_docs/kibana.serverless.overlays.yaml
@@ -1,0 +1,10 @@
+# overlays.yaml
+overlay: 1.0.0
+info:
+  title: Add x-beta to all operations
+  version: 0.0.1
+actions:
+  - target: '$.paths[*][*]'
+    description: Add x-beta
+    update:
+      x-beta: true

--- a/oas_docs/makefile
+++ b/oas_docs/makefile
@@ -17,6 +17,10 @@
 api-docs: ## Generate kibana.serverless.yaml
 	@npx @redocly/cli join "kibana.info.serverless.yaml" "../x-pack/plugins/observability_solution/apm/docs/openapi/apm.yaml" "../x-pack/plugins/actions/docs/openapi/bundled_serverless.yaml" "../src/plugins/data_views/docs/openapi/bundled.yaml" "../x-pack/plugins/ml/common/openapi/ml_apis_serverless.yaml" "../packages/core/saved-objects/docs/openapi/bundled_serverless.yaml" "../x-pack/plugins/observability_solution/slo/docs/openapi/slo/bundled.yaml" -o "kibana.serverless.yaml" --prefix-components-with-info-prop title
 
+.PHONY: api-docs-overlay
+api-docs: ## Generate kibana.serverless.new.yaml by applying overlay
+	@npx bump overlay "kibana.serverless.yaml" "kibana.serverless.overlays.yaml" > "kibana.serverless.new.yaml"
+
 .PHONY: api-docs-lint
 api-docs-lint: ## Run spectral API docs linter
 	@npx @stoplight/spectral-cli lint "kibana.serverless.yaml" --ruleset ".spectral.yaml"


### PR DESCRIPTION
## Summary

This PR adds an overlay that applies the [`x-beta`](https://docs.bump.sh/help/specification-support/doc-beta/) property to our Kibana OpenAPI doc, since we don't yet have an `x-technical-preview` custom extension.

Per https://docs.bump.sh/guides/openapi/augmenting-generated-openapi/#deploy-overlay-changes-to-bumpsh this could ultimately be applied during a GitHub action so we don't need to store the modified version of the file.