### PR TITLE
[Security Solution][DO NOT MERGE] A PR to deploy the fix for non-responsive rule details page for 8.15

### DIFF
--- a/x-pack/plugins/security_solution/README.md
+++ b/x-pack/plugins/security_solution/README.md
@@ -13,6 +13,7 @@ the tests given the constraint on an available package registry.
 
 1. Using Docker
 2. Running your own local package registry
+
 3. Using the default external package registry
 
 These scenarios will be outlined the sections below.


### PR DESCRIPTION
## Summary

This is a dumb PR to deploy Kibana 8.15 with a [backport](https://github.com/elastic/kibana/pull/188305#event-13505472958) fixing non-responsive rule details page.
