### PR TITLE
[Integration AutoImport] Small fixes

### DIFF
--- a/x-pack/plugins/integration_assistant/public/common/components/section_wrapper.tsx
+++ b/x-pack/plugins/integration_assistant/public/common/components/section_wrapper.tsx
@@ -26,7 +26,7 @@ export const SectionWrapper = React.memo<SectionWrapperProps>(({ children, title
     <EuiSpacer size="xxl" />
     <EuiFlexGroup direction="column" alignItems="center" justifyContent="center">
       <EuiFlexItem css={contentCss}>
-        <EuiFlexGroup direction="column" alignItems="center" justifyContent="center" gutterSize="m">
+        <EuiFlexGroup direction="column" alignItems="center" justifyContent="center" gutterSize="s">
           <EuiFlexItem>
             <EuiTitle size="l">
               <h1 css={titleCss}>{title}</h1>

--- a/x-pack/plugins/integration_assistant/public/common/lib/api.ts
+++ b/x-pack/plugins/integration_assistant/public/common/lib/api.ts
@@ -110,7 +110,8 @@ export const getInstalledPackages = async ({
   http,
   abortSignal,
 }: RequestDeps): Promise<EpmPackageResponse> =>
-  http.get<EpmPackageResponse>(`${FLEET_PACKAGES_PATH}?prerelease=true`, {
+  http.get<EpmPackageResponse>(FLEET_PACKAGES_PATH, {
     headers: fleetDefaultHeaders,
+    query: { prerelease: true },
     signal: abortSignal,
   });

--- a/x-pack/plugins/integration_assistant/public/common/lib/api.ts
+++ b/x-pack/plugins/integration_assistant/public/common/lib/api.ts
@@ -110,7 +110,7 @@ export const getInstalledPackages = async ({
   http,
   abortSignal,
 }: RequestDeps): Promise<EpmPackageResponse> =>
-  http.get<EpmPackageResponse>(FLEET_PACKAGES_PATH, {
+  http.get<EpmPackageResponse>(`${FLEET_PACKAGES_PATH}?prerelease=true`, {
     headers: fleetDefaultHeaders,
     signal: abortSignal,
   });

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/header/steps.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/header/steps.tsx
@@ -6,8 +6,15 @@
  */
 
 import { EuiStepsHorizontal, type EuiStepStatus, type EuiStepsHorizontalProps } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
+
+// Custom styles for the EuiStepsHorizontal component suggested by design team
+const stepsCss = css`
+  margin-left: -66px;
+  margin-right: -59px;
+`;
 
 interface StepsProps {
   currentStep: number;
@@ -74,6 +81,6 @@ export const Steps = React.memo<StepsProps>(({ currentStep, setStep, isGeneratin
     ];
   }, [currentStep, setStep, isGenerating]);
 
-  return <EuiStepsHorizontal steps={steps} size="s" />;
+  return <EuiStepsHorizontal steps={steps} size="s" css={stepsCss} />;
 });
 Steps.displayName = 'Steps';

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
@@ -134,24 +134,22 @@ const CreateConnectorPopover = React.memo<CreateConnectorPopoverProps>(({ onConn
   return (
     <EuiPopover
       button={
-        <EuiLink data-test-subj="createConnectorPopoverButton" onClick={openPopover}>
-          {i18n.CREATE_CONNECTOR}
-        </EuiLink>
+        <EuiText size="s">
+          <EuiLink data-test-subj="createConnectorPopoverButton" onClick={openPopover}>
+            {i18n.CREATE_CONNECTOR}
+          </EuiLink>
+        </EuiText>
       }
       isOpen={isOpen}
       closePopover={closePopover}
       data-test-subj="createConnectorPopover"
     >
-      <EuiFlexGroup alignItems="flexStart">
-        <EuiFlexItem grow={false}>
-          <ConnectorSetup
-            actionTypeIds={AllowedActionTypeIds}
-            onConnectorSaved={onConnectorSavedAndClose}
-            onClose={closePopover}
-            compressed
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <ConnectorSetup
+        actionTypeIds={AllowedActionTypeIds}
+        onConnectorSaved={onConnectorSavedAndClose}
+        onClose={closePopover}
+        compressed
+      />
     </EuiPopover>
   );
 });

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
@@ -7,7 +7,17 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLoadConnectors } from '@kbn/elastic-assistant';
-import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiPopover, EuiLink } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPopover,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+  EuiIcon,
+  useEuiTheme,
+} from '@elastic/eui';
 import {
   AuthorizationWrapper,
   MissingPrivilegesTooltip,
@@ -30,6 +40,7 @@ interface ConnectorStepProps {
   connector: AIConnector | undefined;
 }
 export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
+  const { euiTheme } = useEuiTheme();
   const { http, notifications } = useKibana().services;
   const { setConnector } = useActions();
   const [connectors, setConnectors] = useState<AIConnector[]>();
@@ -83,6 +94,15 @@ export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
           )}
         </EuiFlexItem>
       </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiText size="s" color="subdued">
+        <EuiFlexGroup direction="row" gutterSize="xs" alignItems="flexStart">
+          <EuiFlexItem grow={false} css={{ margin: euiTheme.size.xxs }}>
+            <EuiIcon type="iInCircle" />
+          </EuiFlexItem>
+          <EuiFlexItem>{i18n.SUPPORTED_MODELS_INFO}</EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiText>
     </StepContentWrapper>
   );
 });

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/translations.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/translations.ts
@@ -24,3 +24,11 @@ export const CREATE_CONNECTOR = i18n.translate(
     defaultMessage: 'Create new connector',
   }
 );
+
+export const SUPPORTED_MODELS_INFO = i18n.translate(
+  'xpack.integrationAssistant.steps.connector.supportedModelsInfo',
+  {
+    defaultMessage:
+      "Automatic Import currently supports Anthropic models via Elastic's connector for Amazon Bedrock. Support for additional LLMs will be introduced soon",
+  }
+);

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
@@ -58,7 +58,7 @@ export const IntegrationAssistantCard = React.memo(() => {
         <EuiFlexItem>
           <EuiFlexGroup
             direction="column"
-            gutterSize="s"
+            gutterSize="xs"
             alignItems="flexStart"
             justifyContent="flexStart"
           >

--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
@@ -26,7 +26,7 @@ export async function buildPackage(integration: Integration): Promise<Buffer> {
   });
 
   const tmpDir = joinPath(tmpdir(), `integration-assistant-${generateUniqueId()}`);
-  const packageDirectoryName = `${integration.name}-0.1.0`;
+  const packageDirectoryName = `${integration.name}-1.0.0`;
   const packageDir = createDirectories(tmpDir, integration, packageDirectoryName);
   const dataStreamsDir = joinPath(packageDir, 'data_stream');
 
@@ -86,7 +86,7 @@ function createBuildFile(packageDir: string): void {
 
 function createChangelog(packageDir: string): void {
   const changelogTemplate = nunjucks.render('changelog.yml.njk', {
-    initial_version: '0.1.0',
+    initial_version: '1.0.0',
   });
 
   createSync(joinPath(packageDir, 'changelog.yml'), changelogTemplate);
@@ -132,7 +132,7 @@ function createPackageManifest(packageDir: string, integration: Integration): vo
     format_version: '3.1.4',
     package_title: integration.title,
     package_name: integration.name,
-    package_version: '0.1.0',
+    package_version: '1.0.0',
     package_description: integration.description,
     package_logo: integration.logo,
     package_owner: '@elastic/custom-integrations',

--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
@@ -16,6 +16,8 @@ import { createDataStream } from './data_stream';
 import { createFieldMapping } from './fields';
 import { createPipeline } from './pipeline';
 
+const initialVersion = '1.0.0';
+
 export async function buildPackage(integration: Integration): Promise<Buffer> {
   const templateDir = joinPath(__dirname, '../templates');
   const agentTemplates = joinPath(templateDir, 'agent');
@@ -26,7 +28,7 @@ export async function buildPackage(integration: Integration): Promise<Buffer> {
   });
 
   const tmpDir = joinPath(tmpdir(), `integration-assistant-${generateUniqueId()}`);
-  const packageDirectoryName = `${integration.name}-1.0.0`;
+  const packageDirectoryName = `${integration.name}-${initialVersion}`;
   const packageDir = createDirectories(tmpDir, integration, packageDirectoryName);
   const dataStreamsDir = joinPath(packageDir, 'data_stream');
 
@@ -86,7 +88,7 @@ function createBuildFile(packageDir: string): void {
 
 function createChangelog(packageDir: string): void {
   const changelogTemplate = nunjucks.render('changelog.yml.njk', {
-    initial_version: '1.0.0',
+    initial_version: initialVersion,
   });
 
   createSync(joinPath(packageDir, 'changelog.yml'), changelogTemplate);
@@ -132,7 +134,7 @@ function createPackageManifest(packageDir: string, integration: Integration): vo
     format_version: '3.1.4',
     package_title: integration.title,
     package_name: integration.name,
-    package_version: '1.0.0',
+    package_version: initialVersion,
     package_description: integration.description,
     package_logo: integration.logo,
     package_owner: '@elastic/custom-integrations',


### PR DESCRIPTION
## Summary

- Some margin/padding changes in the design as suggested by @r4zr32d3k1l
- Adding `?prerelease=true` parameter to the package names retrieval as suggested by @kgeller 
- Change the version of generated packages to `1.0.0`.
- Add the informative message about AI connector support as suggested by @jamiehynds :

<img width="1129" alt="connectors_info_message" src="https://github.com/user-attachments/assets/cddc5077-d0d6-4c86-a1be-b13c0cbe2276">



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->