### PR TITLE
Kubernetes onboarding flow: Add tech preview badge

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.ts
@@ -117,6 +117,7 @@ export function useCustomCardsForCategory(
           id: 'kubernetes-quick-start',
           type: 'virtual',
           title: 'Kubernetes',
+          release: 'preview',
           description: 'Collect logs and metrics from Kubernetes using minimal configuration',
           name: 'kubernetes-quick-start',
           categories: ['observability'],


### PR DESCRIPTION
To highlight that the feature is new and not very mature, a tech preview label is added to the kubernetes flow tile:
<img width="388" alt="Screenshot 2024-07-17 at 12 42 14" src="https://github.com/user-attachments/assets/a06c1a3e-1675-4d87-a77a-d90877b98517">
