### PR TITLE
[OSQuery] - add disable tours in some cy.visit

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/roles/alert_test.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/roles/alert_test.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { disableNewFeaturesTours } from '../../tasks/navigation';
 import { initializeDataViews } from '../../tasks/login';
 import { checkResults, clickRuleName, submitQuery } from '../../tasks/live_query';
 import { loadRule, cleanupRule } from '../../tasks/api_fixtures';
@@ -26,7 +27,9 @@ describe('Alert Test', { tags: ['@ess'] }, () => {
     beforeEach(() => {
       cy.login(ServerlessRoleName.T1_ANALYST);
 
-      cy.visit('/app/security/rules');
+      cy.visit('/app/security/rules', {
+        onBeforeLoad: (win) => disableNewFeaturesTours(win),
+      });
       clickRuleName(ruleName);
       cy.getBySel('expand-event').first().click({ force: true });
 

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_complete.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_complete.cy.ts
@@ -6,7 +6,6 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
-import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Enpoint Complete PLI',
@@ -21,8 +20,5 @@ describe(
       },
     },
   },
-  () => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
-    checkOsqueryResponseActionsPermissions(true);
-  }
+  () => checkOsqueryResponseActionsPermissions(true)
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_complete.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_complete.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
+import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Enpoint Complete PLI',
@@ -20,5 +21,8 @@ describe(
       },
     },
   },
-  () => checkOsqueryResponseActionsPermissions(true)
+  () => {
+    cy.login(ServerlessRoleName.SOC_MANAGER);
+    checkOsqueryResponseActionsPermissions(true);
+  }
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_essentials.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_essentials.cy.ts
@@ -6,7 +6,6 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
-import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Endpoint Essentials PLI',
@@ -21,8 +20,5 @@ describe(
       },
     },
   },
-  () => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
-    checkOsqueryResponseActionsPermissions(false);
-  }
+  () => checkOsqueryResponseActionsPermissions(false)
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_essentials.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/endpoint_essentials.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
+import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Endpoint Essentials PLI',
@@ -20,5 +21,8 @@ describe(
       },
     },
   },
-  () => checkOsqueryResponseActionsPermissions(false)
+  () => {
+    cy.login(ServerlessRoleName.SOC_MANAGER);
+    checkOsqueryResponseActionsPermissions(false);
+  }
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/security_complete.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/security_complete.cy.ts
@@ -6,7 +6,6 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
-import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Security Complete PLI',
@@ -18,8 +17,5 @@ describe(
       },
     },
   },
-  () => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
-    checkOsqueryResponseActionsPermissions(false);
-  }
+  () => checkOsqueryResponseActionsPermissions(false)
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/security_complete.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/security_complete.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
+import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Security Complete PLI',
@@ -17,5 +18,8 @@ describe(
       },
     },
   },
-  () => checkOsqueryResponseActionsPermissions(false)
+  () => {
+    cy.login(ServerlessRoleName.SOC_MANAGER);
+    checkOsqueryResponseActionsPermissions(false);
+  }
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/security_essentials.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/security_essentials.cy.ts
@@ -6,7 +6,6 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
-import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Security Essentials PLI',
@@ -16,8 +15,5 @@ describe(
       ftrConfig: { productTypes: [{ product_line: 'security', product_tier: 'essentials' }] },
     },
   },
-  () => {
-    cy.login(ServerlessRoleName.SOC_MANAGER);
-    checkOsqueryResponseActionsPermissions(false);
-  }
+  () => checkOsqueryResponseActionsPermissions(false)
 );

--- a/x-pack/plugins/osquery/cypress/e2e/tiers/security_essentials.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/tiers/security_essentials.cy.ts
@@ -6,6 +6,7 @@
  */
 
 import { checkOsqueryResponseActionsPermissions } from '../../tasks/response_actions';
+import { ServerlessRoleName } from '../../../../../test_serverless/shared/lib';
 
 describe(
   'App Features for Security Essentials PLI',
@@ -15,5 +16,8 @@ describe(
       ftrConfig: { productTypes: [{ product_line: 'security', product_tier: 'essentials' }] },
     },
   },
-  () => checkOsqueryResponseActionsPermissions(false)
+  () => {
+    cy.login(ServerlessRoleName.SOC_MANAGER);
+    checkOsqueryResponseActionsPermissions(false);
+  }
 );

--- a/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
@@ -22,7 +22,6 @@ import type { PackSavedObject, PackItem } from '../../public/packs/types';
 import type { SavedQuerySO } from '../../public/routes/saved_queries/list';
 import { generateRandomStringName } from './integrations';
 import { request } from './common';
-import { ServerlessRoleName } from '../support/roles';
 
 export const savedQueryFixture = {
   id: generateRandomStringName(1)[0],
@@ -174,10 +173,8 @@ export const loadLiveQuery = (
     },
   }).then((response) => response.body.data);
 
-export const loadRule = (includeResponseActions = false) => {
-  cy.login(ServerlessRoleName.SOC_MANAGER);
-
-  return request<RuleResponse>({
+export const loadRule = (includeResponseActions = false) =>
+  request<RuleResponse>({
     method: 'POST',
     body: {
       type: 'query',
@@ -267,7 +264,6 @@ export const loadRule = (includeResponseActions = false) => {
       'Elastic-Api-Version': API_VERSIONS.public.v1,
     },
   }).then((response) => response.body);
-};
 
 export const cleanupRule = (id: string) => {
   request({

--- a/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
@@ -22,6 +22,7 @@ import type { PackSavedObject, PackItem } from '../../public/packs/types';
 import type { SavedQuerySO } from '../../public/routes/saved_queries/list';
 import { generateRandomStringName } from './integrations';
 import { request } from './common';
+import { ServerlessRoleName } from '../support/roles';
 
 export const savedQueryFixture = {
   id: generateRandomStringName(1)[0],
@@ -173,8 +174,10 @@ export const loadLiveQuery = (
     },
   }).then((response) => response.body.data);
 
-export const loadRule = (includeResponseActions = false) =>
-  request<RuleResponse>({
+export const loadRule = (includeResponseActions = false) => {
+  cy.login(ServerlessRoleName.SOC_MANAGER);
+
+  return request<RuleResponse>({
     method: 'POST',
     body: {
       type: 'query',
@@ -264,6 +267,7 @@ export const loadRule = (includeResponseActions = false) =>
       'Elastic-Api-Version': API_VERSIONS.public.v1,
     },
   }).then((response) => response.body);
+};
 
 export const cleanupRule = (id: string) => {
   request({

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -7,6 +7,7 @@
 
 import { disableNewFeaturesTours } from './navigation';
 import { getAdvancedButton } from '../screens/integrations';
+import { ServerlessRoleName } from '../support/roles';
 import { LIVE_QUERY_EDITOR, OSQUERY_FLYOUT_BODY_EDITOR } from '../screens/live_query';
 import { waitForAlertsToPopulate } from '../../../../test/security_solution_cypress/cypress/tasks/create_new_rule';
 
@@ -117,6 +118,7 @@ export const toggleRuleOffAndOn = (ruleName: string) => {
 };
 
 export const loadRuleAlerts = (ruleName: string) => {
+  cy.login(ServerlessRoleName.SOC_MANAGER);
   cy.visit('/app/security/rules', {
     onBeforeLoad: (win) => disableNewFeaturesTours(win),
   });

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
+import { disableNewFeaturesTours } from './navigation';
 import { getAdvancedButton } from '../screens/integrations';
 import { LIVE_QUERY_EDITOR, OSQUERY_FLYOUT_BODY_EDITOR } from '../screens/live_query';
-import { ServerlessRoleName } from '../support/roles';
 import { waitForAlertsToPopulate } from '../../../../test/security_solution_cypress/cypress/tasks/create_new_rule';
 
 export const DEFAULT_QUERY = 'select * from processes;';
@@ -117,8 +117,9 @@ export const toggleRuleOffAndOn = (ruleName: string) => {
 };
 
 export const loadRuleAlerts = (ruleName: string) => {
-  cy.login(ServerlessRoleName.SOC_MANAGER);
-  cy.visit('/app/security/rules');
+  cy.visit('/app/security/rules', {
+    onBeforeLoad: (win) => disableNewFeaturesTours(win),
+  });
   clickRuleName(ruleName);
   waitForAlertsToPopulate();
 };

--- a/x-pack/plugins/osquery/cypress/tasks/login.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/login.ts
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+import { disableNewFeaturesTours } from './navigation';
 import { ServerlessRoleName } from '../support/roles';
 
 // Login as a SOC_MANAGER to properly initialize Security Solution App
 export const initializeDataViews = () => {
   cy.login(ServerlessRoleName.SOC_MANAGER);
-  cy.visit('/app/security/alerts');
+  cy.visit('/app/security/alerts', {
+    onBeforeLoad: (win) => disableNewFeaturesTours(win),
+  });
   cy.getBySel('globalLoadingIndicator').should('exist');
   cy.getBySel('globalLoadingIndicator').should('not.exist');
   cy.getBySel('manage-alert-detection-rules').should('exist');


### PR DESCRIPTION
## Summary

This PR will help fix some issues raised in other PR with failing OSQuery tests ([this one](https://github.com/elastic/kibana/pull/188186) and [that one](https://github.com/elastic/kibana/pull/188196)).

The PR linked above highlighted a weird issue where the tours throughout Security Solution were not showing on the Cypress tests while they should have. In the Security Solution Cypress tests, we are disabling all the tours, but in OSQuery only one test was doing that.

This PR does the following cleanup:
- ~~remove duplicated and unwanted `cy.login`~~
- add the `disableNewFeaturesTours` logic to a few `cy.visit`

_Notes: originally this logic had been added to the PR linked above, but I think it made more sense to have it as a separate PR_

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->