### PR TITLE
fix i18n error in use_index_errors.ts

### DIFF
--- a/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts
+++ b/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts
@@ -49,7 +49,6 @@ export const useIndexErrors = (
                 defaultMessage: 'Model not found for inference endpoint {inferenceId}',
                 values: {
                   inferenceId: field.source.inference_id as string,
-                  fieldName: field.path.join('.'),
                 },
               }),
             };


### PR DESCRIPTION
## Summary
After https://github.com/elastic/kibana/pull/188326 - on-merge's quick checks started to break on an i18n error:

```
. Got Error: Messsage with ID xpack.idxMgmt.indexOverview.indexErrors.missingModelError in /opt/buildkite-agent/builds/bk-agent-prod-gcp-1721236070282472464/elastic/kibana-on-merge/kibana/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts has the following unnecessary values [fieldName]
```

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->