### PR TITLE
[Data Forge] Restore queue.drain()

### DIFF
--- a/x-pack/packages/kbn-data-forge/src/lib/create_events.ts
+++ b/x-pack/packages/kbn-data-forge/src/lib/create_events.ts
@@ -117,6 +117,7 @@ export async function createEvents(
         .flat();
     }
     await queue.push(events);
+    await queue.drain();
   } else {
     logger.info({ took: 0, latency: 0, indexed: 0 }, 'Indexing 0 documents.');
   }


### PR DESCRIPTION
This PR is a follow up to #187901 – It restores the `await queue.drain()` function call in the `createEvents()` method. Without the `queue.drain()` call, the script will run out of memory when indexing more than 24 hours of data because it will generate events faster than the queue can drain them and eventually run out of memory.