### PR TITLE
[Security Solution] [Attack discovery] Fixes error text wrapping for errors with IDs or non-breaking strings

### DIFF
--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/failure/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/failure/index.test.tsx
@@ -50,4 +50,12 @@ describe('Failure', () => {
       expect(learnMoreLink).toHaveTextContent(LEARN_MORE);
     });
   });
+
+  describe('error text formatting', () => {
+    it('allows errors containing long strings of text, e.g. alert IDs, to wrap when necessary', () => {
+      const bodyText = screen.getByTestId('bodyText');
+
+      expect(bodyText).toHaveStyle('word-wrap: break-word');
+    });
+  });
 });

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/failure/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/failure/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiLink, EuiText } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React from 'react';
 
 import * as i18n from './translations';
@@ -18,7 +19,13 @@ const FailureComponent: React.FC<{ failureReason: string }> = ({ failureReason }
           iconType="error"
           color="danger"
           body={
-            <EuiText color="subdued" data-test-subj="bodyText">
+            <EuiText
+              color="subdued"
+              css={css`
+                word-wrap: break-word;
+              `}
+              data-test-subj="bodyText"
+            >
               {failureReason}
             </EuiText>
           }


### PR DESCRIPTION
## [Security Solution] [Attack discovery] Fixes error text wrapping for errors with IDs or non-breaking strings

### Summary

This PR fixes a text wrapping issue where Attack discovery errors containing alert IDs (or non-breaking strings) didn't wrap, as illustrated by the _After_ and _Before_ screenshots below:

#### After

![after](https://github.com/user-attachments/assets/917a3c53-f5da-4481-b9b3-4c0f977f9115)

_Above: After the fix, the alert IDs wrap (when necessary)_

#### Before

![before](https://github.com/user-attachments/assets/16357d36-0e01-422c-99ab-4bbc4162acd0)

_Above: Before the fix, non-breaking strings (i.e. alert IDs) did NOT wrap_

### Desk testing

Reproduction steps:

1) Configure a connector with invalid credentials, such that requests to the connector will always fail

2) Navigate to Security > Attack discovery

3) Select the newly-configured connector

4) Click `Generate`

**Expected result**

- An EUI Empty prompt containing the error is displayed, as illustrated by the screenshot below:

![example_error](https://github.com/user-attachments/assets/fa663404-a224-4e4d-ab71-c8e41ba744c4)

5) Right-click anywhere on the page, and choose `Inpsect` from the popup menu

6) Using the `Elements` tab of the browser's dev tools, select the error body text, which has the following `data-test-subj`:

```
data-test-subj="bodyText"
```

and replace the `div`'s text (via dev tools) with the following text:

```
Failed to parse. Text: "Here is the JSON output, formatted according to the provided JSON Schema: "'*json [ { "alertls": [
"a492cd3202717d0c86f9b44623b12ac4d19855722e0fadb2f84a547afb45871a",
"fc0f6f9939277cc4f526148c15813f5d48094e557fdcf0ba9e773b2a16ec8c2e",
"b60a5c344b579cab9406becdec14a11d56f4eccc2bf6caaf6eb72ddf1707124c",
"2ca52c7af115ea3ff91afc3f8ca7f899e8c8c78e9b12592b47f9e03185f18e47"
"7fdf3a399b0a6df74784f478c2712a0e47ff997f73701593b3a5a56fa452056f",
"df26b2d23068b77fdc001ea44f46505a259f02ceccc9faOb2401c5e35190e710",
"67f41b973f82fc141d75fbbd1d6caba11066c19b2a1c720fcec9e681e1cfa60c"
1 "detailsMarkdown". "_ A malicious Fycel file {S
```

**Expected result**

- The alert IDs in the error text wrap, as illustrated by the _After_ screenshot below:

![after](https://github.com/user-attachments/assets/917a3c53-f5da-4481-b9b3-4c0f977f9115)

**Actual result**

- The alert IDs in the error text do NOT wrap, as illustrated by the _Before_ screenshot below:

![before](https://github.com/user-attachments/assets/16357d36-0e01-422c-99ab-4bbc4162acd0)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->