### PR TITLE
[CI] Backport reset changes (#188298)

### DIFF
--- a/packages/kbn-pm/dist/index.js
+++ b/packages/kbn-pm/dist/index.js
@@ -69491,6 +69491,14 @@ const ResetCommand = {
       });
       _utils_log__WEBPACK_IMPORTED_MODULE_6__["log"].success('Removed disk caches');
     }
+
+    // Deletes the data folder
+    if (await Object(_utils_fs__WEBPACK_IMPORTED_MODULE_5__["isDirectory"])(kbn.getDataFolder())) {
+      await del__WEBPACK_IMPORTED_MODULE_1___default()(kbn.getDataFolder(), {
+        force: true
+      });
+      _utils_log__WEBPACK_IMPORTED_MODULE_6__["log"].success('Removed data folder');
+    }
     if (toDelete.length === 0) {
       return;
     }
@@ -69950,6 +69958,9 @@ class Kibana {
       }
       throw error;
     }
+  }
+  getDataFolder() {
+    return this.getAbsolute('data');
   }
 }
 

--- a/packages/kbn-pm/src/commands/reset.ts
+++ b/packages/kbn-pm/src/commands/reset.ts
@@ -76,6 +76,12 @@ export const ResetCommand: ICommand = {
       log.success('Removed disk caches');
     }
 
+    // Deletes the data folder
+    if (await isDirectory(kbn.getDataFolder())) {
+      await del(kbn.getDataFolder(), { force: true });
+      log.success('Removed data folder');
+    }
+
     if (toDelete.length === 0) {
       return;
     }

--- a/packages/kbn-pm/src/utils/kibana.ts
+++ b/packages/kbn-pm/src/utils/kibana.ts
@@ -159,4 +159,8 @@ export class Kibana {
       throw error;
     }
   }
+
+  getDataFolder() {
+    return this.getAbsolute('data');
+  }
 }


### PR DESCRIPTION
## Summary
Manual backport of https://github.com/elastic/kibana/pull/188298

Also deletes the data folder when `yarn kbn reset` is ran.