### PR TITLE
Remove extra call to navigateTo from Dataset Quality functional tests

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/home.ts
+++ b/x-pack/test/functional/apps/dataset_quality/home.ts
@@ -44,7 +44,6 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
       });
 
       it('dataset quality table exists', async () => {
-        await PageObjects.datasetQuality.navigateTo();
         await testSubjects.existOrFail(
           PageObjects.datasetQuality.testSubjectSelectors.datasetQualityTable
         );

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/home.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/home.ts
@@ -48,7 +48,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       it('dataset quality table exists', async () => {
-        await PageObjects.datasetQuality.navigateTo();
         await PageObjects.datasetQuality.waitUntilTableLoaded();
         await testSubjects.existOrFail(
           PageObjects.datasetQuality.testSubjectSelectors.datasetQualityTable


### PR DESCRIPTION
Removes extra call to navigateTo from Dataset Quality functional tests as it's already called from the before block.