### PR TITLE
[7.17] Migrations: Don't auto-create temp index (#158182)

### DIFF
--- a/src/core/server/saved_objects/migrationsv2/__snapshots__/migrations_state_action_machine.test.ts.snap
+++ b/src/core/server/saved_objects/migrationsv2/__snapshots__/migrations_state_action_machine.test.ts.snap
@@ -44,6 +44,7 @@ Object {
                 "properties": Object {},
               },
               "tempIndex": ".my-so-index_7.11.0_reindex_temp",
+              "tempIndexAlias": ".my-so-index_7.11.0_reindex_temp_alias",
               "tempIndexMappings": Object {
                 "dynamic": false,
                 "properties": Object {
@@ -181,6 +182,7 @@ Object {
                 "properties": Object {},
               },
               "tempIndex": ".my-so-index_7.11.0_reindex_temp",
+              "tempIndexAlias": ".my-so-index_7.11.0_reindex_temp_alias",
               "tempIndexMappings": Object {
                 "dynamic": false,
                 "properties": Object {
@@ -322,6 +324,7 @@ Object {
                 "properties": Object {},
               },
               "tempIndex": ".my-so-index_7.11.0_reindex_temp",
+              "tempIndexAlias": ".my-so-index_7.11.0_reindex_temp_alias",
               "tempIndexMappings": Object {
                 "dynamic": false,
                 "properties": Object {
@@ -467,6 +470,7 @@ Object {
                 "properties": Object {},
               },
               "tempIndex": ".my-so-index_7.11.0_reindex_temp",
+              "tempIndexAlias": ".my-so-index_7.11.0_reindex_temp_alias",
               "tempIndexMappings": Object {
                 "dynamic": false,
                 "properties": Object {
@@ -643,6 +647,7 @@ Object {
                 "properties": Object {},
               },
               "tempIndex": ".my-so-index_7.11.0_reindex_temp",
+              "tempIndexAlias": ".my-so-index_7.11.0_reindex_temp_alias",
               "tempIndexMappings": Object {
                 "dynamic": false,
                 "properties": Object {
@@ -791,6 +796,7 @@ Object {
                 "properties": Object {},
               },
               "tempIndex": ".my-so-index_7.11.0_reindex_temp",
+              "tempIndexAlias": ".my-so-index_7.11.0_reindex_temp_alias",
               "tempIndexMappings": Object {
                 "dynamic": false,
                 "properties": Object {

--- a/src/core/server/saved_objects/migrationsv2/actions/bulk_overwrite_transformed_documents.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/bulk_overwrite_transformed_documents.ts
@@ -50,6 +50,12 @@ export interface BulkOverwriteTransformedDocumentsParams {
   index: string;
   transformedDocs: SavedObjectsRawDoc[];
   refresh?: estypes.Refresh;
+  /**
+   * If true, we prevent Elasticsearch from auto-creating the index if it
+   * doesn't exist. We use the ES paramater require_alias: true so `index`
+   * must be an alias, otherwise the bulk index will fail.
+   */
+  useAliasToPreventAutoCreate?: boolean;
 }
 
 /**
@@ -62,6 +68,7 @@ export const bulkOverwriteTransformedDocuments =
     index,
     transformedDocs,
     refresh = false,
+    useAliasToPreventAutoCreate = false,
   }: BulkOverwriteTransformedDocumentsParams): TaskEither.TaskEither<
     | RetryableEsClientError
     | TargetIndexHadWriteBlock
@@ -83,7 +90,7 @@ export const bulkOverwriteTransformedDocuments =
         // mappings. Such tampering could lead to many other problems and is
         // probably unlikely so for now we'll accept this risk and wait till
         // system indices puts in place a hard control.
-        require_alias: false,
+        require_alias: useAliasToPreventAutoCreate,
         wait_for_active_shards: WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
         refresh,
         filter_path: ['items.*.error'],

--- a/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/actions/integration_tests/actions.test.ts
@@ -70,6 +70,7 @@ describe('migration actions', () => {
     await createIndex({
       client,
       indexName: 'existing_index_with_docs',
+      aliases: ['existing_index_with_docs_alias'],
       mappings: {
         dynamic: true,
         properties: {},
@@ -133,7 +134,9 @@ describe('migration actions', () => {
       expect(res.right).toEqual(
         expect.objectContaining({
           existing_index_with_docs: {
-            aliases: {},
+            aliases: {
+              existing_index_with_docs_alias: {},
+            },
             mappings: expect.anything(),
             settings: expect.anything(),
           },
@@ -1518,6 +1521,30 @@ describe('migration actions', () => {
                   "right": "bulk_index_succeeded",
                 }
               `);
+    });
+    it('resolves left index_not_found_exception if the index does not exist and useAliasToPreventAutoCreate=true', async () => {
+      const newDocs = [
+        { _source: { title: 'doc 5' } },
+        { _source: { title: 'doc 6' } },
+        { _source: { title: 'doc 7' } },
+      ] as unknown as SavedObjectsRawDoc[];
+      await expect(
+        bulkOverwriteTransformedDocuments({
+          client,
+          index: 'existing_index_with_docs_alias_that_does_not_exist',
+          useAliasToPreventAutoCreate: true,
+          transformedDocs: newDocs,
+          refresh: 'wait_for',
+        })()
+      ).resolves.toMatchInlineSnapshot(`
+          Object {
+            "_tag": "Left",
+            "left": Object {
+              "index": "existing_index_with_docs_alias_that_does_not_exist",
+              "type": "index_not_found_exception",
+            },
+          }
+      `);
     });
     it('resolves left target_index_had_write_block if there are write_block errors', async () => {
       const newDocs = [

--- a/src/core/server/saved_objects/migrationsv2/initial_state.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/initial_state.test.ts
@@ -72,6 +72,7 @@ describe('createInitialState', () => {
         },
       },
       tempIndex: '.kibana_task_manager_8.1.0_reindex_temp',
+      tempIndexAlias: '.kibana_task_manager_8.1.0_reindex_temp_alias',
       tempIndexMappings: {
         dynamic: false,
         properties: {

--- a/src/core/server/saved_objects/migrationsv2/initial_state.ts
+++ b/src/core/server/saved_objects/migrationsv2/initial_state.ts
@@ -73,6 +73,7 @@ export const createInitialState = ({
     versionAlias: `${indexPrefix}_${kibanaVersion}`,
     versionIndex: `${indexPrefix}_${kibanaVersion}_001`,
     tempIndex: `${indexPrefix}_${kibanaVersion}_reindex_temp`,
+    tempIndexAlias: `${indexPrefix}_${kibanaVersion}_reindex_temp_alias`,
     kibanaVersion,
     preMigrationScript: Option.fromNullable(preMigrationScript),
     targetIndexMappings: targetMappings,

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes.test.ts
@@ -90,7 +90,7 @@ describe('migration v2', function () {
     await root.preboot();
     await root.setup();
     await expect(root.start()).rejects.toMatchInlineSnapshot(
-      `[Error: Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715277 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.]`
+      `[Error: Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715237 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.]`
     );
 
     await retryAsync(
@@ -103,7 +103,7 @@ describe('migration v2', function () {
         expect(
           records.find((rec) =>
             rec.message.startsWith(
-              `Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715277 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.`
+              `Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715237 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.`
             )
           )
         ).toBeDefined();

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes.test.ts
@@ -43,7 +43,7 @@ describe('migration v2', function () {
         es: {
           license: 'basic',
           dataArchive: Path.join(__dirname, 'archives', '7.14.0_xpack_sample_saved_objects.zip'),
-          esArgs: ['http.max_content_length=1715277b'],
+          esArgs: ['http.max_content_length=1715329b'],
         },
       },
     }));
@@ -61,7 +61,7 @@ describe('migration v2', function () {
   });
 
   it('completes the migration even when a full batch would exceed ES http.max_content_length', async () => {
-    root = createRoot({ maxBatchSizeBytes: 1715277 });
+    root = createRoot({ maxBatchSizeBytes: 1715329 });
     esServer = await startES();
     await root.preboot();
     await root.setup();
@@ -90,7 +90,7 @@ describe('migration v2', function () {
     await root.preboot();
     await root.setup();
     await expect(root.start()).rejects.toMatchInlineSnapshot(
-      `[Error: Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715237 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.]`
+      `[Error: Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715283 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.]`
     );
 
     await retryAsync(
@@ -103,7 +103,7 @@ describe('migration v2', function () {
         expect(
           records.find((rec) =>
             rec.message.startsWith(
-              `Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715237 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.`
+              `Unable to complete saved object migrations for the [.kibana] index: The document with _id "canvas-workpad-template:workpad-template-061d7868-2b4e-4dc8-8bf7-3772b52926e5" is 1715283 bytes which exceeds the configured maximum batch size of 1015275 bytes. To proceed, please increase the 'migrations.maxBatchSizeBytes' Kibana configuration option and ensure that the Elasticsearch 'http.max_content_length' configuration option is set to an equal or larger value.`
             )
           )
         ).toBeDefined();

--- a/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes_exceeds_es_content_length.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/integration_tests/batch_size_bytes_exceeds_es_content_length.test.ts
@@ -54,7 +54,7 @@ describe('migration v2', () => {
   });
 
   it('fails with a descriptive message when maxBatchSizeBytes exceeds ES http.max_content_length', async () => {
-    root = createRoot({ maxBatchSizeBytes: 1715277 });
+    root = createRoot({ maxBatchSizeBytes: 1715329 });
     esServer = await startES();
     await root.preboot();
     await root.setup();

--- a/src/core/server/saved_objects/migrationsv2/model/model.test.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/model.test.ts
@@ -81,6 +81,7 @@ describe('migrations v2 model', () => {
     versionAlias: '.kibana_7.11.0',
     versionIndex: '.kibana_7.11.0_001',
     tempIndex: '.kibana_7.11.0_reindex_temp',
+    tempIndexAlias: '.kibana_7.11.0_reindex_temp_alias',
     unusedTypesQuery: {
       bool: {
         must_not: [

--- a/src/core/server/saved_objects/migrationsv2/model/model.ts
+++ b/src/core/server/saved_objects/migrationsv2/model/model.ts
@@ -504,7 +504,7 @@ export const model = (currentState: State, resW: ResponseType<AllActionStates>):
       if (stateP.corruptDocumentIds.length === 0 && stateP.transformErrors.length === 0) {
         const batches = createBatches(
           res.right.processedDocs,
-          stateP.tempIndex,
+          stateP.tempIndexAlias,
           stateP.maxBatchSizeBytes
         );
         if (Either.isRight(batches)) {

--- a/src/core/server/saved_objects/migrationsv2/types.ts
+++ b/src/core/server/saved_objects/migrationsv2/types.ts
@@ -117,10 +117,16 @@ export interface BaseState extends ControlState {
    */
   readonly versionIndex: string;
   /**
-   * An alias on the target index used as part of an "reindex block" that
-   * prevents lost deletes e.g. `.kibana_7.11.0_reindex`.
+   * A temporary index used as part of an "reindex block" that
+   * prevents lost deletes e.g. `.kibana_7.11.0_reindex_temp`.
    */
   readonly tempIndex: string;
+  /**
+   * An alias to the tempIndex used to prevent ES from auto-creating the temp
+   * index if one node deletes it while another writes to it
+   * e.g. `.kibana_7.11.0_reindex_temp_alias`.
+   */
+  readonly tempIndexAlias: string;
   /**
    * When reindexing we use a source query to exclude saved objects types which
    * are no longer used. These saved objects will still be kept in the outdated


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Migrations: Don't auto-create temp index (#158182)](https://github.com/elastic/kibana/pull/158182)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rudolf Meijering","email":"skaapgif@gmail.com"},"sourceCommit":{"committedDate":"2023-06-04T22:34:08Z","message":"Migrations: Don't auto-create temp index (#158182)\n\n## Summary\r\n\r\nTry to fix\r\nhttps://github.com/elastic/kibana/issues/156117#issuecomment-1557029863\r\n\r\n## Release notes\r\nFixes a race condition that could cause intermittent upgrade migration\r\nfailures when Kibana connects to a single node Elasticsearch cluster.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"8e7e2632bbb5f2dfffe8ab6c2563e176c5d7cf6b","branchLabelMapping":{"^v8.9.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:Core","release_note:fix","Feature:Migrations","backport:prev-minor","backport:prev-MAJOR","v8.9.0","v8.8.1","v8.16.0"],"number":158182,"url":"https://github.com/elastic/kibana/pull/158182","mergeCommit":{"message":"Migrations: Don't auto-create temp index (#158182)\n\n## Summary\r\n\r\nTry to fix\r\nhttps://github.com/elastic/kibana/issues/156117#issuecomment-1557029863\r\n\r\n## Release notes\r\nFixes a race condition that could cause intermittent upgrade migration\r\nfailures when Kibana connects to a single node Elasticsearch cluster.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"8e7e2632bbb5f2dfffe8ab6c2563e176c5d7cf6b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.9.0","labelRegex":"^v8.9.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158182","number":158182,"mergeCommit":{"message":"Migrations: Don't auto-create temp index (#158182)\n\n## Summary\r\n\r\nTry to fix\r\nhttps://github.com/elastic/kibana/issues/156117#issuecomment-1557029863\r\n\r\n## Release notes\r\nFixes a race condition that could cause intermittent upgrade migration\r\nfailures when Kibana connects to a single node Elasticsearch cluster.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"8e7e2632bbb5f2dfffe8ab6c2563e176c5d7cf6b"}},{"branch":"8.8","label":"v8.8.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/158996","number":158996,"state":"MERGED","mergeCommit":{"sha":"46217b9129c9de9d7be064b6ad6d6f51897981e0","message":"[8.8] Migrations: Don't auto-create temp index (#158182) (#158996)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.8`:\n- [Migrations: Don't auto-create temp index\n(#158182)](https://github.com/elastic/kibana/pull/158182)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Rudolf\nMeijering\",\"email\":\"skaapgif@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2023-06-04T22:34:08Z\",\"message\":\"Migrations:\nDon't auto-create temp index (#158182)\\n\\n## Summary\\r\\n\\r\\nTry to\nfix\\r\\nhttps://github.com/elastic/kibana/issues/156117#issuecomment-1557029863\\r\\n\\r\\n##\nRelease notes\\r\\nFixes a race condition that could cause intermittent\nupgrade migration\\r\\nfailures when Kibana connects to a single node\nElasticsearch cluster.\\r\\n\\r\\n### Checklist\\r\\n\\r\\nDelete any items that\nare not applicable to this PR.\\r\\n\\r\\n- [ ] Any text added follows\n[EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [ ] Any UI\ntouched in this PR is usable by keyboard only (learn more\\r\\nabout\n[keyboard accessibility](https://webaim.org/techniques/keyboard/))\\r\\n-\n[ ] Any UI touched in this PR does not create any new axe\nfailures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n\\r\\n###\nRisk Matrix\\r\\n\\r\\nDelete this section if it is not applicable to this\nPR.\\r\\n\\r\\nBefore closing this PR, invite QA, stakeholders, and other\ndevelopers to\\r\\nidentify risks that should be tested prior to the\nchange/feature\\r\\nrelease.\\r\\n\\r\\nWhen forming the risk matrix, consider\nsome of the following examples\\r\\nand how they may potentially impact\nthe change:\\r\\n\\r\\n| Risk | Probability | Severity | Mitigation/Notes\n|\\r\\n\\r\\n|---------------------------|-------------|----------|-------------------------|\\r\\n|\nMultiple Spaces&mdash;unexpected behavior in non-default Kibana\nSpace.\\r\\n| Low | High | Integration tests will verify that all features\nare still\\r\\nsupported in non-default Kibana Space and when user\nswitches between\\r\\nspaces. |\\r\\n| Multiple nodes&mdash;Elasticsearch\npolling might have race conditions\\r\\nwhen multiple Kibana nodes are\npolling for the same tasks. | High | Low\\r\\n| Tasks are idempotent, so\nexecuting them multiple times will not result\\r\\nin logical error, but\nwill degrade performance. To test for this case we\\r\\nadd plenty of unit\ntests around this logic and document manual testing\\r\\nprocedure. |\\r\\n|\nCode should gracefully handle cases when feature X or plugin Y\nare\\r\\ndisabled. | Medium | High | Unit tests will verify that any\nfeature flag\\r\\nor plugin combination still results in our service\noperational. |\\r\\n| [See more potential\nrisk\\r\\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n|\\r\\n\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"8e7e2632bbb5f2dfffe8ab6c2563e176c5d7cf6b\",\"branchLabelMapping\":{\"^v8.9.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"Team:Core\",\"release_note:fix\",\"Feature:Migrations\",\"backport:prev-minor\",\"v8.9.0\"],\"number\":158182,\"url\":\"https://github.com/elastic/kibana/pull/158182\",\"mergeCommit\":{\"message\":\"Migrations:\nDon't auto-create temp index (#158182)\\n\\n## Summary\\r\\n\\r\\nTry to\nfix\\r\\nhttps://github.com/elastic/kibana/issues/156117#issuecomment-1557029863\\r\\n\\r\\n##\nRelease notes\\r\\nFixes a race condition that could cause intermittent\nupgrade migration\\r\\nfailures when Kibana connects to a single node\nElasticsearch cluster.\\r\\n\\r\\n### Checklist\\r\\n\\r\\nDelete any items that\nare not applicable to this PR.\\r\\n\\r\\n- [ ] Any text added follows\n[EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [ ] Any UI\ntouched in this PR is usable by keyboard only (learn more\\r\\nabout\n[keyboard accessibility](https://webaim.org/techniques/keyboard/))\\r\\n-\n[ ] Any UI touched in this PR does not create any new axe\nfailures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n\\r\\n###\nRisk Matrix\\r\\n\\r\\nDelete this section if it is not applicable to this\nPR.\\r\\n\\r\\nBefore closing this PR, invite QA, stakeholders, and other\ndevelopers to\\r\\nidentify risks that should be tested prior to the\nchange/feature\\r\\nrelease.\\r\\n\\r\\nWhen forming the risk matrix, consider\nsome of the following examples\\r\\nand how they may potentially impact\nthe change:\\r\\n\\r\\n| Risk | Probability | Severity | Mitigation/Notes\n|\\r\\n\\r\\n|---------------------------|-------------|----------|-------------------------|\\r\\n|\nMultiple Spaces&mdash;unexpected behavior in non-default Kibana\nSpace.\\r\\n| Low | High | Integration tests will verify that all features\nare still\\r\\nsupported in non-default Kibana Space and when user\nswitches between\\r\\nspaces. |\\r\\n| Multiple nodes&mdash;Elasticsearch\npolling might have race conditions\\r\\nwhen multiple Kibana nodes are\npolling for the same tasks. | High | Low\\r\\n| Tasks are idempotent, so\nexecuting them multiple times will not result\\r\\nin logical error, but\nwill degrade performance. To test for this case we\\r\\nadd plenty of unit\ntests around this logic and document manual testing\\r\\nprocedure. |\\r\\n|\nCode should gracefully handle cases when feature X or plugin Y\nare\\r\\ndisabled. | Medium | High | Unit tests will verify that any\nfeature flag\\r\\nor plugin combination still results in our service\noperational. |\\r\\n| [See more potential\nrisk\\r\\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n|\\r\\n\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"8e7e2632bbb5f2dfffe8ab6c2563e176c5d7cf6b\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.9.0\",\"labelRegex\":\"^v8.9.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/158182\",\"number\":158182,\"mergeCommit\":{\"message\":\"Migrations:\nDon't auto-create temp index (#158182)\\n\\n## Summary\\r\\n\\r\\nTry to\nfix\\r\\nhttps://github.com/elastic/kibana/issues/156117#issuecomment-1557029863\\r\\n\\r\\n##\nRelease notes\\r\\nFixes a race condition that could cause intermittent\nupgrade migration\\r\\nfailures when Kibana connects to a single node\nElasticsearch cluster.\\r\\n\\r\\n### Checklist\\r\\n\\r\\nDelete any items that\nare not applicable to this PR.\\r\\n\\r\\n- [ ] Any text added follows\n[EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [ ] Any UI\ntouched in this PR is usable by keyboard only (learn more\\r\\nabout\n[keyboard accessibility](https://webaim.org/techniques/keyboard/))\\r\\n-\n[ ] Any UI touched in this PR does not create any new axe\nfailures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n\\r\\n###\nRisk Matrix\\r\\n\\r\\nDelete this section if it is not applicable to this\nPR.\\r\\n\\r\\nBefore closing this PR, invite QA, stakeholders, and other\ndevelopers to\\r\\nidentify risks that should be tested prior to the\nchange/feature\\r\\nrelease.\\r\\n\\r\\nWhen forming the risk matrix, consider\nsome of the following examples\\r\\nand how they may potentially impact\nthe change:\\r\\n\\r\\n| Risk | Probability | Severity | Mitigation/Notes\n|\\r\\n\\r\\n|---------------------------|-------------|----------|-------------------------|\\r\\n|\nMultiple Spaces&mdash;unexpected behavior in non-default Kibana\nSpace.\\r\\n| Low | High | Integration tests will verify that all features\nare still\\r\\nsupported in non-default Kibana Space and when user\nswitches between\\r\\nspaces. |\\r\\n| Multiple nodes&mdash;Elasticsearch\npolling might have race conditions\\r\\nwhen multiple Kibana nodes are\npolling for the same tasks. | High | Low\\r\\n| Tasks are idempotent, so\nexecuting them multiple times will not result\\r\\nin logical error, but\nwill degrade performance. To test for this case we\\r\\nadd plenty of unit\ntests around this logic and document manual testing\\r\\nprocedure. |\\r\\n|\nCode should gracefully handle cases when feature X or plugin Y\nare\\r\\ndisabled. | Medium | High | Unit tests will verify that any\nfeature flag\\r\\nor plugin combination still results in our service\noperational. |\\r\\n| [See more potential\nrisk\\r\\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n|\\r\\n\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"8e7e2632bbb5f2dfffe8ab6c2563e176c5d7cf6b\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Rudolf Meijering <skaapgif@gmail.com>"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->