### PR TITLE
[Infra] Fix functions table height in asset details view profiling tab

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/profiling/functions.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/profiling/functions.tsx
@@ -85,6 +85,7 @@ export function Functions({ kuery }: Props) {
         isLoading={isPending(status)}
         rangeFrom={from}
         rangeTo={to}
+        height="60vh"
       />
     </>
   );

--- a/x-pack/plugins/observability_solution/observability_shared/public/components/profiling/embeddables/embeddable_functions.tsx
+++ b/x-pack/plugins/observability_solution/observability_shared/public/components/profiling/embeddables/embeddable_functions.tsx
@@ -16,18 +16,23 @@ interface Props {
   isLoading: boolean;
   rangeFrom: number;
   rangeTo: number;
+  height?: string;
 }
 
 export function EmbeddableFunctions(props: Props) {
   const EmbeddableFunctionsComponent = getProfilingComponent<Props>(EMBEDDABLE_FUNCTIONS);
+  const { height } = props;
+  const heightSetting = height ? `height: ${height}` : 'min-height: 0';
+
   return (
     <div
       css={css`
         width: 100%;
+        ${heightSetting};
+        overflow: visible;
         display: flex;
         flex: 1 1 100%;
         z-index: 1;
-        min-height: 0;
       `}
     >
       {EmbeddableFunctionsComponent && <EmbeddableFunctionsComponent {...props} />}


### PR DESCRIPTION
## Summary

closes #188397 

Similar to the flamegraph component this PR sets height to the Functions component. 

One note: the height is used only in infra because in APM we don't have an empty state view for the profiling functions (it will be **good to have** IMO) and we don't want to set the height of an empty table there.

## Testing 
- Go to the asset details page
- Check the Universal Profiling tab > Top 10 Functions tab

https://github.com/user-attachments/assets/51303da7-918b-43e5-8d93-65976b288e15

- Before this change, the table was showing only the header with a small scrollbar: 
![image](https://github.com/user-attachments/assets/173d38d8-a8a3-4d79-a163-2eff4c1e3e49)

