### PR TITLE
[Fleet] Use aarch64 in Mac instructions

### DIFF
--- a/x-pack/plugins/fleet/dev_docs/local_setup/developing_kibana_and_fleet_server.md
+++ b/x-pack/plugins/fleet/dev_docs/local_setup/developing_kibana_and_fleet_server.md
@@ -149,7 +149,7 @@ $ DEV=true SNAPSHOT=true make release-darwin/amd64
 
 # Run dev build, provide your fingerprint and service token from before
 # Replace 8.13.0-SNAPSHOT with the latest version on main
-$ ./build/binaries/fleet-server-8.13.0-SNAPSHOT-darwin-x86_64/fleet-server -c fleet-server.dev.yml
+$ ./build/binaries/fleet-server-8.13.0-SNAPSHOT-darwin-aarch64/fleet-server -c fleet-server.dev.yml
 ```
 
 Now you should have a local ES snapshot running on http://localhost:9200, a local Kibana running on http://localhost:5601, and a local Fleet Server running on http://localhost:8220. You can now navigate to http://localhost:5601/app/fleet and [enroll agents](#enroll-agents).

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
@@ -35,9 +35,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--darwin-x86_64.tar.gz
-        tar xzvf elastic-agent--darwin-x86_64.tar.gz
-        cd elastic-agent--darwin-x86_64
+        "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--darwin-aarch64.tar.gz
+        tar xzvf elastic-agent--darwin-aarch64.tar.gz
+        cd elastic-agent--darwin-aarch64
         sudo ./elastic-agent install \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\
@@ -156,9 +156,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--darwin-x86_64.tar.gz
-        tar xzvf elastic-agent--darwin-x86_64.tar.gz
-        cd elastic-agent--darwin-x86_64
+        "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--darwin-aarch64.tar.gz
+        tar xzvf elastic-agent--darwin-aarch64.tar.gz
+        cd elastic-agent--darwin-aarch64
         sudo ./elastic-agent install \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\
@@ -301,9 +301,9 @@ describe('getInstallCommandForPlatform', () => {
       );
 
       expect(res).toMatchInlineSnapshot(`
-        "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--darwin-x86_64.tar.gz
-        tar xzvf elastic-agent--darwin-x86_64.tar.gz
-        cd elastic-agent--darwin-x86_64
+        "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--darwin-aarch64.tar.gz
+        tar xzvf elastic-agent--darwin-aarch64.tar.gz
+        cd elastic-agent--darwin-aarch64
         sudo ./elastic-agent install --url=http://fleetserver:8220 \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
@@ -35,9 +35,9 @@ function getArtifact(
     },
     mac: {
       downloadCommand: [
-        `curl -L -O ${ARTIFACT_BASE_URL}/elastic-agent-${kibanaVersion}-darwin-x86_64.tar.gz`,
-        `tar xzvf elastic-agent-${kibanaVersion}-darwin-x86_64.tar.gz`,
-        `cd elastic-agent-${kibanaVersion}-darwin-x86_64`,
+        `curl -L -O ${ARTIFACT_BASE_URL}/elastic-agent-${kibanaVersion}-darwin-aarch64.tar.gz`,
+        `tar xzvf elastic-agent-${kibanaVersion}-darwin-aarch64.tar.gz`,
+        `cd elastic-agent-${kibanaVersion}-darwin-aarch64`,
       ].join(`\n`),
     },
     windows: {

--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -59,9 +59,9 @@ tar xzvf elastic-agent-${agentVersion}-linux-x86_64.tar.gz
 cd elastic-agent-${agentVersion}-linux-x86_64
 sudo ./elastic-agent install ${enrollArgs}`;
 
-  const macCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-x86_64.tar.gz
-tar xzvf elastic-agent-${agentVersion}-darwin-x86_64.tar.gz
-cd elastic-agent-${agentVersion}-darwin-x86_64
+  const macCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
+tar xzvf elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
+cd elastic-agent-${agentVersion}-darwin-aarch64
 sudo ./elastic-agent install ${enrollArgs}`;
 
   const windowsCommand = `$ProgressPreference = 'SilentlyContinue'

--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/standalone/index.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/standalone/index.tsx
@@ -18,9 +18,9 @@ tar xzvf elastic-agent-${agentVersion}-linux-x86_64.tar.gz
 cd elastic-agent-${agentVersion}-linux-x86_64
 sudo ./elastic-agent install`;
 
-  const macCommand = `curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-x86_64.tar.gz
-tar xzvf elastic-agent-${agentVersion}-darwin-x86_64.tar.gz
-cd elastic-agent-${agentVersion}-darwin-x86_64
+  const macCommand = `curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
+tar xzvf elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
+cd elastic-agent-${agentVersion}-darwin-aarch64
 sudo ./elastic-agent install`;
 
   const windowsCommand = `$ProgressPreference = 'SilentlyContinue'


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/184628

Replaced `darwin-x86_64` by `darwin-aarch64` in `elastic-agent install` instructions for Mac.

To verify, check `Add agent` flyout.

Standalone:
<img width="779" alt="image" src="https://github.com/user-attachments/assets/478bc6ab-2c3a-4ec0-8d3d-9b8ff13b1859">
Managed:
<img width="810" alt="image" src="https://github.com/user-attachments/assets/33e8f1c3-6ed5-456c-99e2-5c8cd8faa3cc">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->