### PR TITLE
[Security Assistant] Cleanup MKI test configs

### DIFF
--- a/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_gen_ai.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_periodic/mki_periodic_gen_ai.yml
@@ -21,20 +21,6 @@ steps:
   - group: "API MKI - GenAI"
     key: api_test_ai_assistant
     steps:
-      - label: Running genai:qa:serverless
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh genai:qa:serverless
-        key: genai:qa:serverless
-        agents:
-          image: family/kibana-ubuntu-2004
-          imageProject: elastic-images-prod
-          provider: gcp
-          machineType: n2-standard-4
-          preemptible: true
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
 
       - label: Running nlp_cleanup_task:complete:qa:serverless
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh nlp_cleanup_task:complete:qa:serverless

--- a/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_gen_ai.yml
+++ b/.buildkite/pipelines/security_solution_quality_gate/mki_quality_gate/mki_quality_gate_gen_ai.yml
@@ -21,21 +21,6 @@ steps:
   - group: "API MKI - GenAI"
     key: api_test_ai_assistant
     steps:
-      - label: Running genai:qa:serverless:release
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh genai:qa:serverless:release
-        key: genai:qa:serverless:release
-        agents:
-          image: family/kibana-ubuntu-2004
-          imageProject: elastic-images-prod
-          provider: gcp
-          machineType: n2-standard-4
-          preemptible: true
-        timeout_in_minutes: 120
-        retry:
-          automatic:
-            - exit_status: "1"
-              limit: 2
-
       - label: Running nlp_cleanup_task:complete:qa:serverless:release
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/api_integration/api-integration-tests.sh nlp_cleanup_task:complete:qa:serverless:release
         key: nlp_cleanup_task:complete:qa:serverless:release


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/pull/188168 we cleaned up some of our API tests, but missed these other references and so have failures on the [periodic test pipeline](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-gen-ai/builds/854). This PR updates these configs to remove the test commands that no longer exist.



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->