### PR TITLE
[Fleet] Omit spaceId when updating a package policy

### DIFF
--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1541,7 +1541,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
   ) {
     const updatePackagePolicy = updatePackageInputs(
       {
-        ...omit(packagePolicy, 'id'),
+        ...omit(packagePolicy, 'id', 'spaceId'),
         inputs: packagePolicy.inputs,
         package: {
           ...packagePolicy.package!,
@@ -1626,7 +1626,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
   ): Promise<UpgradePackagePolicyDryRunResponseItem> {
     const updatedPackagePolicy = updatePackageInputs(
       {
-        ...omit(packagePolicy, 'id'),
+        ...omit(packagePolicy, 'id', 'spaceId'),
         inputs: packagePolicy.inputs,
         package: {
           ...packagePolicy.package!,
@@ -1881,6 +1881,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
                 const omitted = {
                   ...omit(result, [
                     'id',
+                    'spaceId',
                     'version',
                     'revision',
                     'updated_at',


### PR DESCRIPTION
## Summary

The package policy service now return the spaceId of the package policy, this was causing issue when upgrading managed package policy with the following error:

```
dynamic introduction of [spaceId]
```

To avoid that the package policy service should omit that property.

## Tests

The change is covered with unit tests

You can manually test that by creating a synthetics package policy and creating a new version of the `synthetics` integration

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->