### PR TITLE
[Security Solution] Skips failing EQL test in MKI

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/eql_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/eql_rule.cy.ts
@@ -164,27 +164,33 @@ describe('EQL rules', { tags: ['@ess', '@serverless'] }, () => {
       cy.task('esArchiverUnload', { archiveName: 'auditbeat_multiple' });
     });
 
-    it('Creates and enables a new EQL rule with a sequence', function () {
-      login();
-      visit(CREATE_RULE_URL);
-      selectEqlRuleType();
-      fillDefineEqlRuleAndContinue(rule);
-      fillAboutRuleAndContinue(rule);
-      fillScheduleRuleAndContinue(rule);
-      createAndEnableRule();
-      openRuleManagementPageViaBreadcrumbs();
-      goToRuleDetailsOf(rule.name);
-      waitForAlertsToPopulate();
+    it(
+      'Creates and enables a new EQL rule with a sequence',
+      {
+        tags: ['@skipServerlessInMKI'],
+      },
+      function () {
+        login();
+        visit(CREATE_RULE_URL);
+        selectEqlRuleType();
+        fillDefineEqlRuleAndContinue(rule);
+        fillAboutRuleAndContinue(rule);
+        fillScheduleRuleAndContinue(rule);
+        createAndEnableRule();
+        openRuleManagementPageViaBreadcrumbs();
+        goToRuleDetailsOf(rule.name);
+        waitForAlertsToPopulate();
 
-      cy.get(ALERTS_COUNT).should('have.text', expectedNumberOfSequenceAlerts);
-      cy.get(ALERT_DATA_GRID)
-        .invoke('text')
-        .then((text) => {
-          cy.log('ALERT_DATA_GRID', text);
-          expect(text).contains(rule.name);
-          expect(text).contains(rule.severity);
-        });
-    });
+        cy.get(ALERTS_COUNT).should('have.text', expectedNumberOfSequenceAlerts);
+        cy.get(ALERT_DATA_GRID)
+          .invoke('text')
+          .then((text) => {
+            cy.log('ALERT_DATA_GRID', text);
+            expect(text).contains(rule.name);
+            expect(text).contains(rule.severity);
+          });
+      }
+    );
   });
 
   describe('with source data requiring EQL overrides', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/eql_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/eql_rule.cy.ts
@@ -167,7 +167,7 @@ describe('EQL rules', { tags: ['@ess', '@serverless'] }, () => {
     it(
       'Creates and enables a new EQL rule with a sequence',
       {
-        tags: ['@skipServerlessInMKI'],
+        tags: ['@skipInServerlessMKI'],
       },
       function () {
         login();


### PR DESCRIPTION
Raised an issue to unskip in test : https://github.com/elastic/kibana/issues/188734

This PR simple skips a test failing in MKI Build. Build link & logs  can be found below:


Build link: https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-detection-engine/builds/845#0190c5bd-7072-4c35-a6af-48f4dda768a4


Logs 
```
Security Solution Cypress
x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/eql_rule.cy·ts

EQL rules Detection rules, sequence EQL Creates and enables a new EQL rule with a sequence Creates and enables a new EQL rule with a sequence

Failures in tracked branches: 1
https://dryrun

Buildkite Job
https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-detection-engine/builds/845#0190c5bd-7072-4c35-a6af-48f4dda768a4

AssertionError: Timed out retrying after 300000ms: Expected to find element: `[data-test-subj="eqlRuleType"]`, but never found it.
    at selectEqlRuleType (webpack:///./tasks/create_new_rule.ts:838:5)
    at Context.eval (webpack:///./e2e/detection_response/detection_engine/rule_creation/eql_rule.cy.ts:170:24)


```



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->