### PR TITLE
[Security Solution] Skips Timeline tests failing in MKI

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy.ts
@@ -28,7 +28,12 @@ const defaultPageSize = 25;
 describe(
   'Timeline Pagination',
   {
-    tags: ['@ess', '@serverless'],
+    /*
+     * Tests with feature flag should not be enabled on serverless mki
+     * so skipping it. When you remove the feature flag, remove the
+     * skipInServerlessMKI tag as well.
+     * */
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
         kbnServerArgs: [


### PR DESCRIPTION
## Summary
Since MKI does not support feature flags, this PR disables a test suite in the MKI environment because it was failing.

Build: https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-investigations/builds/845

## Logs

```
Security Solution Cypress
x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy·ts

Timeline Pagination "before each" hook for "should paginate records correctly" "before each" hook for "should paginate records correctly"

Failures in tracked branches: 1
https://dryrun

Buildkite Job
https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-investigations/builds/845#0190c5bd-7038-41fc-8260-0fe4d26559aa

AssertionError: Timed out retrying after 300000ms: Expected to find element: `[data-test-subj="timeline-bottom-bar"] [data-test-subj="timeline-bottom-bar-title-button"]`, but never found it.

Because this error occurred during a `before each` hook we are skipping the remaining tests in the current suite: `Timeline Pagination`
    at eval (webpack:///./tasks/security_main.ts:20:9)
    at Context.cypressRecurse (webpack:////opt/buildkite-agent/builds/bk-agent-prod-gcp-1721304521078283210/elastic/kibana-serverless-security-solution-quality-gate-investigations/kibana/node_modules/cypress-recurse/src/index.js:197:0)


```


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->