### PR TITLE
[ML] Single metric viewer functional test: add retry to reduce flakiness

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/single_metric_viewer_dashboard_embeddables.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/single_metric_viewer_dashboard_embeddables.ts
@@ -45,8 +45,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     for (const testData of testDataList) {
-      // FLAKY: https://github.com/elastic/kibana/issues/188493
-      describe.skip(testData.suiteSuffix, function () {
+      describe(testData.suiteSuffix, function () {
         before(async () => {
           await ml.api.createAndRunAnomalyDetectionLookbackJob(
             testData.jobConfig,

--- a/x-pack/test/functional/services/ml/single_metric_viewer.ts
+++ b/x-pack/test/functional/services/ml/single_metric_viewer.ts
@@ -92,7 +92,7 @@ export function MachineLearningSingleMetricViewerProvider(
     },
 
     async ensureAnomalyActionDiscoverButtonClicked() {
-      await retry.tryForTime(3 * 1000, async () => {
+      await retry.tryForTime(10 * 1500, async () => {
         await testSubjects.click('mlAnomaliesListRowAction_viewInDiscoverButton');
         await testSubjects.existOrFail('discoverLayoutResizableContainer');
       });

--- a/x-pack/test/functional/services/ml/single_metric_viewer.ts
+++ b/x-pack/test/functional/services/ml/single_metric_viewer.ts
@@ -92,9 +92,9 @@ export function MachineLearningSingleMetricViewerProvider(
     },
 
     async ensureAnomalyActionDiscoverButtonClicked() {
-      await retry.tryForTime(10 * 1500, async () => {
+      await retry.tryForTime(30 * 1000, async () => {
         await testSubjects.click('mlAnomaliesListRowAction_viewInDiscoverButton');
-        await testSubjects.existOrFail('discoverLayoutResizableContainer');
+        await testSubjects.existOrFail('discoverLayoutResizableContainer', { timeout: 10 * 1000 });
       });
     },
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/188493

This PR unskips the single metric viewer functional test that is failing (confirmed functionality is working as expected) and increases the retries to reduce flakiness. 

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6593


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



