### PR TITLE
Fix names for observability teams in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -312,7 +312,7 @@
     {
       "groupName": "Profiling",
       "matchDepNames": ["peggy", "@types/dagre"],
-      "reviewers": ["team:profiling-ui"],
+      "reviewers": ["team:obs-ux-infra_services-team"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "backport:skip"],
       "minimumReleaseAge": "7 days",
@@ -349,7 +349,7 @@
       "groupName": "XState",
       "matchDepNames": ["xstate"],
       "matchDepPrefixes": ["@xstate/"],
-      "reviewers": ["team:obs-ux-logs"],
+      "reviewers": ["team:obs-ux-logs-team"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Obs UX Logs", "release_note:skip"],
       "minimumReleaseAge": "7 days",
@@ -358,7 +358,7 @@
     {
       "groupName": "OpenTelemetry modules",
       "matchDepPrefixes": ["@opentelemetry/"],
-      "reviewers": ["team:monitoring"],
+      "reviewers": ["team:stack-monitoring"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Monitoring"],
       "minimumReleaseAge": "7 days",


### PR DESCRIPTION
These were either outdated or using an incorrect GitHub team name.