### PR TITLE
[integration automatic-import] Missing input config fix

### DIFF
--- a/x-pack/plugins/integration_assistant/common/api/model/common_attributes.schema.yaml
+++ b/x-pack/plugins/integration_assistant/common/api/model/common_attributes.schema.yaml
@@ -66,16 +66,16 @@ components:
       type: string
       description: The input type for the dataStream to pull logs from.
       enum:
-        - aws_cloudwatch
-        - aws_s3
-        - azure_blob_storage
-        - azure_eventhub
+        - aws-cloudwatch
+        - aws-s3
+        - azure-blob-storage
+        - azure-eventhub
         - cel
         - cloudfoundry
         - filestream
-        - gcp_pubsub
+        - gcp-pubsub
         - gcs
-        - http_endpoint
+        - http-endpoint
         - journald
         - kafka
         - tcp

--- a/x-pack/plugins/integration_assistant/common/api/model/common_attributes.ts
+++ b/x-pack/plugins/integration_assistant/common/api/model/common_attributes.ts
@@ -77,16 +77,16 @@ export const Pipeline = z.object({
  */
 export type InputType = z.infer<typeof InputType>;
 export const InputType = z.enum([
-  'aws_cloudwatch',
-  'aws_s3',
-  'azure_blob_storage',
-  'azure_eventhub',
+  'aws-cloudwatch',
+  'aws-s3',
+  'azure-blob-storage',
+  'azure-eventhub',
   'cel',
   'cloudfoundry',
   'filestream',
-  'gcp_pubsub',
+  'gcp-pubsub',
   'gcs',
-  'http_endpoint',
+  'http-endpoint',
   'journald',
   'kafka',
   'tcp',

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import {
   EuiComboBox,
@@ -16,27 +15,28 @@ import {
   EuiFormRow,
   EuiPanel,
 } from '@elastic/eui';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { InputType } from '../../../../../../common';
 import { useActions, type State } from '../../state';
 import type { IntegrationSettings } from '../../types';
 import { StepContentWrapper } from '../step_content_wrapper';
-import { SampleLogsInput } from './sample_logs_input';
 import type { OnComplete } from './generation_modal';
 import { GenerationModal } from './generation_modal';
-import { useLoadPackageNames } from './use_load_package_names';
+import { SampleLogsInput } from './sample_logs_input';
 import * as i18n from './translations';
+import { useLoadPackageNames } from './use_load_package_names';
 
 export const InputTypeOptions: Array<EuiComboBoxOptionOption<InputType>> = [
-  { value: 'aws_cloudwatch', label: 'AWS Cloudwatch' },
-  { value: 'aws_s3', label: 'AWS S3' },
-  { value: 'azure_blob_storage', label: 'Azure Blob Storage' },
-  { value: 'azure_eventhub', label: 'Azure Event Hub' },
+  { value: 'aws-cloudwatch', label: 'AWS Cloudwatch' },
+  { value: 'aws-s3', label: 'AWS S3' },
+  { value: 'azure-blob-storage', label: 'Azure Blob Storage' },
+  { value: 'azure-eventhub', label: 'Azure Event Hub' },
   { value: 'cel', label: 'Common Expression Language (CEL)' },
   { value: 'cloudfoundry', label: 'Cloud Foundry' },
   { value: 'filestream', label: 'File Stream' },
-  { value: 'gcp_pubsub', label: 'GCP Pub/Sub' },
+  { value: 'gcp-pubsub', label: 'GCP Pub/Sub' },
   { value: 'gcs', label: 'Google Cloud Storage' },
-  { value: 'http_endpoint', label: 'HTTP Endpoint' },
+  { value: 'http-endpoint', label: 'HTTP Endpoint' },
   { value: 'journald', label: 'Journald' },
   { value: 'kafka', label: 'Kafka' },
   { value: 'tcp', label: 'TCP' },

--- a/x-pack/plugins/integration_assistant/server/templates/build.yml.njk
+++ b/x-pack/plugins/integration_assistant/server/templates/build.yml.njk
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: "git@{{ ecs_version }}"
+    reference: "git@v{{ ecs_version }}"


### PR DESCRIPTION
## Summary

- Fixing missing configuration options by correcting input names from _ to -
- Prefixing ECS version with v in build file

<img width="982" alt="Screenshot 2024-07-18 at 3 48 42 PM" src="https://github.com/user-attachments/assets/ba7476e8-6ebd-4177-9465-bd91d85f8aca">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->