### PR TITLE
Skip serverless response header API tests for MKI runs

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/platform_security/response_headers.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/platform_security/response_headers.ts
@@ -17,6 +17,9 @@ export default function ({ getService }: FtrProviderContext) {
   let roleAuthc: RoleCredentials;
 
   describe('security/response_headers', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/188714
+    this.tags(['failsOnMKI']);
+
     const baseCSP = `script-src 'report-sample' 'self'; worker-src 'report-sample' 'self' blob:; style-src 'report-sample' 'self' 'unsafe-inline'; frame-ancestors 'self'`;
     const defaultCOOP = 'same-origin';
     const defaultPermissionsPolicy =


### PR DESCRIPTION
## Summary

This PR skips the serverless response header API integration tests for MKI runs.
Details about the failure in #188714.
