### PR TITLE
Add dev console autocomplete for params for POST _query

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/esql.query.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/esql.query.json
@@ -1,0 +1,26 @@
+{
+  "esql.query": {
+    "data_autocomplete_rules": {
+      "columnar": false,
+      "locale": "",
+      "params": [],
+      "query": ""
+    },
+    "url_params": {
+      "format": [
+        "cbor",
+        "csv",
+        "json",
+        "text",
+        "tsv",
+        "yaml",
+        "smile"
+      ],
+      "delimiter": "",
+      "drop_null_columns": [
+        "false",
+        "true"
+      ]
+    }
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/esql.query.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/esql.query.json
@@ -16,7 +16,6 @@
         "tsv",
         "yaml"
       ],
-      "delimiter": "",
       "drop_null_columns": [
         "false",
         "true"

--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/esql.query.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/esql.query.json
@@ -11,10 +11,10 @@
         "cbor",
         "csv",
         "json",
+        "smile",
         "text",
         "tsv",
-        "yaml",
-        "smile"
+        "yaml"
       ],
       "delimiter": "",
       "drop_null_columns": [


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/181429

For ES|QL `POST _query` API we are missing dev console autocomplete options.

To verify this PR, we can see now we are showing the autocomplete options for `POST _query`:

<img width="554" alt="Screenshot 2024-07-19 at 12 50 11" src="https://github.com/user-attachments/assets/8212cca9-a946-4282-a7b1-baa7a8b95233">
<img width="205" alt="Screenshot 2024-07-19 at 12 50 22" src="https://github.com/user-attachments/assets/64022e7b-dbd2-4fb0-b695-70d7cda7526f">

Values can be selected for url params:
<img width="623" alt="Screenshot 2024-07-19 at 12 48 33" src="https://github.com/user-attachments/assets/67011ed2-d180-4b48-b718-d218f19d93db">
<img width="362" alt="Screenshot 2024-07-19 at 12 50 01" src="https://github.com/user-attachments/assets/b5af07ca-8f72-4252-af06-a66afbee8ecc">

Default values for autocompleted request params:
<img width="184" alt="Screenshot 2024-07-19 at 12 50 44" src="https://github.com/user-attachments/assets/f4598fac-8bcd-4d83-80e3-2763bcc3e3a8">



For reference:

This list the API's parameters:
https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-query-api.html

For the list of values `format` can take:
https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-rest.html#esql-rest-format
