### PR TITLE
[8.15] [Security Solution] [Notes] [Cases] Create shared hook for fetching notes for tables (#188621)

### DIFF
--- a/x-pack/plugins/cases/public/client/ui/get_cases.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_cases.tsx
@@ -32,6 +32,7 @@ export const getCasesLazy = ({
   ruleDetailsNavigation,
   showAlertDetails,
   useFetchAlertData,
+  onAlertsTableLoaded,
   refreshRef,
   timelineIntegration,
   features,
@@ -55,6 +56,7 @@ export const getCasesLazy = ({
         ruleDetailsNavigation={ruleDetailsNavigation}
         showAlertDetails={showAlertDetails}
         useFetchAlertData={useFetchAlertData}
+        onAlertsTableLoaded={onAlertsTableLoaded}
         refreshRef={refreshRef}
         timelineIntegration={timelineIntegration}
       />

--- a/x-pack/plugins/cases/public/components/app/routes.tsx
+++ b/x-pack/plugins/cases/public/components/app/routes.tsx
@@ -36,6 +36,7 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
   ruleDetailsNavigation,
   showAlertDetails,
   useFetchAlertData,
+  onAlertsTableLoaded,
   refreshRef,
   timelineIntegration,
 }) => {
@@ -84,6 +85,7 @@ const CasesRoutesComponent: React.FC<CasesRoutesProps> = ({
               ruleDetailsNavigation={ruleDetailsNavigation}
               showAlertDetails={showAlertDetails}
               useFetchAlertData={useFetchAlertData}
+              onAlertsTableLoaded={onAlertsTableLoaded}
               refreshRef={refreshRef}
               timelineIntegration={timelineIntegration}
             />

--- a/x-pack/plugins/cases/public/components/app/types.ts
+++ b/x-pack/plugins/cases/public/components/app/types.ts
@@ -21,4 +21,5 @@ export interface CasesRoutesProps {
    */
   refreshRef?: MutableRefObject<CaseViewRefreshPropInterface>;
   timelineIntegration?: CasesTimelineIntegration;
+  onAlertsTableLoaded?: (eventIds: Array<Partial<{ _id: string }>>) => void;
 }

--- a/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/case_view_page.tsx
@@ -39,6 +39,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
     actionsNavigation,
     showAlertDetails,
     useFetchAlertData,
+    onAlertsTableLoaded,
   }) => {
     const { features } = useCasesContext();
     const { urlParams } = useUrlParams();
@@ -121,7 +122,7 @@ export const CaseViewPage = React.memo<CaseViewPageProps>(
             />
           )}
           {activeTabId === CASE_VIEW_PAGE_TABS.ALERTS && features.alerts.enabled && (
-            <CaseViewAlerts caseData={caseData} />
+            <CaseViewAlerts caseData={caseData} onAlertsTableLoaded={onAlertsTableLoaded} />
           )}
           {activeTabId === CASE_VIEW_PAGE_TABS.FILES && <CaseViewFiles caseData={caseData} />}
         </EuiFlexGroup>

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.tsx
@@ -20,8 +20,9 @@ import { CaseViewTabs } from '../case_view_tabs';
 import { CASE_VIEW_PAGE_TABS } from '../../../../common/types';
 interface CaseViewAlertsProps {
   caseData: CaseUI;
+  onAlertsTableLoaded?: (eventIds: Array<Partial<{ _id: string }>>) => void;
 }
-export const CaseViewAlerts = ({ caseData }: CaseViewAlertsProps) => {
+export const CaseViewAlerts = ({ caseData, onAlertsTableLoaded }: CaseViewAlertsProps) => {
   const { triggersActionsUi } = useKibana().services;
 
   const alertIds = getManualAlertIds(caseData.comments);
@@ -58,6 +59,7 @@ export const CaseViewAlerts = ({ caseData }: CaseViewAlertsProps) => {
         : alertData?.featureIds ?? []) as ValidFeatureId[],
       query: alertIdsQuery,
       showAlertStatusWithFlapping: caseData.owner !== SECURITY_SOLUTION_OWNER,
+      onLoaded: onAlertsTableLoaded,
     }),
     [
       triggersActionsUi.alertsTableConfigurationRegistry,
@@ -65,6 +67,7 @@ export const CaseViewAlerts = ({ caseData }: CaseViewAlertsProps) => {
       caseData.owner,
       alertData?.featureIds,
       alertIdsQuery,
+      onAlertsTableLoaded,
     ]
   );
 

--- a/x-pack/plugins/cases/public/components/case_view/index.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/index.tsx
@@ -33,6 +33,7 @@ export const CaseView = React.memo(
     showAlertDetails,
     timelineIntegration,
     useFetchAlertData,
+    onAlertsTableLoaded,
     refreshRef,
   }: CaseViewProps) => {
     const { spaces: spacesApi } = useKibana().services;
@@ -85,6 +86,7 @@ export const CaseView = React.memo(
           ruleDetailsNavigation={ruleDetailsNavigation}
           showAlertDetails={showAlertDetails}
           useFetchAlertData={useFetchAlertData}
+          onAlertsTableLoaded={onAlertsTableLoaded}
           refreshRef={refreshRef}
         />
       </CasesTimelineIntegrationProvider>

--- a/x-pack/plugins/cases/public/components/case_view/types.ts
+++ b/x-pack/plugins/cases/public/components/case_view/types.ts
@@ -16,6 +16,7 @@ export interface CaseViewBaseProps {
   ruleDetailsNavigation?: CasesNavigation<string | null | undefined, 'configurable'>;
   showAlertDetails?: (alertId: string, index: string) => void;
   useFetchAlertData: UseFetchAlertData;
+  onAlertsTableLoaded?: (eventIds: Array<Partial<{ _id: string }>>) => void;
   /**
    * A React `Ref` that Exposes data refresh callbacks.
    * **NOTE**: Do not hold on to the `.current` object, as it could become stale

--- a/x-pack/plugins/security_solution/public/cases/pages/index.tsx
+++ b/x-pack/plugins/security_solution/public/cases/pages/index.tsx
@@ -35,6 +35,7 @@ import * as timelineMarkdownPlugin from '../../common/components/markdown_editor
 import { DetailsPanel } from '../../timelines/components/side_panel';
 import { useFetchAlertData } from './use_fetch_alert_data';
 import { useUpsellingMessage } from '../../common/hooks/use_upselling';
+import { useFetchNotes } from '../../notes/hooks/use_fetch_notes';
 
 const TimelineDetailsPanel = () => {
   const { browserFields, runtimeMappings } = useSourcererDataView(SourcererScopeName.detections);
@@ -102,6 +103,8 @@ const CaseContainerComponent: React.FC = () => {
     },
     [dispatch, expandableFlyoutDisabled, openFlyout, telemetry]
   );
+
+  const { onLoad: onAlertsTableLoaded } = useFetchNotes();
 
   const endpointDetailsHref = (endpointId: string) =>
     getAppUrl({
@@ -195,6 +198,7 @@ const CaseContainerComponent: React.FC = () => {
             },
           },
           useFetchAlertData,
+          onAlertsTableLoaded,
           permissions: userCasesPermissions,
         })}
       </CaseDetailsRefreshContext.Provider>

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/use_timelines_events.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/use_timelines_events.tsx
@@ -29,13 +29,13 @@ import type {
   TimelineStrategyResponseType,
 } from '@kbn/timelines-plugin/common/search_strategy';
 import { dataTableActions, Direction, TableId } from '@kbn/securitysolution-data-table';
-import { fetchNotesByDocumentIds } from '../../../notes/store/notes.slice';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
 import { TimelineEventsQueries } from '../../../../common/search_strategy';
 import type { KueryFilterQueryKind } from '../../../../common/types';
 import type { ESQuery } from '../../../../common/typed_json';
 import type { AlertWorkflowStatus } from '../../types';
 import { getSearchTransactionName, useStartTransaction } from '../../lib/apm/use_start_transaction';
+import { useFetchNotes } from '../../../notes/hooks/use_fetch_notes';
 export type InspectResponse = Inspect & { response: string[] };
 
 export const detectionsTimelineIds = [TableId.alertsOnAlertsPage, TableId.alertsOnRuleDetailsPage];
@@ -458,14 +458,15 @@ export const useTimelineEvents = ({
     data,
   });
 
+  const { onLoad } = useFetchNotes();
+
   useEffect(() => {
     if (!timelineSearchHandler) return;
     timelineSearchHandler();
 
     // fetch notes for the events
-    const events = timelineResponse.events.map((event: TimelineItem) => event._id);
-    dispatch(fetchNotesByDocumentIds({ documentIds: events }));
-  }, [dispatch, timelineResponse.events, timelineSearchHandler]);
+    onLoad(timelineResponse.events);
+  }, [dispatch, timelineResponse.events, timelineSearchHandler, onLoad]);
 
   return [loading, timelineResponse];
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -11,7 +11,7 @@ import type { Filter } from '@kbn/es-query';
 import type { FC } from 'react';
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import type { AlertsTableStateProps } from '@kbn/triggers-actions-ui-plugin/public/application/sections/alerts_table/alerts_table_state';
-import type { Alert, Alerts } from '@kbn/triggers-actions-ui-plugin/public/types';
+import type { Alert } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { ALERT_BUILDING_BLOCK_TYPE } from '@kbn/rule-data-utils';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
@@ -22,7 +22,6 @@ import {
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
-import { fetchNotesByDocumentIds } from '../../../notes/store/notes.slice';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useLicense } from '../../../common/hooks/use_license';
 import { VIEW_SELECTION } from '../../../../common/constants';
@@ -49,6 +48,7 @@ import type { State } from '../../../common/store';
 import * as i18n from './translations';
 import { eventRenderedViewColumns } from '../../configurations/security_solution_detections/columns';
 import { getAlertsDefaultModel } from './default_config';
+import { useFetchNotes } from '../../../notes/hooks/use_fetch_notes';
 
 const { updateIsLoading, updateTotalCount } = dataTableActions;
 
@@ -266,13 +266,7 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
     };
   }, []);
 
-  const onLoaded = useCallback(
-    (alerts: Alerts) => {
-      const alertIds = alerts.map((alert: Alert) => alert._id);
-      dispatch(fetchNotesByDocumentIds({ documentIds: alertIds }));
-    },
-    [dispatch]
-  );
+  const { onLoad } = useFetchNotes();
 
   const alertStateProps: AlertsTableStateProps = useMemo(
     () => ({
@@ -289,7 +283,7 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
       browserFields: finalBrowserFields,
       onUpdate: onAlertTableUpdate,
       cellContext,
-      onLoaded,
+      onLoaded: onLoad,
       runtimeMappings,
       toolbarVisibility: {
         showColumnSelector: !isEventRenderedView,
@@ -310,7 +304,7 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
       runtimeMappings,
       isEventRenderedView,
       cellContext,
-      onLoaded,
+      onLoad,
     ]
   );
 

--- a/x-pack/plugins/security_solution/public/notes/hooks/use_fetch_notes.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/hooks/use_fetch_notes.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useDispatch } from 'react-redux';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { fetchNotesByDocumentIds } from '../store/notes.slice';
+import { useFetchNotes } from './use_fetch_notes';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../common/hooks/use_experimental_features', () => ({
+  useIsExperimentalFeatureEnabled: jest.fn(),
+}));
+
+jest.mock('../store/notes.slice', () => ({
+  fetchNotesByDocumentIds: jest.fn(),
+}));
+
+const mockedUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+const mockedUseIsExperimentalFeatureEnabled =
+  useIsExperimentalFeatureEnabled as jest.MockedFunction<typeof useIsExperimentalFeatureEnabled>;
+
+describe('useFetchNotes', () => {
+  let mockDispatch: jest.Mock;
+
+  beforeEach(() => {
+    mockDispatch = jest.fn();
+    mockedUseDispatch.mockReturnValue(mockDispatch);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return onLoad function', () => {
+    const { result } = renderHook(() => useFetchNotes());
+    expect(result.current).toHaveProperty('onLoad');
+    expect(typeof result.current.onLoad).toBe('function');
+  });
+
+  it('should not dispatch action when securitySolutionNotesEnabled is false', () => {
+    mockedUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+    const { result } = renderHook(() => useFetchNotes());
+
+    result.current.onLoad([{ _id: '1' }]);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('should not dispatch action when events array is empty', () => {
+    mockedUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    const { result } = renderHook(() => useFetchNotes());
+
+    result.current.onLoad([]);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('should dispatch fetchNotesByDocumentIds with correct ids when conditions are met', () => {
+    mockedUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    const { result } = renderHook(() => useFetchNotes());
+
+    const events = [{ _id: '1' }, { _id: '2' }, { _id: '3' }];
+    result.current.onLoad(events);
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      fetchNotesByDocumentIds({ documentIds: ['1', '2', '3'] })
+    );
+  });
+
+  it('should memoize onLoad function', () => {
+    mockedUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    const { result, rerender } = renderHook(() => useFetchNotes());
+
+    const firstOnLoad = result.current.onLoad;
+    rerender();
+    const secondOnLoad = result.current.onLoad;
+
+    expect(firstOnLoad).toBe(secondOnLoad);
+  });
+
+  it('should update onLoad when securitySolutionNotesEnabled changes', () => {
+    mockedUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    const { result, rerender } = renderHook(() => useFetchNotes());
+
+    const firstOnLoad = result.current.onLoad;
+
+    mockedUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+    rerender();
+    const secondOnLoad = result.current.onLoad;
+
+    expect(firstOnLoad).not.toBe(secondOnLoad);
+  });
+});

--- a/x-pack/plugins/security_solution/public/notes/hooks/use_fetch_notes.ts
+++ b/x-pack/plugins/security_solution/public/notes/hooks/use_fetch_notes.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
+import { fetchNotesByDocumentIds } from '..';
+
+export const useFetchNotes = () => {
+  const dispatch = useDispatch();
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
+  const onLoad = useCallback(
+    (events: Array<Partial<{ _id: string }>>) => {
+      if (!securitySolutionNotesEnabled || events.length === 0) return;
+
+      const eventIds: string[] = events
+        .map((event) => event._id)
+        .filter((id) => id != null) as string[];
+      dispatch(fetchNotesByDocumentIds({ documentIds: eventIds }));
+    },
+    [dispatch, securitySolutionNotesEnabled]
+  );
+
+  return { onLoad };
+};

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
@@ -46,6 +46,7 @@ import type {
 } from '../../../common/search_strategy/timeline/events/eql';
 import { useTrackHttpRequest } from '../../common/lib/apm/use_track_http_request';
 import { APP_UI_ID } from '../../../common/constants';
+import { useFetchNotes } from '../../notes/hooks/use_fetch_notes';
 
 export interface TimelineArgs {
   events: TimelineItem[];
@@ -499,11 +500,13 @@ export const useTimelineEvents = ({
     skip,
     timerangeKind,
   });
+  const { onLoad } = useFetchNotes();
 
   useEffect(() => {
     if (!timelineSearchHandler) return;
     timelineSearchHandler();
-  }, [timelineSearchHandler]);
+    onLoad(timelineResponse.events);
+  }, [timelineSearchHandler, onLoad, timelineResponse.events]);
 
   return [dataLoadingState, timelineResponse];
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Security Solution] [Notes] [Cases] Create shared hook for fetching notes for tables (#188621)](https://github.com/elastic/kibana/pull/188621)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-07-19T15:59:17Z","message":"[Security Solution] [Notes] [Cases] Create shared hook for fetching notes for tables (#188621)\n\n## Summary\r\n\r\nThis pr updates the cases public component props to accept an onLoad\r\nprop that is already exposed by the alerts table in trigger actions ui,\r\nto be used in the cases alerts table by security solution to fetch notes\r\ndata whenever the set of documents in the table changes. Also creates a\r\nnew hook for using this logic in the data fetching hooks powering the\r\nvarious data tables in the security solution.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"a1bb786aa1341a2d8df6440957b248af562b0a09","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","Team:Threat Hunting:Investigations","v8.16.0"],"number":188621,"url":"https://github.com/elastic/kibana/pull/188621","mergeCommit":{"message":"[Security Solution] [Notes] [Cases] Create shared hook for fetching notes for tables (#188621)\n\n## Summary\r\n\r\nThis pr updates the cases public component props to accept an onLoad\r\nprop that is already exposed by the alerts table in trigger actions ui,\r\nto be used in the cases alerts table by security solution to fetch notes\r\ndata whenever the set of documents in the table changes. Also creates a\r\nnew hook for using this logic in the data fetching hooks powering the\r\nvarious data tables in the security solution.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"a1bb786aa1341a2d8df6440957b248af562b0a09"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188621","number":188621,"mergeCommit":{"message":"[Security Solution] [Notes] [Cases] Create shared hook for fetching notes for tables (#188621)\n\n## Summary\r\n\r\nThis pr updates the cases public component props to accept an onLoad\r\nprop that is already exposed by the alerts table in trigger actions ui,\r\nto be used in the cases alerts table by security solution to fetch notes\r\ndata whenever the set of documents in the table changes. Also creates a\r\nnew hook for using this logic in the data fetching hooks powering the\r\nvarious data tables in the security solution.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"a1bb786aa1341a2d8df6440957b248af562b0a09"}}]}] BACKPORT-->