### PR TITLE
Revert org wide PR bot

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
-        ELASTIC_GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true'
+        GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true'
         GITHUB_COMMIT_STATUS_CONTEXT: buildkite/on-merge
         REPORT_FAILED_TESTS_TO_GITHUB: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'

--- a/.buildkite/pipeline-resource-definitions/kibana-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-pr.yml
@@ -19,7 +19,7 @@ spec:
       description: Runs manually for pull requests
     spec:
       env:
-        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+        PR_COMMENTS_ENABLED: 'true'
         GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true'
         GITHUB_BUILD_COMMIT_STATUS_CONTEXT: kibana-ci
         GITHUB_STEP_COMMIT_STATUS_ENABLED: 'true'

--- a/.buildkite/pipeline-resource-definitions/kibana-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-pr.yml
@@ -20,9 +20,9 @@ spec:
     spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
-        ELASTIC_GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true'
-        ELASTIC_GITHUB_STEP_COMMIT_STATUS_ENABLED: 'true'
+        GITHUB_BUILD_COMMIT_STATUS_ENABLED: 'true'
         GITHUB_BUILD_COMMIT_STATUS_CONTEXT: kibana-ci
+        GITHUB_STEP_COMMIT_STATUS_ENABLED: 'true'
       allow_rebuilds: true
       branch_configuration: ''
       cancel_intermediate_builds: true

--- a/.buildkite/pipeline-utils/test-failures/annotate.ts
+++ b/.buildkite/pipeline-utils/test-failures/annotate.ts
@@ -170,7 +170,7 @@ export const annotateTestFailures = async () => {
 
   buildkite.setAnnotation('test_failures', 'error', getAnnotation(failures, failureHtmlArtifacts));
 
-  if (process.env.ELASTIC_PR_COMMENTS_ENABLED === 'true') {
+  if (process.env.PR_COMMENTS_ENABLED === 'true') {
     buildkite.setMetadata(
       'pr_comment:test_failures:body',
       getPrComment(failures, failureHtmlArtifacts)

--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 BUILD_SUCCESSFUL=$(ts-node "$(dirname "${0}")/build_status.ts")
 export BUILD_SUCCESSFUL
 
-if [[ "${ELASTIC_GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
+if [[ "${GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
   "$(dirname "${0}")/commit_status_complete.sh"
 fi
 

--- a/.buildkite/scripts/lifecycle/pre_build.sh
+++ b/.buildkite/scripts/lifecycle/pre_build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-if [[ "${ELASTIC_GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
+if [[ "${GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
   "$(dirname "${0}")/commit_status_start.sh"
 fi
 


### PR DESCRIPTION
We're seeing frequent check timeouts on the org wide version.  This rolls back to the Kibana version

<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->