### PR TITLE
[Detection Engine] Enable ML alert suppression for 8.15

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -168,7 +168,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables alerts suppression for machine learning rules
    */
-  alertSuppressionForMachineLearningRuleEnabled: false,
+  alertSuppressionForMachineLearningRuleEnabled: true,
 
   /**
    * Enables experimental Experimental S1 integration data to be available in Analyzer


### PR DESCRIPTION
This keeps the feature flag around, but simply makes it enabled by default. This is a simplified version of https://github.com/elastic/kibana/pull/188747, which removes the feature flag entirely.