### PR TITLE
[Search] Fix missing sync rules in native connectors

### DIFF
--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -1276,6 +1276,10 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       defaultMessage: 'Github',
     }),
     features: {
+      [FeatureName.SYNC_RULES]: {
+        advanced: { enabled: true },
+        basic: { enabled: true },
+      },
       [FeatureName.INCREMENTAL_SYNC]: {
         enabled: true,
       },
@@ -2566,7 +2570,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
     },
     features: {
       [FeatureName.SYNC_RULES]: {
-        advanced: { enabled: false },
+        advanced: { enabled: true },
         basic: { enabled: true },
       },
     },
@@ -2868,7 +2872,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
     },
     features: {
       [FeatureName.SYNC_RULES]: {
-        advanced: { enabled: false },
+        advanced: { enabled: true },
         basic: { enabled: true },
       },
       [FeatureName.INCREMENTAL_SYNC]: {
@@ -3098,6 +3102,10 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       defaultMessage: 'OneDrive',
     }),
     features: {
+      [FeatureName.SYNC_RULES]: {
+        advanced: { enabled: true },
+        basic: { enabled: true },
+      },
       [FeatureName.DOCUMENT_LEVEL_SECURITY]: {
         enabled: true,
       },
@@ -3864,7 +3872,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
     },
     features: {
       [FeatureName.SYNC_RULES]: {
-        advanced: { enabled: false },
+        advanced: { enabled: true },
         basic: { enabled: true },
       },
     },
@@ -4013,7 +4021,12 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         value: false,
       },
     },
-    features: {},
+    features: {
+      [FeatureName.SYNC_RULES]: {
+        advanced: { enabled: true },
+        basic: { enabled: true },
+      },
+    },
     name: i18n.translate('searchConnectors.content.nativeConnectors.s3.name', {
       defaultMessage: 'S3',
     }),
@@ -4021,6 +4034,10 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
   },
   salesforce: {
     features: {
+      FeatureName.SYNC_RULES]: {
+        advanced: { enabled: true },
+        basic: { enabled: true },
+      },
       [FeatureName.INCREMENTAL_SYNC]: {
         enabled: true,
       },

--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -4034,7 +4034,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
   },
   salesforce: {
     features: {
-      FeatureName.SYNC_RULES]: {
+      [FeatureName.SYNC_RULES]: {
         advanced: { enabled: true },
         basic: { enabled: true },
       },

--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -1404,6 +1404,10 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       },
     },
     features: {
+      [FeatureName.SYNC_RULES]: {
+        advanced: { enabled: true },
+        basic: { enabled: true },
+      },
       [FeatureName.DOCUMENT_LEVEL_SECURITY]: {
         enabled: true,
       },
@@ -2973,7 +2977,12 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         value: '',
       },
     },
-    features: {},
+    features: {
+      [FeatureName.SYNC_RULES]: {
+        advanced: { enabled: true },
+        basic: { enabled: true },
+      },
+    },
     name: i18n.translate('searchConnectors.nativeConnectors.notion.name', {
       defaultMessage: 'Notion',
     }),


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2686 

## Summary

The following set of connectors gained support for the advanced sync rules feature in a later release compared to the one where they were made available as native connector. Consequently, enabling advanced rules for these connectors was missed.
- Postgres
- Network Drive
- MSSQL
- GitHub
- OneDrive
- Salesforce
- S3
- GMail
- Notion


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->