### PR TITLE
[ES|QL] Max/Min support IP fields

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -116,8 +116,8 @@ describe('autocomplete.suggest', () => {
       test('when typing inside function left paren', async () => {
         const { assertSuggestions } = await setup();
         const expected = [
-          ...getFieldNamesByType(['number', 'date', 'boolean']),
-          ...getFunctionSignaturesByReturnType('stats', ['number', 'date', 'boolean'], {
+          ...getFieldNamesByType(['number', 'date', 'boolean', 'ip']),
+          ...getFunctionSignaturesByReturnType('stats', ['number', 'date', 'boolean', 'ip'], {
             evalMath: true,
           }),
         ];

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/aggs.ts
@@ -112,6 +112,10 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
           params: [{ name: 'column', type: 'boolean', noNestingFunctions: true }],
           returnType: 'boolean',
         },
+        {
+          params: [{ name: 'column', type: 'ip', noNestingFunctions: true }],
+          returnType: 'ip',
+        },
       ],
       examples: [`from index | stats result = max(field)`, `from index | stats max(field)`],
     },
@@ -134,6 +138,10 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
         {
           params: [{ name: 'column', type: 'boolean', noNestingFunctions: true }],
           returnType: 'boolean',
+        },
+        {
+          params: [{ name: 'column', type: 'ip', noNestingFunctions: true }],
+          returnType: 'ip',
         },
       ],
       examples: [`from index | stats result = min(field)`, `from index | stats min(field)`],

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -24202,6 +24202,58 @@
       "warning": []
     },
     {
+      "query": "from a_index | stats var = max(ipField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats max(ipField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where max(ipField)",
+      "error": [
+        "WHERE does not support function max"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where max(ipField) > 0",
+      "error": [
+        "WHERE does not support function max"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = max(ipField)",
+      "error": [
+        "EVAL does not support function max"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = max(ipField) > 0",
+      "error": [
+        "EVAL does not support function max"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval max(ipField)",
+      "error": [
+        "EVAL does not support function max"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval max(ipField) > 0",
+      "error": [
+        "EVAL does not support function max"
+      ],
+      "warning": []
+    },
+    {
       "query": "from a_index | stats var = min(numberField)",
       "error": [],
       "warning": []
@@ -24521,6 +24573,58 @@
     },
     {
       "query": "from a_index | eval min(booleanField) > 0",
+      "error": [
+        "EVAL does not support function min"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats var = min(ipField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | stats min(ipField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where min(ipField)",
+      "error": [
+        "WHERE does not support function min"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where min(ipField) > 0",
+      "error": [
+        "WHERE does not support function min"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = min(ipField)",
+      "error": [
+        "EVAL does not support function min"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = min(ipField) > 0",
+      "error": [
+        "EVAL does not support function min"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval min(ipField)",
+      "error": [
+        "EVAL does not support function min"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval min(ipField) > 0",
       "error": [
         "EVAL does not support function min"
       ],

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -9202,6 +9202,32 @@ describe('validation logic', () => {
         testErrorsAndWarnings('from a_index | eval max(booleanField) > 0', [
           'EVAL does not support function max',
         ]);
+        testErrorsAndWarnings('from a_index | stats var = max(ipField)', []);
+        testErrorsAndWarnings('from a_index | stats max(ipField)', []);
+
+        testErrorsAndWarnings('from a_index | where max(ipField)', [
+          'WHERE does not support function max',
+        ]);
+
+        testErrorsAndWarnings('from a_index | where max(ipField) > 0', [
+          'WHERE does not support function max',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval var = max(ipField)', [
+          'EVAL does not support function max',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval var = max(ipField) > 0', [
+          'EVAL does not support function max',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval max(ipField)', [
+          'EVAL does not support function max',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval max(ipField) > 0', [
+          'EVAL does not support function max',
+        ]);
       });
 
       describe('min', () => {
@@ -9372,6 +9398,32 @@ describe('validation logic', () => {
         ]);
 
         testErrorsAndWarnings('from a_index | eval min(booleanField) > 0', [
+          'EVAL does not support function min',
+        ]);
+        testErrorsAndWarnings('from a_index | stats var = min(ipField)', []);
+        testErrorsAndWarnings('from a_index | stats min(ipField)', []);
+
+        testErrorsAndWarnings('from a_index | where min(ipField)', [
+          'WHERE does not support function min',
+        ]);
+
+        testErrorsAndWarnings('from a_index | where min(ipField) > 0', [
+          'WHERE does not support function min',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval var = min(ipField)', [
+          'EVAL does not support function min',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval var = min(ipField) > 0', [
+          'EVAL does not support function min',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval min(ipField)', [
+          'EVAL does not support function min',
+        ]);
+
+        testErrorsAndWarnings('from a_index | eval min(ipField) > 0', [
           'EVAL does not support function min',
         ]);
       });


### PR DESCRIPTION
## Summary

Follow up of https://github.com/elastic/elasticsearch/pull/110921

ES|QL max and min aggregations support now IP fields.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

