### PR TITLE
[i18n] remove `Object.freeze` in `initTranslations`

### DIFF
--- a/packages/core/i18n/core-i18n-server-internal/src/init_translations.ts
+++ b/packages/core/i18n/core-i18n-server-internal/src/init_translations.ts
@@ -11,5 +11,6 @@ import { i18n, i18nLoader } from '@kbn/i18n';
 export const initTranslations = async (locale: string, translationFiles: string[]) => {
   i18nLoader.registerTranslationFiles(translationFiles);
   const translations = await i18nLoader.getTranslationsByLocale(locale);
-  i18n.init(Object.freeze({ ...translations, locale }));
+  translations.locale = locale;
+  i18n.init(translations);
 };

--- a/packages/kbn-i18n/src/loader.ts
+++ b/packages/kbn-i18n/src/loader.ts
@@ -6,9 +6,8 @@
  * Side Public License, v 1.
  */
 
-import * as fs from 'fs';
+import { readFile } from 'fs/promises';
 import * as path from 'path';
-import { promisify } from 'util';
 import { TranslationInput } from './translation';
 
 const TRANSLATION_FILE_EXTENSION = '.json';
@@ -54,8 +53,7 @@ function getLocaleFromFileName(fullFileName: string) {
  * @returns
  */
 async function loadFile(pathToFile: string): Promise<TranslationInput> {
-  // doing this at the moment because fs is mocked in a lot of places where this would otherwise fail
-  return JSON.parse(await promisify(fs.readFile)(pathToFile, 'utf8'));
+  return JSON.parse(await readFile(pathToFile, 'utf8'));
 }
 
 /**
@@ -123,10 +121,10 @@ export async function getTranslationsByLocale(locale: string): Promise<Translati
     return { locale, messages: {} };
   }
 
-  const fileTrasnlationDetails = files.map((file) => loadedFiles[file]);
+  const fileTranslationDetails = files.map((file) => loadedFiles[file]);
 
-  const filesLocale = fileTrasnlationDetails[0].locale || locale;
-  const translationInput = fileTrasnlationDetails.reduce((acc, translation) => ({
+  const filesLocale = fileTranslationDetails[0].locale || locale;
+  const translationInput = fileTranslationDetails.reduce((acc, translation) => ({
     locale,
     formats: translation.formats
       ? Object.assign(acc.formats || {}, translation.formats)


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/180810

Title.