### PR TITLE
[i18n] include i18nrc file in 3rd party plugin bundles

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -96,6 +96,7 @@ it('builds a generated plugin into a viable archive', async () => {
 
   expect(files).toMatchInlineSnapshot(`
     Array [
+      "kibana/fooTestPlugin/.i18nrc.json",
       "kibana/fooTestPlugin/common/index.js",
       "kibana/fooTestPlugin/kibana.json",
       "kibana/fooTestPlugin/node_modules/.yarn-integrity",

--- a/packages/kbn-plugin-helpers/src/tasks/write_server_files.ts
+++ b/packages/kbn-plugin-helpers/src/tasks/write_server_files.ts
@@ -32,6 +32,7 @@ export async function writeServerFiles({
     vfs.src(
       [
         'kibana.json',
+        '.i18nrc.json',
         ...(plugin.manifest.server
           ? config.serverSourcePatterns || [
               'yarn.lock',


### PR DESCRIPTION
## Summary

Fix #57273

Include the `. i18nrc.json` file when bundling 3rd party plugins