### PR TITLE
[FTR] Fixup Requester Attempt Logic (specifically cli output)

### DIFF
--- a/packages/kbn-test/src/kbn_client/kbn_client_requester.ts
+++ b/packages/kbn-test/src/kbn_client/kbn_client_requester.ts
@@ -121,6 +121,7 @@ export class KbnClientRequester {
     const maxAttempts = options.retries ?? DEFAULT_MAX_ATTEMPTS;
     const msgOrThrow = errMsg({
       redacted,
+      maxAttempts,
       requestedRetries: options.retries !== undefined,
       failedToGetResponseSvc: (error: Error) => isAxiosRequestError(error),
       ...options,
@@ -138,7 +139,7 @@ export class KbnClientRequester {
           continue;
         }
         throw new KbnClientRequesterError(
-          `${msgOrThrow(attempt, maxAttempts, error)} -- and ran out of retries`,
+          `${msgOrThrow(attempt, error)} -- and ran out of retries`,
           error
         );
       }
@@ -149,16 +150,18 @@ export class KbnClientRequester {
 export function errMsg({
   redacted,
   requestedRetries,
+  maxAttempts,
   failedToGetResponseSvc,
   path,
   method,
   description,
 }: ReqOptions & {
   redacted: string;
+  maxAttempts: number;
   requestedRetries: boolean;
   failedToGetResponseSvc: (x: Error) => boolean;
 }) {
-  return function errMsgOrReThrow(attempt: number, maxAttempts: number, _: any) {
+  return function errMsgOrReThrow(attempt: number, _: any) {
     const result = isConcliftOnGetError(_)
       ? `Conflict on GET (path=${path}, attempt=${attempt}/${maxAttempts})`
       : requestedRetries || failedToGetResponseSvc(_)


### PR DESCRIPTION
## Summary
### What 
Simply change function signatures and types (for one variable), such that the `attempt` variable is accurate at invocation time.

### Why
After merging https://github.com/elastic/kibana/pull/188292
I noticed the output did not properly have the integers shown on the cli:

## Before
```
                 └- ✖ fail: index_patterns index_patterns/service/lib index_patterns/* error handler "before all" hook in "index_patterns/* error handler"
                 │      KbnClientRequesterError: [GET - http://localhost:5620/api/status] request failed (attempt=0/5): ECONNREFUSED -- and ran out of retries
                 │       at KbnClientRequester.request (kbn_client_requester.ts:142:15)
                 │       at processTicksAndRejections (node:internal/process/task_queues:95:5)
                 │       at KbnClientStatus.get (kbn_client_status.ts:43:22)
                 │       at KbnClientPlugins.getEnabledIds (kbn_client_plugins.ts:17:21)
                 │       at loadAction (load.ts:80:27)
                 │       at Proxy.load (es_archiver.ts:99:12)
                 │       at Context.<anonymous> (errors.js:29:7)
                 │       at Object.apply (wrap_function.js:73:16)
                 │ 
```
## After
```
                 └- ✖ fail: index_patterns index_patterns/service/lib index_patterns/* error handler "before all" hook in "index_patterns/* error handler"
                 │      KbnClientRequesterError: [GET - http://localhost:5620/api/status] request failed (attempt=5/5): ECONNREFUSED -- and ran out of retries
                 │       at KbnClientRequester.request (kbn_client_requester.ts:140:15)
                 │       at processTicksAndRejections (node:internal/process/task_queues:95:5)
                 │       at KbnClientStatus.get (kbn_client_status.ts:43:22)
                 │       at KbnClientPlugins.getEnabledIds (kbn_client_plugins.ts:17:21)
                 │       at loadAction (load.ts:80:27)
                 │       at Proxy.load (es_archiver.ts:99:12)
                 │       at Context.<anonymous> (errors.js:29:7)
                 │       at Object.apply (wrap_function.js:73:16)
```
Please draw your attention to: 
 **BEFORE**: `KbnClientRequesterError: [GET - http://localhost:5620/api/status] request failed (attempt=0/5): ECONNREFUSED -- and ran out of retries` 
 vs 
 **AFTER**: `KbnClientRequesterError: [GET - http://localhost:5620/api/status] request failed (attempt=5/5): ECONNREFUSED -- and ran out of retries` 
 
 So it's now `(attempt=5/5)` and no longer `(attempt=0/5)`
 
 ## To Verify
 **no need to start server**
 Place a `.only` on [this line](https://github.com/elastic/kibana/blob/7089f35803f500c18b35a407d50c9d0b883fc05f/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts#L40)
 Then run the test with the `.only`
 ```
TEST_BROWSER_HEADLESS=1 node scripts/functional_test_runner --config=x-pack/test_serverless/functional/test_suites/security/config.context_awareness.ts
```
