### PR TITLE
[8.14] [Telemetry][Security Solution] Enrich endpoint alerts with license info (#188760)

### DIFF
--- a/x-pack/plugins/security_solution/server/integration_tests/lib/helpers.ts
+++ b/x-pack/plugins/security_solution/server/integration_tests/lib/helpers.ts
@@ -22,8 +22,8 @@ const asyncUnlink = Util.promisify(Fs.unlink);
  */
 export async function eventually<T>(
   cb: () => Promise<T>,
-  duration: number = 60000,
-  interval: number = 1000
+  duration: number = 120000,
+  interval: number = 3000
 ) {
   let elapsed = 0;
 

--- a/x-pack/plugins/security_solution/server/integration_tests/telemetry.test.ts
+++ b/x-pack/plugins/security_solution/server/integration_tests/telemetry.test.ts
@@ -262,7 +262,7 @@ describe('telemetry tasks', () => {
       // wait until the events are sent to the telemetry server
       const body = await eventually(async () => {
         const found = mockedAxiosPost.mock.calls.find(([url]) => {
-          return url.startsWith(ENDPOINT_STAGING) && url.endsWith('alerts-endpoint');
+          return url.startsWith(ENDPOINT_STAGING) && url.endsWith(TelemetryChannel.ENDPOINT_ALERTS);
         });
 
         expect(found).not.toBeFalsy();
@@ -272,6 +272,25 @@ describe('telemetry tasks', () => {
 
       expect(body).not.toBeFalsy();
       expect(body.Endpoint).not.toBeFalsy();
+    });
+
+    it('should enrich with license info', async () => {
+      await mockAndScheduleEndpointDiagnosticsTask();
+
+      // wait until the events are sent to the telemetry server
+      const body = await eventually(async () => {
+        const found = mockedAxiosPost.mock.calls.find(([url]) => {
+          return url.startsWith(ENDPOINT_STAGING) && url.endsWith(TelemetryChannel.ENDPOINT_ALERTS);
+        });
+
+        expect(found).not.toBeFalsy();
+
+        return JSON.parse((found ? found[1] : '{}') as string);
+      });
+
+      expect(body).not.toBeFalsy();
+      expect(body.license).not.toBeFalsy();
+      expect(body.license.status).not.toBeFalsy();
     });
   });
 
@@ -679,8 +698,7 @@ describe('telemetry tasks', () => {
       expect(body.file).toStrictEqual(alertsDetectionsRequest.file);
     });
 
-    // Flaky: https://github.com/elastic/kibana/issues/188234
-    it.skip('should manage runtime errors searching endpoint metrics', async () => {
+    it('should manage runtime errors searching endpoint metrics', async () => {
       const errorMessage = 'Something went wront';
 
       async function* mockedGenerator(

--- a/x-pack/plugins/security_solution/server/lib/telemetry/async_sender.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/async_sender.ts
@@ -21,7 +21,7 @@ import { TelemetryChannel, TelemetryCounter } from './types';
 import * as collections from './collections_helpers';
 import { CachedSubject, retryOnError$ } from './rxjs_helpers';
 import { SenderUtils } from './sender_helpers';
-import { newTelemetryLogger } from './helpers';
+import { copyLicenseFields, newTelemetryLogger } from './helpers';
 import { type TelemetryLogger } from './telemetry_logger';
 
 export const DEFAULT_QUEUE_CONFIG: QueueConfig = {
@@ -281,6 +281,14 @@ export class AsyncTelemetryEventsSender implements IAsyncTelemetryEventsSender {
       } else {
         additional = {
           cluster_uuid: clusterInfo?.cluster_uuid,
+        };
+      }
+
+      if (event.channel === TelemetryChannel.ENDPOINT_ALERTS) {
+        const licenseInfo = this.telemetryReceiver?.getLicenseInfo();
+        additional = {
+          ...additional,
+          ...(licenseInfo ? { license: copyLicenseFields(licenseInfo) } : {}),
         };
       }
 

--- a/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -101,6 +101,8 @@ export interface ITelemetryReceiver {
 
   fetchClusterInfo(): Promise<ESClusterInfo>;
 
+  getLicenseInfo(): Nullable<ESLicense>;
+
   fetchLicenseInfo(): Promise<Nullable<ESLicense>>;
 
   closePointInTime(pitId: string): Promise<void>;
@@ -245,6 +247,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
   private getIndexForType?: (type: string) => string;
   private alertsIndex?: string;
   private clusterInfo?: ESClusterInfo;
+  private licenseInfo?: Nullable<ESLicense>;
   private processTreeFetcher?: Fetcher;
   private packageService?: PackageService;
   private experimentalFeatures: ExperimentalFeatures | undefined;
@@ -277,6 +280,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     this.soClient =
       core?.savedObjects.createInternalRepository() as unknown as SavedObjectsClientContract;
     this.clusterInfo = await this.fetchClusterInfo();
+    this.licenseInfo = await this.fetchLicenseInfo();
     this.experimentalFeatures = endpointContextService?.experimentalFeatures;
     const elasticsearch = core?.elasticsearch.client as unknown as IScopedClusterClient;
     this.processTreeFetcher = new Fetcher(elasticsearch);
@@ -286,6 +290,10 @@ export class TelemetryReceiver implements ITelemetryReceiver {
 
   public getClusterInfo(): ESClusterInfo | undefined {
     return this.clusterInfo;
+  }
+
+  public getLicenseInfo(): Nullable<ESLicense> {
+    return this.licenseInfo;
   }
 
   public getAlertsIndex(): string | undefined {

--- a/x-pack/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/tasks/diagnostic.ts
@@ -8,11 +8,10 @@
 import type { Logger } from '@kbn/core/server';
 import { newTelemetryLogger, getPreviousDiagTaskTimestamp } from '../helpers';
 import type { ITelemetryEventsSender } from '../sender';
-import type { TelemetryEvent } from '../types';
+import { TelemetryChannel, type TelemetryEvent } from '../types';
 import type { ITelemetryReceiver } from '../receiver';
 import type { TaskExecutionPeriod } from '../task';
 import type { ITaskMetricsService } from '../task_metrics.types';
-import { TELEMETRY_CHANNEL_ENDPOINT_ALERTS } from '../constants';
 import { copyAllowlistedFields, filterList } from '../filterlists';
 
 export function createTelemetryDiagnosticsTaskConfig() {
@@ -64,7 +63,7 @@ export function createTelemetryDiagnosticsTaskConfig() {
 
           alertCount += alerts.length;
           log.l(`Sending ${alerts.length} diagnostic alerts`);
-          await sender.sendOnDemand(TELEMETRY_CHANNEL_ENDPOINT_ALERTS, processedAlerts);
+          sender.sendAsync(TelemetryChannel.ENDPOINT_ALERTS, processedAlerts);
         }
 
         taskMetricsService.end(trace);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Telemetry][Security Solution] Enrich endpoint alerts with license info (#188760)](https://github.com/elastic/kibana/pull/188760)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2024-07-22T10:56:27Z","message":"[Telemetry][Security Solution] Enrich endpoint alerts with license info (#188760)","sha":"aa6aa2686641b428730f64c65a30003031d39c98","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","v8.13.0","v8.14.0","v8.15.0","v8.16.0"],"number":188760,"url":"https://github.com/elastic/kibana/pull/188760","mergeCommit":{"message":"[Telemetry][Security Solution] Enrich endpoint alerts with license info (#188760)","sha":"aa6aa2686641b428730f64c65a30003031d39c98"}},"sourceBranch":"main","suggestedTargetBranches":["8.13","8.14"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/188831","number":188831,"state":"OPEN"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188760","number":188760,"mergeCommit":{"message":"[Telemetry][Security Solution] Enrich endpoint alerts with license info (#188760)","sha":"aa6aa2686641b428730f64c65a30003031d39c98"}}]}] BACKPORT-->