### PR TITLE
chore():enable autocommit for dirty `yarn_deduplicate`

### DIFF
--- a/.buildkite/scripts/steps/checks/yarn_deduplicate.sh
+++ b/.buildkite/scripts/steps/checks/yarn_deduplicate.sh
@@ -7,4 +7,4 @@ source .buildkite/scripts/common/util.sh
 echo "--- Check yarn.lock for duplicated modules"
 node scripts/yarn_deduplicate
 
-check_for_changed_files 'node scripts/yarn_deduplicate' false 'TO FIX: Run node '"'"'scripts/yarn_deduplicate && yarn kbn bootstrap'"'"' locally, or add an exception to src/dev/yarn_deduplicate/index.ts and then commit the changes and push to your branch'
+check_for_changed_files 'node scripts/yarn_deduplicate' true 'TO FIX: Run node '"'"'scripts/yarn_deduplicate && yarn kbn bootstrap'"'"' locally, or add an exception to src/dev/yarn_deduplicate/index.ts and then commit the changes and push to your branch'

--- a/.buildkite/scripts/steps/checks/yarn_deduplicate.sh
+++ b/.buildkite/scripts/steps/checks/yarn_deduplicate.sh
@@ -5,6 +5,6 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo "--- Check yarn.lock for duplicated modules"
-node scripts/yarn_deduplicate
+node scripts/yarn_deduplicate && yarn kbn bootstrap
 
 check_for_changed_files 'node scripts/yarn_deduplicate' true 'TO FIX: Run node '"'"'scripts/yarn_deduplicate && yarn kbn bootstrap'"'"' locally, or add an exception to src/dev/yarn_deduplicate/index.ts and then commit the changes and push to your branch'


### PR DESCRIPTION
## Summary

We noticed that renovate tends to require us to clone most of the PRs only to locally run `yarn_deduplicate`. This PR enables CI to auto-commit the changes when `yarn_deduplicate` changes the lock file.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
