### PR TITLE
[8.14] Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
@@ -13,12 +13,12 @@ import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 // eslint-disable-next-line import/no-default-export
 export default function createAlertsAsDataInstallResourcesTest({ getService }: FtrProviderContext) {
   const es = getService('es');
+  const retry = getService('retry');
   const frameworkMappings = mappingFromFieldMap(alertFieldMap, 'strict');
   const legacyAlertMappings = mappingFromFieldMap(legacyAlertFieldMap, 'strict');
   const ecsMappings = mappingFromFieldMap(ecsFieldMap, 'strict');
 
-  // Failing: See https://github.com/elastic/kibana/issues/181296
-  describe.skip('install alerts as data resources', () => {
+  describe('install alerts as data resources', () => {
     it('should install common alerts as data resources on startup', async () => {
       const ilmPolicyName = '.alerts-ilm-policy';
       const frameworkComponentTemplateName = '.alerts-framework-mappings';
@@ -174,42 +174,43 @@ export default function createAlertsAsDataInstallResourcesTest({ getService }: F
         },
       });
 
-      const contextIndex = await es.indices.get({
-        index: indexName,
-      });
+      await retry.try(async () => {
+        const contextIndex = await es.indices.get({
+          index: indexName,
+        });
+        expect(contextIndex[indexName].aliases).to.eql({
+          '.alerts-test.patternfiring.alerts-default': {
+            is_write_index: true,
+          },
+        });
+        expect(contextIndex[indexName].mappings?._meta?.managed).to.eql(true);
+        expect(contextIndex[indexName].mappings?._meta?.namespace).to.eql('default');
+        expect(contextIndex[indexName].mappings?._meta?.kibana?.version).to.be.a('string');
+        expect(contextIndex[indexName].mappings?.dynamic).to.eql('false');
+        expect(contextIndex[indexName].mappings?.properties).to.eql({
+          ...contextSpecificMappings,
+          ...frameworkMappings.properties,
+        });
 
-      expect(contextIndex[indexName].aliases).to.eql({
-        '.alerts-test.patternfiring.alerts-default': {
-          is_write_index: true,
-        },
-      });
-      expect(contextIndex[indexName].mappings?._meta?.managed).to.eql(true);
-      expect(contextIndex[indexName].mappings?._meta?.namespace).to.eql('default');
-      expect(contextIndex[indexName].mappings?._meta?.kibana?.version).to.be.a('string');
-      expect(contextIndex[indexName].mappings?.dynamic).to.eql('false');
-      expect(contextIndex[indexName].mappings?.properties).to.eql({
-        ...contextSpecificMappings,
-        ...frameworkMappings.properties,
-      });
+        expect(contextIndex[indexName].settings?.index?.lifecycle).to.eql({
+          name: '.alerts-ilm-policy',
+          rollover_alias: '.alerts-test.patternfiring.alerts-default',
+        });
 
-      expect(contextIndex[indexName].settings?.index?.lifecycle).to.eql({
-        name: '.alerts-ilm-policy',
-        rollover_alias: '.alerts-test.patternfiring.alerts-default',
-      });
+        expect(contextIndex[indexName].settings?.index?.mapping).to.eql({
+          ignore_malformed: 'true',
+          total_fields: {
+            limit: '2500',
+          },
+        });
 
-      expect(contextIndex[indexName].settings?.index?.mapping).to.eql({
-        ignore_malformed: 'true',
-        total_fields: {
-          limit: '2500',
-        },
+        expect(contextIndex[indexName].settings?.index?.hidden).to.eql('true');
+        expect(contextIndex[indexName].settings?.index?.number_of_shards).to.eql(1);
+        expect(contextIndex[indexName].settings?.index?.auto_expand_replicas).to.eql('0-1');
+        expect(contextIndex[indexName].settings?.index?.provided_name).to.eql(
+          '.internal.alerts-test.patternfiring.alerts-default-000001'
+        );
       });
-
-      expect(contextIndex[indexName].settings?.index?.hidden).to.eql('true');
-      expect(contextIndex[indexName].settings?.index?.number_of_shards).to.eql(1);
-      expect(contextIndex[indexName].settings?.index?.auto_expand_replicas).to.eql('0-1');
-      expect(contextIndex[indexName].settings?.index?.provided_name).to.eql(
-        '.internal.alerts-test.patternfiring.alerts-default-000001'
-      );
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181759)](https://github.com/elastic/kibana/pull/181759)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2024-04-26T00:28:09Z","message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181759)\n\nResolves https://github.com/elastic/kibana/issues/181296\r\n\r\n## Summary\r\n\r\nInspecting the logs of the flaky runs, everything looks like it's\r\ngetting installed correctly but the test is checking for the existence\r\nof the concrete index before it has a chance to get installed. Added a\r\nretry in order to allow for more time to let the index get installed.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5766","sha":"5b2300bf0e4580c0e777474cc1d281bc9a747639","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","backport:skip","Team:ResponseOps","v8.15.0"],"number":181759,"url":"https://github.com/elastic/kibana/pull/181759","mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181759)\n\nResolves https://github.com/elastic/kibana/issues/181296\r\n\r\n## Summary\r\n\r\nInspecting the logs of the flaky runs, everything looks like it's\r\ngetting installed correctly but the test is checking for the existence\r\nof the concrete index before it has a chance to get installed. Added a\r\nretry in order to allow for more time to let the index get installed.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5766","sha":"5b2300bf0e4580c0e777474cc1d281bc9a747639"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181759","number":181759,"mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181759)\n\nResolves https://github.com/elastic/kibana/issues/181296\r\n\r\n## Summary\r\n\r\nInspecting the logs of the flaky runs, everything looks like it's\r\ngetting installed correctly but the test is checking for the existence\r\nof the concrete index before it has a chance to get installed. Added a\r\nretry in order to allow for more time to let the index get installed.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5766","sha":"5b2300bf0e4580c0e777474cc1d281bc9a747639"}}]}] BACKPORT-->