### PR TITLE
[CI] Trigger the alert-test-failed pipeline on the initial comment

### DIFF
--- a/.github/workflows/alert-failed-test.yml
+++ b/.github/workflows/alert-failed-test.yml
@@ -7,7 +7,7 @@ jobs:
     name: Alert on failed test
     if: |
       !github.event.issue.pull_request
-      && github.event.comment.user.login == 'kibanamachine'
+      && (github.event.comment.user.login == 'kibanamachine' || github.event.comment.user.login == 'elasticmachine')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout kibana-operations


### PR DESCRIPTION
## Summary
There was an issue, where after @walterra set up the [integration](https://github.com/elastic/kibana-operations/pull/160), and an issue was created (https://github.com/elastic/kibana/issues/188896) there were no notifications sent to the requested channel. 

The cause is probably the initial, [labeling comment](https://github.com/elastic/kibana/issues/188896#issuecomment-2244327259) PR coming from `elasticmachine`.

for more context: https://elastic.slack.com/archives/C5UDAFZQU/p1721715448357519?thread_ts=1721390987.440079&cid=C5UDAFZQU