### PR TITLE
Update warning on `xpack.fleet.enableExperimental`

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -311,4 +311,10 @@ List of proxies to access {fleet-server} that are configured when the {fleet} ap
 `xpack.fleet.enableExperimental`::
 List of experimental feature flag to enable in Fleet.
 
+[NOTE]
+====
+Experimental features should not be enabled in production environments.
+The features in this section are experimental and may be changed or removed completely in future releases.
+Elastic will make a best effort to fix any issues, but experimental features are not supported to the same level as generally available (GA) features.
+====
 


### PR DESCRIPTION
## Summary

Add warning on `xpack.fleet.enableExperimental` settings.

### For maintainers

- [x] Review the wording.
- [ ] Backport to all versions


<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->