### PR TITLE
[APM] [Alerts table] Fix alert reason not being hyperlinked

### DIFF
--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
@@ -30,6 +30,6 @@ export default defineCypressConfig({
     setupNodeEvents,
     baseUrl: 'http://localhost:5601',
     supportFile: './cypress/support/e2e.ts',
-    specPattern: './cypress/e2e/alerts/error_count.cy.{js,jsx,ts,tsx}',
+    specPattern: './cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
   },
 });

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
@@ -30,6 +30,6 @@ export default defineCypressConfig({
     setupNodeEvents,
     baseUrl: 'http://localhost:5601',
     supportFile: './cypress/support/e2e.ts',
-    specPattern: './cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    specPattern: './cypress/e2e/alerts/error_count.cy.{js,jsx,ts,tsx}',
   },
 });

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/alerts/error_count.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/alerts/error_count.cy.ts
@@ -57,8 +57,7 @@ describe('Alerts', () => {
     synthtrace.clean();
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/180981
-  describe.skip('when rendered from Service view in APM app', () => {
+  describe('when rendered from Service view in APM app', () => {
     const ruleName = 'Error count threshold';
     const confirmModalButtonSelector = '.euiModal button[data-test-subj=confirmModalConfirmButton]';
 

--- a/x-pack/plugins/observability_solution/apm/public/components/app/alerts_overview/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/alerts_overview/index.tsx
@@ -18,7 +18,6 @@ import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
 import { SERVICE_NAME } from '../../../../common/es_fields/apm';
 import { getEnvironmentKuery } from '../../../../common/environment_filter_values';
 import { push } from '../../shared/links/url_helpers';
-import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 
 export const ALERT_STATUS_ALL = 'all';
 
@@ -51,9 +50,8 @@ export function AlertsOverview() {
       },
     },
     uiSettings,
+    observability: { observabilityRuleTypeRegistry },
   } = services;
-
-  const { observabilityRuleTypeRegistry } = useApmPluginContext();
 
   const useToasts = () => notifications!.toasts;
 

--- a/x-pack/plugins/observability_solution/apm/public/components/app/alerts_overview/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/alerts_overview/index.tsx
@@ -18,6 +18,7 @@ import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
 import { SERVICE_NAME } from '../../../../common/es_fields/apm';
 import { getEnvironmentKuery } from '../../../../common/environment_filter_values';
 import { push } from '../../shared/links/url_helpers';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 
 export const ALERT_STATUS_ALL = 'all';
 
@@ -51,6 +52,8 @@ export function AlertsOverview() {
     },
     uiSettings,
   } = services;
+
+  const { observabilityRuleTypeRegistry } = useApmPluginContext();
 
   const useToasts = () => notifications!.toasts;
 
@@ -109,6 +112,7 @@ export function AlertsOverview() {
               featureIds={[AlertConsumers.APM, AlertConsumers.OBSERVABILITY]}
               query={esQuery}
               showAlertStatusWithFlapping
+              cellContext={{ observabilityRuleTypeRegistry }}
             />
           )}
         </EuiFlexItem>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/188921

Fixes alert reason link in APM service view -> Alerts tab

<img width="1647" alt="Screenshot 2024-07-23 at 13 54 29" src="https://github.com/user-attachments/assets/054b124f-eba1-4b7b-a896-11c01de9c3c2">
