### PR TITLE
[8.14] Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
@@ -124,54 +124,58 @@ export default function createAlertsAsDataInstallResourcesTest({ getService }: F
         },
       };
 
-      const { component_templates: componentTemplates } = await es.cluster.getComponentTemplate({
-        name: componentTemplateName,
+      await retry.try(async () => {
+        const { component_templates: componentTemplates } = await es.cluster.getComponentTemplate({
+          name: componentTemplateName,
+        });
+        expect(componentTemplates.length).to.eql(1);
+        const contextComponentTemplate = componentTemplates[0];
+        expect(contextComponentTemplate.name).to.eql(componentTemplateName);
+        expect(contextComponentTemplate.component_template.template.mappings).to.eql({
+          dynamic: 'strict',
+          properties: contextSpecificMappings,
+        });
+        expect(contextComponentTemplate.component_template.template.settings).to.eql({});
       });
-      expect(componentTemplates.length).to.eql(1);
-      const contextComponentTemplate = componentTemplates[0];
-      expect(contextComponentTemplate.name).to.eql(componentTemplateName);
-      expect(contextComponentTemplate.component_template.template.mappings).to.eql({
-        dynamic: 'strict',
-        properties: contextSpecificMappings,
-      });
-      expect(contextComponentTemplate.component_template.template.settings).to.eql({});
 
-      const { index_templates: indexTemplates } = await es.indices.getIndexTemplate({
-        name: indexTemplateName,
-      });
-      expect(indexTemplates.length).to.eql(1);
-      const contextIndexTemplate = indexTemplates[0];
-      expect(contextIndexTemplate.name).to.eql(indexTemplateName);
-      expect(contextIndexTemplate.index_template.index_patterns).to.eql([
-        '.internal.alerts-test.patternfiring.alerts-default-*',
-      ]);
-      expect(contextIndexTemplate.index_template.composed_of).to.eql([
-        '.alerts-test.patternfiring.alerts-mappings',
-        '.alerts-framework-mappings',
-      ]);
-      expect(contextIndexTemplate.index_template.template!.mappings?.dynamic).to.eql(false);
-      expect(contextIndexTemplate.index_template.template!.mappings?._meta?.managed).to.eql(true);
-      expect(contextIndexTemplate.index_template.template!.mappings?._meta?.namespace).to.eql(
-        'default'
-      );
-      expect(
-        contextIndexTemplate.index_template.template!.mappings?._meta?.kibana?.version
-      ).to.be.a('string');
-      expect(contextIndexTemplate.index_template.template!.settings).to.eql({
-        index: {
-          lifecycle: {
-            name: '.alerts-ilm-policy',
-            rollover_alias: '.alerts-test.patternfiring.alerts-default',
-          },
-          mapping: {
-            ignore_malformed: 'true',
-            total_fields: {
-              limit: '2500',
+      await retry.try(async () => {
+        const { index_templates: indexTemplates } = await es.indices.getIndexTemplate({
+          name: indexTemplateName,
+        });
+        expect(indexTemplates.length).to.eql(1);
+        const contextIndexTemplate = indexTemplates[0];
+        expect(contextIndexTemplate.name).to.eql(indexTemplateName);
+        expect(contextIndexTemplate.index_template.index_patterns).to.eql([
+          '.internal.alerts-test.patternfiring.alerts-default-*',
+        ]);
+        expect(contextIndexTemplate.index_template.composed_of).to.eql([
+          '.alerts-test.patternfiring.alerts-mappings',
+          '.alerts-framework-mappings',
+        ]);
+        expect(contextIndexTemplate.index_template.template!.mappings?.dynamic).to.eql(false);
+        expect(contextIndexTemplate.index_template.template!.mappings?._meta?.managed).to.eql(true);
+        expect(contextIndexTemplate.index_template.template!.mappings?._meta?.namespace).to.eql(
+          'default'
+        );
+        expect(
+          contextIndexTemplate.index_template.template!.mappings?._meta?.kibana?.version
+        ).to.be.a('string');
+        expect(contextIndexTemplate.index_template.template!.settings).to.eql({
+          index: {
+            lifecycle: {
+              name: '.alerts-ilm-policy',
+              rollover_alias: '.alerts-test.patternfiring.alerts-default',
             },
+            mapping: {
+              ignore_malformed: 'true',
+              total_fields: {
+                limit: '2500',
+              },
+            },
+            hidden: 'true',
+            auto_expand_replicas: '0-1',
           },
-          hidden: 'true',
-          auto_expand_replicas: '0-1',
-        },
+        });
       });
 
       await retry.try(async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181841)](https://github.com/elastic/kibana/pull/181841)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2024-04-30T17:22:10Z","message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181841)\n\nResolves https://github.com/elastic/kibana/issues/181296\r\n\r\n## Summary\r\n\r\n[Previous PR](https://github.com/elastic/kibana/pull/181759) added a\r\nretry around one part of the resource installation test but another part\r\nof it flaked so this adds a retry around the rest of it.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5772\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"76d0683e2c53ae9f5cec25afa72d6c6b6c1be36e","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","v8.15.0"],"number":181841,"url":"https://github.com/elastic/kibana/pull/181841","mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181841)\n\nResolves https://github.com/elastic/kibana/issues/181296\r\n\r\n## Summary\r\n\r\n[Previous PR](https://github.com/elastic/kibana/pull/181759) added a\r\nretry around one part of the resource installation test but another part\r\nof it flaked so this adds a retry around the rest of it.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5772\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"76d0683e2c53ae9f5cec25afa72d6c6b6c1be36e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/181841","number":181841,"mergeCommit":{"message":"Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group4.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources·ts - Alerting alerts_as_data install alerts as data resources should install context specific alerts as data resources on startup (#181841)\n\nResolves https://github.com/elastic/kibana/issues/181296\r\n\r\n## Summary\r\n\r\n[Previous PR](https://github.com/elastic/kibana/pull/181759) added a\r\nretry around one part of the resource installation test but another part\r\nof it flaked so this adds a retry around the rest of it.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5772\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"76d0683e2c53ae9f5cec25afa72d6c6b6c1be36e"}}]}] BACKPORT-->