### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find·ts - alerting api integration security and spaces enabled Alerts - Group 1 alerts backfill rule runs find backfill superuser at space1 should handle finding backfill requests with query string appropriately

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find.ts
@@ -135,8 +135,7 @@ export default function findBackfillTests({ getService }: FtrProviderContext) {
 
     for (const scenario of UserAtSpaceScenarios) {
       const { user, space } = scenario;
-      // FLAKY: https://github.com/elastic/kibana/issues/181862
-      describe.skip(scenario.id, () => {
+      describe(scenario.id, () => {
         const apiOptions = {
           spaceId: space.id,
           username: user.username,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/181862