### PR TITLE
[Fleet] Fix copy agent policy, missed bump revision

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -750,7 +750,14 @@ class AgentPolicyService {
       throw new AgentPolicyNotFoundError('Copied agent policy not found');
     }
 
-    await this.deployPolicy(soClient, newAgentPolicy.id);
+    // bump revision if agent policy is updated after creation
+    if (baseAgentPolicy.package_policies || baseAgentPolicy.is_protected) {
+      await this.bumpRevision(soClient, esClient, newAgentPolicy.id, {
+        user: options?.user,
+      });
+    } else {
+      await this.deployPolicy(soClient, newAgentPolicy.id);
+    }
     logger.debug(`Completed copy of agent policy ${id}`);
     return updatedAgentPolicy;
   }

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -744,20 +744,23 @@ class AgentPolicyService {
       );
     }
 
-    // Get updated agent policy with package policies and adjusted tamper protection
-    const updatedAgentPolicy = await this.get(soClient, newAgentPolicy.id, true);
-    if (!updatedAgentPolicy) {
-      throw new AgentPolicyNotFoundError('Copied agent policy not found');
-    }
+    const policyNeedsBump = baseAgentPolicy.package_policies || baseAgentPolicy.is_protected;
 
     // bump revision if agent policy is updated after creation
-    if (baseAgentPolicy.package_policies || baseAgentPolicy.is_protected) {
+    if (policyNeedsBump) {
       await this.bumpRevision(soClient, esClient, newAgentPolicy.id, {
         user: options?.user,
       });
     } else {
       await this.deployPolicy(soClient, newAgentPolicy.id);
     }
+
+    // Get updated agent policy with package policies and adjusted tamper protection
+    const updatedAgentPolicy = await this.get(soClient, newAgentPolicy.id, true);
+    if (!updatedAgentPolicy) {
+      throw new AgentPolicyNotFoundError('Copied agent policy not found');
+    }
+
     logger.debug(`Completed copy of agent policy ${id}`);
     return updatedAgentPolicy;
   }

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -526,7 +526,7 @@ export default function (providerContext: FtrProviderContext) {
           is_managed: false,
           namespace: 'default',
           monitoring_enabled: ['logs', 'metrics'],
-          revision: 1,
+          revision: 2,
           schema_version: FLEET_AGENT_POLICIES_SCHEMA_VERSION,
           updated_by: 'elastic',
           package_policies: [],
@@ -650,6 +650,7 @@ export default function (providerContext: FtrProviderContext) {
           .expect(200);
 
         expect(newPolicy.is_protected).to.eql(true);
+        expect(newPolicy.revision).to.eql(2);
       });
 
       it('should increment package policy copy names', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/188929

It looks like the copy agent functionality was not working well when the agent policy has integration policies or tamper protection enabled. The revision was not bumped, and the resulting documents in `.fleet-policies` were incorrect.

To verify:
- run local kibana with fleet-server 8.15 
- create agent policy and add endpoint integration
- copy the policy
- verify that the copied policy is on `revision:2` and there is one document in `.fleet-policies` with `revision:2` and `coordinator_idx:1` and the `data.inputs` field has `endpoint` in it
- enable tamper protection on the original agent policy
- copy again and verify the same is true (`revision:2`, etc.)

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/4492dced-56db-485d-8691-be60ba65b2cb">

```
// no tamper
GET .fleet-policies/_search
{"query": {
  "bool": {
    "must": [
      {"match": {
        "coordinator_idx": 1
      }},
      {"match": {
        "revision_idx": 2
      }},
       {"match": {
        "policy_id": "ae7c5e99-d79a-4364-9209-1c3da5789cd8"
      }}
    ]
  }
}}

  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 4.4079456,
    "hits": [
      {
        "_index": ".fleet-policies-7",
        "_id": "W7iD35ABUS1gQZsO-P6F",
        "_score": 4.4079456,
        "_source": {
          "coordinator_idx": 1,
          "data": {
            "agent": {
              "download": {
                "sourceURI": "https://artifacts.elastic.co/downloads/"
              },
            },
            "fleet": {
              "hosts": [
                "https://192.168.178.216:8220"
              ]
            },
            "id": "ae7c5e99-d79a-4364-9209-1c3da5789cd8",
            "inputs": [
              {
               
                  "manifest_version": "1.0.0",
                  "schema_version": "v1"
                },
                "data_stream": {
                  "namespace": "default"
                },
                "id": "16c83e6a-b764-459d-847d-024697603269",
                "integration_config": {
                  "endpointConfig": {
                    "preset": "EDRComplete"
                  },
                  "type": "endpoint"
                },
                "meta": {
                  "package": {
                    "name": "endpoint",
                    "version": "8.15.0"
                  }
                },
                "name": "endpoint (copy)",


// tamper

GET .fleet-policies/_search
{"query": {
  "bool": {
    "must": [
      {"match": {
        "coordinator_idx": 1
      }},
      {"match": {
        "revision_idx": 2
      }},
       {"match": {
        "policy_id": "d3dae391-a68e-4d0d-b8cd-d09f431c8a52"
      }}
    ]
  }
}}

 "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 4.4079456,
    "hits": [
      {
        "_index": ".fleet-policies-7",
        "_id": "8LmF35ABUS1gQZsOEwrC",
        "_score": 4.4079456,
        "_source": {
          "coordinator_idx": 1,
          "data": {atures": {},
              "protection": {
                "enabled": true,
              }
            },
            "fleet": {
              "hosts": [
                "https://192.168.178.216:8220"
              ]
            },
            "id": "d3dae391-a68e-4d0d-b8cd-d09f431c8a52",
            "inputs": [
              {
                "id": "cbf33dcf-289a-4124-b6a9-50e988247307",
                "integration_config": {
                  "endpointConfig": {
                    "preset": "EDRComplete"
                  },
                  "type": "endpoint"
                },
                "meta": {
                  "package": {
                    "name": "endpoint",
                    "version": "8.15.0"
                  }
                },
                "name": "endpoint (copy 2)",
                "package_policy_id": "cbf33dcf-289a-4124-b6a9-50e988247307",
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->