### PR TITLE
[SecuritySolution] asSecondaryAuthUser

### DIFF
--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/lib/fetch_stats.ts
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/lib/fetch_stats.ts
@@ -39,16 +39,12 @@ export const parseIndicesStats = (
 
 export const fetchMeteringStats = (
   client: IScopedClusterClient,
-  indexPattern: string,
-  secondaryAuthorization?: string | string[] | undefined
+  indexPattern: string
 ): Promise<MeteringIndicesStatsResponse> =>
-  client.asInternalUser.transport.request(
-    {
-      method: 'GET',
-      path: `/_metering/stats/${indexPattern}`,
-    },
-    { headers: { 'es-secondary-authorization': secondaryAuthorization } }
-  );
+  client.asSecondaryAuthUser.transport.request({
+    method: 'GET',
+    path: `/_metering/stats/${indexPattern}`,
+  });
 
 export const parseMeteringStats = (meteringStatsIndices: MeteringStatsIndex[]) =>
   meteringStatsIndices.reduce<Record<string, MeteringStatsIndex>>((acc, curr) => {

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.test.ts
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.test.ts
@@ -188,6 +188,31 @@ describe('getIndexStatsRoute route', () => {
     );
   });
 
+  test('returns an empty object when fetchMeteringStats throws a 404', async () => {
+    const request = requestMock.create({
+      method: 'get',
+      path: GET_INDEX_STATS,
+      params: {
+        pattern: `auditbeat-*`,
+      },
+      query: {
+        isILMAvailable: false,
+        startDate: `now-7d`,
+        endDate: `now`,
+      },
+    });
+
+    (fetchMeteringStats as jest.Mock).mockRejectedValue({ statusCode: 404 });
+
+    const response = await server.inject(request, requestContextMock.convertContext(context));
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({});
+    expect(fetchAvailableIndices).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      `No metering stats indices found under pattern: auditbeat-*`
+    );
+  });
+
   test('returns an empty object when "availableIndices" indices are empty', async () => {
     const request = requestMock.create({
       method: 'get',

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
@@ -69,12 +69,7 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
           if (startDate && endDate) {
             const decodedStartDate = decodeURIComponent(startDate);
             const decodedEndDate = decodeURIComponent(endDate);
-            const meteringStats = await fetchMeteringStats(
-              client,
-              decodedIndexName,
-              request.headers.authorization
-            );
-
+            const meteringStats = await fetchMeteringStats(client, decodedIndexName);
             if (!meteringStats.indices) {
               logger.warn(`No metering stats indices found under pattern: ${decodedIndexName}`);
               return response.ok({

--- a/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
+++ b/x-pack/solutions/security/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
@@ -112,6 +112,14 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
           }
         } catch (err) {
           logger.error(JSON.stringify(err));
+
+          const decodedIndexName = decodeURIComponent(request.params.pattern);
+
+          if (err.statusCode === 404) {
+            logger.warn(`No metering stats indices found under pattern: ${decodedIndexName}`);
+            return response.ok({ body: {} });
+          }
+
           return resp.error({
             body: err.message ?? API_DEFAULT_ERROR_MESSAGE,
             statusCode: err.statusCode ?? 500,


### PR DESCRIPTION
## Summary

Relevant issue:
https://github.com/elastic/kibana/issues/260716
https://github.com/elastic/kibana/issues/179458

Context:

The metering stats api requires an operator user right. ES team built it in a way that the user's context can be passed along in order to get the indices that a user has access to.

Before https://github.com/elastic/kibana/pull/184901 was implemented, we use `asInternalUser` with an extra header to access metering stats api as an work around. Now we are using the designated client for this use case.


### Steps to verify:



1. Start serverless (with or without) and ESS Kibana locally. (serverless with CPS: `node scripts/scout start-server --arch serverless --domain security_complete --serverConfigSet cps_local`) [details](https://docs.google.com/document/d/16c6H8EVyyAUwp7QDm-77__RHz_hSJ2_wE40_as7WIqE/edit?pli=1&disco=AAAB44hK0Os)
2. Visit data quality dashboard page.
3. Should not be redirected.


### Before
Unexpected redirect on all serverless environments with or without CPS.


https://github.com/user-attachments/assets/fcc33af7-5ca6-4adf-9912-d025661fb8a1

### After

https://github.com/user-attachments/assets/0592ed1b-a0b1-4a62-bbea-b0526e1ea3c2




<!--ONMERGE {"backportTargets":["8.19","9.2","9.3"]} ONMERGE-->