### PR TITLE
[Search] Create generate connector name endpoint

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/generate_connector_names_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/generate_connector_names_api_logic.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { createApiLogic } from '../../../shared/api_logic/create_api_logic';
+import { HttpLogic } from '../../../shared/http';
+
+export interface GenerateConnectorNamesApiArgs {
+  connectorType?: string;
+}
+
+export const generateConnectorNames = async (
+  { connectorType }: GenerateConnectorNamesApiArgs = { connectorType: 'custom' }
+) => {
+  const route = `/internal/enterprise_search/connectors/generate_connector_name`;
+  return await HttpLogic.values.http.post(route, {
+    body: JSON.stringify({ connectorType }),
+  });
+};
+
+export const GenerateConnectorNamesApiLogic = createApiLogic(
+  ['generate_config_api_logic'],
+  generateConnectorNames
+);

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/generate_connector_name.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/generate_connector_name.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+
+import { ErrorCode } from '../../../common/types/error_codes';
+
+import { toAlphanumeric } from '../../../common/utils/to_alphanumeric';
+import { indexOrAliasExists } from '../indices/exists_index';
+
+export const generateConnectorName = async (
+  client: IScopedClusterClient,
+  connectorType: string
+): Promise<{ apiKeyName: string; connectorName: string; indexName: string }> => {
+  const prefix = toAlphanumeric(connectorType);
+  if (!prefix || prefix.length === 0) {
+    throw new Error('Connector type is required');
+  }
+  for (let i = 0; i < 20; i++) {
+    const connectorName = `${prefix}-${uuidv4().split('-')[1]}`;
+    const indexName = `connector-${connectorName}`;
+
+    const result = await indexOrAliasExists(client, indexName);
+    if (!result) {
+      return {
+        apiKeyName: indexName,
+        connectorName,
+        indexName,
+      };
+    }
+  }
+  throw new Error(ErrorCode.GENERATE_INDEX_NAME_ERROR);
+};


### PR DESCRIPTION
## Summary

Creates default connector name, index name, api key name combos to be used in UI's.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
