### PR TITLE
[Fleet] Fix get one agent when feature flag disabled

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -45,8 +45,12 @@ import { defaultFleetErrorHandler, FleetNotFoundError } from '../../errors';
 import * as AgentService from '../../services/agents';
 import { fetchAndAssignAgentMetrics } from '../../services/agents/agent_metrics';
 import { getAgentStatusForAgentPolicy } from '../../services/agents';
+import { appContextService } from '../../services';
 
 export function verifyNamespace(agent: Agent, currentNamespace?: string) {
+  if (!appContextService.getExperimentalFeatures().useSpaceAwareness) {
+    return;
+  }
   const isInNamespace =
     (currentNamespace && agent.namespaces?.includes(currentNamespace)) ||
     (!currentNamespace &&


### PR DESCRIPTION
## Summary

@jillguyonnet found an issue [here ](https://github.com/elastic/kibana/pull/188507#issuecomment-2245375730)

We should not check agent namespaces when the `useSpaceAwareness` feature flag is not enabled, that PR address that.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->