### PR TITLE
Enabled http2 functional configs for SAML and OIDC

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -323,6 +323,7 @@ enabled:
   - x-pack/test/security_functional/oidc.config.ts
   - x-pack/test/security_functional/saml.config.ts
   - x-pack/test/security_functional/oidc.http2.config.ts
+  - x-pack/test/security_functional/oidc.tls.config.ts
   - x-pack/test/security_functional/saml.http2.config.ts
   - x-pack/test/security_functional/insecure_cluster_warning.config.ts
   - x-pack/test/security_functional/user_profiles.config.ts

--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -325,6 +325,7 @@ enabled:
   - x-pack/test/security_functional/oidc.http2.config.ts
   - x-pack/test/security_functional/oidc.tls.config.ts
   - x-pack/test/security_functional/saml.http2.config.ts
+  - x-pack/test/security_functional/saml.tls.config.ts
   - x-pack/test/security_functional/insecure_cluster_warning.config.ts
   - x-pack/test/security_functional/user_profiles.config.ts
   - x-pack/test/security_functional/expired_session.config.ts

--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -35,10 +35,6 @@ disabled:
   - x-pack/test/fleet_cypress/config.ts
   - x-pack/test/fleet_cypress/visual_config.ts
 
-  # http/2 security muted tests
-  - x-pack/test/security_functional/saml.http2.config.ts
-  - x-pack/test/security_functional/oidc.http2.config.ts
-
 defaultQueue: 'n2-4-spot'
 enabled:
   - test/accessibility/config.ts
@@ -326,6 +322,8 @@ enabled:
   - x-pack/test/security_functional/login_selector.config.ts
   - x-pack/test/security_functional/oidc.config.ts
   - x-pack/test/security_functional/saml.config.ts
+  - x-pack/test/security_functional/oidc.http2.config.ts
+  - x-pack/test/security_functional/saml.http2.config.ts
   - x-pack/test/security_functional/insecure_cluster_warning.config.ts
   - x-pack/test/security_functional/user_profiles.config.ts
   - x-pack/test/security_functional/expired_session.config.ts

--- a/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
+++ b/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
@@ -116,7 +116,8 @@ function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean
     // Use fake device for Media Stream to replace actual camera and microphone.
     'use-fake-device-for-media-stream',
     // Bypass the media stream infobar by selecting the default device for media streams (e.g. WebRTC). Works with --use-fake-device-for-media-stream.
-    'use-fake-ui-for-media-stream'
+    'use-fake-ui-for-media-stream',
+    'disable-component-update'
   );
 
   if (process.platform === 'linux') {

--- a/x-pack/test/security_functional/oidc.tls.config.ts
+++ b/x-pack/test/security_functional/oidc.tls.config.ts
@@ -41,7 +41,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       ],
     },
     junit: {
-      reportName: 'Chrome X-Pack Security Functional Tests HTTP/2 (OpenID Connect)',
+      reportName: 'Chrome X-Pack Security Functional Tests TLS (OpenID Connect)',
     },
   });
 }

--- a/x-pack/test/security_functional/oidc.tls.config.ts
+++ b/x-pack/test/security_functional/oidc.tls.config.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+import { CA_CERT_PATH } from '@kbn/dev-utils';
+import { configureTLS } from '../../../test/common/configure_tls';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const kibanaFunctionalConfig = await readConfigFile(
+    require.resolve('../../../test/functional/config.base.js')
+  );
+  const functionalConfig = await readConfigFile(require.resolve('./oidc.config'));
+  const kibanaPort = kibanaFunctionalConfig.get('servers.kibana.port');
+  const jwksPath = require.resolve('@kbn/security-api-integration-helpers/oidc/jwks.json');
+
+  return configureTLS({
+    ...functionalConfig.getAll(),
+    esTestCluster: {
+      license: 'trial',
+      from: 'snapshot',
+      serverArgs: [
+        'xpack.security.authc.token.enabled=true',
+        'xpack.security.authc.realms.oidc.oidc1.order=0',
+        `xpack.security.authc.realms.oidc.oidc1.rp.client_id=0oa8sqpov3TxMWJOt356`,
+        `xpack.security.authc.realms.oidc.oidc1.rp.client_secret=0oa8sqpov3TxMWJOt356`,
+        `xpack.security.authc.realms.oidc.oidc1.rp.response_type=code`,
+        `xpack.security.authc.realms.oidc.oidc1.rp.redirect_uri=https://localhost:${kibanaPort}/api/security/oidc/callback`,
+        `xpack.security.authc.realms.oidc.oidc1.rp.post_logout_redirect_uri=https://localhost:${kibanaPort}/security/logged_out`,
+        `xpack.security.authc.realms.oidc.oidc1.op.authorization_endpoint=https://localhost:${kibanaPort}/oidc_provider/authorize`,
+        `xpack.security.authc.realms.oidc.oidc1.op.endsession_endpoint=https://localhost:${kibanaPort}/oidc_provider/endsession`,
+        `xpack.security.authc.realms.oidc.oidc1.op.token_endpoint=https://localhost:${kibanaPort}/api/oidc_provider/token_endpoint`,
+        `xpack.security.authc.realms.oidc.oidc1.op.userinfo_endpoint=https://localhost:${kibanaPort}/api/oidc_provider/userinfo_endpoint`,
+        `xpack.security.authc.realms.oidc.oidc1.op.issuer=https://test-op.elastic.co`,
+        `xpack.security.authc.realms.oidc.oidc1.op.jwkset_path=${jwksPath}`,
+        `xpack.security.authc.realms.oidc.oidc1.claims.principal=sub`,
+        `xpack.security.authc.realms.oidc.oidc1.ssl.certificate_authorities=${CA_CERT_PATH}`,
+      ],
+    },
+    junit: {
+      reportName: 'Chrome X-Pack Security Functional Tests HTTP/2 (OpenID Connect)',
+    },
+  });
+}

--- a/x-pack/test/security_functional/saml.tls.config.ts
+++ b/x-pack/test/security_functional/saml.tls.config.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { resolve } from 'path';
+import { FtrConfigProviderContext } from '@kbn/test';
+import { CA_CERT_PATH } from '@kbn/dev-utils';
+import { configureTLS } from '../../../test/common/configure_tls';
+
+// the default export of config files must be a config provider
+// that returns an object with the projects config values
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const functionalConfig = await readConfigFile(require.resolve('./saml.config'));
+  const kibanaFunctionalConfig = await readConfigFile(
+    require.resolve('../../../test/functional/config.base.js')
+  );
+
+  const kibanaPort = kibanaFunctionalConfig.get('servers.kibana.port');
+  const idpPath = resolve(
+    __dirname,
+    '../security_api_integration/plugins/saml_provider/metadata.xml'
+  );
+
+  return configureTLS({
+    ...functionalConfig.getAll(),
+    esTestCluster: {
+      license: 'trial',
+      from: 'snapshot',
+      serverArgs: [
+        'xpack.security.authc.token.enabled=true',
+        'xpack.security.authc.realms.saml.saml1.order=0',
+        `xpack.security.authc.realms.saml.saml1.idp.metadata.path=${idpPath}`,
+        'xpack.security.authc.realms.saml.saml1.idp.entity_id=http://www.elastic.co/saml1',
+        `xpack.security.authc.realms.saml.saml1.sp.entity_id=https://localhost:${kibanaPort}`,
+        `xpack.security.authc.realms.saml.saml1.sp.logout=https://localhost:${kibanaPort}/logout`,
+        `xpack.security.authc.realms.saml.saml1.sp.acs=https://localhost:${kibanaPort}/api/security/saml/callback`,
+        'xpack.security.authc.realms.saml.saml1.attributes.principal=urn:oid:0.0.7',
+        `xpack.security.authc.realms.saml.saml1.ssl.certificate_authorities=${CA_CERT_PATH}`,
+      ],
+    },
+    junit: {
+      reportName: 'Chrome X-Pack Security Functional Tests TLS (SAML)',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Enabled http2 functional configs for SAML and OIDC


### Checklist

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
