### PR TITLE
[8.14] Fixing flaky ml test (#183139)

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/transform_health/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/transform_health/rule.ts
@@ -23,15 +23,12 @@ import { TRANSFORM_HEALTH_RESULTS } from '@kbn/transform-plugin/common/constants
 import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
 import { Spaces } from '../../../../../scenarios';
-import { runSoon } from '../../../group3/test_helpers';
 
 const CONNECTOR_TYPE_ID = '.index';
 const RULE_TYPE_ID = 'transform_health';
 const ES_TEST_INDEX_SOURCE = 'transform-alert:transform-health';
 const ES_TEST_INDEX_REFERENCE = '-na-';
 const ES_TEST_OUTPUT_INDEX_NAME = `${ES_TEST_INDEX_NAME}-ts-output`;
-
-const RULE_INTERVAL_SECONDS = 10000;
 
 interface CreateRuleParams {
   name: string;
@@ -115,14 +112,12 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     });
 
     it('runs correctly', async () => {
+      await stopTransform(transformId);
+
       const ruleId = await createRule({
         name: 'Test all transforms',
         includeTransforms: ['*'],
       });
-
-      await stopTransform(transformId);
-
-      await runSoon({ id: ruleId, supertest, retry });
 
       log.debug('Checking created alerts...');
 
@@ -197,7 +192,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
           consumer: 'alerts',
           enabled: true,
           rule_type_id: RULE_TYPE_ID,
-          schedule: { interval: `${RULE_INTERVAL_SECONDS}s` },
+          schedule: { interval: '1d' },
           actions: [action],
           notify_when: 'onActiveAlert',
           params: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Fixing flaky ml test (#183139)](https://github.com/elastic/kibana/pull/183139)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2024-05-10T20:55:01Z","message":"Fixing flaky ml test (#183139)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/177215\r\n\r\nChanging ML rule functional test to stop the transform first, then\r\ncreating the rule. The rule runs when it is created and the test is\r\ntesting for `event.action: \"open\"` which is written on a new alert, so\r\nwe only want to rule to run once. Removed the unnecessary `runSoon`\r\ncall.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5929","sha":"57d5f935c1ec9c0c5e1320a4632d298fab66c37c","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Alerting/RuleTypes","v8.14.0","v8.15.0"],"number":183139,"url":"https://github.com/elastic/kibana/pull/183139","mergeCommit":{"message":"Fixing flaky ml test (#183139)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/177215\r\n\r\nChanging ML rule functional test to stop the transform first, then\r\ncreating the rule. The rule runs when it is created and the test is\r\ntesting for `event.action: \"open\"` which is written on a new alert, so\r\nwe only want to rule to run once. Removed the unnecessary `runSoon`\r\ncall.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5929","sha":"57d5f935c1ec9c0c5e1320a4632d298fab66c37c"}},"sourceBranch":"main","suggestedTargetBranches":["8.14"],"targetPullRequestStates":[{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/183139","number":183139,"mergeCommit":{"message":"Fixing flaky ml test (#183139)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/177215\r\n\r\nChanging ML rule functional test to stop the transform first, then\r\ncreating the rule. The rule runs when it is created and the test is\r\ntesting for `event.action: \"open\"` which is written on a new alert, so\r\nwe only want to rule to run once. Removed the unnecessary `runSoon`\r\ncall.\r\n\r\nFlaky test runner:\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5929","sha":"57d5f935c1ec9c0c5e1320a4632d298fab66c37c"}}]}] BACKPORT-->