### PR TITLE
[ES|QL] Rename the variables from earliest / latest to start / end

### DIFF
--- a/packages/kbn-esql-ast/src/walker/walker.test.ts
+++ b/packages/kbn-esql-ast/src/walker/walker.test.ts
@@ -607,7 +607,7 @@ describe('Walker.params', () => {
         type: 'literal',
         literalType: 'param',
         paramType: 'named',
-        value: 'latest',
+        value: 'end',
       },
     ]);
   });

--- a/packages/kbn-esql-ast/src/walker/walker.test.ts
+++ b/packages/kbn-esql-ast/src/walker/walker.test.ts
@@ -592,8 +592,7 @@ describe('Walker.params', () => {
   });
 
   test('can collect all params from grouping functions', () => {
-    const query =
-      'ROW x=1, time=2024-07-10 | stats z = avg(x) by bucket(time, 20, ?earliest,?latest)';
+    const query = 'ROW x=1, time=2024-07-10 | stats z = avg(x) by bucket(time, 20, ?start,?end)';
     const { ast } = getAstAndSyntaxErrors(query);
     const params = Walker.params(ast);
 
@@ -602,7 +601,7 @@ describe('Walker.params', () => {
         type: 'literal',
         literalType: 'param',
         paramType: 'named',
-        value: 'earliest',
+        value: 'start',
       },
       {
         type: 'literal',

--- a/packages/kbn-esql-utils/index.ts
+++ b/packages/kbn-esql-utils/index.ts
@@ -21,8 +21,8 @@ export {
   getESQLQueryColumnsRaw,
   getESQLResults,
   getTimeFieldFromESQLQuery,
-  getEarliestLatestParams,
-  hasEarliestLatestParams,
+  getStartEndParams,
+  hasStartEndParams,
   TextBasedLanguages,
 } from './src';
 

--- a/packages/kbn-esql-utils/src/index.ts
+++ b/packages/kbn-esql-utils/src/index.ts
@@ -22,6 +22,6 @@ export {
   getESQLQueryColumns,
   getESQLQueryColumnsRaw,
   getESQLResults,
-  getEarliestLatestParams,
-  hasEarliestLatestParams,
+  getStartEndParams,
+  hasStartEndParams,
 } from './utils/run_query';

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -150,12 +150,10 @@ describe('esql query helpers', () => {
     });
 
     it('should return the time field if there is at least one time param', () => {
-      expect(getTimeFieldFromESQLQuery('from a | eval b = 1 | where time >= ?earliest')).toBe(
-        'time'
-      );
+      expect(getTimeFieldFromESQLQuery('from a | eval b = 1 | where time >= ?start')).toBe('time');
     });
 
-    it('should return undefined if there is one named param but is not ?earliest or ?latest', () => {
+    it('should return undefined if there is one named param but is not ?start or ?end', () => {
       expect(
         getTimeFieldFromESQLQuery('from a | eval b = 1 | where time >= ?late')
       ).toBeUndefined();
@@ -163,14 +161,14 @@ describe('esql query helpers', () => {
 
     it('should return undefined if there is one named param but is used without a time field', () => {
       expect(
-        getTimeFieldFromESQLQuery('from a | eval b = DATE_TRUNC(1 day, ?earliest)')
+        getTimeFieldFromESQLQuery('from a | eval b = DATE_TRUNC(1 day, ?start)')
       ).toBeUndefined();
     });
 
     it('should return the time field if there is at least one time param in the bucket function', () => {
       expect(
         getTimeFieldFromESQLQuery(
-          'from a | stats meow = avg(bytes) by bucket(event.timefield, 200, ?earliest, ?latest)'
+          'from a | stats meow = avg(bytes) by bucket(event.timefield, 200, ?start, ?end)'
         )
       ).toBe('event.timefield');
     });

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -56,7 +56,7 @@ export function removeDropCommandsFromESQLQuery(esql?: string): string {
 }
 
 /**
- * When the ?earliest and ?latest params are used, we want to retrieve the timefield from the query.
+ * When the ?start and ?end params are used, we want to retrieve the timefield from the query.
  * @param esql:string
  * @returns string
  */
@@ -69,9 +69,7 @@ export const getTimeFieldFromESQLQuery = (esql: string) => {
   });
 
   const params = Walker.params(ast);
-  const timeNamedParam = params.find(
-    (param) => param.value === 'earliest' || param.value === 'latest'
-  );
+  const timeNamedParam = params.find((param) => param.value === 'start' || param.value === 'end');
   if (!timeNamedParam || !functions.length) {
     return undefined;
   }

--- a/packages/kbn-esql-utils/src/utils/run_query.test.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.test.ts
@@ -5,38 +5,38 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { getEarliestLatestParams } from './run_query';
+import { getStartEndParams } from './run_query';
 
-describe('getEarliestLatestParams', () => {
+describe('getStartEndParams', () => {
   it('should return an empty array if there are no time params', () => {
     const time = { from: 'now-15m', to: 'now' };
     const query = 'FROM foo';
-    const params = getEarliestLatestParams(query, time);
+    const params = getStartEndParams(query, time);
     expect(params).toEqual([]);
   });
 
-  it('should return an array with the earliest param if exists at the query', () => {
+  it('should return an array with the start param if exists at the query', () => {
     const time = { from: 'Jul 5, 2024 @ 08:03:56.849', to: 'Jul 5, 2024 @ 10:03:56.849' };
-    const query = 'FROM foo | where time > ?earliest';
-    const params = getEarliestLatestParams(query, time);
+    const query = 'FROM foo | where time > ?start';
+    const params = getStartEndParams(query, time);
     expect(params).toHaveLength(1);
-    expect(params[0]).toHaveProperty('earliest');
+    expect(params[0]).toHaveProperty('start');
   });
 
-  it('should return an array with the latest param if exists at the query', () => {
+  it('should return an array with the end param if exists at the query', () => {
     const time = { from: 'Jul 5, 2024 @ 08:03:56.849', to: 'Jul 5, 2024 @ 10:03:56.849' };
-    const query = 'FROM foo | where time < ?latest';
-    const params = getEarliestLatestParams(query, time);
+    const query = 'FROM foo | where time < ?end';
+    const params = getStartEndParams(query, time);
     expect(params).toHaveLength(1);
-    expect(params[0]).toHaveProperty('latest');
+    expect(params[0]).toHaveProperty('end');
   });
 
-  it('should return an array with the latest and earliest params if exist at the query', () => {
+  it('should return an array with the end and start params if exist at the query', () => {
     const time = { from: 'Jul 5, 2024 @ 08:03:56.849', to: 'Jul 5, 2024 @ 10:03:56.849' };
-    const query = 'FROM foo | where time < ?latest amd time > ?earliest';
-    const params = getEarliestLatestParams(query, time);
+    const query = 'FROM foo | where time < ?end amd time > ?start';
+    const params = getStartEndParams(query, time);
     expect(params).toHaveLength(2);
-    expect(params[0]).toHaveProperty('earliest');
-    expect(params[1]).toHaveProperty('latest');
+    expect(params[0]).toHaveProperty('start');
+    expect(params[1]).toHaveProperty('end');
   });
 });

--- a/packages/kbn-esql-utils/src/utils/run_query.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.ts
@@ -14,22 +14,22 @@ import { esFieldTypeToKibanaFieldType } from '@kbn/field-types';
 import type { ESQLColumn, ESQLSearchResponse, ESQLSearchParams } from '@kbn/es-types';
 import { lastValueFrom } from 'rxjs';
 
-export const hasEarliestLatestParams = (query: string) => /\?earliest|\?latest/i.test(query);
+export const hasStartEndParams = (query: string) => /\?start|\?end/i.test(query);
 
-export const getEarliestLatestParams = (query: string, time?: TimeRange) => {
-  const earliestNamedParams = /\?earliest/i.test(query);
-  const latestNamedParams = /\?latest/i.test(query);
-  if (time && (earliestNamedParams || latestNamedParams)) {
+export const getStartEndParams = (query: string, time?: TimeRange) => {
+  const startNamedParams = /\?start/i.test(query);
+  const endNamedParams = /\?end/i.test(query);
+  if (time && (startNamedParams || endNamedParams)) {
     const timeParams = {
-      earliest: earliestNamedParams ? dateMath.parse(time.from)?.toISOString() : undefined,
-      latest: latestNamedParams ? dateMath.parse(time.to)?.toISOString() : undefined,
+      start: startNamedParams ? dateMath.parse(time.from)?.toISOString() : undefined,
+      end: endNamedParams ? dateMath.parse(time.to)?.toISOString() : undefined,
     };
     const namedParams = [];
-    if (timeParams?.earliest) {
-      namedParams.push({ earliest: timeParams.earliest });
+    if (timeParams?.start) {
+      namedParams.push({ start: timeParams.start });
     }
-    if (timeParams?.latest) {
-      namedParams.push({ latest: timeParams.latest });
+    if (timeParams?.end) {
+      namedParams.push({ end: timeParams.end });
     }
     return namedParams;
   }
@@ -61,7 +61,7 @@ export async function getESQLQueryColumnsRaw({
   timeRange?: TimeRange;
 }): Promise<ESQLColumn[]> {
   try {
-    const namedParams = getEarliestLatestParams(esqlQuery, timeRange);
+    const namedParams = getStartEndParams(esqlQuery, timeRange);
     const response = await lastValueFrom(
       search(
         {
@@ -135,7 +135,7 @@ export async function getESQLResults({
   response: ESQLSearchResponse;
   params: ESQLSearchParams;
 }> {
-  const namedParams = getEarliestLatestParams(esqlQuery, timeRange);
+  const namedParams = getStartEndParams(esqlQuery, timeRange);
   const result = await lastValueFrom(
     search(
       {

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -28,7 +28,7 @@ const allFunctions = statsAggregationFunctionDefinitions
   .concat(evalFunctionDefinitions)
   .concat(groupingFunctionDefinitions);
 
-export const TIME_SYSTEM_PARAMS = ['?earliest', '?latest'];
+export const TIME_SYSTEM_PARAMS = ['?start', '?end'];
 
 export const TRIGGER_SUGGESTION_COMMAND = {
   title: 'Trigger Suggestion Dialog',

--- a/packages/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.params.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.params.test.ts
@@ -23,16 +23,16 @@ test('should allow param inside agg function argument', async () => {
 test('allow params in WHERE command expressions', async () => {
   const { validate } = await setup();
 
-  const res1 = await validate('FROM index | WHERE stringField >= ?earliest');
+  const res1 = await validate('FROM index | WHERE stringField >= ?start');
   const res2 = await validate(`
     FROM index
-      | WHERE stringField >= ?earliest
+      | WHERE stringField >= ?start
       | WHERE stringField <= ?0
       | WHERE stringField == ?
   `);
   const res3 = await validate(`
     FROM index
-      | WHERE stringField >= ?earliest
+      | WHERE stringField >= ?start
         AND stringField <= ?0
         AND stringField == ?
   `);

--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
 import type { Datatable, ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
 import { RequestAdapter } from '@kbn/inspector-plugin/common';
-import { getEarliestLatestParams } from '@kbn/esql-utils';
+import { getStartEndParams } from '@kbn/esql-utils';
 
 import { zipObject } from 'lodash';
 import { Observable, defer, throwError } from 'rxjs';
@@ -154,7 +154,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
               uiSettings as Parameters<typeof getEsQueryConfig>[0]
             );
 
-            const namedParams = getEarliestLatestParams(query, input.timeRange);
+            const namedParams = getStartEndParams(query, input.timeRange);
 
             if (namedParams.length) {
               params.params = namedParams;

--- a/src/plugins/discover/public/application/main/state_management/utils/get_esql_data_view.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/get_esql_data_view.test.ts
@@ -32,7 +32,7 @@ describe('getEsqlDataView', () => {
   });
 
   it('returns an adhoc dataview if it is adhoc with named params and query index pattern is the same as the dataview index pattern', async () => {
-    const query = { esql: 'from data-view-ad-hoc-title | where time >= ?earliest' };
+    const query = { esql: 'from data-view-ad-hoc-title | where time >= ?start' };
     const dataView = await getEsqlDataView(query, dataViewAdHocNoAtTimestamp, services);
     expect(dataView.timeFieldName).toBe('time');
   });

--- a/test/functional/apps/discover/esql/_esql_view.ts
+++ b/test/functional/apps/discover/esql/_esql_view.ts
@@ -113,11 +113,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(false);
       });
 
-      it('should render the histogram for indices with no @timestamp field when the ?earliest, ?latest params are in the query', async function () {
+      it('should render the histogram for indices with no @timestamp field when the ?start, ?end params are in the query', async function () {
         await PageObjects.discover.selectTextBaseLang();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
-        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?earliest and timestamp <= ?latest`;
+        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?start and timestamp <= ?end`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_esql_overall_stats_data.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_esql_overall_stats_data.ts
@@ -9,7 +9,7 @@ import { ESQL_ASYNC_SEARCH_STRATEGY, KBN_FIELD_TYPES } from '@kbn/data-plugin/co
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { AggregateQuery, TimeRange } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
-import { getEarliestLatestParams } from '@kbn/esql-utils';
+import { getStartEndParams } from '@kbn/esql-utils';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { type UseCancellableSearch, useCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { estypes } from '@elastic/elasticsearch';
@@ -83,7 +83,7 @@ const getESQLDocumentCountStats = async (
   const esqlBaseQuery = query.esql;
   let earliestMs = Infinity;
   let latestMs = -Infinity;
-  const namedParams = getEarliestLatestParams(esqlBaseQuery, timeRange);
+  const namedParams = getStartEndParams(esqlBaseQuery, timeRange);
 
   if (timeFieldName) {
     const aggQuery = appendToESQLQuery(
@@ -298,7 +298,7 @@ export const useESQLOverallStatsData = (
         // And use this one query to
         // 1) identify populated/empty fields
         // 2) gather examples for populated text fields
-        const namedParams = getEarliestLatestParams(esqlBaseQuery, timeRange);
+        const namedParams = getStartEndParams(esqlBaseQuery, timeRange);
         const columnsResp = (await runRequest(
           {
             params: {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_boolean_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_boolean_field_stats.ts
@@ -9,7 +9,7 @@ import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_ASYNC_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import pLimit from 'p-limit';
-import { appendToESQLQuery, getEarliestLatestParams } from '@kbn/esql-utils';
+import { appendToESQLQuery, getStartEndParams } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import { isFulfilled, isRejected } from '../../../common/util/promise_all_settled_utils';
@@ -33,7 +33,7 @@ export const getESQLBooleanFieldStats = async ({
   timeRange,
 }: Params): Promise<Array<BooleanFieldStats | FieldStatsError | undefined>> => {
   const limiter = pLimit(MAX_CONCURRENT_REQUESTS);
-  const namedParams = getEarliestLatestParams(esqlBaseQuery, timeRange);
+  const namedParams = getStartEndParams(esqlBaseQuery, timeRange);
   const booleanFields = columns
     .filter((f) => f.secondaryType === 'boolean')
     .map((field) => {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_count_and_cardinality.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_count_and_cardinality.ts
@@ -10,7 +10,7 @@ import { chunk } from 'lodash';
 import { isDefined } from '@kbn/ml-is-defined';
 import type { TimeRange } from '@kbn/es-query';
 import type { ESQLSearchResponse } from '@kbn/es-types';
-import { appendToESQLQuery, getEarliestLatestParams } from '@kbn/esql-utils';
+import { appendToESQLQuery, getStartEndParams } from '@kbn/esql-utils';
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { i18n } from '@kbn/i18n';
@@ -94,7 +94,7 @@ const getESQLOverallStatsInChunk = async ({
     let countQuery = fieldsToFetch.length > 0 ? '| STATS ' : '';
     countQuery += fieldsToFetch.map((field) => field.query).join(',');
     const query = appendToESQLQuery(esqlBaseQueryWithLimit, countQuery);
-    const namedParams = getEarliestLatestParams(esqlBaseQueryWithLimit, timeRange);
+    const namedParams = getStartEndParams(esqlBaseQueryWithLimit, timeRange);
 
     const request = {
       params: {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_date_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_date_field_stats.ts
@@ -9,7 +9,7 @@ import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type { TimeRange } from '@kbn/es-query';
 import { ESQL_ASYNC_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
-import { appendToESQLQuery, getEarliestLatestParams } from '@kbn/esql-utils';
+import { appendToESQLQuery, getStartEndParams } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import type { DateFieldStats, FieldStatsError } from '../../../../../common/types/field_stats';
@@ -39,7 +39,7 @@ export const getESQLDateFieldStats = async ({
   });
 
   if (dateFields.length > 0) {
-    const namedParams = getEarliestLatestParams(esqlBaseQuery, timeRange);
+    const namedParams = getStartEndParams(esqlBaseQuery, timeRange);
     const dateStatsQuery = ' | STATS ' + dateFields.map(({ query }) => query).join(',');
     const query = appendToESQLQuery(esqlBaseQuery, dateStatsQuery);
     const request = {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_keyword_fields.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_keyword_fields.ts
@@ -9,7 +9,7 @@ import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_ASYNC_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import pLimit from 'p-limit';
-import { appendToESQLQuery, getEarliestLatestParams } from '@kbn/esql-utils';
+import { appendToESQLQuery, getStartEndParams } from '@kbn/esql-utils';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
 import { getSafeESQLName } from '../requests/esql_utils';
 import { isFulfilled, isRejected } from '../../../common/util/promise_all_settled_utils';
@@ -32,7 +32,7 @@ export const getESQLKeywordFieldStats = async ({
   timeRange,
 }: Params) => {
   const limiter = pLimit(MAX_CONCURRENT_REQUESTS);
-  const namedParams = getEarliestLatestParams(esqlBaseQuery, timeRange);
+  const namedParams = getStartEndParams(esqlBaseQuery, timeRange);
   const keywordFields = columns.map((field) => {
     const query = appendToESQLQuery(
       esqlBaseQuery,

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_numeric_field_stats.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/search_strategy/esql_requests/get_numeric_field_stats.ts
@@ -8,7 +8,7 @@ import type { TimeRange } from '@kbn/es-query';
 import type { UseCancellableSearch } from '@kbn/ml-cancellable-search';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import { ESQL_ASYNC_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
-import { appendToESQLQuery, getEarliestLatestParams } from '@kbn/esql-utils';
+import { appendToESQLQuery, getStartEndParams } from '@kbn/esql-utils';
 import { chunk } from 'lodash';
 import pLimit from 'p-limit';
 import type { Column } from '../../hooks/esql/use_esql_overall_stats_data';
@@ -69,7 +69,7 @@ const getESQLNumericFieldStatsInChunk = async ({
     const numericStatsQuery = '| STATS ' + numericFields.map(({ query }) => query).join(',');
 
     const query = appendToESQLQuery(esqlBaseQuery, numericStatsQuery);
-    const namedParams = getEarliestLatestParams(esqlBaseQuery, timeRange);
+    const namedParams = getStartEndParams(esqlBaseQuery, timeRange);
     const request = {
       params: {
         query,

--- a/x-pack/plugins/lens/public/datasources/text_based/utils.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/utils.test.ts
@@ -291,7 +291,7 @@ describe('Text based languages utils', () => {
       const expressionsMock = expressionsPluginMock.createStartContract();
       const updatedState = await getStateFromAggregateQuery(
         state,
-        { esql: 'FROM my-fake-index-pattern | WHERE time <= ?latest' },
+        { esql: 'FROM my-fake-index-pattern | WHERE time <= ?end' },
         {
           ...dataViewsMock,
           getIdsWithTitle: jest.fn().mockReturnValue(
@@ -361,7 +361,7 @@ describe('Text based languages utils', () => {
             errors: [],
             index: '4',
             query: {
-              esql: 'FROM my-fake-index-pattern | WHERE time <= ?latest',
+              esql: 'FROM my-fake-index-pattern | WHERE time <= ?end',
             },
             timeField: 'time',
           },

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -14,8 +14,8 @@ import { Adapters } from '@kbn/inspector-plugin/common/adapters';
 import {
   getIndexPatternFromESQLQuery,
   getLimitFromESQLQuery,
-  getEarliestLatestParams,
-  hasEarliestLatestParams,
+  getStartEndParams,
+  hasStartEndParams,
 } from '@kbn/esql-utils';
 import { buildEsQuery } from '@kbn/es-query';
 import type { Filter, Query } from '@kbn/es-query';
@@ -117,11 +117,11 @@ export class ESQLSource
   }
 
   getApplyGlobalQuery() {
-    return this._descriptor.narrowByGlobalSearch || hasEarliestLatestParams(this._descriptor.esql);
+    return this._descriptor.narrowByGlobalSearch || hasStartEndParams(this._descriptor.esql);
   }
 
   async isTimeAware() {
-    return this._descriptor.narrowByGlobalTime || hasEarliestLatestParams(this._descriptor.esql);
+    return this._descriptor.narrowByGlobalTime || hasStartEndParams(this._descriptor.esql);
   }
 
   getApplyGlobalTime() {
@@ -214,7 +214,7 @@ export class ESQLSource
       }
     }
 
-    const namedParams = getEarliestLatestParams(this._descriptor.esql, timeRange);
+    const namedParams = getStartEndParams(this._descriptor.esql, timeRange);
     if (namedParams.length) {
       params.params = namedParams;
     }

--- a/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
@@ -114,11 +114,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(false);
       });
 
-      it('should render the histogram for indices with no @timestamp field when the ?earliest, ?latest params are in the query', async function () {
+      it('should render the histogram for indices with no @timestamp field when the ?start, ?end params are in the query', async function () {
         await PageObjects.discover.selectTextBaseLang();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
-        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?earliest and timestamp <= ?latest`;
+        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?start and timestamp <= ?end`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');


### PR DESCRIPTION
## Summary
Talked with @timductive and decided to use `?start` and `?end` instead. So this PR is mostly a rename and nothing more