### PR TITLE
chore(): add gh action ld/find-code-references

### DIFF
--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -1,0 +1,25 @@
+name: Find LaunchDarkly flag code references
+
+on:
+  push:
+    branches:
+      - 'main'
+
+# cancel in-flight workflow run if another push was triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  launchDarklyCodeReferences:
+    name: LaunchDarkly Code References
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
+    - name: LaunchDarkly Code References
+      uses: launchdarkly/find-code-references@v2.12.0
+      with:
+        accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
+        projKey: ${{ secrets.LD_PROJECT_KEY }}


### PR DESCRIPTION
## Summary

Adds a GH action to populate the code references in LaunchDarkly's feature flags. The idea is that it will run only on `main`.

❗ I need some help creating the secrets. I don't seem to have access to change that in this project.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
