### PR TITLE
[8.15] [ResponseOps] log error when ES Query rules find docs out of time range (#186332)

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts
@@ -6,7 +6,7 @@
  */
 import { sha256 } from 'js-sha256';
 import { i18n } from '@kbn/i18n';
-import { CoreSetup } from '@kbn/core/server';
+import { CoreSetup, Logger } from '@kbn/core/server';
 import { isGroupAggregation, UngroupedGroupId } from '@kbn/triggers-actions-ui-plugin/common';
 import {
   ALERT_EVALUATION_THRESHOLD,
@@ -16,6 +16,9 @@ import {
 } from '@kbn/rule-data-utils';
 
 import { AlertsClientError } from '@kbn/alerting-plugin/server';
+import { get } from 'lodash';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
 import { ComparatorFns } from '../../../common';
 import {
   addMessages,
@@ -71,7 +74,7 @@ export async function executor(core: CoreSetup, options: ExecutorOptions<EsQuery
   let latestTimestamp: string | undefined = tryToParseAsDate(state.latestTimestamp);
   const { dateStart, dateEnd } = getTimeRange(`${params.timeWindowSize}${params.timeWindowUnit}`);
 
-  const { parsedResults, link, index } = searchSourceRule
+  const { parsedResults, link, index, query } = searchSourceRule
     ? await fetchSearchSourceQuery({
         ruleId,
         alertLimit,
@@ -121,6 +124,19 @@ export async function executor(core: CoreSetup, options: ExecutorOptions<EsQuery
   for (const result of parsedResults.results) {
     const alertId = result.group;
     const value = result.value ?? result.count;
+
+    // check hits for dates out of range
+    if (!esqlQueryRule) {
+      checkHitsForDateOutOfRange(
+        logger,
+        ruleId,
+        result.hits,
+        params.timeField,
+        dateStart,
+        dateEnd,
+        query
+      );
+    }
 
     // group aggregations use the bucket selector agg to compare conditions
     // within the ES query, so only 'met' results are returned, therefore we don't need
@@ -229,6 +245,84 @@ export async function executor(core: CoreSetup, options: ExecutorOptions<EsQuery
     });
   }
   return { state: { latestTimestamp } };
+}
+
+// diagnostic to help solve a puzzle of sometimes returning documents
+// not matching the expected time range; usually kql using ccs.
+function checkHitsForDateOutOfRange(
+  logger: Logger,
+  ruleId: string,
+  hits: Array<estypes.SearchHit<unknown>>,
+  timeField: string | undefined,
+  dateStart: string,
+  dateEnd: string,
+  query: unknown
+) {
+  if (!timeField) return;
+
+  const epochStart = new Date(dateStart).getTime();
+  const epochEnd = new Date(dateEnd).getTime();
+  const messageMeta = { tags: ['query-result-out-of-time-range'] };
+
+  const messagePrefix = `For rule '${ruleId}'`;
+  const usingQuery = `using query <${JSON.stringify(query)}>`;
+  const hitsWereReturned = 'hits were returned with invalid time range';
+
+  let errors = 0;
+  if (isNaN(epochStart)) {
+    errors++;
+    logger.error(
+      `${messagePrefix}, ${hitsWereReturned} start date '${dateStart}' from field '${timeField}' ${usingQuery}`,
+      messageMeta
+    );
+  }
+
+  if (isNaN(epochEnd)) {
+    errors++;
+    logger.error(
+      `${messagePrefix}, ${hitsWereReturned} end date '${dateEnd}' from field '${timeField}' ${usingQuery}`,
+      messageMeta
+    );
+  }
+
+  if (errors > 0) return;
+
+  const outsideTimeRange = 'outside the query time range';
+
+  for (const hit of hits) {
+    const dateVal = get(hit, `_source.${timeField}`);
+    const epochDate = getEpochDateFromString(dateVal);
+
+    if (epochDate) {
+      if (epochDate < epochStart || epochDate > epochEnd) {
+        const message = `the hit with date '${dateVal}' from field '${timeField}' is ${outsideTimeRange}`;
+        const queryString = `Query: <${JSON.stringify(query)}>`;
+        const document = `Document: <${JSON.stringify(hit)}>`;
+        logger.error(`${messagePrefix}, ${message}. ${queryString}. ${document}`, messageMeta);
+      }
+    }
+  }
+}
+
+function getEpochDateFromString(dateString: string): number | null {
+  let date: Date;
+  try {
+    date = new Date(dateString);
+  } catch (e) {
+    return null;
+  }
+
+  const time = date.getTime();
+  if (!isNaN(time)) return time;
+
+  // if not a valid date string, try it as a stringified number
+  const dateNum = parseInt(dateString, 10);
+  if (isNaN(dateNum)) return null;
+
+  const timeFromNumber = new Date(dateNum).getTime();
+  if (isNaN(timeFromNumber)) return null;
+
+  return timeFromNumber;
 }
 
 export function getValidTimefieldSort(

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_es_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_es_query.ts
@@ -144,6 +144,7 @@ export async function fetchEsQuery({
       sourceFieldsParams: params.sourceFields,
     }),
     link,
+    query: sortedQuery,
     index: params.index,
   };
 }

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
@@ -56,6 +56,7 @@ export async function fetchEsqlQuery({
 
   return {
     link,
+    query,
     numMatches: Number(response.values.length),
     parsedResults: parseAggregationResults({
       isCountAgg: true,

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
@@ -69,11 +69,8 @@ export async function fetchSearchSourceQuery({
     alertLimit
   );
 
-  logger.debug(
-    `search source query rule (${ruleId}) query: ${JSON.stringify(
-      searchSource.getSearchRequestBody()
-    )}`
-  );
+  const searchRequestBody: unknown = searchSource.getSearchRequestBody();
+  logger.debug(`search source query rule (${ruleId}) query: ${JSON.stringify(searchRequestBody)}`);
 
   const searchResult = await searchSource.fetch();
 
@@ -98,6 +95,7 @@ export async function fetchSearchSourceQuery({
       sourceFieldsParams: params.sourceFields,
     }),
     index: [index.name],
+    query: searchRequestBody,
   };
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ResponseOps] log error when ES Query rules find docs out of time range (#186332)](https://github.com/elastic/kibana/pull/186332)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2024-07-23T20:17:11Z","message":"[ResponseOps] log error when ES Query rules find docs out of time range (#186332)\n\nresolves https://github.com/elastic/kibana/issues/175980\r\n\r\n## Summary\r\n\r\nAdds a check with logging if an ES Query rule returns hits which fall\r\noutside the time range it's searching. This shouldn't ever happen, but\r\nseems to be happening on rare occaisons, so we wanted to add some\r\ndiagnostics to try to help narrow down the problem.\r\n\r\nNote that the ES|QL flavor rule does not use this diagnostic, just\r\nsearch source (KQL) and query dsl.\r\n\r\nWe check 3 things:\r\n- ensure the `dateStart` sent to fetch was valid\r\n- ensure the `dateEnd` sent to fetch was valid\r\n- ensure the relevant time fields in hits are within the\r\ndateStart/dateEnd range\r\n\r\nThese produce three different error messages:\r\n\r\n`For rule '<rule-id>', hits were returned with invalid time range start\r\ndate '<date>' from field '<field>' using query <query>`\r\n\r\n`For rule '<rule-id>', hits were returned with invalid time range end\r\ndate '<date>' from field '<field>' using query <query>`\r\n\r\n`For rule '<rule-id>', the hit with date '<date>' from field '<field>'\r\nis outside the query time range. Query: <query>. Document: <document>`\r\n\r\nEach message has one tag on it: `query-result-out-of-time-range`\r\n\r\n## To Verify\r\n\r\nTo test invalid dateStart/dateEnd, hack the Kibana code to set the\r\nvalues to NaN's:\r\n\r\n\r\nhttps://github.com/elastic/kibana/blob/d30da09707f85d84d7fd555733ba8e0cb595228b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts#L263-L264\r\n\r\nFor instance, change that to:\r\n\r\n    const epochStart = new Date('x').getTime();\r\n    const epochEnd = new Date('y').getTime();\r\n\r\nTo test the invdivual document hits, first back out the change you made\r\nabove - when those error, the checks we're testing below do not run.\r\nHack the Kibana code to make the time out of range:\r\n\r\n\r\nhttps://github.com/elastic/kibana/blob/d30da09707f85d84d7fd555733ba8e0cb595228b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts#L294\r\n\r\nFor instance, change that to:\r\n\r\n    const epochDate = epochStart - 100\r\n\r\nFor both tests, create an es query rule - kql or dsl - make the relevant\r\nchanges, and arrange for the rule to get hits each time. The relevant\r\nmessages should be logged in the Kibana console when the rule runs.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e12e4496e0594d34509ef9235d1d7b7e3461e5d8","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:Alerting/RulesFramework","backport:prev-minor","v8.16.0"],"number":186332,"url":"https://github.com/elastic/kibana/pull/186332","mergeCommit":{"message":"[ResponseOps] log error when ES Query rules find docs out of time range (#186332)\n\nresolves https://github.com/elastic/kibana/issues/175980\r\n\r\n## Summary\r\n\r\nAdds a check with logging if an ES Query rule returns hits which fall\r\noutside the time range it's searching. This shouldn't ever happen, but\r\nseems to be happening on rare occaisons, so we wanted to add some\r\ndiagnostics to try to help narrow down the problem.\r\n\r\nNote that the ES|QL flavor rule does not use this diagnostic, just\r\nsearch source (KQL) and query dsl.\r\n\r\nWe check 3 things:\r\n- ensure the `dateStart` sent to fetch was valid\r\n- ensure the `dateEnd` sent to fetch was valid\r\n- ensure the relevant time fields in hits are within the\r\ndateStart/dateEnd range\r\n\r\nThese produce three different error messages:\r\n\r\n`For rule '<rule-id>', hits were returned with invalid time range start\r\ndate '<date>' from field '<field>' using query <query>`\r\n\r\n`For rule '<rule-id>', hits were returned with invalid time range end\r\ndate '<date>' from field '<field>' using query <query>`\r\n\r\n`For rule '<rule-id>', the hit with date '<date>' from field '<field>'\r\nis outside the query time range. Query: <query>. Document: <document>`\r\n\r\nEach message has one tag on it: `query-result-out-of-time-range`\r\n\r\n## To Verify\r\n\r\nTo test invalid dateStart/dateEnd, hack the Kibana code to set the\r\nvalues to NaN's:\r\n\r\n\r\nhttps://github.com/elastic/kibana/blob/d30da09707f85d84d7fd555733ba8e0cb595228b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts#L263-L264\r\n\r\nFor instance, change that to:\r\n\r\n    const epochStart = new Date('x').getTime();\r\n    const epochEnd = new Date('y').getTime();\r\n\r\nTo test the invdivual document hits, first back out the change you made\r\nabove - when those error, the checks we're testing below do not run.\r\nHack the Kibana code to make the time out of range:\r\n\r\n\r\nhttps://github.com/elastic/kibana/blob/d30da09707f85d84d7fd555733ba8e0cb595228b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts#L294\r\n\r\nFor instance, change that to:\r\n\r\n    const epochDate = epochStart - 100\r\n\r\nFor both tests, create an es query rule - kql or dsl - make the relevant\r\nchanges, and arrange for the rule to get hits each time. The relevant\r\nmessages should be logged in the Kibana console when the rule runs.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e12e4496e0594d34509ef9235d1d7b7e3461e5d8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/186332","number":186332,"mergeCommit":{"message":"[ResponseOps] log error when ES Query rules find docs out of time range (#186332)\n\nresolves https://github.com/elastic/kibana/issues/175980\r\n\r\n## Summary\r\n\r\nAdds a check with logging if an ES Query rule returns hits which fall\r\noutside the time range it's searching. This shouldn't ever happen, but\r\nseems to be happening on rare occaisons, so we wanted to add some\r\ndiagnostics to try to help narrow down the problem.\r\n\r\nNote that the ES|QL flavor rule does not use this diagnostic, just\r\nsearch source (KQL) and query dsl.\r\n\r\nWe check 3 things:\r\n- ensure the `dateStart` sent to fetch was valid\r\n- ensure the `dateEnd` sent to fetch was valid\r\n- ensure the relevant time fields in hits are within the\r\ndateStart/dateEnd range\r\n\r\nThese produce three different error messages:\r\n\r\n`For rule '<rule-id>', hits were returned with invalid time range start\r\ndate '<date>' from field '<field>' using query <query>`\r\n\r\n`For rule '<rule-id>', hits were returned with invalid time range end\r\ndate '<date>' from field '<field>' using query <query>`\r\n\r\n`For rule '<rule-id>', the hit with date '<date>' from field '<field>'\r\nis outside the query time range. Query: <query>. Document: <document>`\r\n\r\nEach message has one tag on it: `query-result-out-of-time-range`\r\n\r\n## To Verify\r\n\r\nTo test invalid dateStart/dateEnd, hack the Kibana code to set the\r\nvalues to NaN's:\r\n\r\n\r\nhttps://github.com/elastic/kibana/blob/d30da09707f85d84d7fd555733ba8e0cb595228b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts#L263-L264\r\n\r\nFor instance, change that to:\r\n\r\n    const epochStart = new Date('x').getTime();\r\n    const epochEnd = new Date('y').getTime();\r\n\r\nTo test the invdivual document hits, first back out the change you made\r\nabove - when those error, the checks we're testing below do not run.\r\nHack the Kibana code to make the time out of range:\r\n\r\n\r\nhttps://github.com/elastic/kibana/blob/d30da09707f85d84d7fd555733ba8e0cb595228b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts#L294\r\n\r\nFor instance, change that to:\r\n\r\n    const epochDate = epochStart - 100\r\n\r\nFor both tests, create an es query rule - kql or dsl - make the relevant\r\nchanges, and arrange for the rule to get hits each time. The relevant\r\nmessages should be logged in the Kibana console when the rule runs.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e12e4496e0594d34509ef9235d1d7b7e3461e5d8"}}]}] BACKPORT-->