### PR TITLE
[UII] Fix truncation and wrapping issues with agent policy name + description link

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_policy_summary_line.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_policy_summary_line.tsx
@@ -15,6 +15,7 @@ import type { AgentPolicy, Agent } from '../../common/types';
 import { useLink } from '../hooks';
 const MIN_WIDTH: CSSProperties = { minWidth: 0 };
 const NO_WRAP_WHITE_SPACE: CSSProperties = { whiteSpace: 'nowrap' };
+const WRAP_WHITE_SPACE: CSSProperties = { whiteSpace: 'normal' };
 
 export const AgentPolicySummaryLine = memo<{
   policy: AgentPolicy;
@@ -27,7 +28,7 @@ export const AgentPolicySummaryLine = memo<{
 
   const revision = agent ? agent.policy_revision : policy.revision;
   return (
-    <EuiFlexGroup direction="column" gutterSize="xs">
+    <EuiFlexGroup direction="column" gutterSize="xs" wrap={true}>
       <EuiFlexItem>
         <EuiFlexGroup
           direction={direction}
@@ -37,11 +38,11 @@ export const AgentPolicySummaryLine = memo<{
           responsive={false}
           justifyContent={'flexStart'}
         >
-          <EuiFlexItem grow={false} className="eui-textTruncate">
+          <EuiFlexItem grow={false}>
             <EuiFlexGroup style={MIN_WIDTH} gutterSize="s" alignItems="baseline" responsive={false}>
-              <EuiFlexItem grow={false} className="eui-textTruncate">
+              <EuiFlexItem grow={false}>
                 <EuiLink
-                  className={`eui-textTruncate`}
+                  style={WRAP_WHITE_SPACE}
                   href={getHref('policy_details', { policyId: id })}
                   title={name || id}
                   data-test-subj="agentPolicyNameLink"
@@ -85,7 +86,7 @@ export const AgentPolicySummaryLine = memo<{
       </EuiFlexItem>
       {withDescription && description && (
         <EuiFlexItem>
-          <EuiText color="subdued" className="eui-textTruncate" title={description} size="xs">
+          <EuiText color="subdued" title={description} size="xs">
             {description}
           </EuiText>
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Resolves #184562 while working on a related area.

This PR fixes various issues with the component that displays a linked agent policy name, description, managed lock icon, and revision number.

Basically, we now allow everything to wrap inside the parent flex group instead of attempting to truncate each element, which was causing weird flex/block issues.

<img width="596" alt="image" src="https://github.com/user-attachments/assets/b7376b9a-3a32-4d67-8059-478b4ce8963a">

<img width="599" alt="image" src="https://github.com/user-attachments/assets/b261b63e-0a80-4d1a-b2bf-4a7e428feeac">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->