### PR TITLE
[Fleet] made unprivileged text more generic

### DIFF
--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/unprivileged_info.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/unprivileged_info.tsx
@@ -19,10 +19,10 @@ export const UnprivilegedInfo: React.FC = () => {
         <p>
           <FormattedMessage
             id="xpack.fleet.agentEnrollmentFlyout.unprivilegedMessage"
-            defaultMessage="To install Elastic Agent without root privileges, add the {flag} flag to the {command} install command below. For more information, see the {guideLink}"
+            defaultMessage="To install Elastic Agent without root privileges, add the {flag} flag to the {command} command below. For more information, see the {guideLink}"
             values={{
               flag: <EuiCode>--unprivileged</EuiCode>,
-              command: <EuiCode>sudo ./elastic-agent</EuiCode>,
+              command: <EuiCode>elastic-agent install</EuiCode>,
               guideLink: (
                 <EuiLink href={docLinks.links.fleet.unprivilegedMode} target="_blank" external>
                   <FormattedMessage


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/188893

Adjust text so it's more generic, fits Windows platform better.

<img width="828" alt="image" src="https://github.com/user-attachments/assets/a9205944-e690-44be-bef4-e322f153153a">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->