### PR TITLE
[OpenAI Connector] Update default model to gpt-4o

### DIFF
--- a/docs/management/connectors/pre-configured-connectors.asciidoc
+++ b/docs/management/connectors/pre-configured-connectors.asciidoc
@@ -328,7 +328,7 @@ xpack.actions.preconfigured:
     config:
       apiUrl: https://api.openai.com/v1/chat/completions <1>
       apiProvider: 'OpenAI' <2>
-      defaultModel: gpt-4 <3>
+      defaultModel: gpt-4o <3>
     secrets:
       apiKey: superlongapikey <4>
 --

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/models/model_selector/model_selector.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/models/model_selector/model_selector.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { MODEL_GPT_3_5_TURBO, MODEL_GPT_4, ModelSelector } from './model_selector';
+import { MODEL_GPT_4O, MODEL_GPT_4_TURBO, ModelSelector } from './model_selector';
 import { fireEvent, render } from '@testing-library/react';
 
 describe('ModelSelector', () => {
@@ -15,7 +15,7 @@ describe('ModelSelector', () => {
     const { getByTestId } = render(
       <ModelSelector onModelSelectionChange={onModelSelectionChange} />
     );
-    expect(getByTestId('comboBoxSearchInput')).toHaveValue(MODEL_GPT_3_5_TURBO);
+    expect(getByTestId('comboBoxSearchInput')).toHaveValue(MODEL_GPT_4O);
   });
   it('should call onModelSelectionChange when custom option', () => {
     const onModelSelectionChange = jest.fn();
@@ -39,7 +39,7 @@ describe('ModelSelector', () => {
     );
     const comboBox = getByTestId('comboBoxSearchInput');
     fireEvent.click(comboBox);
-    fireEvent.click(getByTestId(MODEL_GPT_4));
-    expect(onModelSelectionChange).toHaveBeenCalledWith(MODEL_GPT_4);
+    fireEvent.click(getByTestId(MODEL_GPT_4_TURBO));
+    expect(onModelSelectionChange).toHaveBeenCalledWith(MODEL_GPT_4_TURBO);
   });
 });

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/models/model_selector/model_selector.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/models/model_selector/model_selector.tsx
@@ -10,10 +10,10 @@ import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
 
 import * as i18n from './translations';
 
-export const MODEL_GPT_3_5_TURBO = 'gpt-3.5-turbo';
-export const MODEL_GPT_4 = 'gpt-4';
+export const MODEL_GPT_4_TURBO = 'gpt-4-turbo';
+export const MODEL_GPT_4O_MINI = 'gpt-4o-mini';
 export const MODEL_GPT_4O = 'gpt-4o';
-const DEFAULT_MODELS = [MODEL_GPT_3_5_TURBO, MODEL_GPT_4, MODEL_GPT_4O];
+const DEFAULT_MODELS = [MODEL_GPT_4O, MODEL_GPT_4_TURBO, MODEL_GPT_4O_MINI];
 
 interface Props {
   onModelSelectionChange?: (model?: string) => void;

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/models/model_selector/model_selector.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/models/model_selector/model_selector.tsx
@@ -12,7 +12,8 @@ import * as i18n from './translations';
 
 export const MODEL_GPT_3_5_TURBO = 'gpt-3.5-turbo';
 export const MODEL_GPT_4 = 'gpt-4';
-const DEFAULT_MODELS = [MODEL_GPT_3_5_TURBO, MODEL_GPT_4];
+export const MODEL_GPT_4O = 'gpt-4o';
+const DEFAULT_MODELS = [MODEL_GPT_3_5_TURBO, MODEL_GPT_4, MODEL_GPT_4O];
 
 interface Props {
   onModelSelectionChange?: (model?: string) => void;

--- a/x-pack/packages/kbn-langchain/server/language_models/chat_openai.test.ts
+++ b/x-pack/packages/kbn-langchain/server/language_models/chat_openai.test.ts
@@ -93,7 +93,7 @@ describe('ActionsClientChatOpenAI', () => {
     const defaultStreamingArgs: OpenAI.ChatCompletionCreateParamsStreaming = {
       messages: [{ content: prompt, role: 'user' }],
       stream: true,
-      model: 'gpt-4',
+      model: 'gpt-4o',
       n: 99,
       stop: ['a stop sequence'],
       functions: [jest.fn()],
@@ -112,7 +112,7 @@ describe('ActionsClientChatOpenAI', () => {
         actionId: connectorId,
         params: {
           subActionParams: {
-            model: 'gpt-4',
+            model: 'gpt-4o',
             messages: [{ role: 'user', content: 'Do you know my name?' }],
             signal,
             timeout: 999999,
@@ -133,7 +133,7 @@ describe('ActionsClientChatOpenAI', () => {
     const defaultNonStreamingArgs: OpenAI.ChatCompletionCreateParamsNonStreaming = {
       messages: [{ content: prompt, role: 'user' }],
       stream: false,
-      model: 'gpt-4',
+      model: 'gpt-4o',
     };
     it('returns the expected data', async () => {
       const actionsClientChatOpenAI = new ActionsClientChatOpenAI(defaultArgs);
@@ -145,7 +145,7 @@ describe('ActionsClientChatOpenAI', () => {
         actionId: connectorId,
         params: {
           subActionParams: {
-            body: '{"temperature":0.2,"model":"gpt-4","messages":[{"role":"user","content":"Do you know my name?"}]}',
+            body: '{"temperature":0.2,"model":"gpt-4o","messages":[{"role":"user","content":"Do you know my name?"}]}',
             signal,
             timeout: 999999,
           },

--- a/x-pack/packages/kbn-langchain/server/language_models/constants.ts
+++ b/x-pack/packages/kbn-langchain/server/language_models/constants.ts
@@ -26,7 +26,7 @@ export const getDefaultArguments = (
 export const DEFAULT_OPEN_AI_TEMPERATURE = 0.2;
 // this is a fallback for logging, connector will default to the connector model
 // x-pack/plugins/stack_connectors/common/openai/constants.ts
-export const DEFAULT_OPEN_AI_MODEL = 'gpt-4';
+export const DEFAULT_OPEN_AI_MODEL = 'gpt-4o';
 const DEFAULT_BEDROCK_TEMPERATURE = 0;
 const DEFAULT_BEDROCK_STOP_SEQUENCES = ['\n\nHuman:', '\nObservation:'];
 const DEFAULT_GEMINI_TEMPERATURE = 0;

--- a/x-pack/plugins/elastic_assistant/scripts/model_evaluator_script.ts
+++ b/x-pack/plugins/elastic_assistant/scripts/model_evaluator_script.ts
@@ -8,7 +8,7 @@
 import yargs from 'yargs/yargs';
 import { ToolingLog } from '@kbn/tooling-log';
 
-export const AVAILABLE_MODELS = ['gpt-3.5', 'gpt-4'] as const;
+export const AVAILABLE_MODELS = ['gpt-3.5', 'gpt-4', 'gpt-4o'] as const;
 
 /**
  * Work in progress developer script for evaluating models against datasets.

--- a/x-pack/plugins/stack_connectors/common/openai/constants.ts
+++ b/x-pack/plugins/stack_connectors/common/openai/constants.ts
@@ -31,7 +31,7 @@ export enum OpenAiProviderType {
 
 export const DEFAULT_TIMEOUT_MS = 120000;
 
-export const DEFAULT_OPENAI_MODEL = 'gpt-4';
+export const DEFAULT_OPENAI_MODEL = 'gpt-4o';
 
 export const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions' as const;
 export const OPENAI_LEGACY_COMPLETION_URL = 'https://api.openai.com/v1/completions' as const;

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/openai.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/openai.ts
@@ -90,7 +90,7 @@ export default function genAiTest({ getService }: FtrProviderContext) {
           is_missing_secrets: false,
           config: {
             ...config,
-            defaultModel: 'gpt-4',
+            defaultModel: 'gpt-4o',
           },
         });
       });


### PR DESCRIPTION
## Summary

Updates the default model for OpenAI connectors to gpt-4o

Updates the model options in the Security Assistant OpenAI model dropdown

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->