### PR TITLE
[ES|QL] capitalize function and operator signatures

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -73,13 +73,12 @@ describe('autocomplete.suggest', () => {
       test('on function left paren', async () => {
         const { assertSuggestions } = await setup();
 
-        await assertSuggestions(
-          'from a | stats by bucket(/',
-          [
-            ...getFieldNamesByType(['number', 'date']),
-            ...getFunctionSignaturesByReturnType('eval', ['date', 'number'], { scalar: true }),
-          ].map((field) => `${field},`)
-        );
+        await assertSuggestions('from a | stats by bucket(/', [
+          ...getFieldNamesByType(['number', 'date']).map((field) => `${field},`),
+          ...getFunctionSignaturesByReturnType('eval', ['date', 'number'], { scalar: true }).map(
+            (s) => ({ ...s, text: `${s.text},` })
+          ),
+        ]);
 
         await assertSuggestions('from a | stats round(/', [
           ...getFunctionSignaturesByReturnType('stats', 'number', { agg: true, grouping: true }),

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -313,11 +313,28 @@ export const setup = async (caret = '/') => {
     );
   };
 
-  const assertSuggestions = async (query: string, expected: string[], opts?: SuggestOptions) => {
+  const assertSuggestions = async (
+    query: string,
+    expected: Array<string | PartialSuggestionWithText>,
+    opts?: SuggestOptions
+  ) => {
     const result = await suggest(query, opts);
     const resultTexts = [...result.map((suggestion) => suggestion.text)].sort();
 
-    expect(resultTexts).toEqual([...expected].sort());
+    const expectedTexts = expected
+      .map((suggestion) => (typeof suggestion === 'string' ? suggestion : suggestion.text ?? ''))
+      .sort();
+
+    expect(resultTexts).toEqual(expectedTexts);
+
+    const expectedNonStringSuggestions = expected.filter(
+      (suggestion) => typeof suggestion !== 'string'
+    ) as PartialSuggestionWithText[];
+
+    for (const expectedSuggestion of expectedNonStringSuggestions) {
+      const suggestion = result.find((s) => s.text === expectedSuggestion.text);
+      expect(suggestion).toEqual(expect.objectContaining(expectedSuggestion));
+    }
   };
 
   return {

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -668,7 +668,7 @@ describe('autocomplete', () => {
       ...getFieldNamesByType('string').map((v) => `${v},`),
       ...getFunctionSignaturesByReturnType('eval', 'string', { scalar: true }, undefined, [
         'concat',
-      ]).map((v) => `${v},`),
+      ]).map((v) => ({ ...v, text: `${v.text},` })),
     ]);
     testSuggestions(
       'from a | eval a=concat(stringField, ',
@@ -696,7 +696,7 @@ describe('autocomplete', () => {
       ...getFieldNamesByType('ip').map((v) => `${v},`),
       ...getFunctionSignaturesByReturnType('eval', 'ip', { scalar: true }, undefined, [
         'cidr_match',
-      ]).map((v) => `${v},`),
+      ]).map((v) => ({ ...v, text: `${v.text},` })),
     ]);
     testSuggestions(
       'from a | eval a=cidr_match(ipField, ',
@@ -884,7 +884,7 @@ describe('autocomplete', () => {
           ...getLiteralsByType('time_literal').map((t) => `${t},`),
           ...getFunctionSignaturesByReturnType('eval', 'date', { scalar: true }, undefined, [
             'date_trunc',
-          ]).map((t) => `${t},`),
+          ]).map((t) => ({ ...t, text: `${t.text},` })),
           ...getFieldNamesByType('date').map((t) => `${t},`),
           TIME_PICKER_SUGGESTION,
         ],

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -49,7 +49,7 @@ function getSafeInsertSourceText(text: string) {
 }
 
 export function getSuggestionFunctionDefinition(fn: FunctionDefinition): SuggestionRawDefinition {
-  const fullSignatures = getFunctionSignatures(fn);
+  const fullSignatures = getFunctionSignatures(fn, { capitalize: true, withTypes: true });
   return {
     label: fullSignatures[0].declaration,
     text: `${fn.name.toUpperCase()}($0)`,
@@ -69,7 +69,7 @@ export function getSuggestionFunctionDefinition(fn: FunctionDefinition): Suggest
 export function getSuggestionBuiltinDefinition(fn: FunctionDefinition): SuggestionRawDefinition {
   const hasArgs = fn.signatures.some(({ params }) => params.length > 1);
   return {
-    label: fn.name,
+    label: fn.name.toUpperCase(),
     text: hasArgs ? `${fn.name.toUpperCase()} $0` : fn.name.toUpperCase(),
     asSnippet: hasArgs,
     kind: 'Operator',

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/helpers.ts
@@ -17,7 +17,10 @@ import type { CommandDefinition, FunctionDefinition } from './types';
  */
 export function getFunctionSignatures(
   { name, signatures }: FunctionDefinition,
-  { withTypes }: { withTypes: boolean } = { withTypes: true }
+  { withTypes, capitalize }: { withTypes: boolean; capitalize: boolean } = {
+    withTypes: true,
+    capitalize: false,
+  }
 ) {
   return signatures.map(({ params, returnType, minParams }) => {
     // for functions with a minimum number of args, repeat the last arg multiple times
@@ -25,7 +28,7 @@ export function getFunctionSignatures(
     const minParamsToAdd = Math.max((minParams || 0) - params.length, 0);
     const extraArg = Array(minParamsToAdd || 1).fill(params[Math.max(params.length - 1, 0)]);
     return {
-      declaration: `${name}(${params
+      declaration: `${capitalize ? name.toUpperCase() : name}(${params
         .map((arg) => printArguments(arg, withTypes))
         .join(', ')}${handleAdditionalArgs(minParamsToAdd > 0, extraArg, withTypes)})${
         withTypes ? `: ${returnType}` : ''

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/helpers.ts
@@ -17,7 +17,7 @@ import type { CommandDefinition, FunctionDefinition } from './types';
  */
 export function getFunctionSignatures(
   { name, signatures }: FunctionDefinition,
-  { withTypes, capitalize }: { withTypes: boolean; capitalize: boolean } = {
+  { withTypes, capitalize }: { withTypes: boolean; capitalize?: boolean } = {
     withTypes: true,
     capitalize: false,
   }

--- a/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -287,13 +287,12 @@ export function areFieldAndVariableTypesCompatible(
   return fieldType === variableType;
 }
 
-export function printFunctionSignature(arg: ESQLFunction, useCaps = true): string {
+export function printFunctionSignature(arg: ESQLFunction): string {
   const fnDef = getFunctionDefinition(arg.name);
   if (fnDef) {
     const signature = getFunctionSignatures(
       {
         ...fnDef,
-        name: useCaps ? fnDef.name.toUpperCase() : fnDef.name,
         signatures: [
           {
             ...fnDef?.signatures[0],
@@ -310,7 +309,7 @@ export function printFunctionSignature(arg: ESQLFunction, useCaps = true): strin
           },
         ],
       },
-      { withTypes: false }
+      { withTypes: false, capitalize: true }
     );
     return signature[0].declaration;
   }

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -9187,8 +9187,8 @@
     {
       "query": "from a_index | eval date_diff(\"year\", concat(\"20\", \"22\"), concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_diff] must be [date], found value [concat(\"20\", \"22\")] type [string]",
-        "Argument of [date_diff] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_diff] must be [date], found value [concat(\"20\",\"22\")] type [string]",
+        "Argument of [date_diff] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11086,7 +11086,7 @@
     {
       "query": "from a_index | eval date_extract(\"ALIGNED_DAY_OF_WEEK_IN_MONTH\", concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_extract] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_extract] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11173,7 +11173,7 @@
     {
       "query": "from a_index | eval date_format(stringField, concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_format] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_format] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11390,7 +11390,7 @@
     {
       "query": "from a_index | eval date_trunc(1 year, concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_trunc] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_trunc] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11402,8 +11402,8 @@
     {
       "query": "from a_index | eval date_trunc(concat(\"20\", \"22\"), concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_trunc] must be [time_literal], found value [concat(\"20\", \"22\")] type [string]",
-        "Argument of [date_trunc] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_trunc] must be [time_literal], found value [concat(\"20\",\"22\")] type [string]",
+        "Argument of [date_trunc] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -24143,7 +24143,7 @@
     {
       "query": "from a_index | stats max(concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [max] must be [number], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [max] must be [number], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -24520,7 +24520,7 @@
     {
       "query": "from a_index | stats min(concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [min] must be [number], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [min] must be [number], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25184,14 +25184,14 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 1 year)",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
     {
       "query": "from a_index | stats by bucket(concat(\"20\", \"22\"), 1 year)",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25203,7 +25203,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, \"a\", \"a\")",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25215,7 +25215,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, concat(\"20\", \"22\"), concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25227,7 +25227,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, \"a\", concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25239,7 +25239,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, concat(\"20\", \"22\"), \"a\")",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -26579,6 +26579,91 @@
     },
     {
       "query": "row nullVar = null | stats weighted_avg(nullVar, nullVar)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = exp(5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row exp(5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = exp(to_integer(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = exp(true)",
+      "error": [
+        "Argument of [exp] must be [number], found value [true] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where exp(numberField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where exp(booleanField) > 0",
+      "error": [
+        "Argument of [exp] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = exp(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = exp(to_integer(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(booleanField)",
+      "error": [
+        "Argument of [exp] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = exp(*)",
+      "error": [
+        "Using wildcards (*) in exp is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(numberField, extraArg)",
+      "error": [
+        "Error: [exp] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | sort exp(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(null)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row nullVar = null | eval exp(nullVar)",
       "error": [],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -99,7 +99,7 @@ function prepareNestedFunction(fnSignature: FunctionDefinition): string {
         },
       ],
     },
-    { withTypes: false }
+    { withTypes: false, capitalize: false }
   )[0].declaration;
 }
 function getFieldMapping(

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -1780,8 +1780,8 @@ describe('validation logic', () => {
         testErrorsAndWarnings(
           'from a_index | eval date_diff("year", concat("20", "22"), concat("20", "22"))',
           [
-            'Argument of [date_diff] must be [date], found value [concat("20", "22")] type [string]',
-            'Argument of [date_diff] must be [date], found value [concat("20", "22")] type [string]',
+            'Argument of [date_diff] must be [date], found value [concat("20","22")] type [string]',
+            'Argument of [date_diff] must be [date], found value [concat("20","22")] type [string]',
           ]
         );
       });
@@ -2668,7 +2668,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings(
           'from a_index | eval date_extract("ALIGNED_DAY_OF_WEEK_IN_MONTH", concat("20", "22"))',
           [
-            'Argument of [date_extract] must be [date], found value [concat("20", "22")] type [string]',
+            'Argument of [date_extract] must be [date], found value [concat("20","22")] type [string]',
           ]
         );
       });
@@ -2712,7 +2712,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | eval date_format(nullVar, nullVar)', []);
         testErrorsAndWarnings('from a_index | eval date_format(stringField, "2022")', []);
         testErrorsAndWarnings('from a_index | eval date_format(stringField, concat("20", "22"))', [
-          'Argument of [date_format] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [date_format] must be [date], found value [concat("20","22")] type [string]',
         ]);
       });
 
@@ -2817,15 +2817,15 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | eval date_trunc(nullVar, nullVar)', []);
         testErrorsAndWarnings('from a_index | eval date_trunc(1 year, "2022")', []);
         testErrorsAndWarnings('from a_index | eval date_trunc(1 year, concat("20", "22"))', [
-          'Argument of [date_trunc] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [date_trunc] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | eval date_trunc("2022", "2022")', []);
 
         testErrorsAndWarnings(
           'from a_index | eval date_trunc(concat("20", "22"), concat("20", "22"))',
           [
-            'Argument of [date_trunc] must be [time_literal], found value [concat("20", "22")] type [string]',
-            'Argument of [date_trunc] must be [date], found value [concat("20", "22")] type [string]',
+            'Argument of [date_trunc] must be [time_literal], found value [concat("20","22")] type [string]',
+            'Argument of [date_trunc] must be [date], found value [concat("20","22")] type [string]',
           ]
         );
       });
@@ -9170,7 +9170,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | stats max(nullVar)', []);
         testErrorsAndWarnings('from a_index | stats max("2022")', []);
         testErrorsAndWarnings('from a_index | stats max(concat("20", "22"))', [
-          'Argument of [max] must be [number], found value [concat("20", "22")] type [string]',
+          'Argument of [max] must be [number], found value [concat("20","22")] type [string]',
         ]);
 
         testErrorsAndWarnings('from a_index | stats max(cartesianPointField)', [
@@ -9368,7 +9368,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | stats min(nullVar)', []);
         testErrorsAndWarnings('from a_index | stats min("2022")', []);
         testErrorsAndWarnings('from a_index | stats min(concat("20", "22"))', [
-          'Argument of [min] must be [number], found value [concat("20", "22")] type [string]',
+          'Argument of [min] must be [number], found value [concat("20","22")] type [string]',
         ]);
 
         testErrorsAndWarnings('from a_index | stats min(cartesianPointField)', [
@@ -9742,34 +9742,34 @@ describe('validation logic', () => {
         );
         testErrorsAndWarnings('from a_index | stats bucket("2022", 1 year)', []);
         testErrorsAndWarnings('from a_index | stats bucket(concat("20", "22"), 1 year)', [
-          'Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [bucket] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | stats by bucket(concat("20", "22"), 1 year)', [
-          'Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [bucket] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "a", "a")', []);
         testErrorsAndWarnings('from a_index | stats bucket(concat("20", "22"), 5, "a", "a")', [
-          'Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [bucket] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "2022", "2022")', []);
 
         testErrorsAndWarnings(
           'from a_index | stats bucket(concat("20", "22"), 5, concat("20", "22"), concat("20", "22"))',
-          ['Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]']
+          ['Argument of [bucket] must be [date], found value [concat("20","22")] type [string]']
         );
 
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "a", "2022")', []);
 
         testErrorsAndWarnings(
           'from a_index | stats bucket(concat("20", "22"), 5, "a", concat("20", "22"))',
-          ['Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]']
+          ['Argument of [bucket] must be [date], found value [concat("20","22")] type [string]']
         );
 
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "2022", "a")', []);
 
         testErrorsAndWarnings(
           'from a_index | stats bucket(concat("20", "22"), 5, concat("20", "22"), "a")',
-          ['Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]']
+          ['Argument of [bucket] must be [date], found value [concat("20","22")] type [string]']
         );
       });
 

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -43,7 +43,6 @@ import {
   isSupportedFunction,
   isTimeIntervalItem,
   inKnownTimeInterval,
-  printFunctionSignature,
   sourceExists,
   getColumnExists,
   hasWildcard,
@@ -220,7 +219,7 @@ function validateNestedFunctionArg(
           values: {
             name: astFunction.name,
             argType: parameterDefinition.type,
-            value: printFunctionSignature(actualArg, false) || actualArg.name,
+            value: actualArg.text,
             givenType: argFn.signatures[0].returnType,
           },
           locations: actualArg.location,


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/elastic/kibana/pull/186340. I forgot to capitalize the labels for functions and operators. Fixed now.

**Before**
<img width="1321" alt="Screenshot 2024-07-24 at 10 26 52 AM" src="https://github.com/user-attachments/assets/05102828-0469-4b14-a2f9-34a160edbd18">

**After**
<img width="1286" alt="Screenshot 2024-07-24 at 10 23 59 AM" src="https://github.com/user-attachments/assets/dd01ccde-ec12-4ad3-98f7-561e5d233e52">

Also, this PR changes the validation error messages to actually reflect what the user has typed:

**Before**
<img width="697" alt="Screenshot 2024-07-24 at 11 43 54 AM" src="https://github.com/user-attachments/assets/28cbbd4c-1b3e-4d22-a1af-33b2f17af597">

**After**
<img width="709" alt="Screenshot 2024-07-24 at 11 40 48 AM" src="https://github.com/user-attachments/assets/dffd4a29-d348-44d0-ba58-00a0a70d04b3">
<img width="663" alt="Screenshot 2024-07-24 at 11 39 54 AM" src="https://github.com/user-attachments/assets/dff0c726-d028-4826-a1cd-030e733987a7">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->