### PR TITLE
[Renovate] Restrict prettier version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -105,6 +105,7 @@
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "release_note:skip"],
       "minimumReleaseAge": "7 days",
+      "allowedVersions": "<3.0",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Summary

Upgrade to `prettier@3` is blocked by jest upgrade to `jest@30`. See https://github.com/elastic/kibana/pull/188021#issuecomment-2221253306