### PR TITLE
[OAS][DOCS] Add x-topics info about running APIs in spaces

### DIFF
--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -22,6 +22,8 @@ info:
     ```
     GET kbn:/api/data_views
     ```
+
+    For more information about the console, refer to [Run API requests](https://www.elastic.co/guide/en/kibana/current/console-kibana.html).
   version: "1.0.2"
   license:
     name: Elastic License 2.0

--- a/oas_docs/makefile
+++ b/oas_docs/makefile
@@ -44,7 +44,7 @@ api-docs-lint-serverless: ## Run spectral API docs linter on kibana.serverless.y
 .PHONY: api-docs-overlay
 api-docs-overlay: ## Run spectral API docs linter on kibana.serverless.yaml
 	@npx bump overlay "output/kibana.yaml" "overlays/kibana.overlays.yaml" > "output/kibana.new.yaml"
-	@npx bump overlay "output/kibana.serverless.yaml" "overlays/kibana.overlays.yaml" > "output/kibana.serverless.new.yaml"
+	@npx bump overlay "output/kibana.serverless.yaml" "overlays/kibana.overlays.serverless.yaml" > "output/kibana.serverless.new.yaml"
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -41,6 +41,10 @@ info:
     GET kbn:/api/data_views
 
     ```
+
+
+    For more information about the console, refer to [Run API
+    requests](https://www.elastic.co/guide/en/kibana/current/console-kibana.html).
   version: 1.0.2
   license:
     name: Elastic License 2.0

--- a/oas_docs/overlays/kibana.overlays.serverless.yaml
+++ b/oas_docs/overlays/kibana.overlays.serverless.yaml
@@ -1,0 +1,30 @@
+# overlays.yaml
+overlay: 1.0.0
+info:
+  title: Overlays for the Kibana API document
+  version: 0.0.1
+actions:
+  - target: '$.servers.*'
+    description: Remove all servers so we can add our own.
+    remove: true
+  - target: '$.servers'
+    description: Add server into the now empty server array.
+    update:
+      - url: https://{kibana_url}
+        variables:
+          kibana_url:
+            default: localhost:5601
+  - target: '$.components.securitySchemes'
+    description: Add an API key security scheme
+    update:
+      apiKeyAuth:
+        in: header
+        name: Authorization
+        type: apiKey
+        description: You must create an API key and use the encoded value in the request header. To learn about creating keys, go to [API keys](https://www.elastic.co/docs/current/serverless/api-keys).
+  - target: '$'
+    description: Add document-level security.
+    update:
+      security:
+        - apiKeyAuth: []
+

--- a/oas_docs/overlays/kibana.overlays.yaml
+++ b/oas_docs/overlays/kibana.overlays.yaml
@@ -14,3 +14,42 @@ actions:
         variables:
           kibana_url:
             default: localhost:5601
+  - target: '$.components.securitySchemes'
+    description: Add an API key security scheme
+    update:
+      apiKeyAuth:
+        in: header
+        name: Authorization
+        type: apiKey
+        description: You must create an API key and use the encoded value in the request header. To learn about creating keys, go to [API keys](https://www.elastic.co/guide/en/kibana/current/api-keys.html).
+  - target: '$.components.securitySchemes'
+    description: Add an basic security scheme
+    update:
+      basicAuth:
+        type: http
+        scheme: basic
+  - target: '$'
+    description: Add document-level security.
+    update:
+      security:
+        - apiKeyAuth: []
+        - basicAuth: []
+  - target: '$'
+    description: Add an extra page about spaces
+    update:
+      x-topics:
+        - title: Kibana spaces
+          content: |
+            Spaces enable you to organize your dashboards and other saved objects into meaningful categories.
+            You can use the default space or create your own spaces.
+
+            To run APIs in non-default spaces, you must add `s/{space_id}/` to the path.
+            For example:
+
+            ```
+            curl -X GET "http://localhost:5601/s/marketing/api/data_views"
+            ```
+
+            If you use the Kibana console to send API requests, it automatically adds the appropriate space identifier.
+
+            To learn more, check out [Spaces](https://www.elastic.co/guide/en/kibana/current/xpack-spaces.html).


### PR DESCRIPTION
## Summary

The documentation for the Kibana APIs currently list two paths for almost every endpoint. For example in https://www.elastic.co/guide/en/kibana/current/data-views-api-get-all.html:

````
GET <kibana host>:<port>/api/data_views
GET <kibana host>:<port>/s/<space_id>/api/data_views
````

However in OpenAPI specifications, this must be encoded as two separate paths. Per https://spec.openapis.org/oas/v3.0.3#parameter-object "If the [parameter location](https://spec.openapis.org/oas/v3.0.3#parameterIn) is "path", this property is REQUIRED and its value MUST be true".

When we were manually maintaining the individual openAPI documents, we sometimes included both sets of nearly identical paths, which resulted in a lot of duplication.  Since the automated openAPI document does not include both paths, I've created an extra page that can be added to the Kibana openAPI document via an overlay. It is an [x-topics](https://docs.bump.sh/help/enhance-documentation-content/topics/) page, which can be added by running the `make api-docs-overlay` command before deploying the document to Bump.sh.

I also noticed that the commands that we're currently using to join all our individual documents were making a bit of a mess of the security schemes. So I've added some overlays to re-create a document-level security scheme. Since the serverless and stateful APIs have different security schemes, we now have separate overlay files for those contexts. I have also begun cleaning the operation-level security schemes from the manual documents in separate PRs, so they can default to the document-level security setting. If we end up using different tools to bundle our documents, those security-related overlays might no longer be required.

### Preview

![image](https://github.com/user-attachments/assets/5067b02e-ad43-451b-8ad8-0b22f40477b5)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->