### PR TITLE
[8.15] [DOCS][OAS] Add data view swap saved object references and preview APIs (#187927)

### DIFF
--- a/docs/api/data-views.asciidoc
+++ b/docs/api/data-views.asciidoc
@@ -1,7 +1,7 @@
 [[data-views-api]]
 == Data views API
 
-experimental[] Manage data views, formerly known as {kib} index patterns.
+Manage data views, formerly known as {kib} index patterns.
 
 WARNING: Do not write documents directly to the `.kibana` index. When you write directly
 to the `.kibana` index, the data becomes corrupted and permanently breaks future {kib} versions.

--- a/docs/api/data-views/create.asciidoc
+++ b/docs/api/data-views/create.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Create data view</titleabbrev>
 ++++
 
-experimental[] Create data views.
+Create data views.
 
 [NOTE]
 ====

--- a/docs/api/data-views/default-get.asciidoc
+++ b/docs/api/data-views/default-get.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get default data view</titleabbrev>
 ++++
 
-experimental[] Retrieve a default data view ID. Kibana UI uses the default data view unless user picks a different one.
+Retrieve a default data view ID. Kibana UI uses the default data view unless user picks a different one.
 
 [NOTE]
 ====

--- a/docs/api/data-views/default-set.asciidoc
+++ b/docs/api/data-views/default-set.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Set default data view</titleabbrev>
 ++++
 
-experimental[] Set a default data view ID. Kibana UI will use the default data view unless user picks a different one. 
+Set a default data view ID. Kibana UI will use the default data view unless user picks a different one. 
 The API doesn't validate if given `data_view_id` is a valid id. 
 
 [NOTE]

--- a/docs/api/data-views/delete.asciidoc
+++ b/docs/api/data-views/delete.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete data view</titleabbrev>
 ++++
 
-experimental[] Delete data views.
+Delete data views.
 
 WARNING: Once you delete a data view, _it cannot be recovered_.
 

--- a/docs/api/data-views/get-all.asciidoc
+++ b/docs/api/data-views/get-all.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get all data views</titleabbrev>
 ++++
 
-experimental[] Retrieve a list of all data views.
+Retrieve a list of all data views.
 
 [NOTE]
 ====

--- a/docs/api/data-views/get.asciidoc
+++ b/docs/api/data-views/get.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get data view</titleabbrev>
 ++++
 
-experimental[] Retrieve a single data view by ID.
+Retrieve a single data view by ID.
 
 [NOTE]
 ====

--- a/docs/api/data-views/runtime-fields/create.asciidoc
+++ b/docs/api/data-views/runtime-fields/create.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Create runtime field</titleabbrev>
 ++++
 
-experimental[] Create a runtime field
+Create a runtime field
 
 [[data-views-runtime-field-create-request]]
 ==== Request

--- a/docs/api/data-views/runtime-fields/delete.asciidoc
+++ b/docs/api/data-views/runtime-fields/delete.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete runtime field</titleabbrev>
 ++++
 
-experimental[] Delete a runtime field from a data view.
+Delete a runtime field from a data view.
 
 [[data-views-runtime-field-api-delete-request]]
 ==== Request

--- a/docs/api/data-views/runtime-fields/get.asciidoc
+++ b/docs/api/data-views/runtime-fields/get.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get runtime field</titleabbrev>
 ++++
 
-experimental[] Get a runtime field
+Get a runtime field
 
 [NOTE]
 ====

--- a/docs/api/data-views/runtime-fields/update.asciidoc
+++ b/docs/api/data-views/runtime-fields/update.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update runtime field</titleabbrev>
 ++++
 
-experimental[] Update an existing runtime field
+Update an existing runtime field
 
 
 [[data-views-runtime-field-update-request]]

--- a/docs/api/data-views/runtime-fields/upsert.asciidoc
+++ b/docs/api/data-views/runtime-fields/upsert.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Upsert runtime field</titleabbrev>
 ++++
 
-experimental[] Create or update an existing runtime field
+Create or update an existing runtime field
 
 
 [[data-views-runtime-field-upsert-request]]

--- a/docs/api/data-views/update-fields.asciidoc
+++ b/docs/api/data-views/update-fields.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update data view fields metadata</titleabbrev>
 ++++
 
-experimental[] Update fields presentation metadata, such as `count`,
+Update fields presentation metadata, such as `count`,
 `customLabel`, `customDescription`, and `format`. You can update multiple fields in one request. Updates
 are merged with persisted metadata. To remove existing metadata, specify `null` as the value.
 

--- a/docs/api/data-views/update.asciidoc
+++ b/docs/api/data-views/update.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update data view</titleabbrev>
 ++++
 
-experimental[] Update part of an data view. Only the specified fields are updated in the
+Update part of an data view. Only the specified fields are updated in the
 data view. Unspecified fields stay as they are persisted.
 
 [NOTE]

--- a/oas_docs/.spectral.yaml
+++ b/oas_docs/.spectral.yaml
@@ -48,7 +48,7 @@ rules:
     description: Response code 200 should have at least one example.
     message: "Each response body should have a realistic example. It must not contain any sensitive or confidential data."
     severity: info
-    given: $.paths[*].[*].responses.[200].content.[application/json]
+    given: $.paths[*][*].responses.[200].content.[application/json]
     then:
       field: examples
       function: defined
@@ -57,7 +57,7 @@ rules:
     description: Operations should not have x-internal extension.
     message: "Do not publish x-internal operations"
     severity: error
-    given: $.paths[*].[get,put,post,delete,options,head,patch,trace]
+    given: $.paths[*][*]
     then:
       field: x-internal
       function: undefined
@@ -67,13 +67,13 @@ rules:
     message: "Each operation should have a summary"
     severity: error
     recommended: true
-    given: $.paths[*].[get,put,post,delete,options,head,patch,trace]
+    given: $.paths[*][*]
     then:
       field: summary
       function: defined   
   operation-summary-length:
     description: Operation summary should be between 5 and 45 characters
-    given: "$.paths[*].[get,put,post,delete,options,head,patch,trace]"
+    given: "$.paths[*][*]"
     then:
       field: summary
       function: length

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -847,570 +847,10 @@ paths:
                     description: The status of the action.
         '401':
           $ref: '#/components/responses/Connectors_401'
-  /s/{spaceId}/api/data_views:
-    get:
-      summary: Get all data views
-      operationId: getAllDataViews
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        namespaces:
-                          type: array
-                          items:
-                            type: string
-                        title:
-                          type: string
-                        typeMeta:
-                          type: object
-              examples:
-                getAllDataViewsResponse:
-                  $ref: '#/components/examples/Data_views_get_data_views_response'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-  /s/{spaceId}/api/data_views/data_view:
-    post:
-      summary: Create a data view
-      operationId: createDataView
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Data_views_create_data_view_request_object'
-            examples:
-              createDataViewRequest:
-                $ref: '#/components/examples/Data_views_create_data_view_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_data_view_response_object'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-  /s/{spaceId}/api/data_views/data_view/{viewId}:
-    get:
-      summary: Get a data view
-      operationId: getDataView
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_data_view_response_object'
-              examples:
-                getDataViewResponse:
-                  $ref: '#/components/examples/Data_views_get_data_view_response'
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-    delete:
-      summary: Delete a data view
-      operationId: deleteDataView
-      description: >
-        WARNING: When you delete a data view, it cannot be recovered. This
-        functionality is in technical preview and may be changed or removed in a
-        future release. Elastic will work to fix any issues, but features in
-        technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      responses:
-        '204':
-          description: Indicates a successful call.
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-    post:
-      summary: Update a data view
-      operationId: updateDataView
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Data_views_update_data_view_request_object'
-            examples:
-              updateDataViewRequest:
-                $ref: '#/components/examples/Data_views_update_data_view_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_data_view_response_object'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-  /s/{spaceId}/api/data_views/default:
-    get:
-      summary: Get the default data view identifier
-      operationId: getDefaultDataView
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view_id:
-                    type: string
-              examples:
-                getDefaultDataViewResponse:
-                  $ref: >-
-                    #/components/examples/Data_views_get_default_data_view_response
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-    post:
-      summary: Sets the default data view identifier
-      operationId: setDefaultDatailView
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - data_view_id
-              properties:
-                data_view_id:
-                  type: string
-                  nullable: true
-                  description: >
-                    The data view identifier. NOTE: The API does not validate
-                    whether it is a valid identifier. Use `null` to unset the
-                    default data view.
-                force:
-                  type: boolean
-                  description: Update an existing default data view identifier.
-                  default: false
-            examples:
-              setDefaultDataViewRequest:
-                $ref: '#/components/examples/Data_views_set_default_data_view_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acknowledged:
-                    type: boolean
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-  /s/{spaceId}/api/data_views/data_view/{viewId}/fields:
-    post:
-      summary: Update data view fields metadata
-      operationId: updateFieldsMetadata
-      description: >
-        Update fields presentation metadata such as count, customLabel and
-        format. This functionality is in technical preview and may be changed or
-        removed in a future release. Elastic will work to fix any issues, but
-        features in technical preview are not subject to the support SLA of
-        official GA features. You can update multiple fields in one request.
-        Updates are merged with persisted metadata. To remove existing metadata,
-        specify null as the value.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - fields
-              properties:
-                fields:
-                  description: The field object.
-                  type: object
-            examples:
-              updateFieldsMetadataRequest:
-                $ref: '#/components/examples/Data_views_update_field_metadata_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acknowledged:
-                    type: boolean
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-  /s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field:
-    post:
-      summary: Create a runtime field
-      operationId: createRuntimeField
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-                - runtimeField
-              properties:
-                name:
-                  type: string
-                  description: |
-                    The name for a runtime field.
-                runtimeField:
-                  type: object
-                  description: |
-                    The runtime field definition object.
-            examples:
-              createRuntimeFieldRequest:
-                $ref: '#/components/examples/Data_views_create_runtime_field_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-    put:
-      summary: Create or update a runtime field
-      operationId: createUpdateRuntimeField
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
-        - $ref: '#/components/parameters/Data_views_space_id'
-        - name: viewId
-          in: path
-          description: |
-            The ID of the data view fields you want to update.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-                - runtimeField
-              properties:
-                name:
-                  type: string
-                  description: |
-                    The name for a runtime field.
-                runtimeField:
-                  type: object
-                  description: |
-                    The runtime field definition object.
-            examples:
-              updateRuntimeFieldRequest:
-                $ref: '#/components/examples/Data_views_create_runtime_field_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view:
-                    type: object
-                  fields:
-                    type: array
-                    items:
-                      type: object
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-  /s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
-    get:
-      summary: Get a runtime field
-      operationId: getRuntimeField
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_field_name'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view:
-                    type: object
-                  fields:
-                    type: array
-                    items:
-                      type: object
-              examples:
-                getRuntimeFieldResponse:
-                  $ref: '#/components/examples/Data_views_get_runtime_field_response'
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-    delete:
-      summary: Delete a runtime field from a data view
-      operationId: deleteRuntimeField
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_field_name'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
-    post:
-      summary: Update a runtime field
-      operationId: updateRuntimeField
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/Data_views_field_name'
-        - $ref: '#/components/parameters/Data_views_view_id'
-        - $ref: '#/components/parameters/Data_views_space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - runtimeField
-              properties:
-                runtimeField:
-                  type: object
-                  description: |
-                    The runtime field definition object.
-
-                    You can update following fields:
-
-                    - `type`
-                    - `script`
-            examples:
-              updateRuntimeFieldRequest:
-                $ref: '#/components/examples/Data_views_update_runtime_field_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views:
     get:
-      summary: Get all data views in the default space
+      summary: Get all data views
       operationId: getAllDataViewsDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       responses:
@@ -1447,18 +887,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views/data_view:
     post:
-      summary: Create a data view in the default space
-      operationId: createDataViewDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
+      summary: Create a data view
+      operationId: createDataViewDefaultw
       tags:
         - data views
       parameters:
@@ -1485,18 +917,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views/data_view/{viewId}:
     get:
-      summary: Get a data view in the default space
+      summary: Get a data view
       operationId: getDataViewDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1517,18 +941,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
     delete:
-      summary: Delete a data view from the default space
+      summary: Delete a data view
       operationId: deleteDataViewDefault
-      description: >
-        WARNING: When you delete a data view, it cannot be recovered. This
-        functionality is in technical preview and may be changed or removed in a
-        future release. Elastic will work to fix any issues, but features in
-        technical preview are not subject to the support SLA of official GA
-        features.
+      description: |
+        WARNING: When you delete a data view, it cannot be recovered.
       tags:
         - data views
       parameters:
@@ -1543,17 +960,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
     post:
-      summary: Update a data view in the default space
+      summary: Update a data view
       operationId: updateDataViewDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1581,21 +990,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views/data_view/{viewId}/fields:
     post:
-      summary: Update data view fields metadata in the default space
+      summary: Update data view fields metadata
       operationId: updateFieldsMetadataDefault
       description: >
         Update fields presentation metadata such as count, customLabel,
-        customDescription, and format. This functionality is in technical
-        preview and may be changed or removed in a future release. Elastic will
-        work to fix any issues, but features in technical preview are not
-        subject to the support SLA of official GA features. You can update
-        multiple fields in one request. Updates are merged with persisted
-        metadata. To remove existing metadata, specify null as the value.
+        customDescription, and format.
       tags:
         - data views
       parameters:
@@ -1632,18 +1033,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views/data_view/{viewId}/runtime_field:
     post:
-      summary: Create a runtime field in the default space
+      summary: Create a runtime field
       operationId: createRuntimeFieldDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1677,17 +1070,9 @@ paths:
             application/json:
               schema:
                 type: object
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
     put:
-      summary: Create or update a runtime field in the default space
+      summary: Create or update a runtime field
       operationId: createUpdateRuntimeFieldDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1740,18 +1125,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
     get:
-      summary: Get a runtime field in the default space
+      summary: Get a runtime field
       operationId: getRuntimeFieldDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1780,17 +1157,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
     delete:
-      summary: Delete a runtime field from a data view in the default space
+      summary: Delete a runtime field from a data view
       operationId: deleteRuntimeFieldDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1805,17 +1174,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_404_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
     post:
-      summary: Update a runtime field in the default space
+      summary: Update a runtime field
       operationId: updateRuntimeFieldDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1851,18 +1212,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
   /api/data_views/default:
     get:
-      summary: Get the default data view in the default space
+      summary: Get the default data view
       operationId: getDefaultDataViewDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       responses:
@@ -1885,17 +1238,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
     post:
-      summary: Set the default data view in the default space
+      summary: Set the default data view
       operationId: setDefaultDatailViewDefault
-      description: >
-        This functionality is in technical preview and may be changed or removed
-        in a future release. Elastic will work to fix any issues, but features
-        in technical preview are not subject to the support SLA of official GA
-        features.
       tags:
         - data views
       parameters:
@@ -1939,9 +1284,93 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Data_views_400_response'
-      security:
-        - Data_views_basicAuth: []
-        - Data_views_apiKeyAuth: []
+  /api/data_views/swap_references:
+    post:
+      summary: Swap saved object references
+      operationId: swapDataViewsDefault
+      description: >
+        Changes saved object references from one data view identifier to
+        another. WARNING: Misuse can break large numbers of saved objects!
+        Practicing with a backup is recommended.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data_views_swap_data_view_request_object'
+            examples:
+              swapDataViewRequest:
+                $ref: '#/components/examples/Data_views_swap_data_view_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleteStatus:
+                    type: object
+                    properties:
+                      deletePerformed:
+                        type: boolean
+                      remainingRefs:
+                        type: integer
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: A saved object identifier.
+                        type:
+                          type: string
+                          description: The saved object type.
+  /api/data_views/swap_references/_preview:
+    post:
+      summary: Preview a saved object reference swap
+      operationId: previewSwapDataViewsDefault
+      description: >
+        Preview the impact of swapping saved object references from one data
+        view identifier to another.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/Data_views_kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data_views_swap_data_view_request_object'
+            examples:
+              previewSwapDataViewRequest:
+                $ref: >-
+                  #/components/examples/Data_views_preview_swap_data_view_request
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: A saved object identifier.
+                        type:
+                          type: string
+                          description: The saved object type.
   /api/ml/saved_objects/sync:
     get:
       summary: Sync saved objects in the default space
@@ -3671,16 +3100,6 @@ components:
       schema:
         type: string
         example: c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad
-    Data_views_space_id:
-      in: path
-      name: spaceId
-      description: >-
-        An identifier for the space. If `/s/` and the identifier are omitted
-        from the path, the default space is used.
-      required: true
-      schema:
-        type: string
-        example: default
     Data_views_kbn_xsrf:
       schema:
         type: string
@@ -7826,6 +7245,19 @@ components:
     Data_views_runtimefieldmap:
       type: object
       description: A map of runtime field definitions by field name.
+      required:
+        - script
+        - type
+      properties:
+        script:
+          type: object
+          properties:
+            source:
+              type: string
+              description: Script for the runtime field.
+        type:
+          type: string
+          description: Mapping type of the runtime field.
     Data_views_sourcefilters:
       type: array
       description: The array of field names you want to filter out in Discover.
@@ -7852,6 +7284,16 @@ components:
       description: >-
         When you use rollup indices, contains the field list for the rollup data
         view API endpoints.
+      required:
+        - aggs
+        - params
+      properties:
+        aggs:
+          type: object
+          description: A map of rollup restrictions by aggregation type and field name.
+        params:
+          type: object
+          description: Properties for retrieving rollup fields.
     Data_views_create_data_view_request_object:
       title: Create data view request
       type: object
@@ -7882,7 +7324,9 @@ components:
             namespaces:
               $ref: '#/components/schemas/Data_views_namespaces'
             runtimeFieldMap:
-              $ref: '#/components/schemas/Data_views_runtimefieldmap'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/Data_views_runtimefieldmap'
             sourceFilters:
               $ref: '#/components/schemas/Data_views_sourcefilters'
             timeFieldName:
@@ -7901,6 +7345,19 @@ components:
             Override an existing data view if a data view with the provided
             title already exists.
           default: false
+    Data_views_typemeta_response:
+      type: object
+      description: >-
+        When you use rollup indices, contains the field list for the rollup data
+        view API endpoints.
+      nullable: true
+      properties:
+        aggs:
+          type: object
+          description: A map of rollup restrictions by aggregation type and field name.
+        params:
+          type: object
+          description: Properties for retrieving rollup fields.
     Data_views_data_view_response_object:
       title: Data view response properties
       type: object
@@ -7927,7 +7384,9 @@ components:
             namespaces:
               $ref: '#/components/schemas/Data_views_namespaces'
             runtimeFieldMap:
-              $ref: '#/components/schemas/Data_views_runtimefieldmap'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/Data_views_runtimefieldmap'
             sourceFilters:
               $ref: '#/components/schemas/Data_views_sourcefilters'
             timeFieldName:
@@ -7935,7 +7394,7 @@ components:
             title:
               $ref: '#/components/schemas/Data_views_title'
             typeMeta:
-              $ref: '#/components/schemas/Data_views_typemeta'
+              $ref: '#/components/schemas/Data_views_typemeta_response'
             version:
               type: string
               example: WzQ2LDJd
@@ -7979,7 +7438,9 @@ components:
             name:
               type: string
             runtimeFieldMap:
-              $ref: '#/components/schemas/Data_views_runtimefieldmap'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/Data_views_runtimefieldmap'
             sourceFilters:
               $ref: '#/components/schemas/Data_views_sourcefilters'
             timeFieldName:
@@ -7994,6 +7455,37 @@ components:
           type: boolean
           description: Reloads the data view fields after the data view is updated.
           default: false
+    Data_views_swap_data_view_request_object:
+      title: Data view reference swap request
+      type: object
+      required:
+        - fromId
+        - toId
+      properties:
+        delete:
+          type: boolean
+          description: Deletes referenced saved object if all references are removed.
+        forId:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: Limit the affected saved objects to one or more by identifier.
+        forType:
+          type: string
+          description: Limit the affected saved objects by type.
+        fromId:
+          type: string
+          description: The saved object reference to change.
+        fromType:
+          type: string
+          description: >
+            Specify the type of the saved object reference to alter. The default
+            value is `index-pattern` for data views.
+        toId:
+          type: string
+          description: New saved object reference value to replace the old value.
     Machine_learning_APIs_mlSyncResponseSuccess:
       type: boolean
       description: The success or failure of the synchronization.
@@ -11160,17 +10652,8 @@ components:
           allowNoIndex: false
           name: Kibana Sample Data eCommerce
         refresh_fields: true
-    Data_views_get_default_data_view_response:
-      summary: The get default data view API returns the default data view identifier.
-      value:
-        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
-    Data_views_set_default_data_view_request:
-      summary: Set the default data view identifier.
-      value:
-        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
-        force: true
     Data_views_update_field_metadata_request:
-      summary: Update multiple metadata fields.
+      summary: Update metadata for multiple fields.
       value:
         fields:
           field1:
@@ -11695,6 +11178,28 @@ components:
         runtimeField:
           script:
             source: emit(doc["bar"].value)
+    Data_views_get_default_data_view_response:
+      summary: The get default data view API returns the default data view identifier.
+      value:
+        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+    Data_views_set_default_data_view_request:
+      summary: Set the default data view identifier.
+      value:
+        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+        force: true
+    Data_views_swap_data_view_request:
+      summary: >-
+        Swap references from data view ID "abcd-efg" to "xyz-123" and remove the
+        data view that is no longer referenced.
+      value:
+        fromId: abcd-efg
+        toId: xyz-123
+        delete: true
+    Data_views_preview_swap_data_view_request:
+      summary: Preview swapping references from data view ID "abcd-efg" to "xyz-123".
+      value:
+        fromId: abcd-efg
+        toId: xyz-123
     Machine_learning_APIs_mlSyncExample:
       summary: Two anomaly detection jobs required synchronization in this example.
       value:
@@ -11869,17 +11374,6 @@ components:
           schema:
             $ref: '#/components/schemas/Connectors_action_response_properties'
   securitySchemes:
-    Data_views_basicAuth:
-      type: http
-      scheme: basic
-    Data_views_apiKeyAuth:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: >
-        Serverless APIs support only key-based authentication. You must create
-        an API key and use the encoded value in the request header. For example:
-        'Authorization: ApiKey base64AccessApiKey'.
     Machine_learning_APIs_basicAuth:
       type: http
       scheme: basic

--- a/src/plugins/data_views/docs/openapi/README.md
+++ b/src/plugins/data_views/docs/openapi/README.md
@@ -21,8 +21,4 @@ npx @redocly/cli bundle entrypoint.yaml --output bundled.yaml --ext yaml
 npx @redocly/cli bundle entrypoint.yaml --output bundled.json --ext json
 ```
 
-After generating the json bundle ensure that it is also valid by running the following command:
-
-```bash
-npx @redocly/cli lint bundled.json
-```
+Then join these files with the rest of the Kibana APIs per `oas_docs/README.md`

--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -22,14 +22,6 @@
       }
     }
   ],
-  "security": [
-    {
-      "basicAuth": []
-    },
-    {
-      "apiKeyAuth": []
-    }
-  ],
   "tags": [
     {
       "name": "data views",
@@ -37,763 +29,10 @@
     }
   ],
   "paths": {
-    "/s/{spaceId}/api/data_views": {
-      "get": {
-        "summary": "Get all data views",
-        "operationId": "getAllDataViews",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data_view": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "namespaces": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "typeMeta": {
-                            "type": "object"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "getAllDataViewsResponse": {
-                    "$ref": "#/components/examples/get_data_views_response"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/s/{spaceId}/api/data_views/data_view": {
-      "post": {
-        "summary": "Create a data view",
-        "operationId": "createDataView",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/create_data_view_request_object"
-              },
-              "examples": {
-                "createDataViewRequest": {
-                  "$ref": "#/components/examples/create_data_view_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/data_view_response_object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/s/{spaceId}/api/data_views/data_view/{viewId}": {
-      "get": {
-        "summary": "Get a data view",
-        "operationId": "getDataView",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/data_view_response_object"
-                },
-                "examples": {
-                  "getDataViewResponse": {
-                    "$ref": "#/components/examples/get_data_view_response"
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Object is not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/404_response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete a data view",
-        "operationId": "deleteDataView",
-        "description": "WARNING: When you delete a data view, it cannot be recovered. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Indicates a successful call."
-          },
-          "404": {
-            "description": "Object is not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/404_response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Update a data view",
-        "operationId": "updateDataView",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/update_data_view_request_object"
-              },
-              "examples": {
-                "updateDataViewRequest": {
-                  "$ref": "#/components/examples/update_data_view_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/data_view_response_object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/s/{spaceId}/api/data_views/default": {
-      "get": {
-        "summary": "Get the default data view identifier",
-        "operationId": "getDefaultDataView",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data_view_id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "examples": {
-                  "getDefaultDataViewResponse": {
-                    "$ref": "#/components/examples/get_default_data_view_response"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Sets the default data view identifier",
-        "operationId": "setDefaultDatailView",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "data_view_id"
-                ],
-                "properties": {
-                  "data_view_id": {
-                    "type": "string",
-                    "nullable": true,
-                    "description": "The data view identifier. NOTE: The API does not validate whether it is a valid identifier. Use `null` to unset the default data view.\n"
-                  },
-                  "force": {
-                    "type": "boolean",
-                    "description": "Update an existing default data view identifier.",
-                    "default": false
-                  }
-                }
-              },
-              "examples": {
-                "setDefaultDataViewRequest": {
-                  "$ref": "#/components/examples/set_default_data_view_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "acknowledged": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/s/{spaceId}/api/data_views/data_view/{viewId}/fields": {
-      "post": {
-        "summary": "Update data view fields metadata",
-        "operationId": "updateFieldsMetadata",
-        "description": "Update fields presentation metadata such as count, customLabel and format. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. You can update multiple fields in one request. Updates are merged with persisted metadata. To remove existing metadata, specify null as the value.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "fields"
-                ],
-                "properties": {
-                  "fields": {
-                    "description": "The field object.",
-                    "type": "object"
-                  }
-                }
-              },
-              "examples": {
-                "updateFieldsMetadataRequest": {
-                  "$ref": "#/components/examples/update_field_metadata_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "acknowledged": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field": {
-      "post": {
-        "summary": "Create a runtime field",
-        "operationId": "createRuntimeField",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "runtimeField"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name for a runtime field.\n"
-                  },
-                  "runtimeField": {
-                    "type": "object",
-                    "description": "The runtime field definition object.\n"
-                  }
-                }
-              },
-              "examples": {
-                "createRuntimeFieldRequest": {
-                  "$ref": "#/components/examples/create_runtime_field_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "summary": "Create or update a runtime field",
-        "operationId": "createUpdateRuntimeField",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/kbn_xsrf"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          },
-          {
-            "name": "viewId",
-            "in": "path",
-            "description": "The ID of the data view fields you want to update.\n",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "runtimeField"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name for a runtime field.\n"
-                  },
-                  "runtimeField": {
-                    "type": "object",
-                    "description": "The runtime field definition object.\n"
-                  }
-                }
-              },
-              "examples": {
-                "updateRuntimeFieldRequest": {
-                  "$ref": "#/components/examples/create_runtime_field_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data_view": {
-                      "type": "object"
-                    },
-                    "fields": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field/{fieldName}": {
-      "get": {
-        "summary": "Get a runtime field",
-        "operationId": "getRuntimeField",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/field_name"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data_view": {
-                      "type": "object"
-                    },
-                    "fields": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "getRuntimeFieldResponse": {
-                    "$ref": "#/components/examples/get_runtime_field_response"
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Object is not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/404_response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete a runtime field from a data view",
-        "operationId": "deleteRuntimeField",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/field_name"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call."
-          },
-          "404": {
-            "description": "Object is not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/404_response"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Update a runtime field",
-        "operationId": "updateRuntimeField",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
-        "tags": [
-          "data views"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/field_name"
-          },
-          {
-            "$ref": "#/components/parameters/view_id"
-          },
-          {
-            "$ref": "#/components/parameters/space_id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "runtimeField"
-                ],
-                "properties": {
-                  "runtimeField": {
-                    "type": "object",
-                    "description": "The runtime field definition object.\n\nYou can update following fields:\n\n- `type`\n- `script`\n"
-                  }
-                }
-              },
-              "examples": {
-                "updateRuntimeFieldRequest": {
-                  "$ref": "#/components/examples/update_runtime_field_request"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Indicates a successful call."
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/400_response"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/data_views": {
       "get": {
-        "summary": "Get all data views in the default space",
+        "summary": "Get all data views",
         "operationId": "getAllDataViewsDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -856,9 +95,8 @@
     },
     "/api/data_views/data_view": {
       "post": {
-        "summary": "Create a data view in the default space",
-        "operationId": "createDataViewDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "summary": "Create a data view",
+        "operationId": "createDataViewDefaultw",
         "tags": [
           "data views"
         ],
@@ -908,9 +146,8 @@
     },
     "/api/data_views/data_view/{viewId}": {
       "get": {
-        "summary": "Get a data view in the default space",
+        "summary": "Get a data view",
         "operationId": "getDataViewDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -948,9 +185,9 @@
         }
       },
       "delete": {
-        "summary": "Delete a data view from the default space",
+        "summary": "Delete a data view",
         "operationId": "deleteDataViewDefault",
-        "description": "WARNING: When you delete a data view, it cannot be recovered. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "WARNING: When you delete a data view, it cannot be recovered.\n",
         "tags": [
           "data views"
         ],
@@ -979,9 +216,8 @@
         }
       },
       "post": {
-        "summary": "Update a data view in the default space",
+        "summary": "Update a data view",
         "operationId": "updateDataViewDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1034,9 +270,9 @@
     },
     "/api/data_views/data_view/{viewId}/fields": {
       "post": {
-        "summary": "Update data view fields metadata in the default space",
+        "summary": "Update data view fields metadata",
         "operationId": "updateFieldsMetadataDefault",
-        "description": "Update fields presentation metadata such as count, customLabel, customDescription, and format. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. You can update multiple fields in one request. Updates are merged with persisted metadata. To remove existing metadata, specify null as the value.\n",
+        "description": "Update fields presentation metadata such as count, customLabel, customDescription, and format.\n",
         "tags": [
           "data views"
         ],
@@ -1103,9 +339,8 @@
     },
     "/api/data_views/data_view/{viewId}/runtime_field": {
       "post": {
-        "summary": "Create a runtime field in the default space",
+        "summary": "Create a runtime field",
         "operationId": "createRuntimeFieldDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1160,9 +395,8 @@
         }
       },
       "put": {
-        "summary": "Create or update a runtime field in the default space",
+        "summary": "Create or update a runtime field",
         "operationId": "createUpdateRuntimeFieldDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1246,9 +480,8 @@
     },
     "/api/data_views/data_view/{viewId}/runtime_field/{fieldName}": {
       "get": {
-        "summary": "Get a runtime field in the default space",
+        "summary": "Get a runtime field",
         "operationId": "getRuntimeFieldDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1300,9 +533,8 @@
         }
       },
       "delete": {
-        "summary": "Delete a runtime field from a data view in the default space",
+        "summary": "Delete a runtime field from a data view",
         "operationId": "deleteRuntimeFieldDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1331,9 +563,8 @@
         }
       },
       "post": {
-        "summary": "Update a runtime field in the default space",
+        "summary": "Update a runtime field",
         "operationId": "updateRuntimeFieldDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1388,9 +619,8 @@
     },
     "/api/data_views/default": {
       "get": {
-        "summary": "Get the default data view in the default space",
+        "summary": "Get the default data view",
         "operationId": "getDefaultDataViewDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1428,9 +658,8 @@
         }
       },
       "post": {
-        "summary": "Set the default data view in the default space",
+        "summary": "Set the default data view",
         "operationId": "setDefaultDatailViewDefault",
-        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "tags": [
           "data views"
         ],
@@ -1497,62 +726,140 @@
           }
         }
       }
+    },
+    "/api/data_views/swap_references": {
+      "post": {
+        "summary": "Swap saved object references",
+        "operationId": "swapDataViewsDefault",
+        "description": "Changes saved object references from one data view identifier to another. WARNING: Misuse can break large numbers of saved objects! Practicing with a backup is recommended.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/swap_data_view_request_object"
+              },
+              "examples": {
+                "swapDataViewRequest": {
+                  "$ref": "#/components/examples/swap_data_view_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleteStatus": {
+                      "type": "object",
+                      "properties": {
+                        "deletePerformed": {
+                          "type": "boolean"
+                        },
+                        "remainingRefs": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "A saved object identifier."
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The saved object type."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/data_views/swap_references/_preview": {
+      "post": {
+        "summary": "Preview a saved object reference swap",
+        "operationId": "previewSwapDataViewsDefault",
+        "description": "Preview the impact of swapping saved object references from one data view identifier to another.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/swap_data_view_request_object"
+              },
+              "examples": {
+                "previewSwapDataViewRequest": {
+                  "$ref": "#/components/examples/preview_swap_data_view_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "A saved object identifier."
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The saved object type."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
-    "securitySchemes": {
-      "basicAuth": {
-        "type": "http",
-        "scheme": "basic"
-      },
-      "apiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization",
-        "description": "Serverless APIs support only key-based authentication. You must create an API key and use the encoded value in the request header. For example: 'Authorization: ApiKey base64AccessApiKey'.\n"
-      }
-    },
-    "parameters": {
-      "space_id": {
-        "in": "path",
-        "name": "spaceId",
-        "description": "An identifier for the space. If `/s/` and the identifier are omitted from the path, the default space is used.",
-        "required": true,
-        "schema": {
-          "type": "string",
-          "example": "default"
-        }
-      },
-      "kbn_xsrf": {
-        "schema": {
-          "type": "string"
-        },
-        "in": "header",
-        "name": "kbn-xsrf",
-        "description": "Cross-site request forgery protection",
-        "required": true
-      },
-      "view_id": {
-        "in": "path",
-        "name": "viewId",
-        "description": "An identifier for the data view.",
-        "required": true,
-        "schema": {
-          "type": "string",
-          "example": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
-        }
-      },
-      "field_name": {
-        "in": "path",
-        "name": "fieldName",
-        "description": "The name of the runtime field.",
-        "required": true,
-        "schema": {
-          "type": "string",
-          "example": "hour_of_day"
-        }
-      }
-    },
     "examples": {
       "get_data_views_response": {
         "summary": "The get all data views API returns a list of data views.",
@@ -2772,21 +2079,8 @@
           "refresh_fields": true
         }
       },
-      "get_default_data_view_response": {
-        "summary": "The get default data view API returns the default data view identifier.",
-        "value": {
-          "data_view_id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
-        }
-      },
-      "set_default_data_view_request": {
-        "summary": "Set the default data view identifier.",
-        "value": {
-          "data_view_id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f",
-          "force": true
-        }
-      },
       "update_field_metadata_request": {
-        "summary": "Update multiple metadata fields.",
+        "summary": "Update metadata for multiple fields.",
         "value": {
           "fields": {
             "field1": {
@@ -3439,6 +2733,34 @@
             }
           }
         }
+      },
+      "get_default_data_view_response": {
+        "summary": "The get default data view API returns the default data view identifier.",
+        "value": {
+          "data_view_id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
+        }
+      },
+      "set_default_data_view_request": {
+        "summary": "Set the default data view identifier.",
+        "value": {
+          "data_view_id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f",
+          "force": true
+        }
+      },
+      "swap_data_view_request": {
+        "summary": "Swap references from data view ID \"abcd-efg\" to \"xyz-123\" and remove the data view that is no longer referenced.",
+        "value": {
+          "fromId": "abcd-efg",
+          "toId": "xyz-123",
+          "delete": true
+        }
+      },
+      "preview_swap_data_view_request": {
+        "summary": "Preview swapping references from data view ID \"abcd-efg\" to \"xyz-123\".",
+        "value": {
+          "fromId": "abcd-efg",
+          "toId": "xyz-123"
+        }
       }
     },
     "schemas": {
@@ -3501,7 +2823,26 @@
       },
       "runtimefieldmap": {
         "type": "object",
-        "description": "A map of runtime field definitions by field name."
+        "description": "A map of runtime field definitions by field name.",
+        "required": [
+          "script",
+          "type"
+        ],
+        "properties": {
+          "script": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "Script for the runtime field."
+              }
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "Mapping type of the runtime field."
+          }
+        }
       },
       "sourcefilters": {
         "type": "array",
@@ -3532,7 +2873,21 @@
       },
       "typemeta": {
         "type": "object",
-        "description": "When you use rollup indices, contains the field list for the rollup data view API endpoints."
+        "description": "When you use rollup indices, contains the field list for the rollup data view API endpoints.",
+        "required": [
+          "aggs",
+          "params"
+        ],
+        "properties": {
+          "aggs": {
+            "type": "object",
+            "description": "A map of rollup restrictions by aggregation type and field name."
+          },
+          "params": {
+            "type": "object",
+            "description": "Properties for retrieving rollup fields."
+          }
+        }
       },
       "create_data_view_request_object": {
         "title": "Create data view request",
@@ -3574,7 +2929,10 @@
                 "$ref": "#/components/schemas/namespaces"
               },
               "runtimeFieldMap": {
-                "$ref": "#/components/schemas/runtimefieldmap"
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/runtimefieldmap"
+                }
               },
               "sourceFilters": {
                 "$ref": "#/components/schemas/sourcefilters"
@@ -3600,6 +2958,21 @@
             "type": "boolean",
             "description": "Override an existing data view if a data view with the provided title already exists.",
             "default": false
+          }
+        }
+      },
+      "typemeta_response": {
+        "type": "object",
+        "description": "When you use rollup indices, contains the field list for the rollup data view API endpoints.",
+        "nullable": true,
+        "properties": {
+          "aggs": {
+            "type": "object",
+            "description": "A map of rollup restrictions by aggregation type and field name."
+          },
+          "params": {
+            "type": "object",
+            "description": "Properties for retrieving rollup fields."
           }
         }
       },
@@ -3637,7 +3010,10 @@
                 "$ref": "#/components/schemas/namespaces"
               },
               "runtimeFieldMap": {
-                "$ref": "#/components/schemas/runtimefieldmap"
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/runtimefieldmap"
+                }
               },
               "sourceFilters": {
                 "$ref": "#/components/schemas/sourcefilters"
@@ -3649,7 +3025,7 @@
                 "$ref": "#/components/schemas/title"
               },
               "typeMeta": {
-                "$ref": "#/components/schemas/typemeta"
+                "$ref": "#/components/schemas/typemeta_response"
               },
               "version": {
                 "type": "string",
@@ -3706,7 +3082,10 @@
                 "type": "string"
               },
               "runtimeFieldMap": {
-                "$ref": "#/components/schemas/runtimefieldmap"
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/runtimefieldmap"
+                }
               },
               "sourceFilters": {
                 "$ref": "#/components/schemas/sourcefilters"
@@ -3730,6 +3109,81 @@
             "description": "Reloads the data view fields after the data view is updated.",
             "default": false
           }
+        }
+      },
+      "swap_data_view_request_object": {
+        "title": "Data view reference swap request",
+        "type": "object",
+        "required": [
+          "fromId",
+          "toId"
+        ],
+        "properties": {
+          "delete": {
+            "type": "boolean",
+            "description": "Deletes referenced saved object if all references are removed."
+          },
+          "forId": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "description": "Limit the affected saved objects to one or more by identifier."
+          },
+          "forType": {
+            "type": "string",
+            "description": "Limit the affected saved objects by type."
+          },
+          "fromId": {
+            "type": "string",
+            "description": "The saved object reference to change."
+          },
+          "fromType": {
+            "type": "string",
+            "description": "Specify the type of the saved object reference to alter. The default value is `index-pattern` for data views.\n"
+          },
+          "toId": {
+            "type": "string",
+            "description": "New saved object reference value to replace the old value."
+          }
+        }
+      }
+    },
+    "parameters": {
+      "kbn_xsrf": {
+        "schema": {
+          "type": "string"
+        },
+        "in": "header",
+        "name": "kbn-xsrf",
+        "description": "Cross-site request forgery protection",
+        "required": true
+      },
+      "view_id": {
+        "in": "path",
+        "name": "viewId",
+        "description": "An identifier for the data view.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
+        }
+      },
+      "field_name": {
+        "in": "path",
+        "name": "fieldName",
+        "description": "The name of the runtime field.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "hour_of_day"
         }
       }
     }

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -13,489 +13,14 @@ servers:
     variables:
       kibana_url:
         default: localhost:5601
-security:
-  - basicAuth: []
-  - apiKeyAuth: []
 tags:
   - name: data views
     description: Data view APIs enable you to manage data views, formerly known as Kibana index patterns.
 paths:
-  /s/{spaceId}/api/data_views:
-    get:
-      summary: Get all data views
-      operationId: getAllDataViews
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        namespaces:
-                          type: array
-                          items:
-                            type: string
-                        title:
-                          type: string
-                        typeMeta:
-                          type: object
-              examples:
-                getAllDataViewsResponse:
-                  $ref: '#/components/examples/get_data_views_response'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-  /s/{spaceId}/api/data_views/data_view:
-    post:
-      summary: Create a data view
-      operationId: createDataView
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/create_data_view_request_object'
-            examples:
-              createDataViewRequest:
-                $ref: '#/components/examples/create_data_view_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/data_view_response_object'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-  /s/{spaceId}/api/data_views/data_view/{viewId}:
-    get:
-      summary: Get a data view
-      operationId: getDataView
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/data_view_response_object'
-              examples:
-                getDataViewResponse:
-                  $ref: '#/components/examples/get_data_view_response'
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/404_response'
-    delete:
-      summary: Delete a data view
-      operationId: deleteDataView
-      description: |
-        WARNING: When you delete a data view, it cannot be recovered. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      responses:
-        '204':
-          description: Indicates a successful call.
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/404_response'
-    post:
-      summary: Update a data view
-      operationId: updateDataView
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/update_data_view_request_object'
-            examples:
-              updateDataViewRequest:
-                $ref: '#/components/examples/update_data_view_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/data_view_response_object'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-  /s/{spaceId}/api/data_views/default:
-    get:
-      summary: Get the default data view identifier
-      operationId: getDefaultDataView
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view_id:
-                    type: string
-              examples:
-                getDefaultDataViewResponse:
-                  $ref: '#/components/examples/get_default_data_view_response'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-    post:
-      summary: Sets the default data view identifier
-      operationId: setDefaultDatailView
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - data_view_id
-              properties:
-                data_view_id:
-                  type: string
-                  nullable: true
-                  description: |
-                    The data view identifier. NOTE: The API does not validate whether it is a valid identifier. Use `null` to unset the default data view.
-                force:
-                  type: boolean
-                  description: Update an existing default data view identifier.
-                  default: false
-            examples:
-              setDefaultDataViewRequest:
-                $ref: '#/components/examples/set_default_data_view_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acknowledged:
-                    type: boolean
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-  /s/{spaceId}/api/data_views/data_view/{viewId}/fields:
-    post:
-      summary: Update data view fields metadata
-      operationId: updateFieldsMetadata
-      description: |
-        Update fields presentation metadata such as count, customLabel and format. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. You can update multiple fields in one request. Updates are merged with persisted metadata. To remove existing metadata, specify null as the value.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - fields
-              properties:
-                fields:
-                  description: The field object.
-                  type: object
-            examples:
-              updateFieldsMetadataRequest:
-                $ref: '#/components/examples/update_field_metadata_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  acknowledged:
-                    type: boolean
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-  /s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field:
-    post:
-      summary: Create a runtime field
-      operationId: createRuntimeField
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-                - runtimeField
-              properties:
-                name:
-                  type: string
-                  description: |
-                    The name for a runtime field.
-                runtimeField:
-                  type: object
-                  description: |
-                    The runtime field definition object.
-            examples:
-              createRuntimeFieldRequest:
-                $ref: '#/components/examples/create_runtime_field_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-    put:
-      summary: Create or update a runtime field
-      operationId: createUpdateRuntimeField
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/kbn_xsrf'
-        - $ref: '#/components/parameters/space_id'
-        - name: viewId
-          in: path
-          description: |
-            The ID of the data view fields you want to update.
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-                - runtimeField
-              properties:
-                name:
-                  type: string
-                  description: |
-                    The name for a runtime field.
-                runtimeField:
-                  type: object
-                  description: |
-                    The runtime field definition object.
-            examples:
-              updateRuntimeFieldRequest:
-                $ref: '#/components/examples/create_runtime_field_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view:
-                    type: object
-                  fields:
-                    type: array
-                    items:
-                      type: object
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
-  /s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
-    get:
-      summary: Get a runtime field
-      operationId: getRuntimeField
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/field_name'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data_view:
-                    type: object
-                  fields:
-                    type: array
-                    items:
-                      type: object
-              examples:
-                getRuntimeFieldResponse:
-                  $ref: '#/components/examples/get_runtime_field_response'
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/404_response'
-    delete:
-      summary: Delete a runtime field from a data view
-      operationId: deleteRuntimeField
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/field_name'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      responses:
-        '200':
-          description: Indicates a successful call.
-        '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/404_response'
-    post:
-      summary: Update a runtime field
-      operationId: updateRuntimeField
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      tags:
-        - data views
-      parameters:
-        - $ref: '#/components/parameters/field_name'
-        - $ref: '#/components/parameters/view_id'
-        - $ref: '#/components/parameters/space_id'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - runtimeField
-              properties:
-                runtimeField:
-                  type: object
-                  description: |
-                    The runtime field definition object.
-
-                    You can update following fields:
-
-                    - `type`
-                    - `script`
-            examples:
-              updateRuntimeFieldRequest:
-                $ref: '#/components/examples/update_runtime_field_request'
-      responses:
-        '200':
-          description: Indicates a successful call.
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/400_response'
   /api/data_views:
     get:
-      summary: Get all data views in the default space
+      summary: Get all data views
       operationId: getAllDataViewsDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       responses:
@@ -534,10 +59,8 @@ paths:
                 $ref: '#/components/schemas/400_response'
   /api/data_views/data_view:
     post:
-      summary: Create a data view in the default space
-      operationId: createDataViewDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      summary: Create a data view
+      operationId: createDataViewDefaultw
       tags:
         - data views
       parameters:
@@ -566,10 +89,8 @@ paths:
                 $ref: '#/components/schemas/400_response'
   /api/data_views/data_view/{viewId}:
     get:
-      summary: Get a data view in the default space
+      summary: Get a data view
       operationId: getDataViewDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -591,10 +112,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/404_response'
     delete:
-      summary: Delete a data view from the default space
+      summary: Delete a data view
       operationId: deleteDataViewDefault
       description: |
-        WARNING: When you delete a data view, it cannot be recovered. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        WARNING: When you delete a data view, it cannot be recovered.
       tags:
         - data views
       parameters:
@@ -610,10 +131,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/404_response'
     post:
-      summary: Update a data view in the default space
+      summary: Update a data view
       operationId: updateDataViewDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -643,10 +162,10 @@ paths:
                 $ref: '#/components/schemas/400_response'
   /api/data_views/data_view/{viewId}/fields:
     post:
-      summary: Update data view fields metadata in the default space
+      summary: Update data view fields metadata
       operationId: updateFieldsMetadataDefault
       description: |
-        Update fields presentation metadata such as count, customLabel, customDescription, and format. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. You can update multiple fields in one request. Updates are merged with persisted metadata. To remove existing metadata, specify null as the value.
+        Update fields presentation metadata such as count, customLabel, customDescription, and format.
       tags:
         - data views
       parameters:
@@ -685,10 +204,8 @@ paths:
                 $ref: '#/components/schemas/400_response'
   /api/data_views/data_view/{viewId}/runtime_field:
     post:
-      summary: Create a runtime field in the default space
+      summary: Create a runtime field
       operationId: createRuntimeFieldDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -723,10 +240,8 @@ paths:
               schema:
                 type: object
     put:
-      summary: Create or update a runtime field in the default space
+      summary: Create or update a runtime field
       operationId: createUpdateRuntimeFieldDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -781,10 +296,8 @@ paths:
                 $ref: '#/components/schemas/400_response'
   /api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
     get:
-      summary: Get a runtime field in the default space
+      summary: Get a runtime field
       operationId: getRuntimeFieldDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -814,10 +327,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/404_response'
     delete:
-      summary: Delete a runtime field from a data view in the default space
+      summary: Delete a runtime field from a data view
       operationId: deleteRuntimeFieldDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -833,10 +344,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/404_response'
     post:
-      summary: Update a runtime field in the default space
+      summary: Update a runtime field
       operationId: updateRuntimeFieldDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -874,10 +383,8 @@ paths:
                 $ref: '#/components/schemas/400_response'
   /api/data_views/default:
     get:
-      summary: Get the default data view in the default space
+      summary: Get the default data view
       operationId: getDefaultDataViewDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       responses:
@@ -900,10 +407,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/400_response'
     post:
-      summary: Set the default data view in the default space
+      summary: Set the default data view
       operationId: setDefaultDatailViewDefault
-      description: |
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       tags:
         - data views
       parameters:
@@ -945,49 +450,90 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-components:
-  securitySchemes:
-    basicAuth:
-      type: http
-      scheme: basic
-    apiKeyAuth:
-      type: apiKey
-      in: header
-      name: Authorization
+  /api/data_views/swap_references:
+    post:
+      summary: Swap saved object references
+      operationId: swapDataViewsDefault
       description: |
-        Serverless APIs support only key-based authentication. You must create an API key and use the encoded value in the request header. For example: 'Authorization: ApiKey base64AccessApiKey'.
-  parameters:
-    space_id:
-      in: path
-      name: spaceId
-      description: An identifier for the space. If `/s/` and the identifier are omitted from the path, the default space is used.
-      required: true
-      schema:
-        type: string
-        example: default
-    kbn_xsrf:
-      schema:
-        type: string
-      in: header
-      name: kbn-xsrf
-      description: Cross-site request forgery protection
-      required: true
-    view_id:
-      in: path
-      name: viewId
-      description: An identifier for the data view.
-      required: true
-      schema:
-        type: string
-        example: ff959d40-b880-11e8-a6d9-e546fe2bba5f
-    field_name:
-      in: path
-      name: fieldName
-      description: The name of the runtime field.
-      required: true
-      schema:
-        type: string
-        example: hour_of_day
+        Changes saved object references from one data view identifier to another. WARNING: Misuse can break large numbers of saved objects! Practicing with a backup is recommended.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/swap_data_view_request_object'
+            examples:
+              swapDataViewRequest:
+                $ref: '#/components/examples/swap_data_view_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleteStatus:
+                    type: object
+                    properties:
+                      deletePerformed:
+                        type: boolean
+                      remainingRefs:
+                        type: integer
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: A saved object identifier.
+                        type:
+                          type: string
+                          description: The saved object type.
+  /api/data_views/swap_references/_preview:
+    post:
+      summary: Preview a saved object reference swap
+      operationId: previewSwapDataViewsDefault
+      description: |
+        Preview the impact of swapping saved object references from one data view identifier to another.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/swap_data_view_request_object'
+            examples:
+              previewSwapDataViewRequest:
+                $ref: '#/components/examples/preview_swap_data_view_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: A saved object identifier.
+                        type:
+                          type: string
+                          description: The saved object type.
+components:
   examples:
     get_data_views_response:
       summary: The get all data views API returns a list of data views.
@@ -1956,17 +1502,8 @@ components:
           allowNoIndex: false
           name: Kibana Sample Data eCommerce
         refresh_fields: true
-    get_default_data_view_response:
-      summary: The get default data view API returns the default data view identifier.
-      value:
-        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
-    set_default_data_view_request:
-      summary: Set the default data view identifier.
-      value:
-        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
-        force: true
     update_field_metadata_request:
-      summary: Update multiple metadata fields.
+      summary: Update metadata for multiple fields.
       value:
         fields:
           field1:
@@ -2488,6 +2025,26 @@ components:
         runtimeField:
           script:
             source: emit(doc["bar"].value)
+    get_default_data_view_response:
+      summary: The get default data view API returns the default data view identifier.
+      value:
+        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+    set_default_data_view_request:
+      summary: Set the default data view identifier.
+      value:
+        data_view_id: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+        force: true
+    swap_data_view_request:
+      summary: Swap references from data view ID "abcd-efg" to "xyz-123" and remove the data view that is no longer referenced.
+      value:
+        fromId: abcd-efg
+        toId: xyz-123
+        delete: true
+    preview_swap_data_view_request:
+      summary: Preview swapping references from data view ID "abcd-efg" to "xyz-123".
+      value:
+        fromId: abcd-efg
+        toId: xyz-123
   schemas:
     400_response:
       title: Bad request
@@ -2534,6 +2091,19 @@ components:
     runtimefieldmap:
       type: object
       description: A map of runtime field definitions by field name.
+      required:
+        - script
+        - type
+      properties:
+        script:
+          type: object
+          properties:
+            source:
+              type: string
+              description: Script for the runtime field.
+        type:
+          type: string
+          description: Mapping type of the runtime field.
     sourcefilters:
       type: array
       description: The array of field names you want to filter out in Discover.
@@ -2556,6 +2126,16 @@ components:
     typemeta:
       type: object
       description: When you use rollup indices, contains the field list for the rollup data view API endpoints.
+      required:
+        - aggs
+        - params
+      properties:
+        aggs:
+          type: object
+          description: A map of rollup restrictions by aggregation type and field name.
+        params:
+          type: object
+          description: Properties for retrieving rollup fields.
     create_data_view_request_object:
       title: Create data view request
       type: object
@@ -2586,7 +2166,9 @@ components:
             namespaces:
               $ref: '#/components/schemas/namespaces'
             runtimeFieldMap:
-              $ref: '#/components/schemas/runtimefieldmap'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/runtimefieldmap'
             sourceFilters:
               $ref: '#/components/schemas/sourcefilters'
             timeFieldName:
@@ -2603,6 +2185,17 @@ components:
           type: boolean
           description: Override an existing data view if a data view with the provided title already exists.
           default: false
+    typemeta_response:
+      type: object
+      description: When you use rollup indices, contains the field list for the rollup data view API endpoints.
+      nullable: true
+      properties:
+        aggs:
+          type: object
+          description: A map of rollup restrictions by aggregation type and field name.
+        params:
+          type: object
+          description: Properties for retrieving rollup fields.
     data_view_response_object:
       title: Data view response properties
       type: object
@@ -2629,7 +2222,9 @@ components:
             namespaces:
               $ref: '#/components/schemas/namespaces'
             runtimeFieldMap:
-              $ref: '#/components/schemas/runtimefieldmap'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/runtimefieldmap'
             sourceFilters:
               $ref: '#/components/schemas/sourcefilters'
             timeFieldName:
@@ -2637,7 +2232,7 @@ components:
             title:
               $ref: '#/components/schemas/title'
             typeMeta:
-              $ref: '#/components/schemas/typemeta'
+              $ref: '#/components/schemas/typemeta_response'
             version:
               type: string
               example: WzQ2LDJd
@@ -2677,7 +2272,9 @@ components:
             name:
               type: string
             runtimeFieldMap:
-              $ref: '#/components/schemas/runtimefieldmap'
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/runtimefieldmap'
             sourceFilters:
               $ref: '#/components/schemas/sourcefilters'
             timeFieldName:
@@ -2692,3 +2289,57 @@ components:
           type: boolean
           description: Reloads the data view fields after the data view is updated.
           default: false
+    swap_data_view_request_object:
+      title: Data view reference swap request
+      type: object
+      required:
+        - fromId
+        - toId
+      properties:
+        delete:
+          type: boolean
+          description: Deletes referenced saved object if all references are removed.
+        forId:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: Limit the affected saved objects to one or more by identifier.
+        forType:
+          type: string
+          description: Limit the affected saved objects by type.
+        fromId:
+          type: string
+          description: The saved object reference to change.
+        fromType:
+          type: string
+          description: |
+            Specify the type of the saved object reference to alter. The default value is `index-pattern` for data views.
+        toId:
+          type: string
+          description: New saved object reference value to replace the old value.
+  parameters:
+    kbn_xsrf:
+      schema:
+        type: string
+      in: header
+      name: kbn-xsrf
+      description: Cross-site request forgery protection
+      required: true
+    view_id:
+      in: path
+      name: viewId
+      description: An identifier for the data view.
+      required: true
+      schema:
+        type: string
+        example: ff959d40-b880-11e8-a6d9-e546fe2bba5f
+    field_name:
+      in: path
+      name: fieldName
+      description: The name of the runtime field.
+      required: true
+      schema:
+        type: string
+        example: hour_of_day

--- a/src/plugins/data_views/docs/openapi/components/examples/preview_swap_data_view_request.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/preview_swap_data_view_request.yaml
@@ -1,0 +1,6 @@
+summary: Preview swapping references from data view ID "abcd-efg" to "xyz-123".
+value:
+  {
+    "fromId" : "abcd-efg",
+    "toId" : "xyz-123"
+  }

--- a/src/plugins/data_views/docs/openapi/components/examples/swap_data_view_request.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/swap_data_view_request.yaml
@@ -1,0 +1,7 @@
+summary: Swap references from data view ID "abcd-efg" to "xyz-123" and remove the data view that is no longer referenced.
+value:
+  {
+    "fromId" : "abcd-efg",
+    "toId" : "xyz-123",
+    "delete" : true
+  }

--- a/src/plugins/data_views/docs/openapi/components/examples/swap_data_view_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/swap_data_view_response.yaml
@@ -1,0 +1,9 @@
+summary: The swap references API returns a list of the affected saved objects.
+value:
+  {
+    result: [{ id: "123", type: "visualization" }],
+    deleteStatus: {
+      remainingRefs: 0,
+      deletePerformed: true
+    }
+  }

--- a/src/plugins/data_views/docs/openapi/components/schemas/create_data_view_request_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/create_data_view_request_object.yaml
@@ -27,7 +27,9 @@ properties:
       namespaces:
         $ref: 'namespaces.yaml'
       runtimeFieldMap:
-        $ref: 'runtimefieldmap.yaml'
+        type: object
+        additionalProperties:
+          $ref: 'runtimefieldmap.yaml'
       sourceFilters:
         $ref: 'sourcefilters.yaml'
       timeFieldName:

--- a/src/plugins/data_views/docs/openapi/components/schemas/data_view_response_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/data_view_response_object.yaml
@@ -23,7 +23,9 @@ properties:
       namespaces:
         $ref: 'namespaces.yaml'
       runtimeFieldMap:
-        $ref: 'runtimefieldmap.yaml'
+        type: object
+        additionalProperties:
+          $ref: 'runtimefieldmap.yaml'
       sourceFilters:
         $ref: 'sourcefilters.yaml'
       timeFieldName:
@@ -31,7 +33,7 @@ properties:
       title:
         $ref: 'title.yaml'
       typeMeta:
-        $ref: 'typemeta.yaml'
+        $ref: 'typemeta_response.yaml'
       version:
         type: string
         example: WzQ2LDJd

--- a/src/plugins/data_views/docs/openapi/components/schemas/runtimefieldmap.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/runtimefieldmap.yaml
@@ -1,2 +1,15 @@
 type: object
 description: A map of runtime field definitions by field name.
+required:
+  - script
+  - type
+properties:
+  script:
+    type: object
+    properties:
+      source:
+        type: string
+        description: Script for the runtime field.
+  type:
+    type: string
+    description: Mapping type of the runtime field.

--- a/src/plugins/data_views/docs/openapi/components/schemas/swap_data_view_request_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/swap_data_view_request_object.yaml
@@ -1,0 +1,30 @@
+title: Data view reference swap request
+type: object
+required:
+  - fromId
+  - toId
+properties:
+  delete:
+    type: boolean
+    description: Deletes referenced saved object if all references are removed.
+  forId:
+    oneOf:
+      - type: string
+      - type: array
+        items:
+          type: string
+    description: Limit the affected saved objects to one or more by identifier.
+  forType:
+    type: string
+    description: Limit the affected saved objects by type.
+  fromId:
+    type: string
+    description: The saved object reference to change.
+  fromType:
+    type: string
+    description: >
+      Specify the type of the saved object reference to alter.
+      The default value is `index-pattern` for data views.
+  toId:
+    type: string
+    description: New saved object reference value to replace the old value.

--- a/src/plugins/data_views/docs/openapi/components/schemas/typemeta_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/typemeta_response.yaml
@@ -1,8 +1,6 @@
 type: object
 description: When you use rollup indices, contains the field list for the rollup data view API endpoints.
-required:
-  - aggs
-  - params
+nullable: true
 properties:
   aggs:
     type: object

--- a/src/plugins/data_views/docs/openapi/components/schemas/update_data_view_request_object.yaml
+++ b/src/plugins/data_views/docs/openapi/components/schemas/update_data_view_request_object.yaml
@@ -18,7 +18,9 @@ properties:
       name:
         type: string
       runtimeFieldMap:
-        $ref: 'runtimefieldmap.yaml'
+        type: object
+        additionalProperties:
+          $ref: 'runtimefieldmap.yaml'
       sourceFilters:
         $ref: 'sourcefilters.yaml'
       timeFieldName:

--- a/src/plugins/data_views/docs/openapi/entrypoint.yaml
+++ b/src/plugins/data_views/docs/openapi/entrypoint.yaml
@@ -18,20 +18,24 @@ servers:
         default: localhost:5601
 paths:
 # Non-default space
-  '/s/{spaceId}/api/data_views':
-    $ref: 'paths/s@{spaceid}@api@data_views.yaml'
-  '/s/{spaceId}/api/data_views/data_view':
-    $ref: 'paths/s@{spaceid}@api@data_views@data_view.yaml'
-  '/s/{spaceId}/api/data_views/data_view/{viewId}':
-    $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}.yaml'
-  '/s/{spaceId}/api/data_views/default':
-    $ref: 'paths/s@{spaceid}@api@data_views@default.yaml'
-  '/s/{spaceId}/api/data_views/data_view/{viewId}/fields':
-    $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}@fields.yaml'
-  '/s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field':
-    $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field.yaml'
-  '/s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field/{fieldName}':
-    $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml'
+  # '/s/{spaceId}/api/data_views':
+  #   $ref: 'paths/s@{spaceid}@api@data_views.yaml'
+  # '/s/{spaceId}/api/data_views/data_view':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@data_view.yaml'
+  # '/s/{spaceId}/api/data_views/data_view/{viewId}':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}.yaml'
+  # '/s/{spaceId}/api/data_views/default':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@default.yaml'
+  # '/s/{spaceId}/api/data_views/data_view/{viewId}/fields':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}@fields.yaml'
+  # '/s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field.yaml'
+  # '/s/{spaceId}/api/data_views/data_view/{viewId}/runtime_field/{fieldName}':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml'
+  # '/s/{spaceId}/api/data_views/swap_references':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@swap_references.yaml'
+  # '/s/{spaceId}/api/data_views/swap_references/_preview':
+  #   $ref: 'paths/s@{spaceid}@api@data_views@swap_references@_preview.yaml'
 # Default space
   '/api/data_views':
     $ref: 'paths/api@data_views.yaml'
@@ -47,19 +51,23 @@ paths:
     $ref: 'paths/api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml'
   '/api/data_views/default':
     $ref: 'paths/api@data_views@default.yaml'
-components:
-  securitySchemes:
-    basicAuth:
-      type: http
-      scheme: basic
-    apiKeyAuth:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: >
-        Serverless APIs support only key-based authentication.
-        You must create an API key and use the encoded value in the request header.
-        For example: 'Authorization: ApiKey base64AccessApiKey'.
-security:
-  - basicAuth: []
-  - apiKeyAuth: []
+  '/api/data_views/swap_references':
+    $ref: 'paths/api@data_views@swap_references.yaml'
+  '/api/data_views/swap_references/_preview':
+    $ref: 'paths/api@data_views@swap_references@_preview.yaml'
+# components:
+#   securitySchemes:
+#     basicAuth:
+#       type: http
+#       scheme: basic
+#     apiKeyAuth:
+#       type: apiKey
+#       in: header
+#       name: Authorization
+#       description: >
+#         Serverless APIs support only key-based authentication.
+#         You must create an API key and use the encoded value in the request header.
+#         For example: 'Authorization: ApiKey base64AccessApiKey'.
+# security:
+#   - basicAuth: []
+#   - apiKeyAuth: []

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views.yaml
@@ -1,8 +1,6 @@
 get:
-  summary: Get all data views in the default space
+  summary: Get all data views
   operationId: getAllDataViewsDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   responses:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view.yaml
@@ -1,8 +1,6 @@
 post:
-  summary: Create a data view in the default space
-  operationId: createDataViewDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  summary: Create a data view
+  operationId: createDataViewDefaultw
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
@@ -1,8 +1,6 @@
 get:
-  summary: Get a data view in the default space
+  summary: Get a data view
   operationId: getDataViewDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -25,11 +23,10 @@ get:
             $ref: '../components/schemas/404_response.yaml'
 
 delete:
-  summary: Delete a data view from the default space
+  summary: Delete a data view
   operationId: deleteDataViewDefault
   description: >
     WARNING: When you delete a data view, it cannot be recovered.
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -46,10 +43,8 @@ delete:
             $ref: '../components/schemas/404_response.yaml'
 
 post:
-  summary: Update a data view in the default space
+  summary: Update a data view
   operationId: updateDataViewDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@fields.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@fields.yaml
@@ -1,9 +1,8 @@
 post:
-  summary: Update data view fields metadata in the default space
+  summary: Update data view fields metadata
   operationId: updateFieldsMetadataDefault
   description: >
     Update fields presentation metadata such as count, customLabel, customDescription, and format.
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. You can update multiple fields in one request. Updates are merged with persisted metadata. To remove existing metadata, specify null as the value.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
@@ -1,8 +1,6 @@
 post:
-  summary: Create a runtime field in the default space
+  summary: Create a runtime field
   operationId: createRuntimeFieldDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -38,10 +36,8 @@ post:
             type: object    
 
 put:
-  summary: Create or update a runtime field in the default space
+  summary: Create or update a runtime field
   operationId: createUpdateRuntimeFieldDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml
@@ -1,8 +1,6 @@
 get:
-  summary: Get a runtime field in the default space
+  summary: Get a runtime field
   operationId: getRuntimeFieldDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -33,10 +31,8 @@ get:
             $ref: '../components/schemas/404_response.yaml'
 
 delete:
-  summary: Delete a runtime field from a data view in the default space
+  summary: Delete a runtime field from a data view
   operationId: deleteRuntimeFieldDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -53,10 +49,8 @@ delete:
             $ref: '../components/schemas/404_response.yaml'
 
 post:
-  summary: Update a runtime field in the default space
+  summary: Update a runtime field
   operationId: updateRuntimeFieldDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@default.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@default.yaml
@@ -1,8 +1,6 @@
 get:
-  summary: Get the default data view in the default space
+  summary: Get the default data view
   operationId: getDefaultDataViewDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   responses:
@@ -25,10 +23,8 @@ get:
           schema:
             $ref: '../components/schemas/400_response.yaml'
 post:
-  summary: Set the default data view in the default space
+  summary: Set the default data view
   operationId: setDefaultDatailViewDefault
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@swap_references.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@swap_references.yaml
@@ -1,0 +1,45 @@
+post:
+  summary: Swap saved object references
+  operationId: swapDataViewsDefault
+  description: >
+    Changes saved object references from one data view identifier to another.
+    WARNING: Misuse can break large numbers of saved objects! Practicing with a backup is recommended.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/swap_data_view_request_object.yaml'
+        examples:
+          swapDataViewRequest:
+            $ref: '../components/examples/swap_data_view_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              deleteStatus:
+                type: object
+                properties:
+                  deletePerformed:
+                    type: boolean
+                  remainingRefs:
+                    type: integer
+              result:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: A saved object identifier.
+                    type:
+                      type: string
+                      description: The saved object type.

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@swap_references@_preview.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@swap_references@_preview.yaml
@@ -1,0 +1,37 @@
+post:
+  summary: Preview a saved object reference swap
+  operationId: previewSwapDataViewsDefault
+  description: >
+    Preview the impact of swapping saved object references from one data view identifier to another.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/swap_data_view_request_object.yaml'
+        examples:
+          previewSwapDataViewRequest:
+            $ref: '../components/examples/preview_swap_data_view_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              result:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: A saved object identifier.
+                    type:
+                      type: string
+                      description: The saved object type.

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views.yaml
@@ -1,8 +1,6 @@
 get:
   summary: Get all data views
   operationId: getAllDataViews
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view.yaml
@@ -1,8 +1,6 @@
 post:
   summary: Create a data view
   operationId: createDataView
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}.yaml
@@ -1,8 +1,6 @@
 get:
   summary: Get a data view
   operationId: getDataView
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -30,7 +28,6 @@ delete:
   operationId: deleteDataView
   description: >
     WARNING: When you delete a data view, it cannot be recovered.
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -50,8 +47,6 @@ delete:
 post:
   summary: Update a data view
   operationId: updateDataView
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}@fields.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}@fields.yaml
@@ -3,7 +3,8 @@ post:
   operationId: updateFieldsMetadata
   description: >
     Update fields presentation metadata such as count, customLabel and format.
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. You can update multiple fields in one request. Updates are merged with persisted metadata. To remove existing metadata, specify null as the value.
+    You can update multiple fields in one request. Updates are merged with persisted metadata.
+    To remove existing metadata, specify null as the value.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field.yaml
@@ -1,8 +1,6 @@
 post:
   summary: Create a runtime field
   operationId: createRuntimeField
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -41,8 +39,6 @@ post:
 put:
   summary: Create or update a runtime field
   operationId: createUpdateRuntimeField
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml
@@ -1,8 +1,6 @@
 get:
   summary: Get a runtime field
   operationId: getRuntimeField
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -36,8 +34,6 @@ get:
 delete:
   summary: Delete a runtime field from a data view
   operationId: deleteRuntimeField
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -57,8 +53,6 @@ delete:
 post:
   summary: Update a runtime field
   operationId: updateRuntimeField
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@default.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@default.yaml
@@ -1,8 +1,6 @@
 get:
   summary: Get the default data view identifier
   operationId: getDefaultDataView
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:
@@ -29,8 +27,6 @@ get:
 post:
   summary: Sets the default data view identifier
   operationId: setDefaultDatailView
-  description: >
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   tags:
     - data views
   parameters:

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@swap_references.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@swap_references.yaml
@@ -1,0 +1,46 @@
+post:
+  summary: Swap saved object references
+  operationId: swapDataViews
+  description: >
+    Changes saved object references from one data view identifier to another.
+    WARNING: Misuse can break large numbers of saved objects! Practicing with a backup is recommended.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+    - $ref: '../components/parameters/space_id.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/swap_data_view_request_object.yaml'
+        examples:
+          swapDataViewRequest:
+            $ref: '../components/examples/swap_data_view_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              deleteStatus:
+                type: object
+                properties:
+                  deletePerformed:
+                    type: boolean
+                  remainingRefs:
+                    type: integer
+              result:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: A saved object identifier.
+                    type:
+                      type: string
+                      description: The saved object type.

--- a/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@swap_references@_preview.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/s@{spaceid}@api@data_views@swap_references@_preview.yaml
@@ -1,0 +1,38 @@
+post:
+  summary: Preview a saved object reference swap
+  operationId: previewSwapDataViews
+  description: >
+    Preview the impact of swapping saved object references from one data view identifier to another.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+    - $ref: '../components/parameters/space_id.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/swap_data_view_request_object.yaml'
+        examples:
+          previewSwapDataViewRequest:
+            $ref: '../components/examples/preview_swap_data_view_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              result:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: A saved object identifier.
+                    type:
+                      type: string
+                      description: The saved object type.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[DOCS][OAS] Add data view swap saved object references and preview APIs (#187927)](https://github.com/elastic/kibana/pull/187927)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2024-07-24T22:31:06Z","message":"[DOCS][OAS] Add data view swap saved object references and preview APIs (#187927)","sha":"8dc286067b73e50d52c22e699f914bad280858fe","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Data Views","release_note:skip","backport:skip","docs","v8.16.0"],"number":187927,"url":"https://github.com/elastic/kibana/pull/187927","mergeCommit":{"message":"[DOCS][OAS] Add data view swap saved object references and preview APIs (#187927)","sha":"8dc286067b73e50d52c22e699f914bad280858fe"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/187927","number":187927,"mergeCommit":{"message":"[DOCS][OAS] Add data view swap saved object references and preview APIs (#187927)","sha":"8dc286067b73e50d52c22e699f914bad280858fe"}}]}] BACKPORT-->