### PR TITLE
[UII] Fix standalone agent policy download file name

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/hooks.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/hooks.tsx
@@ -291,8 +291,8 @@ export function useFetchFullPolicy(agentPolicy: AgentPolicy | undefined, isK8s?:
   const downloadYaml = useMemo(
     () => () => {
       const link = document.createElement('a');
-      link.href = `data:text/json;charset=utf-8,${yaml}`;
-      link.download = `elastic-agent.yaml`;
+      link.href = `data:text/x-yaml;charset=utf-8,${yaml}`;
+      link.download = `elastic-agent.yml`;
       link.click();
     },
     [yaml]

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
@@ -99,12 +99,12 @@ export const ConfigureStandaloneAgentStep = ({
     isK8s === 'IS_KUBERNETES' ? (
       <FormattedMessage
         id="xpack.fleet.agentEnrollment.downloadPolicyButtonk8s"
-        defaultMessage="Download Manifest"
+        defaultMessage="Download manifest"
       />
     ) : (
       <FormattedMessage
         id="xpack.fleet.agentEnrollment.downloadPolicyButton"
-        defaultMessage="Download Policy"
+        defaultMessage="Download policy"
       />
     );
 
@@ -121,7 +121,7 @@ export const ConfigureStandaloneAgentStep = ({
             {apiKey && (
               <EuiCallOut
                 title={i18n.translate('xpack.fleet.agentEnrollment.apiKeyBanner.created', {
-                  defaultMessage: 'API Key created.',
+                  defaultMessage: 'API key created.',
                 })}
                 color="success"
                 iconType="check"
@@ -129,8 +129,7 @@ export const ConfigureStandaloneAgentStep = ({
               >
                 <p>
                   {i18n.translate('xpack.fleet.agentEnrollment.apiKeyBanner.created.description', {
-                    defaultMessage:
-                      'Remember to store this information in a safe place. It won’t be displayed anymore after you continue.',
+                    defaultMessage: `Remember to store this information in a safe place. It won't be displayed anymore after you continue.`,
                   })}
                 </p>
                 <EuiFieldText
@@ -140,7 +139,7 @@ export const ConfigureStandaloneAgentStep = ({
                   aria-label={i18n.translate(
                     'xpack.fleet.agentEnrollment.apiKeyBanner.field.label',
                     {
-                      defaultMessage: 'Api Key',
+                      defaultMessage: 'API key',
                     }
                   )}
                   append={
@@ -165,7 +164,7 @@ export const ConfigureStandaloneAgentStep = ({
                 />
               </EuiCallOut>
             )}
-            <EuiSpacer size="m" />
+            <EuiSpacer size="s" />
             <EuiFlexGroup gutterSize="m">
               <EuiFlexItem grow={false}>
                 <EuiButton onClick={onCreateApiKey}>


### PR DESCRIPTION
## Summary

Resolves #189048. This PR fixes the content type and file name for the agent policy that is downloaded for standalone agents, following https://github.com/elastic/kibana/pull/187133.

Also adjusts some copy casing.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->