### PR TITLE
[Lens] add error reason in workspace panel when error happens

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_errors.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_errors.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { useState } from 'react';
-import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiPagination } from '@elastic/eui';
+import {
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPagination,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
 import type { UserMessage } from '../../../types';
 
 interface Props {
@@ -41,7 +48,19 @@ export function WorkspaceErrors(props: Props) {
       }
       body={
         <div data-test-subj="workspace-error-message">
-          {typeof activeError === 'string' ? activeError : activeError.longMessage}
+          {typeof activeError === 'string' ? (
+            activeError
+          ) : (
+            <div>
+              {activeError.shortMessage}
+              {activeError.longMessage ? (
+                <>
+                  <EuiSpacer />
+                  <EuiText size="s"> {activeError.longMessage}</EuiText>
+                </>
+              ) : null}
+            </div>
+          )}
         </div>
       }
       title={<h2>{props.title}</h2>}

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -701,7 +701,7 @@ describe('workspace_panel', () => {
 
       // EuiFlexItem duplicates internally the attribute, so we need to filter only the most inner one here
       expect(instance.find('[data-test-subj="workspace-error-message"]').last().text()).toEqual(
-        `i'm an error`
+        `hey there i'm an error`
       );
       expect(instance.find(expressionRendererMock)).toHaveLength(0);
       expect(getUserMessages).toHaveBeenCalledWith(['visualization', 'visualizationInEditor'], {


### PR DESCRIPTION
## Summary

Somewhere we stopped showing the error cause for workspace panel as `longMessage` started being empty and the content for the error lives principally in the `shortMessage`. This PR fixes it. Only two first images come from actual environment, the other two errors are hardcoded to check how it would look if only .longMessage is filled or both are.

<img width="651" alt="Screenshot 2024-07-25 at 11 13 17" src="https://github.com/user-attachments/assets/2d8e1471-d95c-4f77-8fb5-5a68a05f7df0">
<img width="647" alt="Screenshot 2024-07-25 at 11 13 33" src="https://github.com/user-attachments/assets/b37dc2ab-be83-4421-a8de-7c431f90687a">

<img width="644" alt="Screenshot 2024-07-25 at 11 17 05" src="https://github.com/user-attachments/assets/576b0775-1a7f-4bdd-8e7c-96910fda4742">
only longMessage

<img width="654" alt="Screenshot 2024-07-25 at 11 13 03" src="https://github.com/user-attachments/assets/4b680aed-97af-497c-be30-3bb356203190">
both




<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->