### PR TITLE
[Fleet] fix navigating back to Agent policy integration list

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -197,7 +197,7 @@ export const EditPackagePolicyForm = memo<{
         })
       : policyId
       ? getHref('policy_details', { policyId })
-      : '/';
+      : getHref('agent_list');
   }, [from, getHref, packageInfo, policyId]);
   const successRedirectPath = useMemo(() => {
     return (from === 'package-edit' || from === 'upgrade-from-integrations-policy-list') &&
@@ -207,7 +207,7 @@ export const EditPackagePolicyForm = memo<{
         })
       : policyId
       ? getHref('policy_details', { policyId })
-      : '/';
+      : getHref('agent_list');
   }, [from, getHref, packageInfo, policyId]);
 
   useHistoryBlock(isEdited);

--- a/x-pack/plugins/fleet/public/components/package_policy_actions_menu.test.tsx
+++ b/x-pack/plugins/fleet/public/components/package_policy_actions_menu.test.tsx
@@ -157,4 +157,17 @@ describe('PackagePolicyActionsMenu', () => {
       expect(utils.queryByText('Add agent')).toBeNull();
     });
   });
+
+  it('Should show Edit integration with correct href when agentPolicy is defined', async () => {
+    const agentPolicies = createMockAgentPolicies();
+    const packagePolicy = createMockPackagePolicy();
+    const { utils } = renderMenu({ agentPolicies, packagePolicy });
+    await act(async () => {
+      const editButton = utils.getByTestId('PackagePolicyActionsEditItem');
+      expect(editButton).toHaveAttribute(
+        'href',
+        '/mock/app/fleet/policies/some-uuid1/edit-integration/some-uuid2'
+      );
+    });
+  });
 });

--- a/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
@@ -89,7 +89,8 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
       data-test-subj="PackagePolicyActionsEditItem"
       disabled={!canWriteIntegrationPolicies || !agentPolicy}
       icon="pencil"
-      href={`${getHref('integration_policy_edit', {
+      href={`${getHref('edit_integration', {
+        policyId: agentPolicy?.id ?? '',
         packagePolicyId: packagePolicy.id,
       })}${from ? `?from=${from}` : ''}`}
       key="packagePolicyEdit"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/187336

Fix navigating back from Agent policies and use Fleet url as a fallback when no specific url is defined fro navigation.
To verify:
- Go to an Agent policy Integrations list
- Click on Edit integration action
- Cancel/Submit the form
- Verify that the page goes back to Agent policy Integrations list

<img width="1479" alt="image" src="https://github.com/user-attachments/assets/daa6b0e2-0298-48fd-8c1c-c818d26a2585">
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/84a7a61e-9329-44ec-96c2-e6891f7627dc">
<img width="1475" alt="image" src="https://github.com/user-attachments/assets/3504d934-6944-42b5-bb10-a212cd340784">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->