### PR TITLE
[EDR Workflows][Osquery] Unskip timelines.cy.ts

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/timelines.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/timelines.cy.ts
@@ -10,8 +10,7 @@ import { takeOsqueryActionWithParams } from '../../tasks/live_query';
 import { ServerlessRoleName } from '../../support/roles';
 import { disableNewFeaturesTours } from '../../tasks/navigation';
 
-// Failing: See https://github.com/elastic/kibana/issues/189136
-describe.skip('ALL - Timelines', { tags: ['@ess'] }, () => {
+describe('ALL - Timelines', { tags: ['@ess'] }, () => {
   before(() => {
     initializeDataViews();
   });
@@ -42,7 +41,8 @@ describe.skip('ALL - Timelines', { tags: ['@ess'] }, () => {
     });
     cy.getBySel('sourcerer-save').click();
 
-    cy.getBySel('docTableExpandToggleColumn').first().click();
+    // Force true due to pointer-events: none on parent prevents user mouse interaction.
+    cy.getBySel('docTableExpandToggleColumn').first().click({ force: true });
     takeOsqueryActionWithParams();
   });
 });


### PR DESCRIPTION
Added force to click since the parent of the element `timelines.cy.ts` is supposed to click received `pointer-events: none` style and Cypress is no longer able to click it without `force()`. 

closes https://github.com/elastic/kibana/issues/189136