### PR TITLE
[Fleet] Fix namespaces property of created agent policies

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -194,6 +194,10 @@ export interface FleetServerPolicy {
    */
   coordinator_idx: number;
   /**
+   * The namespaces of the policy
+   */
+  namespaces?: string[];
+  /**
    * The opaque payload.
    */
   data: {

--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -789,7 +789,7 @@ describe('Agent policy', () => {
 
   describe('removeOutputFromAll', () => {
     let mockedAgentPolicyServiceUpdate: jest.SpyInstance<
-      ReturnType<(typeof agentPolicyService)['update']>
+      ReturnType<typeof agentPolicyService['update']>
     >;
     beforeEach(() => {
       mockedAgentPolicyServiceUpdate = jest
@@ -864,7 +864,7 @@ describe('Agent policy', () => {
 
   describe('removeDefaultSourceFromAll', () => {
     let mockedAgentPolicyServiceUpdate: jest.SpyInstance<
-      ReturnType<(typeof agentPolicyService)['update']>
+      ReturnType<typeof agentPolicyService['update']>
     >;
     beforeEach(() => {
       mockedAgentPolicyServiceUpdate = jest
@@ -1269,6 +1269,7 @@ describe('Agent policy', () => {
       soClient.bulkGet.mockResolvedValue({
         saved_objects: [mockSo],
       });
+      soClient.getCurrentNamespace.mockReturnValue('mySpace');
       await agentPolicyService.deployPolicy(soClient, 'policy123');
 
       expect(esClient.bulk).toBeCalledWith(
@@ -1286,6 +1287,7 @@ describe('Agent policy', () => {
               default_fleet_server: false,
               policy_id: 'policy123',
               revision_idx: 1,
+              namespaces: ['mySpace'],
             }),
           ],
           refresh: 'wait_for',

--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -789,7 +789,7 @@ describe('Agent policy', () => {
 
   describe('removeOutputFromAll', () => {
     let mockedAgentPolicyServiceUpdate: jest.SpyInstance<
-      ReturnType<typeof agentPolicyService['update']>
+      ReturnType<(typeof agentPolicyService)['update']>
     >;
     beforeEach(() => {
       mockedAgentPolicyServiceUpdate = jest
@@ -864,7 +864,7 @@ describe('Agent policy', () => {
 
   describe('removeDefaultSourceFromAll', () => {
     let mockedAgentPolicyServiceUpdate: jest.SpyInstance<
-      ReturnType<typeof agentPolicyService['update']>
+      ReturnType<(typeof agentPolicyService)['update']>
     >;
     beforeEach(() => {
       mockedAgentPolicyServiceUpdate = jest
@@ -1230,6 +1230,7 @@ describe('Agent policy', () => {
       mockedGetFullAgentPolicy.mockResolvedValue({
         id: 'policy123',
         revision: 1,
+        namespaces: ['mySpace'],
         inputs: [
           {
             id: 'input-123',
@@ -1269,7 +1270,6 @@ describe('Agent policy', () => {
       soClient.bulkGet.mockResolvedValue({
         saved_objects: [mockSo],
       });
-      soClient.getCurrentNamespace.mockReturnValue('mySpace');
       await agentPolicyService.deployPolicy(soClient, 'policy123');
 
       expect(esClient.bulk).toBeCalledWith(
@@ -1283,7 +1283,12 @@ describe('Agent policy', () => {
             }),
             expect.objectContaining({
               '@timestamp': expect.anything(),
-              data: { id: 'policy123', inputs: [{ id: 'input-123' }], revision: 1 },
+              data: {
+                id: 'policy123',
+                inputs: [{ id: 'input-123' }],
+                revision: 1,
+                namespaces: ['mySpace'],
+              },
               default_fleet_server: false,
               policy_id: 'policy123',
               revision_idx: 1,

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -1137,6 +1137,7 @@ class AgentPolicyService {
         '@timestamp': new Date().toISOString(),
         revision_idx: fullPolicy.revision,
         coordinator_idx: 0,
+        namespaces: fullPolicy.namespaces,
         data: fullPolicy as unknown as FleetServerPolicy['data'],
         policy_id: fullPolicy.id,
         default_fleet_server: policy.is_default_fleet_server === true,


### PR DESCRIPTION
## Summary

I found a small bug while working on https://github.com/elastic/kibana/issues/185040: when agent policies are created, there should be a root-level `namespaces` property, which is currently missing.

`GET .fleet-policies/_mapping` contains a `namespaces` property with `keyword` type that was added in https://github.com/elastic/elasticsearch.

Note: I was looking into removing the existing `data.namespaces` property, however I don't see any issues with it. It is coming from [here](https://github.com/nchaulet/kibana/blob/f77e4d243fca87a87eeae1409f27876cc7ea0836/x-pack/plugins/fleet/server/services/agent_policy.ts#L1140), i.e. the `data` property is generated from the full agent policy which already has a `namespaces` property.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios