### PR TITLE
[Log threshold] Fix showing the correct log view in the rule creation flyout

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/log_threshold/components/expression_editor/editor.tsx
@@ -105,7 +105,10 @@ export const ExpressionEditor: React.FC<
           <Editor {...props} />
         </SourceStatusWrapper>
       ) : (
-        <LogViewProvider logViews={logsShared.logViews.client}>
+        <LogViewProvider
+          logViews={logsShared.logViews.client}
+          initialLogViewReference={props.ruleParams.logView}
+        >
           <SourceStatusWrapper {...props}>
             <Editor {...props} />
           </SourceStatusWrapper>


### PR DESCRIPTION
Related to #187291

## Summary

This PR passes the rule's logView to the Log threshold rule creation flyout. Thanks to @Kerry350 and @weltenwort for explaining how this logic works ❤️ 

For example, if the log view ID is passed an invalid id, like this:

<img src="https://github.com/user-attachments/assets/f9d4ac74-9b16-406e-93e5-141ea82d1687" width=500 />

 it will fall back to the default log view will be used, and now we show the correct log view in the rule flyout.

Example setting:

![image](https://github.com/user-attachments/assets/67b03d70-4e87-433a-830e-295f042bce92)

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/8ac9d0d9-5c2f-424d-9b31-cad42bcbf893)|![image](https://github.com/user-attachments/assets/2b727635-8403-4372-9a03-e124f3987ccb)|

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->