### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests - Alerting - group2.x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection·ts - Alerting monitoring_collection inMemoryMetrics should count timeouts

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection.ts
@@ -123,8 +123,8 @@ export default function alertingMonitoringCollectionTests({ getService }: FtrPro
             rule_type_id: 'test.cancellableRule',
             schedule: { interval: '4s' },
             params: {
-              doLongSearch: true,
-              doLongPostProcessing: false,
+              doLongSearch: false,
+              doLongPostProcessing: true,
             },
           })
         );

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection.ts
@@ -38,8 +38,7 @@ export default function alertingMonitoringCollectionTests({ getService }: FtrPro
     ? dedicatedTaskRunner.getSupertest()
     : supertest;
 
-  // Failing: See https://github.com/elastic/kibana/issues/187275
-  describe.skip('monitoring_collection', () => {
+  describe('monitoring_collection', () => {
     let endDate: string;
     const objectRemover = new ObjectRemover(supertest);
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/187275

When looking at the flaky test logs, I could see some ES errors for the `test.cancellableRule` rule type we're using in this test. This rule type uses a shard delay aggregation to increase the execution duration of a rule to force a timeout. Switching instead to just delaying using an `await new Promise((resolve) => setTimeout(resolve, 10000));`.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->