### PR TITLE
[8.15] [ES|QL] capitalize function and operator signatures (#189109)

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -1104,7 +1104,7 @@ describe('autocomplete', () => {
       ...getFieldNamesByType('string').map((v) => `${v},`),
       ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
         'concat',
-      ]).map((v) => `${v},`),
+      ]).map((v) => ({ ...v, text: `${v.text},` })),
     ]);
     testSuggestions('from a | eval a=concat(stringField, ', [
       ...getFieldNamesByType('string'),
@@ -1124,7 +1124,7 @@ describe('autocomplete', () => {
       ...getFieldNamesByType('ip').map((v) => `${v},`),
       ...getFunctionSignaturesByReturnType('eval', 'ip', { evalMath: true }, undefined, [
         'cidr_match',
-      ]).map((v) => `${v},`),
+      ]).map((v) => ({ ...v, text: `${v.text},` })),
     ]);
     testSuggestions('from a | eval a=cidr_match(ipField, ', [
       ...getFieldNamesByType('string'),
@@ -1289,7 +1289,7 @@ describe('autocomplete', () => {
           ...getLiteralsByType('time_literal').map((t) => `${t},`),
           ...getFunctionSignaturesByReturnType('eval', 'date', { evalMath: true }, undefined, [
             'date_trunc',
-          ]).map((t) => `${t},`),
+          ]).map((t) => ({ ...t, text: `${t.text},` })),
           ...getFieldNamesByType('date').map((t) => `${t},`),
         ],
         '('

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -20,6 +20,10 @@ import { FunctionParameter } from '../definitions/types';
 import { getParamAtPosition } from './helper';
 import { nonNullable } from '../shared/helpers';
 import { METADATA_FIELDS } from '../shared/constants';
+import { SuggestionRawDefinition } from './types';
+import { getFunctionSignatures } from '../definitions/helpers';
+
+export type PartialSuggestionWithText = Partial<SuggestionRawDefinition> & { text: string };
 
 interface Integration {
   name: string;
@@ -196,13 +200,25 @@ function getFunctionSignaturesByReturnType(
       return true;
     })
     .sort(({ name: a }, { name: b }) => a.localeCompare(b))
-    .map(({ type, name, signatures }) => {
+    .map<PartialSuggestionWithText>((definition) => {
+      const { type, name, signatures } = definition;
+
       if (type === 'builtin') {
-        return signatures.some(({ params }) => params.length > 1)
-          ? `${name.toUpperCase()} $0`
-          : name.toUpperCase();
+        return {
+          text: signatures.some(({ params }) => params.length > 1)
+            ? `${name.toUpperCase()} $0`
+            : name.toUpperCase(),
+          label: name.toUpperCase(),
+        };
       }
-      return `${name.toUpperCase()}($0)`;
+      const printedSignatures = getFunctionSignatures(definition, {
+        withTypes: true,
+        capitalize: true,
+      });
+      return {
+        text: `${name.toUpperCase()}($0)`,
+        label: printedSignatures[0].declaration,
+      };
     });
 }
 
@@ -271,14 +287,14 @@ function getPolicyFields(policyName: string) {
 describe('autocomplete', () => {
   type TestArgs = [
     string,
-    string[],
+    Array<string | PartialSuggestionWithText>,
     (string | number)?,
     Parameters<typeof createCustomCallbackMocks>?
   ];
 
   const testSuggestionsFn = (
     statement: string,
-    expected: string[],
+    expected: Array<string | PartialSuggestionWithText>,
     triggerCharacter: string | number = '',
     customCallbacksArgs: Parameters<typeof createCustomCallbackMocks> = [
       undefined,
@@ -312,10 +328,22 @@ describe('autocomplete', () => {
           callbackMocks
         );
 
-        const sortedSuggestions = suggestions.map((suggestion) => suggestion.text).sort();
-        const sortedExpected = expected.sort();
+        const sortedSuggestionTexts = suggestions.map((suggestion) => suggestion.text).sort();
+        const sortedExpectedTexts = expected
+          .map((suggestion) =>
+            typeof suggestion === 'string' ? suggestion : suggestion.text ?? ''
+          )
+          .sort();
 
-        expect(sortedSuggestions).toEqual(sortedExpected);
+        expect(sortedSuggestionTexts).toEqual(sortedExpectedTexts);
+        const expectedNonStringSuggestions = expected.filter(
+          (suggestion) => typeof suggestion !== 'string'
+        ) as PartialSuggestionWithText[];
+
+        for (const expectedSuggestion of expectedNonStringSuggestions) {
+          const suggestion = suggestions.find((s) => s.text === expectedSuggestion.text);
+          expect(suggestion).toEqual(expect.objectContaining(expectedSuggestion));
+        }
       }
     );
   };
@@ -786,13 +814,12 @@ describe('autocomplete', () => {
     ]);
 
     // expect "bucket" NOT to be suggested for its own parameter
-    testSuggestions(
-      'from a | stats by bucket(',
-      [
-        ...getFieldNamesByType(['number', 'date']),
-        ...getFunctionSignaturesByReturnType('eval', ['date', 'number'], { evalMath: true }),
-      ].map((field) => `${field},`)
-    );
+    testSuggestions('from a | stats by bucket(', [
+      ...getFieldNamesByType(['number', 'date']).map((field) => `${field},`),
+      ...getFunctionSignaturesByReturnType('eval', ['date', 'number'], { evalMath: true }).map(
+        (s) => ({ ...s, text: s.text + ',' })
+      ),
+    ]);
 
     testSuggestions('from a | stats avg(b) by numberField % 2 ', [',', '|']);
 
@@ -1201,25 +1228,29 @@ describe('autocomplete', () => {
 
               const suggestedConstants = param.literalSuggestions || param.literalOptions;
 
+              const addCommaIfRequired = (s: string | PartialSuggestionWithText) => {
+                // don't add commas to the empty string or if there are no more required args
+                if (!requiresMoreArgs || s === '' || (typeof s === 'object' && s.text === '')) {
+                  return s;
+                }
+                return typeof s === 'string' ? `${s},` : { ...s, text: `${s.text},` };
+              };
+
               testSuggestions(
                 `from a | eval ${fn.name}(${Array(i).fill('field').join(', ')}${i ? ',' : ''} )`,
                 suggestedConstants?.length
                   ? suggestedConstants.map((option) => `"${option}"${requiresMoreArgs ? ',' : ''}`)
                   : [
-                      ...getFieldNamesByType(getTypesFromParamDefs(acceptsFieldParamDefs)).map(
-                        (f) => (requiresMoreArgs ? `${f},` : f)
-                      ),
+                      ...getFieldNamesByType(getTypesFromParamDefs(acceptsFieldParamDefs)),
                       ...getFunctionSignaturesByReturnType(
                         'eval',
                         getTypesFromParamDefs(acceptsFieldParamDefs),
                         { evalMath: true },
                         undefined,
                         [fn.name]
-                      ).map((l) => (requiresMoreArgs ? `${l},` : l)),
-                      ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)).map((d) =>
-                        requiresMoreArgs ? `${d},` : d
                       ),
-                    ]
+                      ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)),
+                    ].map(addCommaIfRequired)
               );
               testSuggestions(
                 `from a | eval var0 = ${fn.name}(${Array(i).fill('field').join(', ')}${
@@ -1228,20 +1259,16 @@ describe('autocomplete', () => {
                 suggestedConstants?.length
                   ? suggestedConstants.map((option) => `"${option}"${requiresMoreArgs ? ',' : ''}`)
                   : [
-                      ...getFieldNamesByType(getTypesFromParamDefs(acceptsFieldParamDefs)).map(
-                        (f) => (requiresMoreArgs ? `${f},` : f)
-                      ),
+                      ...getFieldNamesByType(getTypesFromParamDefs(acceptsFieldParamDefs)),
                       ...getFunctionSignaturesByReturnType(
                         'eval',
                         getTypesFromParamDefs(acceptsFieldParamDefs),
                         { evalMath: true },
                         undefined,
                         [fn.name]
-                      ).map((l) => (requiresMoreArgs ? `${l},` : l)),
-                      ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)).map((d) =>
-                        requiresMoreArgs ? `${d},` : d
                       ),
-                    ]
+                      ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)),
+                    ].map(addCommaIfRequired)
               );
             }
           });
@@ -1283,6 +1310,7 @@ describe('autocomplete', () => {
           'number',
         ]),
       ]);
+
       testSuggestions(
         'from a | eval var0=date_trunc()',
         [

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -46,7 +46,7 @@ function getSafeInsertSourceText(text: string) {
 }
 
 export function getSuggestionFunctionDefinition(fn: FunctionDefinition): SuggestionRawDefinition {
-  const fullSignatures = getFunctionSignatures(fn);
+  const fullSignatures = getFunctionSignatures(fn, { capitalize: true, withTypes: true });
   return {
     label: fullSignatures[0].declaration,
     text: `${fn.name.toUpperCase()}($0)`,
@@ -66,7 +66,7 @@ export function getSuggestionFunctionDefinition(fn: FunctionDefinition): Suggest
 export function getSuggestionBuiltinDefinition(fn: FunctionDefinition): SuggestionRawDefinition {
   const hasArgs = fn.signatures.some(({ params }) => params.length > 1);
   return {
-    label: fn.name,
+    label: fn.name.toUpperCase(),
     text: hasArgs ? `${fn.name.toUpperCase()} $0` : fn.name.toUpperCase(),
     asSnippet: hasArgs,
     kind: 'Operator',

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/helpers.ts
@@ -17,7 +17,10 @@ import type { CommandDefinition, FunctionDefinition } from './types';
  */
 export function getFunctionSignatures(
   { name, signatures }: FunctionDefinition,
-  { withTypes }: { withTypes: boolean } = { withTypes: true }
+  { withTypes, capitalize }: { withTypes: boolean; capitalize?: boolean } = {
+    withTypes: true,
+    capitalize: false,
+  }
 ) {
   return signatures.map(({ params, returnType, minParams }) => {
     // for functions with a minimum number of args, repeat the last arg multiple times
@@ -25,7 +28,7 @@ export function getFunctionSignatures(
     const minParamsToAdd = Math.max((minParams || 0) - params.length, 0);
     const extraArg = Array(minParamsToAdd || 1).fill(params[Math.max(params.length - 1, 0)]);
     return {
-      declaration: `${name}(${params
+      declaration: `${capitalize ? name.toUpperCase() : name}(${params
         .map((arg) => printArguments(arg, withTypes))
         .join(', ')}${handleAdditionalArgs(minParamsToAdd > 0, extraArg, withTypes)})${
         withTypes ? `: ${returnType}` : ''

--- a/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -290,13 +290,12 @@ export function areFieldAndVariableTypesCompatible(
   return fieldType === variableType;
 }
 
-export function printFunctionSignature(arg: ESQLFunction, useCaps = true): string {
+export function printFunctionSignature(arg: ESQLFunction): string {
   const fnDef = getFunctionDefinition(arg.name);
   if (fnDef) {
     const signature = getFunctionSignatures(
       {
         ...fnDef,
-        name: useCaps ? fnDef.name.toUpperCase() : fnDef.name,
         signatures: [
           {
             ...fnDef?.signatures[0],
@@ -313,7 +312,7 @@ export function printFunctionSignature(arg: ESQLFunction, useCaps = true): strin
           },
         ],
       },
-      { withTypes: false }
+      { withTypes: false, capitalize: true }
     );
     return signature[0].declaration;
   }

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -9187,8 +9187,8 @@
     {
       "query": "from a_index | eval date_diff(\"year\", concat(\"20\", \"22\"), concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_diff] must be [date], found value [concat(\"20\", \"22\")] type [string]",
-        "Argument of [date_diff] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_diff] must be [date], found value [concat(\"20\",\"22\")] type [string]",
+        "Argument of [date_diff] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11080,7 +11080,7 @@
     {
       "query": "from a_index | eval date_extract(\"ALIGNED_DAY_OF_WEEK_IN_MONTH\", concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_extract] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_extract] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11167,7 +11167,7 @@
     {
       "query": "from a_index | eval date_format(stringField, concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_format] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_format] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11384,7 +11384,7 @@
     {
       "query": "from a_index | eval date_trunc(1 year, concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_trunc] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_trunc] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -11396,8 +11396,8 @@
     {
       "query": "from a_index | eval date_trunc(concat(\"20\", \"22\"), concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [date_trunc] must be [time_literal], found value [concat(\"20\", \"22\")] type [string]",
-        "Argument of [date_trunc] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [date_trunc] must be [time_literal], found value [concat(\"20\",\"22\")] type [string]",
+        "Argument of [date_trunc] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -24139,7 +24139,7 @@
     {
       "query": "from a_index | stats max(concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [max] must be [number], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [max] must be [number], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -24412,7 +24412,7 @@
     {
       "query": "from a_index | stats min(concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [min] must be [number], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [min] must be [number], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -24970,14 +24970,14 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 1 year)",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
     {
       "query": "from a_index | stats by bucket(concat(\"20\", \"22\"), 1 year)",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -24989,7 +24989,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, \"a\", \"a\")",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25001,7 +25001,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, concat(\"20\", \"22\"), concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25013,7 +25013,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, \"a\", concat(\"20\", \"22\"))",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -25025,7 +25025,7 @@
     {
       "query": "from a_index | stats bucket(concat(\"20\", \"22\"), 5, concat(\"20\", \"22\"), \"a\")",
       "error": [
-        "Argument of [bucket] must be [date], found value [concat(\"20\", \"22\")] type [string]"
+        "Argument of [bucket] must be [date], found value [concat(\"20\",\"22\")] type [string]"
       ],
       "warning": []
     },
@@ -26365,6 +26365,91 @@
     },
     {
       "query": "row nullVar = null | stats weighted_avg(nullVar, nullVar)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = exp(5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row exp(5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = exp(to_integer(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = exp(true)",
+      "error": [
+        "Argument of [exp] must be [number], found value [true] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where exp(numberField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where exp(booleanField) > 0",
+      "error": [
+        "Argument of [exp] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = exp(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = exp(to_integer(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(booleanField)",
+      "error": [
+        "Argument of [exp] must be [number], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = exp(*)",
+      "error": [
+        "Using wildcards (*) in exp is not allowed"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(numberField, extraArg)",
+      "error": [
+        "Error: [exp] function expects exactly one argument, got 2."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | sort exp(numberField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval exp(null)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row nullVar = null | eval exp(nullVar)",
       "error": [],
       "warning": []
     },

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -103,7 +103,7 @@ function prepareNestedFunction(fnSignature: FunctionDefinition): string {
         },
       ],
     },
-    { withTypes: false }
+    { withTypes: false, capitalize: false }
   )[0].declaration;
 }
 function getFieldMapping(
@@ -1784,8 +1784,8 @@ describe('validation logic', () => {
         testErrorsAndWarnings(
           'from a_index | eval date_diff("year", concat("20", "22"), concat("20", "22"))',
           [
-            'Argument of [date_diff] must be [date], found value [concat("20", "22")] type [string]',
-            'Argument of [date_diff] must be [date], found value [concat("20", "22")] type [string]',
+            'Argument of [date_diff] must be [date], found value [concat("20","22")] type [string]',
+            'Argument of [date_diff] must be [date], found value [concat("20","22")] type [string]',
           ]
         );
       });
@@ -2666,7 +2666,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings(
           'from a_index | eval date_extract("ALIGNED_DAY_OF_WEEK_IN_MONTH", concat("20", "22"))',
           [
-            'Argument of [date_extract] must be [date], found value [concat("20", "22")] type [string]',
+            'Argument of [date_extract] must be [date], found value [concat("20","22")] type [string]',
           ]
         );
       });
@@ -2710,7 +2710,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | eval date_format(nullVar, nullVar)', []);
         testErrorsAndWarnings('from a_index | eval date_format(stringField, "2022")', []);
         testErrorsAndWarnings('from a_index | eval date_format(stringField, concat("20", "22"))', [
-          'Argument of [date_format] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [date_format] must be [date], found value [concat("20","22")] type [string]',
         ]);
       });
 
@@ -2815,15 +2815,15 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | eval date_trunc(nullVar, nullVar)', []);
         testErrorsAndWarnings('from a_index | eval date_trunc(1 year, "2022")', []);
         testErrorsAndWarnings('from a_index | eval date_trunc(1 year, concat("20", "22"))', [
-          'Argument of [date_trunc] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [date_trunc] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | eval date_trunc("2022", "2022")', []);
 
         testErrorsAndWarnings(
           'from a_index | eval date_trunc(concat("20", "22"), concat("20", "22"))',
           [
-            'Argument of [date_trunc] must be [time_literal], found value [concat("20", "22")] type [string]',
-            'Argument of [date_trunc] must be [date], found value [concat("20", "22")] type [string]',
+            'Argument of [date_trunc] must be [time_literal], found value [concat("20","22")] type [string]',
+            'Argument of [date_trunc] must be [date], found value [concat("20","22")] type [string]',
           ]
         );
       });
@@ -9170,7 +9170,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | stats max(nullVar)', []);
         testErrorsAndWarnings('from a_index | stats max("2022")', []);
         testErrorsAndWarnings('from a_index | stats max(concat("20", "22"))', [
-          'Argument of [max] must be [number], found value [concat("20", "22")] type [string]',
+          'Argument of [max] must be [number], found value [concat("20","22")] type [string]',
         ]);
       });
 
@@ -9314,7 +9314,7 @@ describe('validation logic', () => {
         testErrorsAndWarnings('row nullVar = null | stats min(nullVar)', []);
         testErrorsAndWarnings('from a_index | stats min("2022")', []);
         testErrorsAndWarnings('from a_index | stats min(concat("20", "22"))', [
-          'Argument of [min] must be [number], found value [concat("20", "22")] type [string]',
+          'Argument of [min] must be [number], found value [concat("20","22")] type [string]',
         ]);
       });
 
@@ -9632,34 +9632,34 @@ describe('validation logic', () => {
         );
         testErrorsAndWarnings('from a_index | stats bucket("2022", 1 year)', []);
         testErrorsAndWarnings('from a_index | stats bucket(concat("20", "22"), 1 year)', [
-          'Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [bucket] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | stats by bucket(concat("20", "22"), 1 year)', [
-          'Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [bucket] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "a", "a")', []);
         testErrorsAndWarnings('from a_index | stats bucket(concat("20", "22"), 5, "a", "a")', [
-          'Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]',
+          'Argument of [bucket] must be [date], found value [concat("20","22")] type [string]',
         ]);
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "2022", "2022")', []);
 
         testErrorsAndWarnings(
           'from a_index | stats bucket(concat("20", "22"), 5, concat("20", "22"), concat("20", "22"))',
-          ['Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]']
+          ['Argument of [bucket] must be [date], found value [concat("20","22")] type [string]']
         );
 
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "a", "2022")', []);
 
         testErrorsAndWarnings(
           'from a_index | stats bucket(concat("20", "22"), 5, "a", concat("20", "22"))',
-          ['Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]']
+          ['Argument of [bucket] must be [date], found value [concat("20","22")] type [string]']
         );
 
         testErrorsAndWarnings('from a_index | stats bucket("2022", 5, "2022", "a")', []);
 
         testErrorsAndWarnings(
           'from a_index | stats bucket(concat("20", "22"), 5, concat("20", "22"), "a")',
-          ['Argument of [bucket] must be [date], found value [concat("20", "22")] type [string]']
+          ['Argument of [bucket] must be [date], found value [concat("20","22")] type [string]']
         );
       });
 

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -43,7 +43,6 @@ import {
   isSupportedFunction,
   isTimeIntervalItem,
   inKnownTimeInterval,
-  printFunctionSignature,
   sourceExists,
   getColumnExists,
   hasWildcard,
@@ -220,7 +219,7 @@ function validateNestedFunctionArg(
           values: {
             name: astFunction.name,
             argType: parameterDefinition.type,
-            value: printFunctionSignature(actualArg, false) || actualArg.name,
+            value: actualArg.text,
             givenType: argFn.signatures[0].returnType,
           },
           locations: actualArg.location,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ES|QL] capitalize function and operator signatures (#189109)](https://github.com/elastic/kibana/pull/189109)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2024-07-25T14:32:52Z","message":"[ES|QL] capitalize function and operator signatures (#189109)\n\n## Summary\r\n\r\nThis is a follow-up to https://github.com/elastic/kibana/pull/186340. I\r\nforgot to capitalize the labels for functions and operators. Fixed now.\r\n\r\n**Before**\r\n<img width=\"1321\" alt=\"Screenshot 2024-07-24 at 10 26 52 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/05102828-0469-4b14-a2f9-34a160edbd18\">\r\n\r\n**After**\r\n<img width=\"1286\" alt=\"Screenshot 2024-07-24 at 10 23 59 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dd01ccde-ec12-4ad3-98f7-561e5d233e52\">\r\n\r\nAlso, this PR changes the validation error messages to actually reflect\r\nwhat the user has typed:\r\n\r\n**Before**\r\n<img width=\"697\" alt=\"Screenshot 2024-07-24 at 11 43 54 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/28cbbd4c-1b3e-4d22-a1af-33b2f17af597\">\r\n\r\n**After**\r\n<img width=\"709\" alt=\"Screenshot 2024-07-24 at 11 40 48 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dffd4a29-d348-44d0-ba58-00a0a70d04b3\">\r\n<img width=\"663\" alt=\"Screenshot 2024-07-24 at 11 39 54 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dff0c726-d028-4826-a1cd-030e733987a7\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"05b6d7eacc7dfa0f0419982cd002e83e8be6c1b0","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","Feature:ES|QL","Team:ESQL","v8.15.0","v8.16.0"],"number":189109,"url":"https://github.com/elastic/kibana/pull/189109","mergeCommit":{"message":"[ES|QL] capitalize function and operator signatures (#189109)\n\n## Summary\r\n\r\nThis is a follow-up to https://github.com/elastic/kibana/pull/186340. I\r\nforgot to capitalize the labels for functions and operators. Fixed now.\r\n\r\n**Before**\r\n<img width=\"1321\" alt=\"Screenshot 2024-07-24 at 10 26 52 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/05102828-0469-4b14-a2f9-34a160edbd18\">\r\n\r\n**After**\r\n<img width=\"1286\" alt=\"Screenshot 2024-07-24 at 10 23 59 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dd01ccde-ec12-4ad3-98f7-561e5d233e52\">\r\n\r\nAlso, this PR changes the validation error messages to actually reflect\r\nwhat the user has typed:\r\n\r\n**Before**\r\n<img width=\"697\" alt=\"Screenshot 2024-07-24 at 11 43 54 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/28cbbd4c-1b3e-4d22-a1af-33b2f17af597\">\r\n\r\n**After**\r\n<img width=\"709\" alt=\"Screenshot 2024-07-24 at 11 40 48 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dffd4a29-d348-44d0-ba58-00a0a70d04b3\">\r\n<img width=\"663\" alt=\"Screenshot 2024-07-24 at 11 39 54 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dff0c726-d028-4826-a1cd-030e733987a7\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"05b6d7eacc7dfa0f0419982cd002e83e8be6c1b0"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/189109","number":189109,"mergeCommit":{"message":"[ES|QL] capitalize function and operator signatures (#189109)\n\n## Summary\r\n\r\nThis is a follow-up to https://github.com/elastic/kibana/pull/186340. I\r\nforgot to capitalize the labels for functions and operators. Fixed now.\r\n\r\n**Before**\r\n<img width=\"1321\" alt=\"Screenshot 2024-07-24 at 10 26 52 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/05102828-0469-4b14-a2f9-34a160edbd18\">\r\n\r\n**After**\r\n<img width=\"1286\" alt=\"Screenshot 2024-07-24 at 10 23 59 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dd01ccde-ec12-4ad3-98f7-561e5d233e52\">\r\n\r\nAlso, this PR changes the validation error messages to actually reflect\r\nwhat the user has typed:\r\n\r\n**Before**\r\n<img width=\"697\" alt=\"Screenshot 2024-07-24 at 11 43 54 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/28cbbd4c-1b3e-4d22-a1af-33b2f17af597\">\r\n\r\n**After**\r\n<img width=\"709\" alt=\"Screenshot 2024-07-24 at 11 40 48 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dffd4a29-d348-44d0-ba58-00a0a70d04b3\">\r\n<img width=\"663\" alt=\"Screenshot 2024-07-24 at 11 39 54 AM\"\r\nsrc=\"https://github.com/user-attachments/assets/dff0c726-d028-4826-a1cd-030e733987a7\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"05b6d7eacc7dfa0f0419982cd002e83e8be6c1b0"}}]}] BACKPORT-->