### PR TITLE
[Response Ops][Alerting] Assigning extra large cost to indicator match rule types

### DIFF
--- a/x-pack/plugins/alerting/server/rule_type_registry.test.ts
+++ b/x-pack/plugins/alerting/server/rule_type_registry.test.ts
@@ -564,6 +564,39 @@ describe('Create Lifecycle', () => {
       });
     });
 
+    test('injects custom cost for certain rule types', () => {
+      const ruleType: RuleType<never, never, never, never, never, 'default', 'recovered', {}> = {
+        id: 'siem.indicatorRule',
+        name: 'Test',
+        actionGroups: [
+          {
+            id: 'default',
+            name: 'Default',
+          },
+        ],
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        executor: jest.fn(),
+        category: 'test',
+        producer: 'alerts',
+        ruleTaskTimeout: '20m',
+        validate: {
+          params: { validate: (params) => params },
+        },
+      };
+      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
+      registry.register(ruleType);
+      expect(taskManager.registerTaskDefinitions).toHaveBeenCalledTimes(1);
+      expect(taskManager.registerTaskDefinitions.mock.calls[0][0]).toMatchObject({
+        'alerting:siem.indicatorRule': {
+          timeout: '20m',
+          title: 'Test',
+          cost: 10,
+        },
+      });
+    });
+
     test('shallow clones the given rule type', () => {
       const ruleType: RuleType<never, never, never, never, never, 'default', 'recovered', {}> = {
         id: 'test',

--- a/x-pack/plugins/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
+++ b/x-pack/plugins/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Task cost checks detects tasks with cost definitions 1`] = `
+Array [
+  Object {
+    "cost": 10,
+    "taskType": "alerting:siem.indicatorRule",
+  },
+]
+`;

--- a/x-pack/plugins/task_manager/server/integration_tests/task_cost_check.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/task_cost_check.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  type TestElasticsearchUtils,
+  type TestKibanaUtils,
+} from '@kbn/core-test-helpers-kbn-server';
+import { TaskCost, TaskDefinition } from '../task';
+import { setupTestServers } from './lib';
+import { TaskTypeDictionary } from '../task_type_dictionary';
+
+jest.mock('../task_type_dictionary', () => {
+  const actual = jest.requireActual('../task_type_dictionary');
+  return {
+    ...actual,
+    TaskTypeDictionary: jest.fn().mockImplementation((opts) => {
+      return new actual.TaskTypeDictionary(opts);
+    }),
+  };
+});
+
+// Notify response-ops if a task sets a cost to something other than `Normal`
+describe('Task cost checks', () => {
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+  let taskTypeDictionary: TaskTypeDictionary;
+
+  beforeAll(async () => {
+    const setupResult = await setupTestServers();
+    esServer = setupResult.esServer;
+    kibanaServer = setupResult.kibanaServer;
+
+    const mockedTaskTypeDictionary = jest.requireMock('../task_type_dictionary');
+    expect(mockedTaskTypeDictionary.TaskTypeDictionary).toHaveBeenCalledTimes(1);
+    taskTypeDictionary = mockedTaskTypeDictionary.TaskTypeDictionary.mock.results[0].value;
+  });
+
+  afterAll(async () => {
+    if (kibanaServer) {
+      await kibanaServer.stop();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+  });
+
+  it('detects tasks with cost definitions', async () => {
+    const taskTypes = taskTypeDictionary.getAllDefinitions();
+    const taskTypesWithCost = taskTypes
+      .map((taskType: TaskDefinition) =>
+        !!taskType.cost ? { taskType: taskType.type, cost: taskType.cost } : null
+      )
+      .filter(
+        (tt: { taskType: string; cost: TaskCost } | null) =>
+          null != tt && tt.cost !== TaskCost.Normal
+      );
+    expect(taskTypesWithCost).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/189112

## Summary

Adds a mapping to the alerting rule type registry to manage rule types with a custom task cost and register appropriately. Adds an integration test to task manager so we can be alerted to task types that register with non-normal task costs.