### PR TITLE
[CI] Fix LauchDarkly References Action triggering on forks

### DIFF
--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   launchDarklyCodeReferences:
     name: LaunchDarkly Code References
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -17,11 +17,11 @@ jobs:
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
-    - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.12.0
-      with:
-        accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
-        projKey: ${{ secrets.LD_PROJECT_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
+      - name: LaunchDarkly Code References
+        uses: launchdarkly/find-code-references@v2.12.0
+        with:
+          accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
+          projKey: ${{ secrets.LD_PROJECT_KEY }}

--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'fix/ld-action-triggering-on-forks'
 
 # cancel in-flight workflow run if another push was triggered
 concurrency:
@@ -14,7 +13,7 @@ concurrency:
 jobs:
   launchDarklyCodeReferences:
     name: LaunchDarkly Code References
-    if: github.event.repository.fork == true
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'fix/ld-action-triggering-on-forks'
 
 # cancel in-flight workflow run if another push was triggered
 concurrency:
@@ -13,6 +14,7 @@ concurrency:
 jobs:
   launchDarklyCodeReferences:
     name: LaunchDarkly Code References
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

This action is triggering on pushes to `main` on forks as well, this PR skips the action on forks. The action will fail on the fork and notify the developer.

### Testing
Failure on my fork's `main` before this PR
https://github.com/Ikuni17/kibana/actions/runs/10100674569

Tested with this branch in my fork and it skipped properly 96e2ed6e607e93ee446e0738cbf9b53f11beffe3
https://github.com/Ikuni17/kibana/actions/runs/10101514673

Flipped the flag to ensure it's working 2a586ccd73566466cb4edec659a9a576e0a281c6
https://github.com/Ikuni17/kibana/actions/runs/10101534520