### PR TITLE
Change the link of 'Manage Inference endpoints' to 'Inference Management view'

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -205,7 +205,7 @@ export const INFERENCE_ENDPOINTS_PLUGIN = {
   DESCRIPTION: i18n.translate('xpack.enterpriseSearch.inferenceEndpoints.description', {
     defaultMessage: 'View for managing inference endpoints.',
   }),
-  URL: '/app',
+  URL: '/app/enterprise_search/relevance',
   LOGO: 'logoEnterpriseSearch',
   SUPPORT_URL: 'https://discuss.elastic.co/c/enterprise-search/',
 };

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -205,7 +205,7 @@ export const INFERENCE_ENDPOINTS_PLUGIN = {
   DESCRIPTION: i18n.translate('xpack.enterpriseSearch.inferenceEndpoints.description', {
     defaultMessage: 'View for managing inference endpoints.',
   }),
-  URL: '/app/enterprise_search/relevance',
+  URL: '/app',
   LOGO: 'logoEnterpriseSearch',
   SUPPORT_URL: 'https://discuss.elastic.co/c/enterprise-search/',
 };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -88,7 +88,7 @@ const baseNavItems = [
     id: 'relevance',
     items: [
       {
-        href: '/app/enterprise_search/relevance/inference_endpoints',
+        href: '/app/inference_endpoints',
         id: 'inference_endpoints',
         items: undefined,
         name: 'Inference Endpoints',

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -88,7 +88,7 @@ const baseNavItems = [
     id: 'relevance',
     items: [
       {
-        href: '/app/inference_endpoints',
+        href: '/app/enterprise_search/relevance/inference_endpoints',
         id: 'inference_endpoints',
         items: undefined,
         name: 'Inference Endpoints',

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -23,7 +23,14 @@ const mockDispatch = jest.fn();
 
 jest.mock('../../../public/application/app_context', () => ({
   useAppContext: jest.fn().mockReturnValue({
-    core: { application: {} },
+    core: {
+      application: {},
+      http: {
+        basePath: {
+          get: jest.fn().mockReturnValue('/base-path'),
+        },
+      },
+    },
     docLinks: {
       links: {
         enterpriseSearch: {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -89,17 +89,13 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
   value,
 }) => {
   const {
-    core: { application },
+    core: { application, http },
     docLinks,
     plugins: { ml },
   } = useAppContext();
   const config = getFieldConfig('inference_id');
 
-  const getMlTrainedModelPageUrl = useCallback(async () => {
-    return await ml?.locator?.getUrl({
-      page: 'trained_models',
-    });
-  }, [ml]);
+  const inferenceEndpointsPageLink = `${http.basePath.get()}/app/inference_endpoints`;
 
   const [isInferenceFlyoutVisible, setIsInferenceFlyoutVisible] = useState<boolean>(false);
   const [availableTrainedModels, setAvailableTrainedModels] = useState<
@@ -250,10 +246,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
           size="s"
           data-test-subj="manageInferenceEndpointButton"
           onClick={async () => {
-            const mlTrainedPageUrl = await getMlTrainedModelPageUrl();
-            if (typeof mlTrainedPageUrl === 'string') {
-              application.navigateToUrl(mlTrainedPageUrl);
-            }
+            application.navigateToUrl(inferenceEndpointsPageLink);
           }}
         >
           {i18n.translate(

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -95,7 +95,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
   } = useAppContext();
   const config = getFieldConfig('inference_id');
 
-  const inferenceEndpointsPageLink = `${http.basePath.get()}/app/inference_endpoints`;
+  const inferenceEndpointsPageLink = `${http.basePath.get()}/app/enterprise_search/relevance/inference_endpoints`;
 
   const [isInferenceFlyoutVisible, setIsInferenceFlyoutVisible] = useState<boolean>(false);
   const [availableTrainedModels, setAvailableTrainedModels] = useState<

--- a/x-pack/plugins/search_inference_endpoints/public/plugin.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/plugin.ts
@@ -38,7 +38,7 @@ export class SearchInferenceEndpointsPlugin
 
     core.application.register({
       id: PLUGIN_ID,
-      appRoute: '/app',
+      appRoute: '/app/search_inference_endpoints',
       title: PLUGIN_NAME,
       async mount({ element, history }: AppMountParameters) {
         const { renderApp } = await import('./application');

--- a/x-pack/plugins/search_inference_endpoints/public/plugin.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/plugin.ts
@@ -38,7 +38,7 @@ export class SearchInferenceEndpointsPlugin
 
     core.application.register({
       id: PLUGIN_ID,
-      appRoute: '/app/search_inference_endpoints',
+      appRoute: '/app',
       title: PLUGIN_NAME,
       async mount({ element, history }: AppMountParameters) {
         const { renderApp } = await import('./application');


### PR DESCRIPTION
This PR resolves https://github.com/elastic/search-team/issues/7978

Currently, 'Manage inference endpoints' is redirected to the trained models page. In this task, we need to change the link to 'Inference Endpoints' page.


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->