### PR TITLE
[Search/Connector] Make minute-level scheduling default option in ConnectorCronEditor

### DIFF
--- a/packages/kbn-search-connectors/components/scheduling/connector_cron_editor.tsx
+++ b/packages/kbn-search-connectors/components/scheduling/connector_cron_editor.tsx
@@ -26,7 +26,7 @@ interface ConnectorCronEditorProps {
 export const ConnectorCronEditor: React.FC<ConnectorCronEditorProps> = ({
   dataTelemetryIdPrefix,
   disabled = false,
-  frequencyBlockList = ['MINUTE'],
+  frequencyBlockList = [],
   hasSyncTypeChanges,
   onReset,
   onSave,

--- a/packages/kbn-search-connectors/components/scheduling/full_content.tsx
+++ b/packages/kbn-search-connectors/components/scheduling/full_content.tsx
@@ -216,9 +216,6 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
                 hasSyncTypeChanges={hasSyncTypeChanges}
                 setHasSyncTypeChanges={setHasSyncTypeChanges}
                 disabled={isGated}
-                frequencyBlockList={
-                  type === SyncJobType.ACCESS_CONTROL || type === SyncJobType.FULL ? [] : undefined
-                }
                 scheduling={scheduling[type]}
                 onReset={() => {
                   setScheduling({


### PR DESCRIPTION
## Summary

Enable minute level scheduling in UI for all connector sync jobs. This fixes the bug with minute level scheduling not present for incremental sync jobs.

It seems that during [this migration](https://github.com/elastic/kibana/commit/bb5ca2e187c6c302625c38ccd85ae1965c47fdbc#diff-328630e75e33bdb823bad243330681942ab5a391c5b83cad7f3186c4ca651e9dL219) the minute level scheduling for incremental syncs was lost somehow. 

As of now the `ConnectorCronEditor` is only used for connector sync jobs, all connector sync jobs support minute-level scheduling so I deleted the `MINUTE` from default `frequencyBlockList` in the component.

<img width="680" alt="Screenshot 2024-07-26 at 10 32 16" src="https://github.com/user-attachments/assets/7070227e-b332-4217-beea-a169c8b3d4fc">




<!--ONMERGE {"backportTargets":["8.14","8.15"]} ONMERGE-->