### PR TITLE
[Log threhsod, SLO burn rate] Save the ECS group by fields at the AAD root level

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/log_threshold/log_threshold_executor.ts
@@ -31,7 +31,7 @@ import {
   PublicAlertsClient,
   RecoveredAlertData,
 } from '@kbn/alerting-plugin/server/alerts_client/types';
-import { type Group } from '@kbn/observability-alerting-rule-utils';
+import { getEcsGroups, type Group } from '@kbn/observability-alerting-rule-utils';
 
 import { ecsFieldMap } from '@kbn/rule-registry-plugin/common/assets/field_maps/ecs_field_map';
 import { decodeOrThrow } from '@kbn/io-ts-utils';
@@ -191,6 +191,7 @@ export const createLogThresholdExecutor =
             [ALERT_CONTEXT]: alertContext,
             [ALERT_GROUP]: groups,
             ...flattenAdditionalContext(rootLevelContext),
+            ...getEcsGroups(groups),
           };
 
           alertsClient.setAlertData({

--- a/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/executor.ts
+++ b/x-pack/plugins/observability_solution/slo/server/lib/rules/slo_burn_rate/executor.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import numeral from '@elastic/numeral';
+import { getEcsGroups } from '@kbn/observability-alerting-rule-utils';
 import {
   ALERT_EVALUATION_THRESHOLD,
   ALERT_EVALUATION_VALUE,
@@ -184,6 +185,7 @@ export const getRuleExecutor = ({
               [SLO_ID_FIELD]: slo.id,
               [SLO_REVISION_FIELD]: slo.revision,
               [SLO_INSTANCE_ID_FIELD]: instanceId,
+              ...getEcsGroups(groups),
             },
           });
 

--- a/x-pack/plugins/observability_solution/slo/tsconfig.json
+++ b/x-pack/plugins/observability_solution/slo/tsconfig.json
@@ -95,6 +95,7 @@
     "@kbn/react-kibana-context-render",
     "@kbn/core-application-browser",
     "@kbn/core-theme-browser",
-    "@kbn/ebt-tools"
+    "@kbn/ebt-tools",
+    "@kbn/observability-alerting-rule-utils"
   ]
 }


### PR DESCRIPTION
Related to #183220

## Summary

This PR saves ECS groups in the Alert As Data (AAD) document for the log threshold and SLO burn rate rules.

|Rule|AAD document|
|---|---|
|SLO burn rate|![image](https://github.com/user-attachments/assets/c5476e33-95d0-4c39-af12-2ef5a9768ab0)|
|Log threshold|![image](https://github.com/user-attachments/assets/34fc6662-c4c3-4b3e-9d77-f0959f726394)|

### 🧪 How to test
- Create a log threshold and SLO burn rate rule with multiple groups (both ECS and non-ECS fields)
- Check the related AAD document; you should be able to see the ECS fields at the root level and not see non-ECS fields there
- Check the same information for the recovered alerts
- Rules without group by should work as before