### PR TITLE
[Dataset quality] Adding execution context to data quality page within management app

### DIFF
--- a/x-pack/plugins/data_quality/public/application.tsx
+++ b/x-pack/plugins/data_quality/public/application.tsx
@@ -12,10 +12,12 @@ import ReactDOM from 'react-dom';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { Route, Router, Routes } from '@kbn/shared-ux-router';
 import { PerformanceContextProvider } from '@kbn/ebt-tools';
+import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
 import { KbnUrlStateStorageFromRouterProvider } from './utils/kbn_url_state_context';
 import { useKibanaContextForPluginProvider } from './utils/use_kibana';
 import { AppPluginStartDependencies, DataQualityPluginStart } from './types';
 import { DatasetQualityRoute } from './routes';
+import { PLUGIN_ID } from '../common';
 
 export const renderApp = (
   core: CoreStart,
@@ -31,6 +33,33 @@ export const renderApp = (
   return () => {
     ReactDOM.unmountComponentAtNode(params.element);
   };
+};
+
+const AppWithExecutionContext = ({
+  core,
+  params,
+}: {
+  core: CoreStart;
+  params: ManagementAppMountParams;
+}) => {
+  const { executionContext } = core;
+
+  useExecutionContext(executionContext, {
+    type: 'application',
+    page: PLUGIN_ID,
+  });
+
+  return (
+    <KbnUrlStateStorageFromRouterProvider>
+      <Router history={params.history}>
+        <PerformanceContextProvider>
+          <Routes>
+            <Route path="/" exact={true} render={() => <DatasetQualityRoute />} />
+          </Routes>
+        </PerformanceContextProvider>
+      </Router>
+    </KbnUrlStateStorageFromRouterProvider>
+  );
 };
 
 interface AppProps {
@@ -51,15 +80,7 @@ const App = ({ core, plugins, pluginStart, params }: AppProps) => {
   return (
     <KibanaRenderContextProvider {...core} {...params}>
       <KibanaContextProviderForPlugin>
-        <KbnUrlStateStorageFromRouterProvider>
-          <Router history={params.history}>
-            <PerformanceContextProvider>
-              <Routes>
-                <Route path="/" exact={true} render={() => <DatasetQualityRoute />} />
-              </Routes>
-            </PerformanceContextProvider>
-          </Router>
-        </KbnUrlStateStorageFromRouterProvider>
+        <AppWithExecutionContext core={core} params={params} />
       </KibanaContextProviderForPlugin>
     </KibanaRenderContextProvider>
   );


### PR DESCRIPTION
This PR aims to improve `context.page_name` within stack telemetry.
After the changes we will start seeing information about dataset quality in `application:management:data_quality` rather than just a generic pageName such as `application:management`.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d172353a-824d-46f7-8d5e-7c564375827a">
