### PR TITLE
[Search] Fix index error incorrectly showing up

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_error.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_error.tsx
@@ -66,7 +66,7 @@ function hasProperties(field: MappingProperty): field is MappingPropertyBase {
 }
 
 function isLocalModel(model: InferenceServiceSettings): model is LocalInferenceServiceSettings {
-  return Boolean((model as LocalInferenceServiceSettings).service_settings.model_id);
+  return ['elser', 'elasticsearch'].includes((model as LocalInferenceServiceSettings).service);
 }
 
 export const IndexError: React.FC<IndexErrorProps> = ({ indexName }) => {
@@ -124,7 +124,7 @@ export const IndexError: React.FC<IndexErrorProps> = ({ indexName }) => {
             if (!modelStats || modelStats.deployment_stats?.state !== 'started') {
               return {
                 error: i18n.translate(
-                  'xpack.enterpriseSearch.indexOverview.indexErrors.missingModelError',
+                  'xpack.enterpriseSearch.indexOverview.indexErrors.modelNotDeployedError',
                   {
                     defaultMessage:
                       'Model {modelId} for inference endpoint {inferenceId} in field {fieldName} has not been started',


### PR DESCRIPTION
## Summary

This fixes a bug where the index error would show up for third-party models because the logic for determining local models was incorrect.

## Release note

Fixed a bug where an index error about the `semantic_text` field would be incorrectly displayed when the inference endpoint was configured and available.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->