### PR TITLE
[integration automatic-import] appending input.type to title

### DIFF
--- a/x-pack/plugins/integration_assistant/server/templates/manifest/package_manifest.yml.njk
+++ b/x-pack/plugins/integration_assistant/server/templates/manifest/package_manifest.yml.njk
@@ -26,7 +26,7 @@ policy_templates:
     inputs: {% for input in inputs %}
       - type: {{ input.type }}
         title: |
-          {{ input.title }}
+          {{ input.title }} : {{ input.type }}
         description: |
           {{ input.description }} {% endfor %}
 owner:


### PR DESCRIPTION
Appending the input type to the title for better clarity during configuration

Resolves https://github.com/elastic/kibana/issues/189207

<img width="816" alt="Screenshot 2024-07-26 at 10 46 26 AM" src="https://github.com/user-attachments/assets/4c780cc5-7190-498c-b4ff-5633594dcb52">




<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->