### PR TITLE
Observability Onboarding: Show otel tile on integrations page (#189163)

### DIFF
--- a/test/api_integration/apis/custom_integration/integrations.ts
+++ b/test/api_integration/apis/custom_integration/integrations.ts
@@ -22,7 +22,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(resp.body).to.be.an('array');
 
-        expect(resp.body.length).to.be(55);
+        expect(resp.body.length).to.be(56);
 
         // Test for sample data card
         expect(resp.body.findIndex((c: { id: string }) => c.id === 'sample_data_all')).to.be.above(

--- a/x-pack/plugins/observability_solution/observability_onboarding/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_onboarding/kibana.jsonc
@@ -20,7 +20,8 @@
       "discover",
       "share",
       "fleet",
-      "security"
+      "security",
+      "customIntegrations",
     ],
     "optionalPlugins": [
       "cloud",

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/plugin.ts
@@ -13,6 +13,7 @@ import type {
   PluginInitializerContext,
 } from '@kbn/core/server';
 import { mapValues } from 'lodash';
+import { i18n } from '@kbn/i18n';
 import { getObservabilityOnboardingServerRouteRepository } from './routes';
 import { registerRoutes } from './routes/register_routes';
 import { ObservabilityOnboardingRouteHandlerResources } from './routes/types';
@@ -81,6 +82,27 @@ export class ObservabilityOnboardingPlugin
       services: {
         esLegacyConfigService: this.esLegacyConfigService,
       },
+    });
+
+    plugins.customIntegrations.registerCustomIntegration({
+      id: 'otel',
+      title: i18n.translate('xpack.observability_onboarding.otelTile.title', {
+        defaultMessage: 'OpenTelemetry',
+      }),
+      categories: ['observability'],
+      uiInternalPath: '/app/observabilityOnboarding/otel-logs',
+      description: i18n.translate('xpack.observability_onboarding.otelTile.description', {
+        defaultMessage:
+          'Collect logs and host metrics using the Elastic distribution of the OpenTelemetry Collector',
+      }),
+      icons: [
+        {
+          type: 'svg',
+          src: core.http.staticAssets.getPluginAssetHref('opentelemetry.svg') ?? '',
+        },
+      ],
+      shipper: 'tutorial',
+      isBeta: true,
     });
 
     return {};

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/types.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/types.ts
@@ -15,6 +15,10 @@ import { FleetSetupContract, FleetStartContract } from '@kbn/fleet-plugin/server
 import { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/server';
 import { ObservabilityPluginSetup } from '@kbn/observability-plugin/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+import {
+  CustomIntegrationsPluginSetup,
+  CustomIntegrationsPluginStart,
+} from '@kbn/custom-integrations-plugin/server';
 
 export interface ObservabilityOnboardingPluginSetupDependencies {
   data: DataPluginSetup;
@@ -23,6 +27,7 @@ export interface ObservabilityOnboardingPluginSetupDependencies {
   usageCollection: UsageCollectionSetup;
   fleet: FleetSetupContract;
   security: SecurityPluginSetup;
+  customIntegrations: CustomIntegrationsPluginSetup;
 }
 
 export interface ObservabilityOnboardingPluginStartDependencies {
@@ -32,6 +37,7 @@ export interface ObservabilityOnboardingPluginStartDependencies {
   usageCollection: undefined;
   fleet: FleetStartContract;
   security: SecurityPluginStart;
+  customIntegrations: CustomIntegrationsPluginStart;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/x-pack/plugins/observability_solution/observability_onboarding/tsconfig.json
+++ b/x-pack/plugins/observability_solution/observability_onboarding/tsconfig.json
@@ -43,7 +43,8 @@
     "@kbn/spaces-plugin",
     "@kbn/ebt",
     "@kbn/dashboard-plugin",
-    "@kbn/deeplinks-analytics"
+    "@kbn/deeplinks-analytics",
+    "@kbn/custom-integrations-plugin"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - https://github.com/elastic/kibana/pull/189163

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)