### PR TITLE
[Functional test suite] add 'disable-search-engine-choice-screen' option to Chromium options

### DIFF
--- a/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
+++ b/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
@@ -116,7 +116,9 @@ function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean
     // Use fake device for Media Stream to replace actual camera and microphone.
     'use-fake-device-for-media-stream',
     // Bypass the media stream infobar by selecting the default device for media streams (e.g. WebRTC). Works with --use-fake-device-for-media-stream.
-    'use-fake-ui-for-media-stream'
+    'use-fake-ui-for-media-stream',
+    // Do not show "Choose your search engine" dialog (> Chrome v127)
+    'disable-search-engine-choice-screen'
   );
 
   if (process.platform === 'linux') {


### PR DESCRIPTION
After Chrome upgrade to v127, this popup started appearing when running functional test suite and making it impossible for the tests to run:

<img width="1083" alt="Screenshot 2024-07-29 at 12 49 12" src="https://github.com/user-attachments/assets/5fedd3f2-aac9-4fca-a5f5-66ac7342b783">

Adding this flag prevents it from happening.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->