### PR TITLE
[Custom threshold] Hide `aggregate_metric_double` fields for `last_value` aggregation

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
@@ -21,6 +21,7 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { ValidNormalizedTypes } from '@kbn/triggers-actions-ui-plugin/public';
 import { get } from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
+import { ES_FIELD_TYPES } from '@kbn/field-types';
 import { Aggregators } from '../../../../../common/custom_threshold_rule/types';
 import { RuleFlyoutKueryBar } from '../../../rule_kql_filter/kuery_bar';
 import { ClosablePopoverTitle } from '../closable_popover_title';
@@ -68,7 +69,13 @@ export function MetricRowWithAgg({
             fieldValue.normalizedType as ValidNormalizedTypes
           )
         ) {
-          acc.push({ label: fieldValue.name });
+          if (aggType === Aggregators.LAST_VALUE) {
+            if (!fieldValue.esTypes?.includes(ES_FIELD_TYPES.AGGREGATE_METRIC_DOUBLE)) {
+              acc.push({ label: fieldValue.name });
+            }
+          } else {
+            acc.push({ label: fieldValue.name });
+          }
         }
         return acc;
       }, [] as Array<{ label: string }>),

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/custom_equation/types.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/custom_equation/types.ts
@@ -17,6 +17,7 @@ export interface AggregationTypes {
 export interface NormalizedField {
   name: string;
   normalizedType: string;
+  esTypes?: string[];
 }
 
 export type NormalizedFields = NormalizedField[];

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/expression_row.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/expression_row.tsx
@@ -112,6 +112,7 @@ export const ExpressionRow: React.FC<ExpressionRowProps> = (props) => {
 
   const normalizedFields = fields.map((f) => ({
     normalizedType: f.type,
+    esTypes: f.esTypes,
     name: f.name,
   }));
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/189374
