### PR TITLE
Added disable-component-update flag

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -35,10 +35,6 @@ disabled:
   - x-pack/test/fleet_cypress/config.ts
   - x-pack/test/fleet_cypress/visual_config.ts
 
-  # http/2 security muted tests
-  - x-pack/test/security_functional/saml.http2.config.ts
-  - x-pack/test/security_functional/oidc.http2.config.ts
-
 defaultQueue: 'n2-4-spot'
 enabled:
   - test/accessibility/config.ts
@@ -326,6 +322,8 @@ enabled:
   - x-pack/test/security_functional/login_selector.config.ts
   - x-pack/test/security_functional/oidc.config.ts
   - x-pack/test/security_functional/saml.config.ts
+  - x-pack/test/security_functional/saml.http2.config.ts
+  - x-pack/test/security_functional/oidc.http2.config.ts
   - x-pack/test/security_functional/insecure_cluster_warning.config.ts
   - x-pack/test/security_functional/user_profiles.config.ts
   - x-pack/test/security_functional/expired_session.config.ts

--- a/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
+++ b/packages/kbn-ftr-common-functional-ui-services/services/remote/webdriver.ts
@@ -118,7 +118,9 @@ function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean
     // Bypass the media stream infobar by selecting the default device for media streams (e.g. WebRTC). Works with --use-fake-device-for-media-stream.
     'use-fake-ui-for-media-stream',
     // Do not show "Choose your search engine" dialog (> Chrome v127)
-    'disable-search-engine-choice-screen'
+    'disable-search-engine-choice-screen',
+    // Disable component updater used for Chrome Certificate Verifier
+    'disable-component-update'
   );
 
   if (process.platform === 'linux') {


### PR DESCRIPTION
## Summary

Added `disable-component-update` flag to webdriver config.

After enabling HTTP2 for SAML and OIDC, we observed [test flakiness](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6637). There was an error `net::ERR_CERT_VERIFIER_CHANGED` related to certificates. Upon investigation, I found that this issue is linked to Chrome [Component Updater](https://chromium.googlesource.com/chromium/src/+/lkgr/components/component_updater/README.md), which handles certificate updates (additions and revocations) for the [Chrome Certificate Verifier](https://chromium.googlesource.com/chromium/src/+/main/net/data/ssl/chrome_root_store/faq.md#What-is-the-Chrome-Certificate-Verifier).

The issue persists only with TLS over HTTP2 ([OIDC runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6637), [SAML runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6636)). With Component Updater disabled there are no certificate issues with both HTTP2 or HTTP1. The `disable-component-update` flag  has been added for both protocols, as there is no need to keep it enabled in the test environment.

For the reference call chain from chromium source code:
 [kCertVerifierChanged](https://source.chromium.org/chromium/chromium/src/+/main:net/spdy/spdy_session_pool.cc;l=532?q=ERR_CERT_VERIFIER_CHANGED&ss=chromium%2Fchromium%2Fsrc) -> [OnCertVerifierChanged](https://source.chromium.org/chromium/chromium/src/+/main:net/socket/ssl_client_socket.cc;bpv=1;bpt=1;l=188?q=kCertVerifierChanged&ss=chromium%2Fchromium%2Fsrc&gsn=OnCertVerifierChanged&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fchromium.googlesource.com%2Fcodesearch%2Fchromium%2Fsrc%2F%2Fmain%3Flang%3Dc%252B%252B%3Fpath%3Dnet%2Fsocket%2Fssl_client_socket.cc%23pGBJim6uGTetVNACAyPYRzWbtenbhrA0ZIjG00xYZlY) -> [observer.OnCertVerifierChanged()](https://source.chromium.org/chromium/chromium/src/+/main:net/cert/multi_threaded_cert_verifier.cc;l=255;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729) -> [called in UpdateVerifyProcData](https://source.chromium.org/chromium/chromium/src/+/main:net/cert/multi_threaded_cert_verifier.cc;l=233;drc=7b232da0f22e8cdf555d43c52b6491baeb87f729;bpv=1;bpt=1?q=NotifyCertVerifierChanged&ss=chromium%2Fchromium%2Fsrc) -> [UpdateAdditionalCertificates](https://source.chromium.org/chromium/chromium/src/+/main:services/cert_verifier/cert_verifier_service.cc;l=135).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

__Fixes: https://github.com/elastic/kibana/issues/186675, https://github.com/elastic/kibana/issues/186780__