### PR TITLE
OTel onboarding: Change link

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -875,7 +875,7 @@ rm ./otel.yml && cp ./otel_samples/platformlogs_hostmetrics.yml ./otel.yml && mk
                           link: (
                             <EuiLink
                               data-test-subj="observabilityOnboardingOtelLogsPanelDocumentationLink"
-                              href="https://www.elastic.co/guide/en/observability/current/get-started-opentelemetry.html"
+                              href="https://ela.st/elastic-otel"
                               target="_blank"
                               external
                             >


### PR DESCRIPTION
To have more flexibility in changing the location later on, use an ela.st link instead of a hardcoded documentation page.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->