### PR TITLE
[8.15] [ES|QL] distinguish between trigger kinds in tests (#188604)

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -1,0 +1,318 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { camelCase } from 'lodash';
+import { getAstAndSyntaxErrors } from '@kbn/esql-ast';
+import { evalFunctionDefinitions } from '../../definitions/functions';
+import { builtinFunctions } from '../../definitions/builtin';
+import { statsAggregationFunctionDefinitions } from '../../definitions/aggs';
+import { chronoLiterals, timeUnitsToSuggest } from '../../definitions/literals';
+import { groupingFunctionDefinitions } from '../../definitions/grouping';
+import * as autocomplete from '../autocomplete';
+import type { ESQLCallbacks } from '../../shared/types';
+import type { EditorContext, SuggestionRawDefinition } from '../types';
+import { getFunctionSignatures } from '../../definitions/helpers';
+
+export type PartialSuggestionWithText = Partial<SuggestionRawDefinition> & { text: string };
+
+export interface Integration {
+  name: string;
+  hidden: boolean;
+  title?: string;
+  dataStreams: Array<{
+    name: string;
+    title?: string;
+  }>;
+}
+
+export const triggerCharacters = [',', '(', '=', ' '];
+
+export const fields: Array<{ name: string; type: string; suggestedAs?: string }> = [
+  ...[
+    'string',
+    'number',
+    'date',
+    'boolean',
+    'ip',
+    'geo_point',
+    'geo_shape',
+    'cartesian_point',
+    'cartesian_shape',
+  ].map((type) => ({
+    name: `${camelCase(type)}Field`,
+    type,
+  })),
+  { name: 'any#Char$Field', type: 'number', suggestedAs: '`any#Char$Field`' },
+  { name: 'kubernetes.something.something', type: 'number' },
+];
+
+export const indexes = (
+  [] as Array<{ name: string; hidden: boolean; suggestedAs?: string }>
+).concat(
+  [
+    'a',
+    'index',
+    'otherIndex',
+    '.secretIndex',
+    'my-index',
+    'my-index$',
+    'my_index{}',
+    'my-index+1',
+    'synthetics-*',
+  ].map((name) => ({
+    name,
+    hidden: name.startsWith('.'),
+  })),
+  ['my-index[quoted]', 'my:index', 'my,index', 'logstash-{now/d{yyyy.MM.dd|+12:00}}'].map(
+    (name) => ({
+      name,
+      hidden: false,
+      suggestedAs: `"${name}"`,
+    })
+  )
+);
+
+export const integrations: Integration[] = ['nginx', 'k8s'].map((name) => ({
+  name,
+  hidden: false,
+  title: `integration-${name}`,
+  dataStreams: [
+    {
+      name: `${name}-1`,
+      title: `integration-${name}-1`,
+    },
+  ],
+}));
+
+export const policies = [
+  {
+    name: 'policy',
+    sourceIndices: ['enrichIndex1'],
+    matchField: 'otherStringField',
+    enrichFields: ['otherField', 'yetAnotherField', 'yet-special-field'],
+    suggestedAs: undefined,
+  },
+  ...['my-policy[quoted]', 'my-policy$', 'my_policy{}'].map((name) => ({
+    name,
+    sourceIndices: ['enrichIndex1'],
+    matchField: 'otherStringField',
+    enrichFields: ['otherField', 'yetAnotherField', 'yet-special-field'],
+    suggestedAs: `\`${name}\``,
+  })),
+];
+
+/**
+ * Utility to filter down the function list for the given type
+ * It is mainly driven by the return type, but it can be filtered upon with the last optional argument "paramsTypes"
+ * jsut make sure to pass the arguments in the right order
+ * @param command current command context
+ * @param expectedReturnType the expected type returned by the function
+ * @param functionCategories
+ * @param paramsTypes the function argument types (optional)
+ * @returns
+ */
+export function getFunctionSignaturesByReturnType(
+  command: string,
+  _expectedReturnType: string | string[],
+  {
+    agg,
+    grouping,
+    evalMath,
+    builtin,
+    // skipAssign here is used to communicate to not propose an assignment if it's not possible
+    // within the current context (the actual logic has it, but here we want a shortcut)
+    skipAssign,
+  }: {
+    agg?: boolean;
+    grouping?: boolean;
+    evalMath?: boolean;
+    builtin?: boolean;
+    skipAssign?: boolean;
+  } = {},
+  paramsTypes?: string[],
+  ignored?: string[],
+  option?: string
+) {
+  const expectedReturnType = Array.isArray(_expectedReturnType)
+    ? _expectedReturnType
+    : [_expectedReturnType];
+
+  const list = [];
+  if (agg) {
+    list.push(...statsAggregationFunctionDefinitions);
+    // right now all grouping functions are agg functions too
+    list.push(...groupingFunctionDefinitions);
+  }
+  if (grouping) {
+    list.push(...groupingFunctionDefinitions);
+  }
+  // eval functions (eval is a special keyword in JS)
+  if (evalMath) {
+    list.push(...evalFunctionDefinitions);
+  }
+  if (builtin) {
+    list.push(...builtinFunctions.filter(({ name }) => (skipAssign ? name !== '=' : true)));
+  }
+
+  const deduped = Array.from(new Set(list));
+
+  return deduped
+    .filter(({ signatures, ignoreAsSuggestion, supportedCommands, supportedOptions, name }) => {
+      if (ignoreAsSuggestion) {
+        return false;
+      }
+      if (!supportedCommands.includes(command) && !supportedOptions?.includes(option || '')) {
+        return false;
+      }
+      const filteredByReturnType = signatures.filter(
+        ({ returnType }) =>
+          expectedReturnType.includes('any') || expectedReturnType.includes(returnType)
+      );
+      if (!filteredByReturnType.length) {
+        return false;
+      }
+      if (paramsTypes?.length) {
+        return filteredByReturnType.some(
+          ({ params }) =>
+            !params.length ||
+            (paramsTypes.length <= params.length &&
+              paramsTypes.every(
+                (expectedType, i) =>
+                  expectedType === 'any' ||
+                  params[i].type === 'any' ||
+                  expectedType === params[i].type
+              ))
+        );
+      }
+      return true;
+    })
+    .filter(({ name }) => {
+      if (ignored?.length) {
+        return !ignored?.includes(name);
+      }
+      return true;
+    })
+    .sort(({ name: a }, { name: b }) => a.localeCompare(b))
+    .map<PartialSuggestionWithText>((definition) => {
+      const { type, name, signatures } = definition;
+
+      if (type === 'builtin') {
+        return {
+          text: signatures.some(({ params }) => params.length > 1)
+            ? `${name.toUpperCase()} $0`
+            : name.toUpperCase(),
+          label: name.toUpperCase(),
+        };
+      }
+      const printedSignatures = getFunctionSignatures(definition, {
+        withTypes: true,
+        capitalize: true,
+      });
+      return {
+        text: `${name.toUpperCase()}($0)`,
+        label: printedSignatures[0].declaration,
+      };
+    });
+}
+
+export function getFieldNamesByType(_requestedType: string | string[]) {
+  const requestedType = Array.isArray(_requestedType) ? _requestedType : [_requestedType];
+  return fields
+    .filter(({ type }) => requestedType.includes('any') || requestedType.includes(type))
+    .map(({ name, suggestedAs }) => suggestedAs || name);
+}
+
+export function getLiteralsByType(_type: string | string[]) {
+  const type = Array.isArray(_type) ? _type : [_type];
+  if (type.includes('time_literal')) {
+    // return only singular
+    return timeUnitsToSuggest.map(({ name }) => `1 ${name}`).filter((s) => !/s$/.test(s));
+  }
+  if (type.includes('chrono_literal')) return chronoLiterals.map(({ name }) => name);
+  return [];
+}
+
+export function createCustomCallbackMocks(
+  customFields?: Array<{ name: string; type: string }>,
+  customSources?: Array<{ name: string; hidden: boolean }>,
+  customPolicies?: Array<{
+    name: string;
+    sourceIndices: string[];
+    matchField: string;
+    enrichFields: string[];
+  }>
+) {
+  const finalFields = customFields || fields;
+  const finalSources = customSources || indexes;
+  const finalPolicies = customPolicies || policies;
+  return {
+    getFieldsFor: jest.fn(async () => finalFields),
+    getSources: jest.fn(async () => finalSources),
+    getPolicies: jest.fn(async () => finalPolicies),
+  };
+}
+
+export function createCompletionContext(triggerCharacter?: string) {
+  if (triggerCharacter) {
+    return { triggerCharacter, triggerKind: 1 }; // any number is fine here
+  }
+  return {
+    triggerKind: 0,
+  };
+}
+
+export function getPolicyFields(policyName: string) {
+  return policies
+    .filter(({ name }) => name === policyName)
+    .flatMap(({ enrichFields }) =>
+      // ok, this is a bit of cheating as it's using the same logic as in the helper
+      enrichFields.map((field) => (/[^a-zA-Z\d_\.@]/.test(field) ? `\`${field}\`` : field))
+    );
+}
+
+export interface SuggestOptions {
+  ctx?: EditorContext;
+  callbacks?: ESQLCallbacks;
+}
+
+export const setup = async (caret = '/') => {
+  if (caret.length !== 1) {
+    throw new Error('Caret must be a single character');
+  }
+
+  const callbacks = createCustomCallbackMocks();
+
+  const suggest = async (query: string, opts: SuggestOptions = {}) => {
+    const pos = query.indexOf(caret);
+    if (pos < 0) throw new Error(`User cursor/caret "${caret}" not found in query: ${query}`);
+    const querySansCaret = query.slice(0, pos) + query.slice(pos + 1);
+    const ctx =
+      opts.ctx ??
+      (pos > 0 ? { triggerKind: 1, triggerCharacter: query[pos - 1] } : { triggerKind: 0 });
+    return await autocomplete.suggest(
+      querySansCaret,
+      pos,
+      ctx,
+      getAstAndSyntaxErrors,
+      opts.callbacks ?? callbacks
+    );
+  };
+
+  const assertSuggestions = async (query: string, expected: string[], opts?: SuggestOptions) => {
+    const result = await suggest(query, opts);
+    const resultTexts = [...result.map((suggestion) => suggestion.text)].sort();
+
+    expect(resultTexts).toEqual([...expected].sort());
+  };
+
+  return {
+    callbacks,
+    suggest,
+    assertSuggestions,
+  };
+};

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -8,311 +8,57 @@
 
 import { suggest } from './autocomplete';
 import { evalFunctionDefinitions } from '../definitions/functions';
-import { builtinFunctions } from '../definitions/builtin';
-import { statsAggregationFunctionDefinitions } from '../definitions/aggs';
-import { chronoLiterals, timeUnitsToSuggest } from '../definitions/literals';
+import { timeUnitsToSuggest } from '../definitions/literals';
 import { commandDefinitions } from '../definitions/commands';
 import { getUnitDuration, TRIGGER_SUGGESTION_COMMAND } from './factories';
 import { camelCase, partition } from 'lodash';
 import { getAstAndSyntaxErrors } from '@kbn/esql-ast';
-import { groupingFunctionDefinitions } from '../definitions/grouping';
 import { FunctionParameter } from '../definitions/types';
 import { getParamAtPosition } from './helper';
 import { nonNullable } from '../shared/helpers';
+import {
+  policies,
+  getFunctionSignaturesByReturnType,
+  getFieldNamesByType,
+  getLiteralsByType,
+  // getDateLiteralsByFieldType,
+  createCustomCallbackMocks,
+  createCompletionContext,
+  getPolicyFields,
+  PartialSuggestionWithText,
+  indexes,
+  integrations,
+} from './__tests__/helpers';
 import { METADATA_FIELDS } from '../shared/constants';
-import { SuggestionRawDefinition } from './types';
-import { getFunctionSignatures } from '../definitions/helpers';
-
-export type PartialSuggestionWithText = Partial<SuggestionRawDefinition> & { text: string };
-
-interface Integration {
-  name: string;
-  hidden: boolean;
-  title?: string;
-  dataStreams: Array<{
-    name: string;
-    title?: string;
-  }>;
-}
-
-const triggerCharacters = [',', '(', '=', ' '];
-
-const fields: Array<{ name: string; type: string; suggestedAs?: string }> = [
-  ...[
-    'string',
-    'number',
-    'date',
-    'boolean',
-    'ip',
-    'geo_point',
-    'geo_shape',
-    'cartesian_point',
-    'cartesian_shape',
-  ].map((type) => ({
-    name: `${camelCase(type)}Field`,
-    type,
-  })),
-  { name: 'any#Char$Field', type: 'number', suggestedAs: '`any#Char$Field`' },
-  { name: 'kubernetes.something.something', type: 'number' },
-];
-
-const indexes = ([] as Array<{ name: string; hidden: boolean; suggestedAs?: string }>).concat(
-  [
-    'a',
-    'index',
-    'otherIndex',
-    '.secretIndex',
-    'my-index',
-    'my-index$',
-    'my_index{}',
-    'my-index+1',
-    'synthetics-*',
-  ].map((name) => ({
-    name,
-    hidden: name.startsWith('.'),
-  })),
-  ['my-index[quoted]', 'my:index', 'my,index', 'logstash-{now/d{yyyy.MM.dd|+12:00}}'].map(
-    (name) => ({
-      name,
-      hidden: false,
-      suggestedAs: `"${name}"`,
-    })
-  )
-);
-
-const integrations: Integration[] = ['nginx', 'k8s'].map((name) => ({
-  name,
-  hidden: false,
-  title: `integration-${name}`,
-  dataStreams: [
-    {
-      name: `${name}-1`,
-      title: `integration-${name}-1`,
-    },
-  ],
-}));
-const policies = [
-  {
-    name: 'policy',
-    sourceIndices: ['enrichIndex1'],
-    matchField: 'otherStringField',
-    enrichFields: ['otherField', 'yetAnotherField', 'yet-special-field'],
-    suggestedAs: undefined,
-  },
-  ...['my-policy[quoted]', 'my-policy$', 'my_policy{}'].map((name) => ({
-    name,
-    sourceIndices: ['enrichIndex1'],
-    matchField: 'otherStringField',
-    enrichFields: ['otherField', 'yetAnotherField', 'yet-special-field'],
-    suggestedAs: `\`${name}\``,
-  })),
-];
-
-/**
- * Utility to filter down the function list for the given type
- * It is mainly driven by the return type, but it can be filtered upon with the last optional argument "paramsTypes"
- * jsut make sure to pass the arguments in the right order
- * @param command current command context
- * @param expectedReturnType the expected type returned by the function
- * @param functionCategories
- * @param paramsTypes the function argument types (optional)
- * @returns
- */
-function getFunctionSignaturesByReturnType(
-  command: string,
-  _expectedReturnType: string | string[],
-  {
-    agg,
-    grouping,
-    evalMath,
-    builtin,
-    // skipAssign here is used to communicate to not propose an assignment if it's not possible
-    // within the current context (the actual logic has it, but here we want a shortcut)
-    skipAssign,
-  }: {
-    agg?: boolean;
-    grouping?: boolean;
-    evalMath?: boolean;
-    builtin?: boolean;
-    skipAssign?: boolean;
-  } = {},
-  paramsTypes?: string[],
-  ignored?: string[],
-  option?: string
-) {
-  const expectedReturnType = Array.isArray(_expectedReturnType)
-    ? _expectedReturnType
-    : [_expectedReturnType];
-
-  const list = [];
-  if (agg) {
-    list.push(...statsAggregationFunctionDefinitions);
-    // right now all grouping functions are agg functions too
-    list.push(...groupingFunctionDefinitions);
-  }
-  if (grouping) {
-    list.push(...groupingFunctionDefinitions);
-  }
-  // eval functions (eval is a special keyword in JS)
-  if (evalMath) {
-    list.push(...evalFunctionDefinitions);
-  }
-  if (builtin) {
-    list.push(...builtinFunctions.filter(({ name }) => (skipAssign ? name !== '=' : true)));
-  }
-
-  const deduped = Array.from(new Set(list));
-
-  return deduped
-    .filter(({ signatures, ignoreAsSuggestion, supportedCommands, supportedOptions, name }) => {
-      if (ignoreAsSuggestion) {
-        return false;
-      }
-      if (!supportedCommands.includes(command) && !supportedOptions?.includes(option || '')) {
-        return false;
-      }
-      const filteredByReturnType = signatures.filter(
-        ({ returnType }) =>
-          expectedReturnType.includes('any') || expectedReturnType.includes(returnType)
-      );
-      if (!filteredByReturnType.length) {
-        return false;
-      }
-      if (paramsTypes?.length) {
-        return filteredByReturnType.some(
-          ({ params }) =>
-            !params.length ||
-            (paramsTypes.length <= params.length &&
-              paramsTypes.every(
-                (expectedType, i) =>
-                  expectedType === 'any' ||
-                  params[i].type === 'any' ||
-                  expectedType === params[i].type
-              ))
-        );
-      }
-      return true;
-    })
-    .filter(({ name }) => {
-      if (ignored?.length) {
-        return !ignored?.includes(name);
-      }
-      return true;
-    })
-    .sort(({ name: a }, { name: b }) => a.localeCompare(b))
-    .map<PartialSuggestionWithText>((definition) => {
-      const { type, name, signatures } = definition;
-
-      if (type === 'builtin') {
-        return {
-          text: signatures.some(({ params }) => params.length > 1)
-            ? `${name.toUpperCase()} $0`
-            : name.toUpperCase(),
-          label: name.toUpperCase(),
-        };
-      }
-      const printedSignatures = getFunctionSignatures(definition, {
-        withTypes: true,
-        capitalize: true,
-      });
-      return {
-        text: `${name.toUpperCase()}($0)`,
-        label: printedSignatures[0].declaration,
-      };
-    });
-}
-
-function getFieldNamesByType(_requestedType: string | string[]) {
-  const requestedType = Array.isArray(_requestedType) ? _requestedType : [_requestedType];
-  return fields
-    .filter(({ type }) => requestedType.includes('any') || requestedType.includes(type))
-    .map(({ name, suggestedAs }) => suggestedAs || name);
-}
-
-function getLiteralsByType(_type: string | string[]) {
-  const type = Array.isArray(_type) ? _type : [_type];
-  if (type.includes('time_literal')) {
-    // return only singular
-    return timeUnitsToSuggest.map(({ name }) => `1 ${name}`).filter((s) => !/s$/.test(s));
-  }
-  if (type.includes('chrono_literal')) {
-    return chronoLiterals.map(({ name }) => name);
-  }
-  return [];
-}
-
-function createCustomCallbackMocks(
-  customFields: Array<{ name: string; type: string }> | undefined,
-  customSources: Array<{ name: string; hidden: boolean }> | undefined,
-  customPolicies:
-    | Array<{
-        name: string;
-        sourceIndices: string[];
-        matchField: string;
-        enrichFields: string[];
-      }>
-    | undefined
-) {
-  const finalFields = customFields || fields;
-  const finalSources = customSources || indexes;
-  const finalPolicies = customPolicies || policies;
-  return {
-    getFieldsFor: jest.fn(async () => finalFields),
-    getSources: jest.fn(async () => finalSources),
-    getPolicies: jest.fn(async () => finalPolicies),
-  };
-}
-
-function createSuggestContext(text: string, triggerCharacter?: string) {
-  if (triggerCharacter) {
-    return { triggerCharacter, triggerKind: 1 }; // any number is fine here
-  }
-  const foundTriggerCharIndexes = triggerCharacters.map((char) => text.lastIndexOf(char));
-  const maxIndex = Math.max(...foundTriggerCharIndexes);
-  return {
-    triggerCharacter: text[maxIndex],
-    triggerKind: 1,
-  };
-}
-
-function getPolicyFields(policyName: string) {
-  return policies
-    .filter(({ name }) => name === policyName)
-    .flatMap(({ enrichFields }) =>
-      // ok, this is a bit of cheating as it's using the same logic as in the helper
-      enrichFields.map((field) => (/[^a-zA-Z\d_\.@]/.test(field) ? `\`${field}\`` : field))
-    );
-}
 
 describe('autocomplete', () => {
   type TestArgs = [
     string,
     Array<string | PartialSuggestionWithText>,
-    (string | number)?,
+    string?,
+    number?,
     Parameters<typeof createCustomCallbackMocks>?
   ];
 
-  const testSuggestionsFn = (
+  const _testSuggestionsFn = (
+    { only, skip }: { only?: boolean; skip?: boolean } = {},
     statement: string,
     expected: Array<string | PartialSuggestionWithText>,
-    triggerCharacter: string | number = '',
+    triggerCharacter?: string,
+    _offset?: number,
     customCallbacksArgs: Parameters<typeof createCustomCallbackMocks> = [
       undefined,
       undefined,
       undefined,
-    ],
-    { only, skip }: { only?: boolean; skip?: boolean } = {}
+    ]
   ) => {
-    const triggerCharacterString =
-      triggerCharacter == null || typeof triggerCharacter === 'string'
-        ? triggerCharacter
-        : statement[triggerCharacter + 1];
-    const context = createSuggestContext(statement, triggerCharacterString);
-    const offset =
-      typeof triggerCharacter === 'string'
-        ? statement.lastIndexOf(context.triggerCharacter) + 1
-        : triggerCharacter;
+    const context = createCompletionContext(triggerCharacter);
     const testFn = only ? test.only : skip ? test.skip : test;
+    const offset = _offset
+      ? _offset
+      : triggerCharacter
+      ? statement.lastIndexOf(triggerCharacter) + 1
+      : statement.length;
 
     testFn(
       `${statement} (triggerChar: "${context.triggerCharacter}" @ ${offset})=> ["${expected.join(
@@ -353,24 +99,12 @@ describe('autocomplete', () => {
   // DO NOT CHANGE THE NAME OF THIS FUNCTION WITHOUT ALSO CHANGING
   // THE LINTER RULE IN packages/kbn-eslint-config/typescript.js
   //
-  const testSuggestions = Object.assign(testSuggestionsFn, {
+  const testSuggestions = Object.assign(_testSuggestionsFn.bind(null, {}), {
     skip: (...args: TestArgs) => {
-      const paddingArgs = ['', [undefined, undefined, undefined]].slice(args.length - 2);
-      return testSuggestionsFn(
-        ...((args.length > 1 ? [...args, ...paddingArgs] : args) as TestArgs),
-        {
-          skip: true,
-        }
-      );
+      return _testSuggestionsFn({ skip: true }, ...args);
     },
     only: (...args: TestArgs) => {
-      const paddingArgs = ['', [undefined, undefined, undefined]].slice(args.length - 2);
-      return testSuggestionsFn(
-        ...((args.length > 1 ? [...args, ...paddingArgs] : args) as TestArgs),
-        {
-          only: true,
-        }
-      );
+      return _testSuggestionsFn({ only: true }, ...args);
     },
   });
 
@@ -420,7 +154,7 @@ describe('autocomplete', () => {
     testSuggestions('from a,', suggestedIndexes);
     testSuggestions('from a, b ', ['METADATA $0', ',', '|']);
     testSuggestions('from *,', suggestedIndexes);
-    testSuggestions('from index', suggestedIndexes, 5 /* space before index */);
+    testSuggestions('from index', suggestedIndexes, undefined, 5 /* space before index */);
     testSuggestions('from a, b [metadata ]', METADATA_FIELDS, ' ]');
     testSuggestions('from a, b metadata ', METADATA_FIELDS, ' ');
     testSuggestions(
@@ -439,9 +173,21 @@ describe('autocomplete', () => {
     const suggestedDataSources = dataSources
       .filter(({ hidden }) => !hidden)
       .map(({ name, suggestedAs }) => suggestedAs || name);
-    testSuggestions('from ', suggestedDataSources, '', [undefined, dataSources, undefined]);
-    testSuggestions('from a,', suggestedDataSources, '', [undefined, dataSources, undefined]);
-    testSuggestions('from *,', suggestedDataSources, '', [undefined, dataSources, undefined]);
+    testSuggestions('from ', suggestedDataSources, '', undefined, [
+      undefined,
+      dataSources,
+      undefined,
+    ]);
+    testSuggestions('from a,', suggestedDataSources, '', undefined, [
+      undefined,
+      dataSources,
+      undefined,
+    ]);
+    testSuggestions('from *,', suggestedDataSources, '', undefined, [
+      undefined,
+      dataSources,
+      undefined,
+    ]);
   });
 
   describe('show', () => {
@@ -534,7 +280,8 @@ describe('autocomplete', () => {
     testSuggestions(
       'from a | stats a=avg(numberField) | where numberField ',
       [],
-      '',
+      undefined,
+      undefined,
       // make the fields suggest aware of the previous STATS, leave the other callbacks untouched
       [[{ name: 'a', type: 'number' }], undefined, undefined]
     );
@@ -588,6 +335,7 @@ describe('autocomplete', () => {
         ),
         ...getFunctionSignaturesByReturnType('where', 'number', { evalMath: true }),
       ],
+      undefined,
       54 // after the first suggestions
     );
     testSuggestions(
@@ -598,42 +346,53 @@ describe('autocomplete', () => {
         ),
         ...getFunctionSignaturesByReturnType('where', 'number', { evalMath: true }),
       ],
+      undefined,
       58 // after the first suggestions
     );
   });
 
-  for (const command of ['grok', 'dissect']) {
-    describe(command, () => {
-      const constantPattern = command === 'grok' ? '"%{WORD:firstWord}"' : '"%{firstWord}"';
-      const subExpressions = [
-        '',
-        `${command} stringField |`,
-        `${command} stringField ${constantPattern} |`,
-        `dissect stringField ${constantPattern} append_separator = ":" |`,
-      ];
-      if (command === 'grok') {
-        subExpressions.push(`dissect stringField ${constantPattern} |`);
-      }
-      for (const subExpression of subExpressions) {
-        testSuggestions(`from a | ${subExpression} ${command} `, getFieldNamesByType('string'));
-        testSuggestions(`from a | ${subExpression} ${command} stringField `, [constantPattern]);
-        testSuggestions(
-          `from a | ${subExpression} ${command} stringField ${constantPattern} `,
-          (command === 'dissect' ? ['APPEND_SEPARATOR = $0'] : []).concat(['|'])
-        );
-        if (command === 'dissect') {
-          testSuggestions(
-            `from a | ${subExpression} ${command} stringField ${constantPattern} append_separator = `,
-            ['":"', '";"']
-          );
-          testSuggestions(
-            `from a | ${subExpression} ${command} stringField ${constantPattern} append_separator = ":" `,
-            ['|']
-          );
-        }
-      }
-    });
-  }
+  describe('grok', () => {
+    const constantPattern = '"%{WORD:firstWord}"';
+    const subExpressions = [
+      '',
+      `grok stringField |`,
+      `grok stringField ${constantPattern} |`,
+      `dissect stringField ${constantPattern} append_separator = ":" |`,
+      `dissect stringField ${constantPattern} |`,
+    ];
+    for (const subExpression of subExpressions) {
+      testSuggestions(`from a | ${subExpression} grok `, getFieldNamesByType('string'));
+      testSuggestions(`from a | ${subExpression} grok stringField `, [constantPattern], ' ');
+      testSuggestions(`from a | ${subExpression} grok stringField ${constantPattern} `, ['|']);
+    }
+  });
+
+  describe('dissect', () => {
+    const constantPattern = '"%{firstWord}"';
+    const subExpressions = [
+      '',
+      `dissect stringField |`,
+      `dissect stringField ${constantPattern} |`,
+      `dissect stringField ${constantPattern} append_separator = ":" |`,
+    ];
+    for (const subExpression of subExpressions) {
+      testSuggestions(`from a | ${subExpression} dissect `, getFieldNamesByType('string'));
+      testSuggestions(`from a | ${subExpression} dissect stringField `, [constantPattern], ' ');
+      testSuggestions(
+        `from a | ${subExpression} dissect stringField ${constantPattern} `,
+        ['APPEND_SEPARATOR = $0', '|'],
+        ' '
+      );
+      testSuggestions(
+        `from a | ${subExpression} dissect stringField ${constantPattern} append_separator = `,
+        ['":"', '";"']
+      );
+      testSuggestions(
+        `from a | ${subExpression} dissect stringField ${constantPattern} append_separator = ":" `,
+        ['|']
+      );
+    }
+  });
 
   describe('sort', () => {
     testSuggestions('from a | sort ', [
@@ -658,7 +417,7 @@ describe('autocomplete', () => {
 
   describe('rename', () => {
     testSuggestions('from a | rename ', getFieldNamesByType('any'));
-    testSuggestions('from a | rename stringField ', ['AS $0']);
+    testSuggestions('from a | rename stringField ', ['AS $0'], ' ');
     testSuggestions('from a | rename stringField as ', ['var0']);
   });
 
@@ -910,10 +669,11 @@ describe('autocomplete', () => {
         'kubernetes.something.something',
       ]);
       testSuggestions(`from a ${prevCommand}| enrich policy on b `, ['WITH $0', ',', '|']);
-      testSuggestions(`from a ${prevCommand}| enrich policy on b with `, [
-        'var0 =',
-        ...getPolicyFields('policy'),
-      ]);
+      testSuggestions(
+        `from a ${prevCommand}| enrich policy on b with `,
+        ['var0 =', ...getPolicyFields('policy')],
+        ' '
+      );
       testSuggestions(`from a ${prevCommand}| enrich policy on b with var0 `, ['= $0', ',', '|']);
       testSuggestions(`from a ${prevCommand}| enrich policy on b with var0 = `, [
         ...getPolicyFields('policy'),
@@ -935,10 +695,11 @@ describe('autocomplete', () => {
         `from a ${prevCommand}| enrich policy on b with var0 = stringField, var1 = `,
         [...getPolicyFields('policy')]
       );
-      testSuggestions(`from a ${prevCommand}| enrich policy with `, [
-        'var0 =',
-        ...getPolicyFields('policy'),
-      ]);
+      testSuggestions(
+        `from a ${prevCommand}| enrich policy with `,
+        ['var0 =', ...getPolicyFields('policy')],
+        ' '
+      );
       testSuggestions(`from a ${prevCommand}| enrich policy with stringField `, ['= $0', ',', '|']);
     }
   });
@@ -1014,11 +775,13 @@ describe('autocomplete', () => {
     );
     testSuggestions(
       'from a | eval raund(5, ', // note the typo in round
-      []
+      [],
+      ' '
     );
     testSuggestions(
       'from a | eval var0 = raund(5, ', // note the typo in round
-      []
+      [],
+      ' '
     );
     testSuggestions('from a | eval a=round(numberField) ', [
       ',',
@@ -1027,18 +790,26 @@ describe('autocomplete', () => {
         'number',
       ]),
     ]);
-    testSuggestions('from a | eval a=round(numberField, ', [
-      ...getFieldNamesByType('number'),
-      ...getFunctionSignaturesByReturnType('eval', 'number', { evalMath: true }, undefined, [
-        'round',
-      ]),
-    ]);
-    testSuggestions('from a | eval round(numberField, ', [
-      ...getFieldNamesByType('number'),
-      ...getFunctionSignaturesByReturnType('eval', 'number', { evalMath: true }, undefined, [
-        'round',
-      ]),
-    ]);
+    testSuggestions(
+      'from a | eval a=round(numberField, ',
+      [
+        ...getFieldNamesByType('number'),
+        ...getFunctionSignaturesByReturnType('eval', 'number', { evalMath: true }, undefined, [
+          'round',
+        ]),
+      ],
+      ' '
+    );
+    testSuggestions(
+      'from a | eval round(numberField, ',
+      [
+        ...getFieldNamesByType('number'),
+        ...getFunctionSignaturesByReturnType('eval', 'number', { evalMath: true }, undefined, [
+          'round',
+        ]),
+      ],
+      ' '
+    );
     testSuggestions('from a | eval a=round(numberField),', [
       'var0 =',
       ...getFieldNamesByType('any'),
@@ -1073,6 +844,7 @@ describe('autocomplete', () => {
         ...getFunctionSignaturesByReturnType('eval', 'any', { evalMath: true }),
       ],
       ' ',
+      undefined,
       // make aware EVAL of the previous STATS command
       [[], undefined, undefined]
     );
@@ -1094,6 +866,7 @@ describe('autocomplete', () => {
         ...getFunctionSignaturesByReturnType('eval', 'any', { evalMath: true }),
       ],
       ' ',
+      undefined,
       // make aware EVAL of the previous STATS command with the buggy field name from expression
       [[{ name: 'avg_numberField_', type: 'number' }], undefined, undefined]
     );
@@ -1106,6 +879,7 @@ describe('autocomplete', () => {
         ...getFunctionSignaturesByReturnType('eval', 'any', { evalMath: true }),
       ],
       ' ',
+      undefined,
       // make aware EVAL of the previous STATS command with the buggy field name from expression
       [
         [
@@ -1133,19 +907,27 @@ describe('autocomplete', () => {
         'concat',
       ]).map((v) => ({ ...v, text: `${v.text},` })),
     ]);
-    testSuggestions('from a | eval a=concat(stringField, ', [
-      ...getFieldNamesByType('string'),
-      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
-        'concat',
-      ]),
-    ]);
+    testSuggestions(
+      'from a | eval a=concat(stringField, ',
+      [
+        ...getFieldNamesByType('string'),
+        ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+          'concat',
+        ]),
+      ],
+      ' '
+    );
     // test that the arg type is correct after minParams
-    testSuggestions('from a | eval a=cidr_match(ipField, stringField,', [
-      ...getFieldNamesByType('string'),
-      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
-        'cidr_match',
-      ]),
-    ]);
+    testSuggestions(
+      'from a | eval a=cidr_match(ipField, stringField, ',
+      [
+        ...getFieldNamesByType('string'),
+        ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+          'cidr_match',
+        ]),
+      ],
+      ' '
+    );
     // test that comma is correctly added to the suggestions if minParams is not reached yet
     testSuggestions('from a | eval a=cidr_match( ', [
       ...getFieldNamesByType('ip').map((v) => `${v},`),
@@ -1153,12 +935,16 @@ describe('autocomplete', () => {
         'cidr_match',
       ]).map((v) => ({ ...v, text: `${v.text},` })),
     ]);
-    testSuggestions('from a | eval a=cidr_match(ipField, ', [
-      ...getFieldNamesByType('string'),
-      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
-        'cidr_match',
-      ]),
-    ]);
+    testSuggestions(
+      'from a | eval a=cidr_match(ipField, ',
+      [
+        ...getFieldNamesByType('string'),
+        ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+          'cidr_match',
+        ]),
+      ],
+      ' '
+    );
     // test deep function nesting suggestions (and check that the same function is not suggested)
     // round(round(
     // round(round(round(
@@ -1186,6 +972,7 @@ describe('autocomplete', () => {
           'number',
         ]),
       ],
+      undefined,
       38 /* " " after abs(b) */
     );
     testSuggestions(
@@ -1196,6 +983,7 @@ describe('autocomplete', () => {
           'abs',
         ]),
       ],
+      undefined,
       26 /* b column in abs */
     );
 
@@ -1250,7 +1038,8 @@ describe('autocomplete', () => {
                         [fn.name]
                       ),
                       ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)),
-                    ].map(addCommaIfRequired)
+                    ].map(addCommaIfRequired),
+                ' '
               );
               testSuggestions(
                 `from a | eval var0 = ${fn.name}(${Array(i).fill('field').join(', ')}${
@@ -1268,7 +1057,8 @@ describe('autocomplete', () => {
                         [fn.name]
                       ),
                       ...getLiteralsByType(getTypesFromParamDefs(constantOnlyParamDefs)),
-                    ].map(addCommaIfRequired)
+                    ].map(addCommaIfRequired),
+                ' '
               );
             }
           });
@@ -1276,19 +1066,23 @@ describe('autocomplete', () => {
       }
     }
 
-    testSuggestions('from a | eval var0 = bucket(@timestamp,', getUnitDuration(1));
+    testSuggestions('from a | eval var0 = bucket(@timestamp, ', getUnitDuration(1), ' ');
 
     describe('date math', () => {
       const dateSuggestions = timeUnitsToSuggest.map(({ name }) => name);
       // If a literal number is detected then suggest also date period keywords
-      testSuggestions('from a | eval a = 1 ', [
-        ...dateSuggestions,
-        ',',
-        '|',
-        ...getFunctionSignaturesByReturnType('eval', 'any', { builtin: true, skipAssign: true }, [
-          'number',
-        ]),
-      ]);
+      testSuggestions(
+        'from a | eval a = 1 ',
+        [
+          ...dateSuggestions,
+          ',',
+          '|',
+          ...getFunctionSignaturesByReturnType('eval', 'any', { builtin: true, skipAssign: true }, [
+            'number',
+          ]),
+        ],
+        ' '
+      );
       testSuggestions('from a | eval a = 1 year ', [
         ',',
         '|',
@@ -1296,21 +1090,28 @@ describe('autocomplete', () => {
           'time_interval',
         ]),
       ]);
-      testSuggestions('from a | eval a = 1 day + 2 ', [
-        ...dateSuggestions,
-        ',',
-        '|',
-        ...getFunctionSignaturesByReturnType('eval', 'any', { builtin: true, skipAssign: true }, [
-          'number',
-        ]),
-      ]);
-      testSuggestions('from a | eval 1 day + 2 ', [
-        ...dateSuggestions,
-        ...getFunctionSignaturesByReturnType('eval', 'any', { builtin: true, skipAssign: true }, [
-          'number',
-        ]),
-      ]);
-
+      testSuggestions(
+        'from a | eval a = 1 day + 2 ',
+        [
+          ...dateSuggestions,
+          ',',
+          '|',
+          ...getFunctionSignaturesByReturnType('eval', 'any', { builtin: true, skipAssign: true }, [
+            'number',
+          ]),
+        ],
+        ' '
+      );
+      testSuggestions(
+        'from a | eval 1 day + 2 ',
+        [
+          ...dateSuggestions,
+          ...getFunctionSignaturesByReturnType('eval', 'any', { builtin: true, skipAssign: true }, [
+            'number',
+          ]),
+        ],
+        ' '
+      );
       testSuggestions(
         'from a | eval var0=date_trunc()',
         [
@@ -1322,10 +1123,11 @@ describe('autocomplete', () => {
         ],
         '('
       );
-      testSuggestions('from a | eval var0=date_trunc(2 )', [
-        ...dateSuggestions.map((t) => `${t},`),
-        ',',
-      ]);
+      testSuggestions(
+        'from a | eval var0=date_trunc(2 )',
+        [...dateSuggestions.map((t) => `${t},`), ','],
+        ' '
+      );
     });
   });
 
@@ -1334,7 +1136,7 @@ describe('autocomplete', () => {
       const callbackMocks = createCustomCallbackMocks(undefined, undefined, undefined);
       const statement = 'from a | drop stringField | eval var0 = abs(numberField) ';
       const triggerOffset = statement.lastIndexOf(' ');
-      const context = createSuggestContext(statement, statement[triggerOffset]);
+      const context = createCompletionContext(statement[triggerOffset]);
       await suggest(
         statement,
         triggerOffset + 1,
@@ -1350,7 +1152,7 @@ describe('autocomplete', () => {
       const callbackMocks = createCustomCallbackMocks(undefined, undefined, undefined);
       const statement = 'from a | drop | eval var0 = abs(numberField) ';
       const triggerOffset = statement.lastIndexOf('p') + 1; // drop <here>
-      const context = createSuggestContext(statement, statement[triggerOffset]);
+      const context = createCompletionContext(statement[triggerOffset]);
       await suggest(
         statement,
         triggerOffset + 1,
@@ -1366,7 +1168,7 @@ describe('autocomplete', () => {
     function getSuggestionsFor(statement: string) {
       const callbackMocks = createCustomCallbackMocks(undefined, undefined, undefined);
       const triggerOffset = statement.lastIndexOf(' ') + 1; // drop <here>
-      const context = createSuggestContext(statement, statement[triggerOffset]);
+      const context = createCompletionContext(statement[triggerOffset]);
       return suggest(
         statement,
         triggerOffset + 1,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ES|QL] distinguish between trigger kinds in tests (#188604)](https://github.com/elastic/kibana/pull/188604)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2024-07-22T14:25:30Z","message":"[ES|QL] distinguish between trigger kinds in tests (#188604)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/188677\r\n\r\nMonaco editor has different [kinds of completion\r\ntriggers](https://microsoft.github.io/monaco-editor/typedoc/enums/languages.CompletionTriggerKind.html).\r\nHowever, the current tests only validate the \"TriggerCharacter\" events.\r\n\r\nThis PR prepares the tests to support validating \"Invoke\" as well.\r\n\r\n**Note:** It does change many of the tests from a \"TriggerCharacter\" to\r\nan \"Invoke\" scenario. I think this is okay because\r\n- there are still plenty of \"TriggerCharacter\" tests\r\n- it would take a lot of work to update all the tests\r\n- I will be adding a full set of tests to cover both scenarios as part\r\nof https://github.com/elastic/kibana/issues/188677\r\n- We may rely less and less on trigger characters in the future\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"76c6f550dc5c945f1410bb53d54923c7363c7660","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","Feature:ES|QL","Team:ESQL","v8.15.0","v8.16.0"],"number":188604,"url":"https://github.com/elastic/kibana/pull/188604","mergeCommit":{"message":"[ES|QL] distinguish between trigger kinds in tests (#188604)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/188677\r\n\r\nMonaco editor has different [kinds of completion\r\ntriggers](https://microsoft.github.io/monaco-editor/typedoc/enums/languages.CompletionTriggerKind.html).\r\nHowever, the current tests only validate the \"TriggerCharacter\" events.\r\n\r\nThis PR prepares the tests to support validating \"Invoke\" as well.\r\n\r\n**Note:** It does change many of the tests from a \"TriggerCharacter\" to\r\nan \"Invoke\" scenario. I think this is okay because\r\n- there are still plenty of \"TriggerCharacter\" tests\r\n- it would take a lot of work to update all the tests\r\n- I will be adding a full set of tests to cover both scenarios as part\r\nof https://github.com/elastic/kibana/issues/188677\r\n- We may rely less and less on trigger characters in the future\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"76c6f550dc5c945f1410bb53d54923c7363c7660"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188604","number":188604,"mergeCommit":{"message":"[ES|QL] distinguish between trigger kinds in tests (#188604)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/188677\r\n\r\nMonaco editor has different [kinds of completion\r\ntriggers](https://microsoft.github.io/monaco-editor/typedoc/enums/languages.CompletionTriggerKind.html).\r\nHowever, the current tests only validate the \"TriggerCharacter\" events.\r\n\r\nThis PR prepares the tests to support validating \"Invoke\" as well.\r\n\r\n**Note:** It does change many of the tests from a \"TriggerCharacter\" to\r\nan \"Invoke\" scenario. I think this is okay because\r\n- there are still plenty of \"TriggerCharacter\" tests\r\n- it would take a lot of work to update all the tests\r\n- I will be adding a full set of tests to cover both scenarios as part\r\nof https://github.com/elastic/kibana/issues/188677\r\n- We may rely less and less on trigger characters in the future\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"76c6f550dc5c945f1410bb53d54923c7363c7660"}}]}] BACKPORT-->