### PR TITLE
[8.15] [ES|QL] Improve support for `Invoke` completion trigger kind (#188877)

### DIFF
--- a/packages/kbn-esql-ast/src/ast_walker.ts
+++ b/packages/kbn-esql-ast/src/ast_walker.ts
@@ -416,7 +416,7 @@ export function visitRenameClauses(clausesCtx: RenameClauseContext[]): ESQLAstIt
   return clausesCtx
     .map((clause) => {
       const asToken = clause.getToken(esql_parser.AS, 0);
-      if (asToken) {
+      if (asToken && textExistsAndIsValid(asToken.getText())) {
         const fn = createOption(asToken.getText().toLowerCase(), clause);
         for (const arg of [clause._oldName, clause._newName]) {
           if (textExistsAndIsValid(arg.getText())) {

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -122,7 +122,7 @@ export function getFunctionSignaturesByReturnType(
   {
     agg,
     grouping,
-    evalMath,
+    scalar,
     builtin,
     // skipAssign here is used to communicate to not propose an assignment if it's not possible
     // within the current context (the actual logic has it, but here we want a shortcut)
@@ -130,7 +130,7 @@ export function getFunctionSignaturesByReturnType(
   }: {
     agg?: boolean;
     grouping?: boolean;
-    evalMath?: boolean;
+    scalar?: boolean;
     builtin?: boolean;
     skipAssign?: boolean;
   } = {},
@@ -152,7 +152,7 @@ export function getFunctionSignaturesByReturnType(
     list.push(...groupingFunctionDefinitions);
   }
   // eval functions (eval is a special keyword in JS)
-  if (evalMath) {
+  if (scalar) {
     list.push(...evalFunctionDefinitions);
   }
   if (builtin) {

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -42,6 +42,7 @@ import {
   isSingleItem,
   nonNullable,
   getColumnExists,
+  findPreviousWord,
 } from '../shared/helpers';
 import { collectVariables, excludeVariablesFromCurrentCommand } from '../shared/variables';
 import type { ESQLPolicy, ESQLRealField, ESQLVariable, ReferenceMaps } from '../validation/types';
@@ -91,13 +92,9 @@ import {
 import { FunctionParameter } from '../definitions/types';
 
 type GetSourceFn = () => Promise<SuggestionRawDefinition[]>;
-type GetDataSourceFn = (sourceName: string) => Promise<
-  | {
-      name: string;
-      dataStreams?: Array<{ name: string; title?: string }>;
-    }
-  | undefined
->;
+type GetDataStreamsForIntegrationFn = (
+  sourceName: string
+) => Promise<Array<{ name: string; title?: string }> | undefined>;
 type GetFieldsByTypeFn = (
   type: string | string[],
   ignored?: string[]
@@ -180,9 +177,8 @@ export async function suggest(
   const charThatNeedMarkers = [',', ':'];
   if (
     (context.triggerCharacter && charThatNeedMarkers.includes(context.triggerCharacter)) ||
-    (context.triggerKind === 0 &&
-      unclosedRoundBrackets === 0 &&
-      getLastCharFromTrimmed(innerText) !== '_') ||
+    // monaco.editor.CompletionTriggerKind['Invoke'] === 0
+    (context.triggerKind === 0 && unclosedRoundBrackets === 0) ||
     (context.triggerCharacter === ' ' &&
       (isMathFunction(innerText, offset) ||
         isComma(innerText.trimEnd()[innerText.trimEnd().length - 1])))
@@ -324,11 +320,13 @@ function getSourcesRetriever(resourceRetriever?: ESQLCallbacks) {
   };
 }
 
-function getDatastreamsForIntegrationRetriever(resourceRetriever?: ESQLCallbacks) {
+function getDatastreamsForIntegrationRetriever(
+  resourceRetriever?: ESQLCallbacks
+): GetDataStreamsForIntegrationFn {
   const helper = getSourcesHelper(resourceRetriever);
   return async (sourceName: string) => {
     const list = (await helper()) || [];
-    return list.find(({ name }) => name === sourceName);
+    return list.find(({ name }) => name === sourceName)?.dataStreams;
   };
 }
 
@@ -502,7 +500,7 @@ async function getExpressionSuggestionsByType(
     node: ESQLSingleAstItem | undefined;
   },
   getSources: GetSourceFn,
-  getDatastreamsForIntegration: GetDataSourceFn,
+  getDatastreamsForIntegration: GetDataStreamsForIntegrationFn,
   getFieldsByType: GetFieldsByTypeFn,
   getFieldsMap: GetFieldsMapFn,
   getPolicies: GetPoliciesFn,
@@ -859,27 +857,31 @@ async function getExpressionSuggestionsByType(
       } else {
         const index = getSourcesFromCommands(commands, 'index');
         const canRemoveQuote = isNewExpression && innerText.includes('"');
+        // Function to add suggestions based on canRemoveQuote
+        const addSuggestionsBasedOnQuote = async (definitions: SuggestionRawDefinition[]) => {
+          suggestions.push(
+            ...(canRemoveQuote ? removeQuoteForSuggestedSources(definitions) : definitions)
+          );
+        };
 
-        // This is going to be empty for simple indices, and not empty for integrations
         if (index && index.text && index.text !== EDITOR_MARKER) {
           const source = index.text.replace(EDITOR_MARKER, '');
-          const dataSource = await getDatastreamsForIntegration(source);
+          const dataStreams = await getDatastreamsForIntegration(source);
 
-          const newDefinitions = buildSourcesDefinitions(
-            dataSource?.dataStreams?.map(({ name }) => ({ name, isIntegration: false })) || []
-          );
-          suggestions.push(
-            ...(canRemoveQuote ? removeQuoteForSuggestedSources(newDefinitions) : newDefinitions)
-          );
+          if (dataStreams) {
+            // Integration name, suggest the datastreams
+            await addSuggestionsBasedOnQuote(
+              buildSourcesDefinitions(
+                dataStreams.map(({ name }) => ({ name, isIntegration: false }))
+              )
+            );
+          } else {
+            // Not an integration, just a partial source name
+            await addSuggestionsBasedOnQuote(await getSources());
+          }
         } else {
-          // FROM <suggest>
-          // @TODO: filter down the suggestions here based on other existing sources defined
-          const sourcesDefinitions = await getSources();
-          suggestions.push(
-            ...(canRemoveQuote
-              ? removeQuoteForSuggestedSources(sourcesDefinitions)
-              : sourcesDefinitions)
-          );
+          // FROM <suggest> or no index/text
+          await addSuggestionsBasedOnQuote(await getSources());
         }
       }
     }
@@ -1444,7 +1446,11 @@ async function getOptionArgsSuggestions(
   if (command.name === 'enrich') {
     if (option.name === 'on') {
       // if it's a new expression, suggest fields to match on
-      if (isNewExpression || (option && isAssignment(option.args[0]) && !option.args[1])) {
+      if (
+        isNewExpression ||
+        findPreviousWord(innerText) === 'ON' ||
+        (option && isAssignment(option.args[0]) && !option.args[1])
+      ) {
         const policyName = isSourceItem(command.args[0]) ? command.args[0].name : undefined;
         if (policyName) {
           const policyMetadata = await getPolicyMetadata(policyName);
@@ -1477,7 +1483,7 @@ async function getOptionArgsSuggestions(
           innerText
         );
 
-        if (isNewExpression) {
+        if (isNewExpression || findPreviousWord(innerText) === 'WITH') {
           suggestions.push(buildNewVarDefinition(findNewVariable(anyEnhancedVariables)));
         }
 

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -32,7 +32,7 @@ export const TRIGGER_SUGGESTION_COMMAND = {
   id: 'editor.action.triggerSuggest',
 };
 
-function getSafeInsertText(text: string, options: { dashSupported?: boolean } = {}) {
+export function getSafeInsertText(text: string, options: { dashSupported?: boolean } = {}) {
   return shouldBeQuotedText(text, options)
     ? `\`${text.replace(SINGLE_TICK_REGEX, DOUBLE_BACKTICK)}\``
     : text;
@@ -235,7 +235,7 @@ export const buildMatchingFieldsDefinition = (
 ): SuggestionRawDefinition[] =>
   fields.map((label) => ({
     label,
-    text: label,
+    text: getSafeInsertText(label),
     kind: 'Variable',
     detail: i18n.translate(
       'kbn-esql-validation-autocomplete.esql.autocomplete.matchingFieldDefinition',

--- a/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -20,10 +20,10 @@ import { EDITOR_MARKER } from './constants';
 import {
   isOptionItem,
   isColumnItem,
-  getLastCharFromTrimmed,
   getFunctionDefinition,
   isSourceItem,
   isSettingItem,
+  pipePrecedesCurrentWord,
 } from './helpers';
 
 function findNode(nodes: ESQLAstItem[], offset: number): ESQLSingleAstItem | undefined {
@@ -172,12 +172,12 @@ export function getAstContext(queryString: string, ast: ESQLAst, offset: number)
       return { type: 'setting' as const, command, node, option, setting };
     }
   }
-  if (!command || (queryString.length <= offset && getLastCharFromTrimmed(queryString) === '|')) {
+  if (!command || (queryString.length <= offset && pipePrecedesCurrentWord(queryString))) {
     //   // ... | <here>
     return { type: 'newCommand' as const, command: undefined, node, option, setting };
   }
 
-  if (command && command.args.length) {
+  if (command && isOptionItem(command.args[command.args.length - 1])) {
     if (option) {
       return { type: 'option' as const, command, node, option, setting };
     }

--- a/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -557,12 +557,41 @@ export function sourceExists(index: string, sources: Set<string>) {
   return Boolean(fuzzySearch(index, sources.keys()));
 }
 
+/**
+ * Works backward from the cursor position to determine if
+ * the final character of the previous word matches the given character.
+ */
+function characterPrecedesCurrentWord(text: string, char: string) {
+  let inCurrentWord = true;
+  for (let i = text.length - 1; i >= 0; i--) {
+    if (inCurrentWord && /\s/.test(text[i])) {
+      inCurrentWord = false;
+    }
+
+    if (!inCurrentWord && !/\s/.test(text[i])) {
+      return text[i] === char;
+    }
+  }
+}
+
+export function pipePrecedesCurrentWord(text: string) {
+  return characterPrecedesCurrentWord(text, '|');
+}
+
 export function getLastCharFromTrimmed(text: string) {
   return text[text.trimEnd().length - 1];
 }
 
+/**
+ * Are we after a comma? i.e. STATS fieldA, <here>
+ */
 export function isRestartingExpression(text: string) {
-  return getLastCharFromTrimmed(text) === ',';
+  return getLastCharFromTrimmed(text) === ',' || characterPrecedesCurrentWord(text, ',');
+}
+
+export function findPreviousWord(text: string) {
+  const words = text.split(/\s+/);
+  return words[words.length - 2];
 }
 
 export function shouldBeQuotedSource(text: string) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ES|QL] Improve support for `Invoke` completion trigger kind (#188877)](https://github.com/elastic/kibana/pull/188877)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2024-07-24T15:34:57Z","message":"[ES|QL] Improve support for `Invoke` completion trigger kind (#188877)\n\n## Summary\n\nResolve https://github.com/elastic/kibana/issues/188677\n\nThis PR extends our support for Monaco's \"Invoke\" completion trigger\nkind\n([ref](https://microsoft.github.io/monaco-editor/typedoc/enums/languages.CompletionTriggerKind.html)).\n\nWhat this means for the user is that suggestions are now shown when the\nuser types a character in a word even if the suggestion menu isn't\nalready open. This situation often occurs when the user is editing a\nquery. For example, they may follow a flow like this:\n\n1. `FROM my-index | LIMIT 10<cursor-here>`\n2. `FROM <cursor-here> | LIMIT 10` (deleted the index name)\n3. `FROM k<cursor-here> | LIMIT 10` (types the first character of the\nindex name)\n\nPreviously, they wouldn't get any help. Now, we show the list of\nsuggestions.\n\nThe following table shows the cases that I considered as well as the\nones that are now fixed. I also added test coverage, even for cases that\nworked before to prevent subtle regressions.\n\n| | Before | After |\n\n|------------------------------|------------------------------------------|-----------------------|\n| Source command | ✅ | ✅ |\n| Pipe command | ❌ | ✅ |\n| Function argument | ✅ | ✅ |\n| FROM source | ❌ | ✅ |\n| FROM source METADATA | ✅ | ✅ |\n| FROM source METADATA field | ❌ (for `_`) | ✅ |\n| EVAL argument | ✅ | ✅ |\n| DISSECT field | ✅ | ✅ |\n| DISSECT field pattern | ❌ | ❌ |\n| DROP field | ✅ | ✅ |\n| DROP field1, field2 | ❌ | ✅ |\n| ENRICH policy | ✅ | ✅ |\n| ENRICH policy ON | ✅ | ✅ |\n| ENRICH policy ON field | ✅ | ✅ |\n| ENRICH policy WITH | ✅ | ✅ |\n| ENRICH policy WITH field | ✅ | ✅ |\n| GROK field | ✅ | ✅ |\n| GROK field pattern | ❌ | ❌ |\n| KEEP field | ✅ | ✅ |\n| KEEP field1, field2 | ❌ | ✅ |\n| LIMIT number | ❌ | ❌ |\n| MV_EXPAND field | ✅ | ✅ |\n| RENAME field | ✅ | ✅ |\n| RENAME field AS | ❌ | ✅ |\n| RENAME field AS var0 | ✅ | ✅ |\n| SORT field | ✅ | ✅ |\n| SORT field order | ✅ | ✅ |\n| SORT field order nulls-order | ✅ | ✅ |\n| STATS argument | ✅ | ✅ |\n| STATS argument BY | ✅ | ✅ |\n| STATS argument BY expression | ✅ | ✅ |\n| WHERE argument | ✅ | ✅ |\n| WHERE argument comparison    | ✅  | ✅                     |\n\nAs I worked, I encountered a couple small bugs which I also fixed.\n\n### Escaping field values in `ENRICH`\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/88f2bf35-a703-4cf4-8d45-a24452a1b59d\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/69ad0770-f158-44fb-be8d-66b497c7f7f7\n\n### Suggesting variable assignment in `ENRICH ... WITH`\n**Before**\n\n\nhttps://github.com/user-attachments/assets/fec47b6d-eae5-44e8-b739-9b2eecc7458b\n\n\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/dff5afe1-37e7-470b-bb9c-edb5ac87e76d\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c77cd800703b319ee19bc1cae733f1f6fdd4f513","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","Feature:ES|QL","Team:ESQL","v8.15.0","v8.16.0"],"number":188877,"url":"https://github.com/elastic/kibana/pull/188877","mergeCommit":{"message":"[ES|QL] Improve support for `Invoke` completion trigger kind (#188877)\n\n## Summary\n\nResolve https://github.com/elastic/kibana/issues/188677\n\nThis PR extends our support for Monaco's \"Invoke\" completion trigger\nkind\n([ref](https://microsoft.github.io/monaco-editor/typedoc/enums/languages.CompletionTriggerKind.html)).\n\nWhat this means for the user is that suggestions are now shown when the\nuser types a character in a word even if the suggestion menu isn't\nalready open. This situation often occurs when the user is editing a\nquery. For example, they may follow a flow like this:\n\n1. `FROM my-index | LIMIT 10<cursor-here>`\n2. `FROM <cursor-here> | LIMIT 10` (deleted the index name)\n3. `FROM k<cursor-here> | LIMIT 10` (types the first character of the\nindex name)\n\nPreviously, they wouldn't get any help. Now, we show the list of\nsuggestions.\n\nThe following table shows the cases that I considered as well as the\nones that are now fixed. I also added test coverage, even for cases that\nworked before to prevent subtle regressions.\n\n| | Before | After |\n\n|------------------------------|------------------------------------------|-----------------------|\n| Source command | ✅ | ✅ |\n| Pipe command | ❌ | ✅ |\n| Function argument | ✅ | ✅ |\n| FROM source | ❌ | ✅ |\n| FROM source METADATA | ✅ | ✅ |\n| FROM source METADATA field | ❌ (for `_`) | ✅ |\n| EVAL argument | ✅ | ✅ |\n| DISSECT field | ✅ | ✅ |\n| DISSECT field pattern | ❌ | ❌ |\n| DROP field | ✅ | ✅ |\n| DROP field1, field2 | ❌ | ✅ |\n| ENRICH policy | ✅ | ✅ |\n| ENRICH policy ON | ✅ | ✅ |\n| ENRICH policy ON field | ✅ | ✅ |\n| ENRICH policy WITH | ✅ | ✅ |\n| ENRICH policy WITH field | ✅ | ✅ |\n| GROK field | ✅ | ✅ |\n| GROK field pattern | ❌ | ❌ |\n| KEEP field | ✅ | ✅ |\n| KEEP field1, field2 | ❌ | ✅ |\n| LIMIT number | ❌ | ❌ |\n| MV_EXPAND field | ✅ | ✅ |\n| RENAME field | ✅ | ✅ |\n| RENAME field AS | ❌ | ✅ |\n| RENAME field AS var0 | ✅ | ✅ |\n| SORT field | ✅ | ✅ |\n| SORT field order | ✅ | ✅ |\n| SORT field order nulls-order | ✅ | ✅ |\n| STATS argument | ✅ | ✅ |\n| STATS argument BY | ✅ | ✅ |\n| STATS argument BY expression | ✅ | ✅ |\n| WHERE argument | ✅ | ✅ |\n| WHERE argument comparison    | ✅  | ✅                     |\n\nAs I worked, I encountered a couple small bugs which I also fixed.\n\n### Escaping field values in `ENRICH`\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/88f2bf35-a703-4cf4-8d45-a24452a1b59d\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/69ad0770-f158-44fb-be8d-66b497c7f7f7\n\n### Suggesting variable assignment in `ENRICH ... WITH`\n**Before**\n\n\nhttps://github.com/user-attachments/assets/fec47b6d-eae5-44e8-b739-9b2eecc7458b\n\n\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/dff5afe1-37e7-470b-bb9c-edb5ac87e76d\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c77cd800703b319ee19bc1cae733f1f6fdd4f513"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188877","number":188877,"mergeCommit":{"message":"[ES|QL] Improve support for `Invoke` completion trigger kind (#188877)\n\n## Summary\n\nResolve https://github.com/elastic/kibana/issues/188677\n\nThis PR extends our support for Monaco's \"Invoke\" completion trigger\nkind\n([ref](https://microsoft.github.io/monaco-editor/typedoc/enums/languages.CompletionTriggerKind.html)).\n\nWhat this means for the user is that suggestions are now shown when the\nuser types a character in a word even if the suggestion menu isn't\nalready open. This situation often occurs when the user is editing a\nquery. For example, they may follow a flow like this:\n\n1. `FROM my-index | LIMIT 10<cursor-here>`\n2. `FROM <cursor-here> | LIMIT 10` (deleted the index name)\n3. `FROM k<cursor-here> | LIMIT 10` (types the first character of the\nindex name)\n\nPreviously, they wouldn't get any help. Now, we show the list of\nsuggestions.\n\nThe following table shows the cases that I considered as well as the\nones that are now fixed. I also added test coverage, even for cases that\nworked before to prevent subtle regressions.\n\n| | Before | After |\n\n|------------------------------|------------------------------------------|-----------------------|\n| Source command | ✅ | ✅ |\n| Pipe command | ❌ | ✅ |\n| Function argument | ✅ | ✅ |\n| FROM source | ❌ | ✅ |\n| FROM source METADATA | ✅ | ✅ |\n| FROM source METADATA field | ❌ (for `_`) | ✅ |\n| EVAL argument | ✅ | ✅ |\n| DISSECT field | ✅ | ✅ |\n| DISSECT field pattern | ❌ | ❌ |\n| DROP field | ✅ | ✅ |\n| DROP field1, field2 | ❌ | ✅ |\n| ENRICH policy | ✅ | ✅ |\n| ENRICH policy ON | ✅ | ✅ |\n| ENRICH policy ON field | ✅ | ✅ |\n| ENRICH policy WITH | ✅ | ✅ |\n| ENRICH policy WITH field | ✅ | ✅ |\n| GROK field | ✅ | ✅ |\n| GROK field pattern | ❌ | ❌ |\n| KEEP field | ✅ | ✅ |\n| KEEP field1, field2 | ❌ | ✅ |\n| LIMIT number | ❌ | ❌ |\n| MV_EXPAND field | ✅ | ✅ |\n| RENAME field | ✅ | ✅ |\n| RENAME field AS | ❌ | ✅ |\n| RENAME field AS var0 | ✅ | ✅ |\n| SORT field | ✅ | ✅ |\n| SORT field order | ✅ | ✅ |\n| SORT field order nulls-order | ✅ | ✅ |\n| STATS argument | ✅ | ✅ |\n| STATS argument BY | ✅ | ✅ |\n| STATS argument BY expression | ✅ | ✅ |\n| WHERE argument | ✅ | ✅ |\n| WHERE argument comparison    | ✅  | ✅                     |\n\nAs I worked, I encountered a couple small bugs which I also fixed.\n\n### Escaping field values in `ENRICH`\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/88f2bf35-a703-4cf4-8d45-a24452a1b59d\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/69ad0770-f158-44fb-be8d-66b497c7f7f7\n\n### Suggesting variable assignment in `ENRICH ... WITH`\n**Before**\n\n\nhttps://github.com/user-attachments/assets/fec47b6d-eae5-44e8-b739-9b2eecc7458b\n\n\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/dff5afe1-37e7-470b-bb9c-edb5ac87e76d\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c77cd800703b319ee19bc1cae733f1f6fdd4f513"}}]}] BACKPORT-->