### PR TITLE
[DOCS] Remove duplicate section title

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -105,10 +105,6 @@ The 8.14.3 release includes the following bug fixes and known issues.
 
 include::CHANGELOG.asciidoc[tag=known-issue-186969]
 
-[float]
-[[known-issues-8.14.3]]
-=== Known issues
-
 [discrete]
 [[known-185691]]
 .When using the Observability AI Assistant with the OpenAI connector, function calling will result in an error


### PR DESCRIPTION
## Summary

This PR addresses the following build error:

```
INFO:build_docs:asciidoctor: WARNING: CHANGELOG.asciidoc: line 110: id assigned to block already in use: known-issues-8.14.3
```

Which seems to have occurred when https://github.com/elastic/kibana/pull/189236 and https://github.com/elastic/kibana/pull/189331 merged updates to that section in close proximity.