### PR TITLE
[8.15] [ES|QL] remove inaccurate values suggestions (#189228)

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -1130,6 +1130,29 @@ describe('autocomplete', () => {
     });
   });
 
+  describe('values suggestions', () => {
+    testSuggestions('FROM "a"', ['a', 'b'], undefined, 7, [
+      ,
+      [
+        { name: 'a', hidden: false },
+        { name: 'b', hidden: false },
+      ],
+    ]);
+    testSuggestions('FROM " "', [], ' ');
+    // TODO — re-enable these tests when we can support this case
+    testSuggestions.skip('FROM "  a"', [], undefined, 9);
+    testSuggestions.skip('FROM "foo b"', [], undefined, 11);
+    testSuggestions('FROM a | WHERE tags == " "', [], ' ');
+    testSuggestions('FROM a | WHERE tags == """ """', [], ' ');
+    testSuggestions('FROM a | WHERE tags == "a"', [], undefined, 25);
+    testSuggestions('FROM a | EVAL tags == " "', [], ' ');
+    testSuggestions('FROM a | EVAL tags == "a"', [], undefined, 24);
+    testSuggestions('FROM a | STATS tags == " "', [], ' ');
+    testSuggestions('FROM a | STATS tags == "a"', [], undefined, 25);
+    testSuggestions('FROM a | GROK "a" "%{WORD:firstWord}"', [], undefined, 16);
+    testSuggestions('FROM a | DISSECT "a" "%{WORD:firstWord}"', [], undefined, 19);
+  });
+
   describe('callbacks', () => {
     it('should send the fields query without the last command', async () => {
       const callbackMocks = createCustomCallbackMocks(undefined, undefined, undefined);

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -144,17 +144,65 @@ function getFinalSuggestions({ comma }: { comma?: boolean } = { comma: true }) {
  * @param text
  * @returns
  */
-function countBracketsUnclosed(bracketType: '(' | '[', text: string) {
+function countBracketsUnclosed(bracketType: '(' | '[' | '"' | '"""', text: string) {
   const stack = [];
-  const closingBrackets = { '(': ')', '[': ']' };
-  for (const char of text) {
-    if (char === bracketType) {
-      stack.push(bracketType);
-    } else if (char === closingBrackets[bracketType]) {
+  const closingBrackets = { '(': ')', '[': ']', '"': '"', '"""': '"""' };
+  for (let i = 0; i < text.length; i++) {
+    const substr = text.substring(i, i + bracketType.length);
+    if (substr === closingBrackets[bracketType] && stack.length) {
       stack.pop();
+    } else if (substr === bracketType) {
+      stack.push(bracketType);
     }
   }
   return stack.length;
+}
+
+/**
+ * This function attempts to correct the syntax of a partial query to make it valid.
+ *
+ * This is important because a syntactically-invalid query will not generate a good AST.
+ *
+ * @param _query
+ * @param context
+ * @returns
+ */
+function correctQuerySyntax(_query: string, context: EditorContext) {
+  let query = _query;
+  // check if all brackets are closed, otherwise close them
+  const unclosedRoundBrackets = countBracketsUnclosed('(', query);
+  const unclosedSquaredBrackets = countBracketsUnclosed('[', query);
+  const unclosedQuotes = countBracketsUnclosed('"', query);
+  const unclosedTripleQuotes = countBracketsUnclosed('"""', query);
+  // if it's a comma by the user or a forced trigger by a function argument suggestion
+  // add a marker to make the expression still valid
+  const charThatNeedMarkers = [',', ':'];
+  if (
+    (context.triggerCharacter && charThatNeedMarkers.includes(context.triggerCharacter)) ||
+    // monaco.editor.CompletionTriggerKind['Invoke'] === 0
+    (context.triggerKind === 0 && unclosedRoundBrackets === 0) ||
+    (context.triggerCharacter === ' ' &&
+      (isMathFunction(query, query.length) || isComma(query.trimEnd()[query.trimEnd().length - 1])))
+  ) {
+    query += EDITOR_MARKER;
+  }
+
+  // if there are unclosed brackets, close them
+  if (unclosedRoundBrackets || unclosedSquaredBrackets || unclosedQuotes) {
+    for (const [char, count] of [
+      ['"""', unclosedTripleQuotes],
+      ['"', unclosedQuotes],
+      [')', unclosedRoundBrackets],
+      [']', unclosedSquaredBrackets],
+    ]) {
+      if (count) {
+        // inject the closing brackets
+        query += Array(count).fill(char).join('');
+      }
+    }
+  }
+
+  return query;
 }
 
 export async function suggest(
@@ -166,43 +214,16 @@ export async function suggest(
 ): Promise<SuggestionRawDefinition[]> {
   const innerText = fullText.substring(0, offset);
 
-  let finalText = innerText;
+  const correctedQuery = correctQuerySyntax(innerText, context);
 
-  // check if all brackets are closed, otherwise close them
-  const unclosedRoundBrackets = countBracketsUnclosed('(', finalText);
-  const unclosedSquaredBrackets = countBracketsUnclosed('[', finalText);
-  const unclosedBrackets = unclosedRoundBrackets + unclosedSquaredBrackets;
-  // if it's a comma by the user or a forced trigger by a function argument suggestion
-  // add a marker to make the expression still valid
-  const charThatNeedMarkers = [',', ':'];
-  if (
-    (context.triggerCharacter && charThatNeedMarkers.includes(context.triggerCharacter)) ||
-    // monaco.editor.CompletionTriggerKind['Invoke'] === 0
-    (context.triggerKind === 0 && unclosedRoundBrackets === 0) ||
-    (context.triggerCharacter === ' ' &&
-      (isMathFunction(innerText, offset) ||
-        isComma(innerText.trimEnd()[innerText.trimEnd().length - 1])))
-  ) {
-    finalText = `${innerText.substring(0, offset)}${EDITOR_MARKER}${innerText.substring(offset)}`;
-  }
-  // if there are unclosed brackets, close them
-  if (unclosedBrackets) {
-    for (const [char, count] of [
-      [')', unclosedRoundBrackets],
-      [']', unclosedSquaredBrackets],
-    ]) {
-      if (count) {
-        // inject the closing brackets
-        finalText += Array(count).fill(char).join('');
-      }
-    }
-  }
-
-  const { ast } = await astProvider(finalText);
+  const { ast } = await astProvider(correctedQuery);
 
   const astContext = getAstContext(innerText, ast, offset);
   // build the correct query to fetch the list of fields
-  const queryForFields = getQueryForFields(buildQueryUntilPreviousCommand(ast, finalText), ast);
+  const queryForFields = getQueryForFields(
+    buildQueryUntilPreviousCommand(ast, correctedQuery),
+    ast
+  );
   const { getFieldsByType, getFieldsMap } = getFieldsByTypeRetriever(
     queryForFields,
     resourceRetriever
@@ -508,6 +529,12 @@ async function getExpressionSuggestionsByType(
 ) {
   const commandDef = getCommandDefinition(command.name);
   const { argIndex, prevIndex, lastArg, nodeArg } = extractArgMeta(command, node);
+
+  // TODO - this is a workaround because it was too difficult to handle this case in a generic way :(
+  if (commandDef.name === 'from' && node && isSourceItem(node) && /\s/.test(node.name)) {
+    // FROM " <suggest>"
+    return [];
+  }
 
   // A new expression is considered either
   // * just after a command name => i.e. ... | STATS <here>

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/types.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/types.ts
@@ -62,6 +62,11 @@ export interface SuggestionRawDefinition {
 export interface EditorContext {
   /** The actual char that triggered the suggestion (1 single char) */
   triggerCharacter?: string;
-  /** The type of trigger id. triggerKind = 0 is a programmatic trigger, while any other non-zero value is currently ignored. */
+  /**
+   * monaco.editor.CompletionTriggerKind
+   *
+   * 0 is "Invoke" (user starts typing a word)
+   * 1 is "Trigger character" (user types a trigger character)
+   */
   triggerKind: number;
 }

--- a/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -152,6 +152,10 @@ function isBuiltinFunction(node: ESQLFunction) {
 export function getAstContext(queryString: string, ast: ESQLAst, offset: number) {
   const { command, option, setting, node } = findAstPosition(ast, offset);
   if (node) {
+    if (node.type === 'literal' && node.literalType === 'string') {
+      // command ... "<here>"
+      return { type: 'value' as const, command, node, option, setting };
+    }
     if (node.type === 'function') {
       if (['in', 'not_in'].includes(node.name) && Array.isArray(node.args[1])) {
         // command ... a in ( <here> )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ES|QL] remove inaccurate values suggestions (#189228)](https://github.com/elastic/kibana/pull/189228)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2024-07-29T14:33:42Z","message":"[ES|QL] remove inaccurate values suggestions (#189228)\n\n## Summary\r\n\r\nToday, we get a list of field names and functions where values should be\r\nsuggested instead. Since we can't yet suggest values in most cases, this\r\nPR prevents any suggestions from being shown in a values context.\r\n\r\n### Values suggestions hidden\r\n\r\n**Before**\r\n\r\n\r\nhttps://github.com/user-attachments/assets/ddf02092-4c61-4a80-8666-c9b4fca735be\r\n\r\n**After**\r\n\r\n\r\nhttps://github.com/user-attachments/assets/f1c50a8b-6bd1-4e44-b56f-68f8510e53f6\r\n\r\n### But not for index names\r\n\r\nHowever, index names are still suggested within quotes\r\n\r\n\r\nhttps://github.com/user-attachments/assets/a416220c-370b-4bb3-a1bc-c2d4bada18ca\r\n\r\nBut not if a space is entered\r\n\r\n\r\nhttps://github.com/user-attachments/assets/83d3d1e4-b11b-4bdb-b250-c0f1575fe82f\r\n\r\nHowever, there were a few cases with quoted index names which I just\r\ncouldn't find a good way to cover. They are recorded here\r\nhttps://github.com/elastic/kibana/pull/189228/files#diff-4a3b7269c26dc777be5c0b2a9a1d8f4b1897b7921f6d3e7a176defdf67e83fc6R910-R912\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"70cad5eb7567f229b12af6ff3ce9028d54567748","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","Feature:ES|QL","Team:ESQL","v8.15.0","v8.16.0"],"number":189228,"url":"https://github.com/elastic/kibana/pull/189228","mergeCommit":{"message":"[ES|QL] remove inaccurate values suggestions (#189228)\n\n## Summary\r\n\r\nToday, we get a list of field names and functions where values should be\r\nsuggested instead. Since we can't yet suggest values in most cases, this\r\nPR prevents any suggestions from being shown in a values context.\r\n\r\n### Values suggestions hidden\r\n\r\n**Before**\r\n\r\n\r\nhttps://github.com/user-attachments/assets/ddf02092-4c61-4a80-8666-c9b4fca735be\r\n\r\n**After**\r\n\r\n\r\nhttps://github.com/user-attachments/assets/f1c50a8b-6bd1-4e44-b56f-68f8510e53f6\r\n\r\n### But not for index names\r\n\r\nHowever, index names are still suggested within quotes\r\n\r\n\r\nhttps://github.com/user-attachments/assets/a416220c-370b-4bb3-a1bc-c2d4bada18ca\r\n\r\nBut not if a space is entered\r\n\r\n\r\nhttps://github.com/user-attachments/assets/83d3d1e4-b11b-4bdb-b250-c0f1575fe82f\r\n\r\nHowever, there were a few cases with quoted index names which I just\r\ncouldn't find a good way to cover. They are recorded here\r\nhttps://github.com/elastic/kibana/pull/189228/files#diff-4a3b7269c26dc777be5c0b2a9a1d8f4b1897b7921f6d3e7a176defdf67e83fc6R910-R912\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"70cad5eb7567f229b12af6ff3ce9028d54567748"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/189228","number":189228,"mergeCommit":{"message":"[ES|QL] remove inaccurate values suggestions (#189228)\n\n## Summary\r\n\r\nToday, we get a list of field names and functions where values should be\r\nsuggested instead. Since we can't yet suggest values in most cases, this\r\nPR prevents any suggestions from being shown in a values context.\r\n\r\n### Values suggestions hidden\r\n\r\n**Before**\r\n\r\n\r\nhttps://github.com/user-attachments/assets/ddf02092-4c61-4a80-8666-c9b4fca735be\r\n\r\n**After**\r\n\r\n\r\nhttps://github.com/user-attachments/assets/f1c50a8b-6bd1-4e44-b56f-68f8510e53f6\r\n\r\n### But not for index names\r\n\r\nHowever, index names are still suggested within quotes\r\n\r\n\r\nhttps://github.com/user-attachments/assets/a416220c-370b-4bb3-a1bc-c2d4bada18ca\r\n\r\nBut not if a space is entered\r\n\r\n\r\nhttps://github.com/user-attachments/assets/83d3d1e4-b11b-4bdb-b250-c0f1575fe82f\r\n\r\nHowever, there were a few cases with quoted index names which I just\r\ncouldn't find a good way to cover. They are recorded here\r\nhttps://github.com/elastic/kibana/pull/189228/files#diff-4a3b7269c26dc777be5c0b2a9a1d8f4b1897b7921f6d3e7a176defdf67e83fc6R910-R912\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>","sha":"70cad5eb7567f229b12af6ff3ce9028d54567748"}}]}] BACKPORT-->