### PR TITLE
Display only text_embedding and sparse_embedding related inference endpoints

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -16,6 +16,7 @@ import {
   SelectInferenceIdProps,
 } from '../../../public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id';
 import React from 'react';
+import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 
 const createInferenceEndpointMock = jest.fn();
 const mockDispatch = jest.fn();
@@ -58,6 +59,18 @@ jest.mock(
 jest.mock('../../../public/application/components/mappings_editor/mappings_state_context', () => ({
   useMappingsState: () => ({ inferenceToModelIdMap: {} }),
   useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../public/application/services/api', () => ({
+  useLoadInferenceEndpoints: jest.fn().mockReturnValue({
+    data: [
+      { model_id: 'endpoint-1', task_type: 'text_embedding' },
+      { model_id: 'endpoint-2', task_type: 'sparse_embedding' },
+      { model_id: 'endpoint-3', task_type: 'completion' },
+    ] as InferenceAPIConfigResponse[],
+    isLoading: false,
+    error: null,
+  }),
 }));
 
 function getTestForm(Component: React.FC<SelectInferenceIdProps>) {
@@ -107,5 +120,8 @@ describe('SelectInferenceId', () => {
     find('inferenceIdButton').simulate('click');
     expect(find('data-inference-endpoint-list').contains('e5')).toBe(true);
     expect(find('data-inference-endpoint-list').contains('elser_model_2')).toBe(true);
+    expect(find('data-inference-endpoint-list').contains('endpoint-1')).toBe(true);
+    expect(find('data-inference-endpoint-list').contains('endpoint-2')).toBe(true);
+    expect(find('data-inference-endpoint-list').contains('endpoint-3')).toBe(false);
   });
 });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -133,11 +133,16 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
   const { isLoading, data: endpoints, resendRequest } = useLoadInferenceEndpoints();
 
   const options: EuiSelectableOption[] = useMemo(() => {
+    const filteredEndpoints = endpoints?.filter(
+      (endpoint) =>
+        endpoint.task_type === 'text_embedding' || endpoint.task_type === 'sparse_embedding'
+    );
+
     const missingDefaultEndpoints = defaultEndpoints.filter(
-      (endpoint) => !(endpoints || []).find((e) => e.model_id === endpoint.model_id)
+      (endpoint) => !(filteredEndpoints || []).find((e) => e.model_id === endpoint.model_id)
     );
     const newOptions: EuiSelectableOption[] = [
-      ...(endpoints || []),
+      ...(filteredEndpoints || []),
       ...missingDefaultEndpoints,
     ].map((endpoint) => ({
       label: endpoint.model_id,


### PR DESCRIPTION
This PR resolves https://github.com/elastic/search-team/issues/7989

In the semantic_text UI, we should display the inference endpoints related to text_embedding and sparse_embedding only.

### Before
![Screenshot 2024-07-29 at 6 07 24 PM](https://github.com/user-attachments/assets/92ec40a0-3faf-4c5e-a155-84c09805a9a4)


### After
![Screenshot 2024-07-29 at 6 05 59 PM](https://github.com/user-attachments/assets/1ec15a7b-f388-435d-93f4-41a6284fba6f)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->