### PR TITLE
Disable manual rule feature run by default

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -237,7 +237,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the manual rule run
    */
-  manualRuleRunEnabled: true,
+  manualRuleRunEnabled: false,
 
   /**
    * Adds a new option to filter descendants of a process for Management / Event Filters


### PR DESCRIPTION
## Disable manual rule feature run by default

We decide not to release this feature, because @timestamp should be populate with `now` for alerts from manual rule runs.

