### PR TITLE
[Infra] Create endpoint to verify if there is data

### DIFF
--- a/x-pack/plugins/observability_solution/infra/common/http_api/infra/get_infra_metrics.ts
+++ b/x-pack/plugins/observability_solution/infra/common/http_api/infra/get_infra_metrics.ts
@@ -48,7 +48,6 @@ export const GetInfraMetricsRequestBodyPayloadRT = rt.intersection([
     type: rt.literal('host'),
     limit: rt.union([inRangeRt(1, 500), createLiteralValueFromUndefinedRT(20)]),
     metrics: rt.array(rt.type({ type: InfraMetricTypeRT })),
-    sourceId: rt.string,
     range: RangeRT,
   }),
 ]);

--- a/x-pack/plugins/observability_solution/infra/common/metrics_sources/get_has_data.ts
+++ b/x-pack/plugins/observability_solution/infra/common/metrics_sources/get_has_data.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as rt from 'io-ts';
+
+export const getHasDataQueryParamsRT = rt.partial({
+  // Integrations `event.module` value
+  modules: rt.union([rt.string, rt.array(rt.string)]),
+});
+
+export const getHasDataResponseRT = rt.partial({
+  hasData: rt.boolean,
+});
+
+export type GetHasDataQueryParams = rt.TypeOf<typeof getHasDataQueryParamsRT>;
+export type GetHasDataResponse = rt.TypeOf<typeof getHasDataResponseRT>;

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_hosts_view.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_hosts_view.ts
@@ -17,7 +17,6 @@ import createContainer from 'constate';
 import { BoolQuery } from '@kbn/es-query';
 import { isPending, useFetcher } from '../../../../hooks/use_fetcher';
 import { useKibanaContextForPlugin } from '../../../../hooks/use_kibana';
-import { useSourceContext } from '../../../../containers/metrics_source';
 import { useUnifiedSearchContext } from './use_unified_search';
 import {
   GetInfraMetricsRequestBodyPayload,
@@ -39,7 +38,6 @@ const HOST_TABLE_METRICS: Array<{ type: InfraAssetMetricType }> = [
 const BASE_INFRA_METRICS_PATH = '/api/metrics/infra';
 
 export const useHostsView = () => {
-  const { sourceId } = useSourceContext();
   const {
     services: { telemetry },
   } = useKibanaContextForPlugin();
@@ -50,10 +48,9 @@ export const useHostsView = () => {
       createInfraMetricsRequest({
         dateRange: parsedDateRange,
         esQuery: buildQuery(),
-        sourceId,
         limit: searchCriteria.limit,
       }),
-    [buildQuery, parsedDateRange, sourceId, searchCriteria.limit]
+    [buildQuery, parsedDateRange, searchCriteria.limit]
   );
 
   const { data, error, status } = useFetcher(
@@ -94,12 +91,10 @@ export const [HostsViewProvider, useHostsViewContext] = HostsView;
 
 const createInfraMetricsRequest = ({
   esQuery,
-  sourceId,
   dateRange,
   limit,
 }: {
   esQuery: { bool: BoolQuery };
-  sourceId: string;
   dateRange: StringDateRange;
   limit: number;
 }): GetInfraMetricsRequestBodyPayload => ({
@@ -111,5 +106,4 @@ const createInfraMetricsRequest = ({
   },
   metrics: HOST_TABLE_METRICS,
   limit,
-  sourceId,
 });

--- a/x-pack/plugins/observability_solution/infra/server/routes/infra/index.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/infra/index.ts
@@ -47,9 +47,8 @@ export const initInfraAssetRoutes = (libs: InfraBackendLibs) => {
         const infraMetricsClient = await getInfraMetricsClient({
           framework,
           request,
-          infraSources: libs.sources,
+          metricsDataAccess: libs.metricsClient,
           requestContext,
-          sourceId: params.sourceId,
         });
 
         const alertsClient = await getInfraAlertsClient({
@@ -102,15 +101,14 @@ export const initInfraAssetRoutes = (libs: InfraBackendLibs) => {
       const body: GetInfraAssetCountRequestBodyPayload = request.body;
       const params: GetInfraAssetCountRequestParamsPayload = request.params;
       const { assetType } = params;
-      const { query, from, to, sourceId } = body;
+      const { query, from, to } = body;
 
       try {
         const infraMetricsClient = await getInfraMetricsClient({
           framework,
           request,
-          infraSources: libs.sources,
+          metricsDataAccess: libs.metricsClient,
           requestContext,
-          sourceId,
         });
 
         const assetCount = await getHostsCount({

--- a/x-pack/plugins/observability_solution/infra/server/routes/metrics_sources/index.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/metrics_sources/index.ts
@@ -8,6 +8,13 @@
 import { schema } from '@kbn/config-schema';
 import Boom from '@hapi/boom';
 import { createRouteValidationFunction } from '@kbn/io-ts-utils';
+import { termsQuery } from '@kbn/observability-plugin/server';
+import { castArray } from 'lodash';
+import { EVENT_MODULE, METRICSET_MODULE } from '../../../common/constants';
+import {
+  getHasDataQueryParamsRT,
+  getHasDataResponseRT,
+} from '../../../common/metrics_sources/get_has_data';
 import { InfraBackendLibs } from '../../lib/infra_types';
 import { hasData } from '../../lib/sources/has_data';
 import { createSearchClient } from '../../lib/create_search_client';
@@ -19,12 +26,15 @@ import {
 } from '../../../common/metrics_sources';
 import { InfraSource, InfraSourceIndexField } from '../../lib/sources';
 import { InfraPluginRequestHandlerContext } from '../../types';
+import { getInfraMetricsClient } from '../../lib/helpers/get_infra_metrics_client';
 
 const defaultStatus = {
   indexFields: [],
   metricIndicesExist: false,
   remoteClustersExist: false,
 };
+
+const MAX_MODULES = 5;
 
 export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => {
   const { framework, logger } = libs;
@@ -202,6 +212,75 @@ export const initMetricsSourceConfigurationRoutes = (libs: InfraBackendLibs) => 
       return response.ok({
         body: { hasData: results, configuration: source.configuration },
       });
+    }
+  );
+
+  framework.registerRoute(
+    {
+      method: 'get',
+      path: '/api/metrics/source/hasData',
+      validate: {
+        query: createRouteValidationFunction(getHasDataQueryParamsRT),
+      },
+    },
+    async (requestContext, request, response) => {
+      try {
+        const modules = castArray(request.query.modules);
+
+        if (modules.length > MAX_MODULES) {
+          throw Boom.badRequest(
+            `'modules' size is greater than maximum of ${MAX_MODULES} allowed.`
+          );
+        }
+
+        const infraMetricsClient = await getInfraMetricsClient({
+          framework,
+          request,
+          metricsDataAccess: libs.metricsClient,
+          requestContext,
+        });
+
+        const results = await infraMetricsClient.search({
+          allow_no_indices: true,
+          ignore_unavailable: true,
+          body: {
+            track_total_hits: true,
+            terminate_after: 1,
+            size: 0,
+            ...(modules.length > 0
+              ? {
+                  query: {
+                    bool: {
+                      should: [
+                        ...termsQuery(EVENT_MODULE, ...modules),
+                        ...termsQuery(METRICSET_MODULE, ...modules),
+                      ],
+                      minimum_should_match: 1,
+                    },
+                  },
+                }
+              : {}),
+          },
+        });
+
+        return response.ok({
+          body: getHasDataResponseRT.encode({ hasData: results.hits.total.value !== 0 }),
+        });
+      } catch (err) {
+        if (Boom.isBoom(err)) {
+          return response.customError({
+            statusCode: err.output.statusCode,
+            body: { message: err.output.payload.message },
+          });
+        }
+
+        return response.customError({
+          statusCode: err.statusCode ?? 500,
+          body: {
+            message: err.message ?? 'An unexpected error occurred',
+          },
+        });
+      }
     }
   );
 };

--- a/x-pack/test/api_integration/apis/metrics_ui/infra.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/infra.ts
@@ -54,7 +54,6 @@ export default function ({ getService }: FtrProviderContext) {
       to: new Date(DATES['8.0.0'].logs_and_metrics.max).toISOString(),
     },
     query: { bool: { must_not: [], filter: [], should: [], must: [] } },
-    sourceId: 'default',
   };
 
   const makeRequest = async ({

--- a/x-pack/test_serverless/api_integration/test_suites/observability/infra/infra.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/infra/infra.ts
@@ -89,7 +89,6 @@ export default function ({ getService }: FtrProviderContext) {
                 from: timeRange.from,
                 to: timeRange.to,
               },
-              sourceId: 'default',
             },
             roleAuthc
           );


### PR DESCRIPTION
closes [189247](https://github.com/elastic/kibana/issues/189247)
## Summary

Create an endpoint to return whether there is data for modules passed via `modules` query param. When `modules` is not passed, the query will just check if there is any data in the index patterns configured in the Settings page


### How to test

- Start a local Kibana instance
- Run `node scripts/synthtrace infra_hosts_with_apm_hosts --live`
- Run in the Dev tools:
  - `GET kbn:/api/metrics/source/hasData?modules=kubernetes&modules=system`
  - `GET kbn:/api/metrics/source/hasData?modules=system`
  - `GET kbn:/api/metrics/source/hasData?modules=kubernetes&modules=system&modules=kafka&modules=aws&modules=azure` - should return 400
  - `GET kbn:/api/metrics/source/hasData`