### PR TITLE
[renovate] Do not backport redocly/cli updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -75,7 +75,7 @@
       "matchDepNames": ["@redocly/cli"],
       "reviewers": ["team:kibana-core"],
       "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "Team:Core", "backport:all-open"],
+      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
       "minimumReleaseAge": "7 days",
       "enabled": true
     },


### PR DESCRIPTION
## Summary

Related to the discussion in https://github.com/elastic/kibana/pull/189401: we don't want to backport `@redocly/cli` updates.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
