### PR TITLE
[ResponseOps][Cases] Fix `useGetSeverity` for resilient connector flaky test.

### DIFF
--- a/x-pack/plugins/cases/public/components/connectors/jira/use_get_fields_by_issue_type.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/use_get_fields_by_issue_type.test.tsx
@@ -30,7 +30,7 @@ describe('useGetFieldsByIssueType', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'getFieldsByIssueType');
-    const { waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useGetFieldsByIssueType({
           http,
@@ -40,7 +40,7 @@ describe('useGetFieldsByIssueType', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => result.current.isSuccess);
 
     expect(spy).toHaveBeenCalledWith({
       http,
@@ -88,7 +88,7 @@ describe('useGetFieldsByIssueType', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetFieldsByIssueType({
           http,
@@ -98,8 +98,9 @@ describe('useGetFieldsByIssueType', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 
   it('calls addError when the getFieldsByIssueType api returns successfully but contains an error', async () => {
@@ -113,7 +114,7 @@ describe('useGetFieldsByIssueType', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetFieldsByIssueType({
           http,
@@ -123,7 +124,8 @@ describe('useGetFieldsByIssueType', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/jira/use_get_issue_types.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/jira/use_get_issue_types.test.tsx
@@ -30,7 +30,7 @@ describe('useGetIssueTypes', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'getIssueTypes');
-    const { waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useGetIssueTypes({
           http,
@@ -39,7 +39,7 @@ describe('useGetIssueTypes', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => result.current.isSuccess);
 
     expect(spy).toHaveBeenCalledWith({
       http,
@@ -70,7 +70,7 @@ describe('useGetIssueTypes', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetIssueTypes({
           http,
@@ -79,8 +79,9 @@ describe('useGetIssueTypes', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 
   it('calls addError when the getIssueTypes api returns successfully but contains an error', async () => {
@@ -94,7 +95,7 @@ describe('useGetIssueTypes', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetIssueTypes({
           http,
@@ -103,7 +104,8 @@ describe('useGetIssueTypes', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/resilient/use_get_incident_types.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/use_get_incident_types.test.tsx
@@ -30,7 +30,7 @@ describe('useGetIncidentTypes', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'getIncidentTypes');
-    const { waitFor } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useGetIncidentTypes({
           http,
@@ -39,9 +39,7 @@ describe('useGetIncidentTypes', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitFor(() => {
-      expect(spy).toHaveBeenCalled();
-    });
+    await waitFor(() => result.current.isSuccess);
 
     expect(spy).toHaveBeenCalledWith({
       http,

--- a/x-pack/plugins/cases/public/components/connectors/resilient/use_get_severity.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/resilient/use_get_severity.test.tsx
@@ -19,8 +19,7 @@ jest.mock('./api');
 
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 
-// FLAKY: https://github.com/elastic/kibana/issues/187456
-describe.skip('useGetSeverity', () => {
+describe('useGetSeverity', () => {
   const { http } = useKibanaMock().services;
   let appMockRender: AppMockRenderer;
 
@@ -31,7 +30,7 @@ describe.skip('useGetSeverity', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'getSeverity');
-    const { waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useGetSeverity({
           http,
@@ -40,7 +39,7 @@ describe.skip('useGetSeverity', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => result.current.isSuccess);
 
     expect(spy).toHaveBeenCalledWith({
       http,
@@ -71,7 +70,7 @@ describe.skip('useGetSeverity', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetSeverity({
           http,
@@ -80,8 +79,9 @@ describe.skip('useGetSeverity', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 
   it('calls addError when the getSeverity api returns successfully but contains an error', async () => {
@@ -95,7 +95,7 @@ describe.skip('useGetSeverity', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetSeverity({
           http,
@@ -104,7 +104,8 @@ describe.skip('useGetSeverity', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/servicenow/use_get_choices.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/servicenow/use_get_choices.test.tsx
@@ -47,7 +47,7 @@ describe('useGetChoices', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'getChoices');
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetChoices({
           http,
@@ -57,7 +57,9 @@ describe('useGetChoices', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
 
     expect(spy).toHaveBeenCalledWith({
       http,
@@ -90,7 +92,7 @@ describe('useGetChoices', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetChoices({
           http,
@@ -100,8 +102,9 @@ describe('useGetChoices', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 
   it('calls addError when the getChoices api returns successfully but contains an error', async () => {
@@ -115,7 +118,7 @@ describe('useGetChoices', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess: jest.fn(), addError });
 
-    const { waitForNextUpdate } = renderHook(
+    const { waitFor } = renderHook(
       () =>
         useGetChoices({
           http,
@@ -125,7 +128,8 @@ describe('useGetChoices', () => {
       { wrapper: appMockRender.AppWrapper }
     );
 
-    await waitForNextUpdate();
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(addError).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
fixes #187456

## Summary

Following @JiaweiWu 's classic advice I replaced `waitForNextUpdate` with `waitFor` 😁 

I looked for other places in cases that did the same and fixed them too.