### PR TITLE
[ResponseOps][Cases] Unskip flaky test

### DIFF
--- a/x-pack/plugins/cases/public/components/create/template.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/template.test.tsx
@@ -13,8 +13,7 @@ import { createAppMockRenderer } from '../../common/mock';
 import { templatesConfigurationMock } from '../../containers/mock';
 import { TemplateSelector } from './templates';
 
-// FLAKY: https://github.com/elastic/kibana/issues/178457
-describe.skip('CustomFields', () => {
+describe('CustomFields', () => {
   let appMockRender: AppMockRenderer;
   const onTemplateChange = jest.fn();
 

--- a/x-pack/plugins/cases/public/components/custom_fields/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/form.test.tsx
@@ -18,8 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { customFieldsConfigurationMock } from '../../containers/mock';
 import type { FormState } from '../configure_cases/flyout';
 
-// FLAKY: https://github.com/elastic/kibana/issues/187554
-describe.skip('CustomFieldsForm ', () => {
+describe('CustomFieldsForm ', () => {
   let appMockRender: AppMockRenderer;
   const onChange = jest.fn();
 


### PR DESCRIPTION
fixes #178457
fixes #187554

## Summary

I think this test was skipped by mistake.

The [failing build](https://buildkite.com/elastic/kibana-on-merge/builds/42401#018e2f40-5109-4a2a-a877-f0aeed20f20f) points to `x-pack/plugins/cases/public/components/create/custom_fields.test.tsx` but this file does not exist anymore.

[In the commit where the pipeline failed](https://github.com/elastic/kibana/tree/cd16d03ca9627b21452eff6b72d771318e85557f) the file `x-pack/plugins/cases/public/components/create/template.test.tsx` did not exist.

The `renders correctly` test is **very** different between these two files so I think there was some mistake here.

Additionally, there is [this skipped test](https://github.com/elastic/kibana/issues/188133) which IMO is the correct one. I fix that in a different PR.

PS: I kept looking into our flaky test list and I think the same is the case for #187554 the file skipped there does not match the one in the failing pipeline and it did not exist at the time of that commit. I think there was some confusion and time difference between the failing tests and the tests being skipped. When the tests were skipped the original file did not exist anymore and prob all custom field related `renders correctly` tests were skipped indiscriminately 🤷 