### PR TITLE
[Move `@kbn/config-schema` to server] `@kbn/apm-config-loader`

### DIFF
--- a/packages/kbn-apm-config-loader/kibana.jsonc
+++ b/packages/kbn-apm-config-loader/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-server",
   "id": "@kbn/apm-config-loader",
   "owner": ["@elastic/kibana-core", "@vigneshshanmugam"]
 }

--- a/packages/kbn-docs-utils/kibana.jsonc
+++ b/packages/kbn-docs-utils/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-server",
   "id": "@kbn/docs-utils",
   "devOnly": true,
   "owner": "@elastic/kibana-operations"

--- a/packages/kbn-plugin-check/kibana.jsonc
+++ b/packages/kbn-plugin-check/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-server",
   "id": "@kbn/plugin-check",
   "owner": "@elastic/appex-sharedux"
 }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/189476.

We want to avoid `@kbn/config-schema` from leaking to the browser, and this package depends on it.

- `@kbn/docs-utils` depends on `@kbn/apm-config-loader`
- `@kbn/plugin-check` depends on `@kbn/docs-utils`

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
