### PR TITLE
[Move `@kbn/config-schema` to server] `@kbn/cli-dev-mode`

### DIFF
--- a/packages/kbn-cli-dev-mode/kibana.jsonc
+++ b/packages/kbn-cli-dev-mode/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-server",
   "id": "@kbn/cli-dev-mode",
   "devOnly": true,
   "owner": "@elastic/kibana-operations"


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/189476.

We want to avoid `@kbn/config-schema` from leaking to the browser.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
