### PR TITLE
[Uptime] only check index status on plugin register if the user has uptime privileges

### DIFF
--- a/x-pack/plugins/observability_solution/uptime/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/uptime/public/plugin.ts
@@ -309,17 +309,20 @@ function setUptimeAppStatus(
       registerAlertRules(coreStart, pluginsStart, stackVersion, false);
       updater.next(() => ({ status: AppStatus.accessible }));
     } else {
-      const indexStatusPromise = UptimeDataHelper(coreStart).indexStatus('now-7d', 'now');
-      indexStatusPromise.then((indexStatus) => {
-        if (indexStatus.indexExists) {
-          registerUptimeRoutesWithNavigation(coreStart, pluginsStart);
-          updater.next(() => ({ status: AppStatus.accessible }));
-          registerAlertRules(coreStart, pluginsStart, stackVersion, false);
-        } else {
-          updater.next(() => ({ status: AppStatus.inaccessible }));
-          registerAlertRules(coreStart, pluginsStart, stackVersion, true);
-        }
-      });
+      const hasUptimePrivileges = coreStart.application.capabilities.uptime?.show;
+      if (hasUptimePrivileges) {
+        const indexStatusPromise = UptimeDataHelper(coreStart).indexStatus('now-7d', 'now');
+        indexStatusPromise.then((indexStatus) => {
+          if (indexStatus.indexExists) {
+            registerUptimeRoutesWithNavigation(coreStart, pluginsStart);
+            updater.next(() => ({ status: AppStatus.accessible }));
+            registerAlertRules(coreStart, pluginsStart, stackVersion, false);
+          } else {
+            updater.next(() => ({ status: AppStatus.inaccessible }));
+            registerAlertRules(coreStart, pluginsStart, stackVersion, true);
+          }
+        });
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/186838

Prevents checking for Uptime data on plugin register when the user does not have Uptime privileges

## Background Context
Uptime is hidden by default. However, there are two ways that the Uptime app can become accessible.
1. Turning on the Uptime app in the advanced settings
2. If you have data in your Uptime indices within the past 7 days.

The data check present in Uptime plugin register is intended to enable Uptime if there is Uptime data within the past 7 days. However, there's no need to check this data if the user does not have privileges.

### Testing
1. Create a user without Uptime Kibana privileges
2. Open up the network tab in dev tools
3. Refresh any page in Kibana
4. You should not see a call to `internal/uptime/index_status`

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->