### PR TITLE
Flaky test #118488

### DIFF
--- a/test/functional/page_objects/management/saved_objects_page.ts
+++ b/test/functional/page_objects/management/saved_objects_page.ts
@@ -385,6 +385,7 @@ export class SavedObjectsPageObject extends FtrService {
     await this.testSubjects.click('savedObjectsManagementDelete');
     if (confirmDelete) {
       await this.testSubjects.click('confirmModalConfirmButton');
+      await this.testSubjects.waitForDeleted('confirmModalConfirmButton');
       await this.waitTableIsLoaded();
     }
   }

--- a/test/plugin_functional/test_suites/saved_objects_management/hidden_types.ts
+++ b/test/plugin_functional/test_suites/saved_objects_management/hidden_types.ts
@@ -21,8 +21,7 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
   const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
 
-  // Failing: See https://github.com/elastic/kibana/issues/118488
-  describe.skip('saved objects management with hidden types', () => {
+  describe('saved objects management with hidden types', () => {
     before(async () => {
       await esArchiver.load(
         'test/functional/fixtures/es_archiver/saved_objects_management/hidden_types'


### PR DESCRIPTION
## Summary

Resolves #118488


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
	- ✅ 100x: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6643


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->