### PR TITLE
[ResponseOps][alerting] remove debug log causing null dereference on `alert::getUuid()`

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
@@ -518,13 +518,6 @@ export class AlertsClient<
                 rule: this.rule,
               })
         );
-      } else {
-        this.options.logger.debug(
-          () =>
-            `Could not find alert document to update for recovered alert with id ${id} and uuid ${currentRecoveredAlerts[
-              id
-            ].getUuid()}`
-        );
       }
     }
 


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/189551

See the reference issue for more details.

We just remove the else clause that is logging the error, as it's both very unlikely we'd ever see it since it's debug level, but we also don't think it's needed from the recent work done in this module.



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->