### PR TITLE
Flaky #156117

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
@@ -106,8 +106,7 @@ async function createRoot({ logFileName }: CreateRootConfig) {
 // suite is very long, the 10mins default can cause timeouts
 jest.setTimeout(15 * 60 * 1000);
 
-// FLAKY: https://github.com/elastic/kibana/issues/156117
-describe.skip('migration v2', () => {
+describe('migration v2', () => {
   let esServer: TestElasticsearchUtils;
   let rootA: Root;
   let rootB: Root;


### PR DESCRIPTION
## Summary

Resolves #156117

https://github.com/elastic/kibana/pull/158182 might have fixed it, so this PR just unskips the test.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->