### PR TITLE
[8.15] [ResponseOps][alerting] remove debug log causing null dereference on `alert::getUuid()` (#189572)

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
@@ -518,12 +518,6 @@ export class AlertsClient<
                 rule: this.rule,
               })
         );
-      } else {
-        this.options.logger.debug(
-          `Could not find alert document to update for recovered alert with id ${id} and uuid ${currentRecoveredAlerts[
-            id
-          ].getUuid()}`
-        );
       }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ResponseOps][alerting] remove debug log causing null dereference on `alert::getUuid()` (#189572)](https://github.com/elastic/kibana/pull/189572)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patrick Mueller","email":"patrick.mueller@elastic.co"},"sourceCommit":{"committedDate":"2024-07-31T00:17:13Z","message":"[ResponseOps][alerting] remove debug log causing null dereference on `alert::getUuid()` (#189572)\n\nresolves https://github.com/elastic/kibana/issues/189551\r\n\r\nSee the reference issue for more details.\r\n\r\nWe just remove the else clause that is logging the error, as it's both\r\nvery unlikely we'd ever see it since it's debug level, but we also don't\r\nthink it's needed from the recent work done in this module.","sha":"86bd347e136bfd1463d689999cce628a770bca4c","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","Feature:Alerting/RulesFramework","backport:prev-minor","v8.15.0","v8.16.0"],"number":189572,"url":"https://github.com/elastic/kibana/pull/189572","mergeCommit":{"message":"[ResponseOps][alerting] remove debug log causing null dereference on `alert::getUuid()` (#189572)\n\nresolves https://github.com/elastic/kibana/issues/189551\r\n\r\nSee the reference issue for more details.\r\n\r\nWe just remove the else clause that is logging the error, as it's both\r\nvery unlikely we'd ever see it since it's debug level, but we also don't\r\nthink it's needed from the recent work done in this module.","sha":"86bd347e136bfd1463d689999cce628a770bca4c"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/189572","number":189572,"mergeCommit":{"message":"[ResponseOps][alerting] remove debug log causing null dereference on `alert::getUuid()` (#189572)\n\nresolves https://github.com/elastic/kibana/issues/189551\r\n\r\nSee the reference issue for more details.\r\n\r\nWe just remove the else clause that is logging the error, as it's both\r\nvery unlikely we'd ever see it since it's debug level, but we also don't\r\nthink it's needed from the recent work done in this module.","sha":"86bd347e136bfd1463d689999cce628a770bca4c"}}]}] BACKPORT-->