### PR TITLE
[ES|QL][Discover] Hide null values from the document viewer

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -139,11 +139,13 @@ export const DocViewerTable = ({
   columnsMeta,
   hit,
   dataView,
+  textBasedHits,
   filter,
   decreaseAvailableHeightBy,
   onAddColumn,
   onRemoveColumn,
 }: DocViewRenderProps) => {
+  const isEsqlMode = Array.isArray(textBasedHits);
   const [containerRef, setContainerRef] = useState<HTMLDivElement | null>(null);
   const { fieldFormats, storage, uiSettings, fieldsMetadata } = getUnifiedDocViewerServices();
   const showMultiFields = uiSettings.get(SHOW_MULTIFIELDS);
@@ -272,7 +274,8 @@ export const DocViewerTable = ({
         if (!shouldShowFieldHandler(curFieldName)) {
           return acc;
         }
-        const shouldHideNullValue = areNullValuesHidden && flattened[curFieldName] == null;
+        const shouldHideNullValue =
+          areNullValuesHidden && flattened[curFieldName] == null && isEsqlMode;
         if (shouldHideNullValue) {
           return acc;
         }
@@ -510,23 +513,25 @@ export const DocViewerTable = ({
           <EuiFlexItem grow={false}>
             <EuiSpacer size="s" />
           </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            css={css`
-              align-self: end;
-              padding-bottom: ${euiTheme.size.s};
-            `}
-          >
-            <EuiSwitch
-              label={i18n.translate('unifiedDocViewer.hideNullValues.switchLabel', {
-                defaultMessage: 'Hide fields with null values',
-              })}
-              checked={areNullValuesHidden ?? false}
-              onChange={onHideNullValuesChange}
-              compressed
-              data-test-subj="unifiedDocViewerHideNullValuesSwitch"
-            />
-          </EuiFlexItem>
+          {isEsqlMode && (
+            <EuiFlexItem
+              grow={false}
+              css={css`
+                align-self: end;
+                padding-bottom: ${euiTheme.size.s};
+              `}
+            >
+              <EuiSwitch
+                label={i18n.translate('unifiedDocViewer.hideNullValues.switchLabel', {
+                  defaultMessage: 'Hide fields with null values',
+                })}
+                checked={areNullValuesHidden ?? false}
+                onChange={onHideNullValuesChange}
+                compressed
+                data-test-subj="unifiedDocViewerHideNullValuesSwitch"
+              />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem
             grow={Boolean(containerHeight)}
             css={css`

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -273,17 +273,19 @@ export const DocViewerTable = ({
           return acc;
         }
         const shouldHideNullValue = areNullValuesHidden && flattened[curFieldName] == null;
-        if (pinnedFields.includes(curFieldName) && !shouldHideNullValue) {
+        if (shouldHideNullValue) {
+          return acc;
+        }
+        if (pinnedFields.includes(curFieldName)) {
           acc.pinnedItems.push(fieldToItem(curFieldName, true));
         } else {
           const fieldMapping = mapping(curFieldName);
           if (
-            (!searchText?.trim() ||
-              fieldNameWildcardMatcher(
-                { name: curFieldName, displayName: fieldMapping?.displayName },
-                searchText
-              )) &&
-            !shouldHideNullValue
+            !searchText?.trim() ||
+            fieldNameWildcardMatcher(
+              { name: curFieldName, displayName: fieldMapping?.displayName },
+              searchText
+            )
           ) {
             // filter only unpinned fields
             acc.restItems.push(fieldToItem(curFieldName, false));

--- a/test/functional/apps/discover/group3/_doc_viewer.ts
+++ b/test/functional/apps/discover/group3/_doc_viewer.ts
@@ -103,5 +103,38 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
     });
+
+    describe('hide null values switch', function () {
+      beforeEach(async () => {
+        await dataGrid.clickRowToggle();
+        await PageObjects.discover.isShowingDocViewer();
+      });
+
+      afterEach(async () => {
+        const hideNullValuesSwitch = await testSubjects.find(
+          'unifiedDocViewerHideNullValuesSwitch'
+        );
+        await hideNullValuesSwitch.click(); // make sure the switch is off
+
+        const fieldSearch = await testSubjects.find('clearSearchButton');
+        await fieldSearch.click(); // clear search
+      });
+
+      it('should hide fields with null values ', async function () {
+        // _ignored is null
+        await PageObjects.discover.findFieldByNameInDocViewer('_i');
+        await retry.waitFor('updates', async () => {
+          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 3;
+        });
+        const hideNullValuesSwitch = await testSubjects.find(
+          'unifiedDocViewerHideNullValuesSwitch'
+        );
+        await hideNullValuesSwitch.click();
+
+        await retry.waitFor('updates', async () => {
+          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 2;
+        });
+      });
+    });
   });
 }

--- a/test/functional/apps/discover/group3/_doc_viewer.ts
+++ b/test/functional/apps/discover/group3/_doc_viewer.ts
@@ -132,9 +132,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should hide fields with null values ', async function () {
         // id is null
-        await PageObjects.discover.findFieldByNameInDocViewer('id');
+        await PageObjects.discover.findFieldByNameInDocViewer('machine');
         await retry.waitFor('updates', async () => {
-          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 2;
+          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 3;
         });
         const hideNullValuesSwitch = await testSubjects.find(
           'unifiedDocViewerHideNullValuesSwitch'
@@ -142,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await hideNullValuesSwitch.click();
 
         await retry.waitFor('updates', async () => {
-          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 1;
+          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 2;
         });
       });
     });

--- a/test/functional/apps/discover/group3/_doc_viewer.ts
+++ b/test/functional/apps/discover/group3/_doc_viewer.ts
@@ -11,7 +11,13 @@ import { FtrProviderContext } from '../ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const PageObjects = getPageObjects(['common', 'discover', 'timePicker', 'header']);
+  const PageObjects = getPageObjects([
+    'common',
+    'discover',
+    'timePicker',
+    'header',
+    'unifiedFieldList',
+  ]);
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const retry = getService('retry');
@@ -104,8 +110,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe('hide null values switch', function () {
+    describe('hide null values switch - ES|QL mode', function () {
       beforeEach(async () => {
+        await PageObjects.discover.selectTextBaseLang();
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
+        await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
         await dataGrid.clickRowToggle();
         await PageObjects.discover.isShowingDocViewer();
       });
@@ -121,10 +131,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should hide fields with null values ', async function () {
-        // _ignored is null
-        await PageObjects.discover.findFieldByNameInDocViewer('_i');
+        // id is null
+        await PageObjects.discover.findFieldByNameInDocViewer('id');
         await retry.waitFor('updates', async () => {
-          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 3;
+          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 2;
         });
         const hideNullValuesSwitch = await testSubjects.find(
           'unifiedDocViewerHideNullValuesSwitch'
@@ -132,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await hideNullValuesSwitch.click();
 
         await retry.waitFor('updates', async () => {
-          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 2;
+          return (await find.allByCssSelector('.kbnDocViewer__fieldName')).length === 1;
         });
       });
     });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/188846

Added a switch to the docViewer that hides the fields with null values. It is visible both in ESQL and dataview mode. The selection is stored in the localStorage

![meow](https://github.com/user-attachments/assets/3a072081-e41c-482c-8c0f-2028f39a34cd)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios