### PR TITLE
[Security Solution][Notes] - fix infinite look refresh note with investigation query

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -18,6 +18,9 @@ import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import { SourcererScopeName } from '../../../../../sourcerer/store/model';
 import type { TimeRange } from '../../../../store/inputs/model';
 
+const fields = ['*'];
+const runtimeMappings = {};
+
 export interface UseInsightQuery {
   dataProviders: DataProvider[];
   filters: Filter[];
@@ -67,16 +70,15 @@ export const useInsightQuery = ({
 
   const [dataLoadingState, { events, totalCount }] = useTimelineEvents({
     dataViewId,
-    fields: ['*'],
+    fields,
     filterQuery: combinedQueries?.filterQuery,
     id: TimelineId.active,
     indexNames: selectedPatterns,
     language: 'kuery',
     limit: 1,
-    runtimeMappings: {},
-    ...(relativeTimerange
-      ? { startDate: relativeTimerange?.from, endDate: relativeTimerange?.to }
-      : {}),
+    runtimeMappings,
+    startDate: relativeTimerange?.from,
+    endDate: relativeTimerange?.to,
     fetchNotes: false,
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.ts
@@ -77,6 +77,7 @@ export const useInsightQuery = ({
     ...(relativeTimerange
       ? { startDate: relativeTimerange?.from, endDate: relativeTimerange?.to }
       : {}),
+    fetchNotes: false,
   });
 
   const isQueryLoading = useMemo(

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
@@ -96,6 +96,7 @@ export interface UseTimelineEventsProps {
   sort?: TimelineRequestSortField[];
   startDate?: string;
   timerangeKind?: 'absolute' | 'relative';
+  fetchNotes?: boolean;
 }
 
 const getTimelineEvents = (timelineEdges: TimelineEdges[]): TimelineItem[] =>
@@ -482,6 +483,7 @@ export const useTimelineEvents = ({
   sort = initSortDefault,
   skip = false,
   timerangeKind,
+  fetchNotes = true,
 }: UseTimelineEventsProps): [DataLoadingState, TimelineArgs] => {
   const [dataLoadingState, timelineResponse, timelineSearchHandler] = useTimelineEventsHandler({
     dataViewId,
@@ -503,9 +505,9 @@ export const useTimelineEvents = ({
 
   const onTimelineSearchComplete: OnNextResponseHandler = useCallback(
     (response) => {
-      onLoad(response.events);
+      if (fetchNotes) onLoad(response.events);
     },
-    [onLoad]
+    [fetchNotes, onLoad]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

This PR fixes an issue when an investigation query is added to a note, which resulted in a infinite loop where the notes kept being refreshed.

What happened is the `InsightComponent` that renders the button for the investigation query uses the `LicensedInsightComponent` which internally uses the `useInsightQuery` hook, which itself uses the [useTimelineEvents](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/timelines/containers/index.tsx#L470) hook.

This hook was [recently modified](https://github.com/elastic/kibana/pull/188770) to use a new `fetchNotes` hook that takes care of fetching all the notes for an array of document ids. We probably missed testing this scenario.

The fix in this PR might not be the most ideal long term, but it fixes the issue simply and with a minimal amount of code change, to limit the risk as we're pretty late in the BC period.

The issue was happening on the alerts page, in the explore pages and in cases... basically everywhere we're loading note in the expandable flyout.

Before fix

https://github.com/user-attachments/assets/717e7f4e-ff0f-488e-9ab4-d056ca3aa3cb

After fix

https://github.com/user-attachments/assets/f2e1b2a1-af00-4a4a-bf9b-75df0741bdfd

https://github.com/elastic/kibana/issues/189490

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->