### PR TITLE
[7.17] Replace `bluebird.mapAsync()` by native `Promise.all()`

### DIFF
--- a/test/functional/apps/saved_objects_management/show_relationships.ts
+++ b/test/functional/apps/saved_objects_management/show_relationships.ts
@@ -11,7 +11,6 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
-  const retry = getService('retry');
   const PageObjects = getPageObjects(['common', 'settings', 'savedObjects']);
 
   describe('saved objects relationships flyout', () => {
@@ -36,12 +35,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       await PageObjects.savedObjects.clickRelationshipsByTitle('Dashboard with missing refs');
 
-      let invalidRelations: any[] = [];
-
-      await retry.waitFor('2 invalid relations to be found', async () => {
-        invalidRelations = await PageObjects.savedObjects.getInvalidRelations();
-        return invalidRelations.length === 2;
-      });
+      const invalidRelations = await PageObjects.savedObjects.getInvalidRelations();
 
       expect(invalidRelations).to.eql([
         {

--- a/test/functional/page_objects/management/saved_objects_page.ts
+++ b/test/functional/page_objects/management/saved_objects_page.ts
@@ -7,7 +7,6 @@
  */
 
 import { keyBy } from 'lodash';
-import { map as mapAsync } from 'bluebird';
 import { FtrService } from '../../ftr_provider_context';
 
 export class SavedObjectsPageObject extends FtrService {
@@ -185,7 +184,7 @@ export class SavedObjectsPageObject extends FtrService {
 
   async getElementsInTable() {
     const rows = await this.testSubjects.findAll('~savedObjectsTableRow');
-    return mapAsync(rows, async (row) => {
+    return await Promise.all(rows.map(async (row) => {
       const checkbox = await row.findByCssSelector('[data-test-subj*="checkboxSelectRow"]');
       // return the object type aria-label="index patterns"
       const objectType = await row.findByTestSubject('objectType');
@@ -229,7 +228,7 @@ export class SavedObjectsPageObject extends FtrService {
         relationshipsElement,
         copySaveObjectsElement,
       };
-    });
+    }));
   }
 
   async getRowTitles() {
@@ -243,7 +242,7 @@ export class SavedObjectsPageObject extends FtrService {
 
   async getRelationshipFlyout() {
     const rows = await this.testSubjects.findAll('relationshipsTableRow');
-    return mapAsync(rows, async (row) => {
+    return await Promise.all(rows.map(async (row) => {
       const objectType = await row.findByTestSubject('relationshipsObjectType');
       const relationship = await row.findByTestSubject('directRelationship');
       const titleElement = await row.findByTestSubject('relationshipsTitle');
@@ -255,12 +254,12 @@ export class SavedObjectsPageObject extends FtrService {
         title: await titleElement.getVisibleText(),
         inspectElement,
       };
-    });
+    }));
   }
 
   async getInvalidRelations() {
     const rows = await this.testSubjects.findAll('invalidRelationshipsTableRow');
-    return mapAsync(rows, async (row) => {
+    return Promise.all(rows.map(async (row) => {
       const objectType = await row.findByTestSubject('relationshipsObjectType');
       const objectId = await row.findByTestSubject('relationshipsObjectId');
       const relationship = await row.findByTestSubject('directRelationship');
@@ -271,7 +270,7 @@ export class SavedObjectsPageObject extends FtrService {
         relationship: await relationship.getVisibleText(),
         error: await error.getVisibleText(),
       };
-    }).then((result) => result.sort((a, b) => a.id.localeCompare(b.id)));
+    })).then((result) => result.sort((a, b) => a.id.localeCompare(b.id)));
   }
 
   async getTableSummary() {

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { map as mapAsync } from 'bluebird';
 import expect from '@kbn/expect';
 import { FtrService } from '../ftr_provider_context';
 
@@ -234,23 +233,23 @@ export class SettingsPageObject extends FtrService {
 
   async getFieldNames() {
     const fieldNameCells = await this.testSubjects.findAll('editIndexPattern > indexedFieldName');
-    return await mapAsync(fieldNameCells, async (cell) => {
+    return await Promise.all(fieldNameCells.map(async (cell) => {
       return (await cell.getVisibleText()).trim();
-    });
+    }));
   }
 
   async getFieldTypes() {
     const fieldNameCells = await this.testSubjects.findAll('editIndexPattern > indexedFieldType');
-    return await mapAsync(fieldNameCells, async (cell) => {
+    return await Promise.all(fieldNameCells.map(async (cell) => {
       return (await cell.getVisibleText()).trim();
-    });
+    }));
   }
 
   async getScriptedFieldLangs() {
     const fieldNameCells = await this.testSubjects.findAll('editIndexPattern > scriptedFieldLang');
-    return await mapAsync(fieldNameCells, async (cell) => {
+    return await Promise.all(fieldNameCells.map(async (cell) => {
       return (await cell.getVisibleText()).trim();
-    });
+    }));
   }
 
   async setFieldTypeFilter(type: string) {
@@ -327,9 +326,9 @@ export class SettingsPageObject extends FtrService {
 
   async getAllIndexPatternNames() {
     const indexPatterns = await this.getIndexPatternList();
-    return await mapAsync(indexPatterns, async (index) => {
+    return await Promise.all(indexPatterns.map(async (index) => {
       return await index.getVisibleText();
-    });
+    }));
   }
 
   async isIndexPatternListEmpty() {
@@ -577,9 +576,9 @@ export class SettingsPageObject extends FtrService {
     const table = await this.find.byClassName('euiTable');
     await this.retry.waitFor('field filter to be added', async () => {
       const tableCells = await table.findAllByCssSelector('td');
-      const fieldNames = await mapAsync(tableCells, async (cell) => {
+      const fieldNames = await Promise.all(tableCells.map(async (cell) => {
         return (await cell.getVisibleText()).trim();
-      });
+      }));
       return fieldNames.includes(name);
     });
   }

--- a/test/functional/services/common/test_subjects.ts
+++ b/test/functional/services/common/test_subjects.ts
@@ -7,7 +7,6 @@
  */
 
 import testSubjSelector from '@kbn/test-subj-selector';
-import { map as mapAsync } from 'bluebird';
 import { WebElementWrapper } from '../lib/web_element_wrapper';
 import { FtrService } from '../../ftr_provider_context';
 
@@ -271,11 +270,11 @@ export class TestSubjects extends FtrService {
 
   private async _mapAll<T>(
     selectorAll: string,
-    mapFn: (element: WebElementWrapper, index?: number, arrayLength?: number) => Promise<T>
+    mapFn: (element: WebElementWrapper, index?: number) => Promise<T>
   ): Promise<T[]> {
     return await this.retry.try(async () => {
       const elements = await this.findAll(selectorAll);
-      return await mapAsync(elements, mapFn);
+      return await Promise.all(elements.map(mapFn));
     });
   }
 

--- a/x-pack/test/functional/page_objects/rollup_page.ts
+++ b/x-pack/test/functional/page_objects/rollup_page.ts
@@ -6,7 +6,6 @@
  */
 
 import expect from '@kbn/expect';
-import { map as mapAsync } from 'bluebird';
 import { FtrService } from '../ftr_provider_context';
 
 export class RollupPageObject extends FtrService {
@@ -111,7 +110,7 @@ export class RollupPageObject extends FtrService {
 
   async getJobList() {
     const jobs = await this.testSubjects.findAll('jobTableRow');
-    return mapAsync(jobs, async (job) => {
+    return await Promise.all(jobs.map(async (job) => {
       const jobNameElement = await job.findByTestSubject('jobTableCell-id');
       const jobStatusElement = await job.findByTestSubject('jobTableCell-status');
       const jobIndexPatternElement = await job.findByTestSubject('jobTableCell-indexPattern');
@@ -131,6 +130,6 @@ export class RollupPageObject extends FtrService {
         jobGroup: await jobGroupElement.getVisibleText(),
         jobMetrics: await jobMetricsElement.getVisibleText(),
       };
-    });
+    }));
   }
 }

--- a/x-pack/test/functional/page_objects/watcher_page.ts
+++ b/x-pack/test/functional/page_objects/watcher_page.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { map as mapAsync } from 'bluebird';
 import { FtrService } from '../ftr_provider_context';
 
 export class WatcherPageObject extends FtrService {
@@ -51,7 +50,7 @@ export class WatcherPageObject extends FtrService {
   // get all the watches in the list
   async getWatches() {
     const watches = await this.find.allByCssSelector('.euiTableRow');
-    return mapAsync(watches, async (watch) => {
+    return await Promise.all(watches.map(async (watch) => {
       const checkBox = await watch.findByCssSelector('td:nth-child(1)');
       const id = await watch.findByCssSelector('td:nth-child(2)');
       const name = await watch.findByCssSelector('td:nth-child(3)');
@@ -61,6 +60,6 @@ export class WatcherPageObject extends FtrService {
         id: await id.getVisibleText(),
         name: (await name.getVisibleText()).split(',').map((role) => role.trim()),
       };
-    });
+    }));
   }
 }

--- a/x-pack/test/functional/services/ace_editor.js
+++ b/x-pack/test/functional/services/ace_editor.js
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { map as mapAsync } from 'bluebird';
-
 export function AceEditorProvider({ getService }) {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
@@ -35,7 +33,7 @@ export function AceEditorProvider({ getService }) {
       return await retry.try(async () => {
         const editor = await testSubjects.find(testSubjectSelector);
         const lines = await editor.findAllByClassName('ace_line');
-        const linesText = await mapAsync(lines, (line) => line.getVisibleText());
+        const linesText = await Promise.all(lines.map((line) => line.getVisibleText()));
         return linesText.join('\n');
       });
     }

--- a/x-pack/test/functional/services/monitoring/cluster_alerts.js
+++ b/x-pack/test/functional/services/monitoring/cluster_alerts.js
@@ -6,7 +6,6 @@
  */
 
 import { range } from 'lodash';
-import { map as mapAsync } from 'bluebird';
 
 export function MonitoringClusterAlertsProvider({ getService, getPageObjects }) {
   const testSubjects = getService('testSubjects');
@@ -61,9 +60,9 @@ export function MonitoringClusterAlertsProvider({ getService, getPageObjects }) 
       const listingRows = await this.getOverviewAlerts();
       const alertIcons = await retry.try(async () => {
         const elements = await find.allByCssSelector(SUBJ_OVERVIEW_ICONS);
-        return await mapAsync(elements, async (element) => {
+        return await Promise.all(elements.map(async (element) => {
           return await element.getVisibleText();
-        });
+        }));
       });
 
       return await this._getAlertSetAll({


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/179977.
Applies PR https://github.com/elastic/kibana/pull/118097 to `7.17` branch.

**Please keep this PR in draft until a new 7.17 failure appears.**

200x FTR - https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6649 - ⌛ 