### PR TITLE
[Security Solution] Add tags by OpenAPI bundler

### DIFF
--- a/packages/kbn-openapi-bundler/src/bundler/merge_documents/merge_documents.ts
+++ b/packages/kbn-openapi-bundler/src/bundler/merge_documents/merge_documents.ts
@@ -67,7 +67,11 @@ export async function mergeDocuments(
       mergedDocument.security = mergeSecurityRequirements(documentsToMerge);
     }
 
-    mergedDocument.tags = mergeTags(documentsToMerge);
+    const mergedTags = [...(options.addTags ?? []), ...(mergeTags(documentsToMerge) ?? [])];
+
+    if (mergedTags.length) {
+      mergedDocument.tags = mergedTags;
+    }
 
     mergedByVersion.set(mergedDocument.info.version, mergedDocument);
   }

--- a/packages/kbn-openapi-bundler/src/bundler/merge_documents/merge_operations.ts
+++ b/packages/kbn-openapi-bundler/src/bundler/merge_documents/merge_operations.ts
@@ -26,10 +26,17 @@ export function mergeOperations(
       continue;
     }
 
+    // Adding tags before merging helps to reuse already existing functionality
+    // without changes. It imitates a case when such tags already existed in source operations.
+    const extendedTags = [
+      ...(options.addTags?.map((t) => t.name) ?? []),
+      ...(sourceOperation.tags ?? []),
+    ];
     const normalizedSourceOperation = {
       ...sourceOperation,
       ...(options.skipServers ? { servers: undefined } : { servers: sourceOperation.servers }),
       ...(options.skipSecurity ? { security: undefined } : { security: sourceOperation.security }),
+      ...(extendedTags.length > 0 ? { tags: extendedTags } : {}),
     };
 
     if (!mergedOperation || deepEqual(normalizedSourceOperation, mergedOperation)) {

--- a/packages/kbn-openapi-bundler/src/bundler/merge_documents/merge_options.ts
+++ b/packages/kbn-openapi-bundler/src/bundler/merge_documents/merge_options.ts
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
+import { OpenAPIV3 } from 'openapi-types';
+
 export interface MergeOptions {
   skipServers: boolean;
   skipSecurity: boolean;
+  addTags?: OpenAPIV3.TagObject[];
 }

--- a/packages/kbn-openapi-bundler/src/openapi_bundler.ts
+++ b/packages/kbn-openapi-bundler/src/openapi_bundler.ts
@@ -32,7 +32,7 @@ interface BundleOptions {
    */
   prototypeDocument?: PrototypeDocument | string;
   /**
-   * When specified the produced bundle will contain only
+   * When `includeLabels` are specified the produced bundle will contain only
    * operations objects with matching labels
    */
   includeLabels?: string[];
@@ -40,7 +40,7 @@ interface BundleOptions {
 
 export const bundle = async ({
   sourceGlob,
-  outputFilePath = 'bundled-{version}.schema.yaml',
+  outputFilePath = 'bundled_{version}.schema.yaml',
   options,
 }: BundlerConfig) => {
   const prototypeDocument = options?.prototypeDocument
@@ -82,6 +82,7 @@ export const bundle = async ({
     splitDocumentsByVersion: true,
     skipServers: Boolean(prototypeDocument?.servers),
     skipSecurity: Boolean(prototypeDocument?.security),
+    addTags: prototypeDocument?.tags,
   });
 
   await writeDocuments(resultDocumentsMap, outputFilePath);

--- a/packages/kbn-openapi-bundler/src/openapi_merger.ts
+++ b/packages/kbn-openapi-bundler/src/openapi_merger.ts
@@ -75,6 +75,7 @@ export const merge = async ({
     splitDocumentsByVersion: false,
     skipServers: Boolean(prototypeDocument?.servers),
     skipSecurity: Boolean(prototypeDocument?.security),
+    addTags: prototypeDocument?.tags,
   });
   // Only one document is expected when `splitDocumentsByVersion` is set to `false`
   const mergedDocument = Array.from(resultDocumentsMap.values())[0];

--- a/packages/kbn-openapi-bundler/src/prototype_document.ts
+++ b/packages/kbn-openapi-bundler/src/prototype_document.ts
@@ -9,21 +9,37 @@
 import { OpenAPIV3 } from 'openapi-types';
 
 /**
- * `PrototypeDocument` is used as a prototype for the result file. In the other words
- * it provides a way to specify the following properties
- *
- * - `info` info object
- * - `servers` servers used to replace `servers` in the source OpenAPI specs
- * - `security` security requirements used to replace `security` in the source OpenAPI specs
- *   It must be specified together with `components.securitySchemes`.
- *
- * All the other properties will be ignored.
+ * `PrototypeDocument` is used as a prototype for the result file.
+ * Only specified properties are used. All the other properties will be ignored.
  */
 export interface PrototypeDocument {
+  /**
+   * Defines OpenAPI Info Object to be used in the result document.
+   * `bundle()` utility doesn't use `info.version`.
+   */
   info?: Partial<OpenAPIV3.InfoObject>;
+  /**
+   * Defines `servers` to be used in the result document. When `servers`
+   * are set existing source documents `servers` aren't included into
+   * the result document.
+   */
   servers?: OpenAPIV3.ServerObject[];
+  /**
+   * Defines security requirements to be used in the result document. It must
+   * be used together with `components.securitySchemes` When `security`
+   * is set existing source documents `security` isn't included into
+   * the result document.
+   */
   security?: OpenAPIV3.SecurityRequirementObject[];
   components?: {
+    /**
+     * Defines security schemes for security requirements.
+     */
     securitySchemes: Record<string, OpenAPIV3.SecuritySchemeObject>;
   };
+  /**
+   * Defines tags to be added to the result document. Tags are added to
+   * root level tags and prepended to operation object tags.
+   */
+  tags?: OpenAPIV3.TagObject[];
 }

--- a/packages/kbn-openapi-bundler/src/validate_prototype_document.ts
+++ b/packages/kbn-openapi-bundler/src/validate_prototype_document.ts
@@ -25,6 +25,14 @@ export async function validatePrototypeDocument(
       ? await readDocument(prototypeDocumentOrString)
       : prototypeDocumentOrString;
 
+  if (prototypeDocument.servers && !Array.isArray(prototypeDocument.servers)) {
+    throw new Error(`Prototype document's ${chalk.bold('servers')} must be an array`);
+  }
+
+  if (prototypeDocument.tags && !Array.isArray(prototypeDocument.tags)) {
+    throw new Error(`Prototype document's ${chalk.bold('tags')} must be an array`);
+  }
+
   if (prototypeDocument.security && !prototypeDocument.components?.securitySchemes) {
     throw new Error(
       `Prototype document must contain ${chalk.bold(

--- a/packages/kbn-openapi-bundler/src/validate_prototype_document.ts
+++ b/packages/kbn-openapi-bundler/src/validate_prototype_document.ts
@@ -29,8 +29,28 @@ export async function validatePrototypeDocument(
     throw new Error(`Prototype document's ${chalk.bold('servers')} must be an array`);
   }
 
+  if (prototypeDocument.servers && prototypeDocument.servers.length === 0) {
+    throw new Error(
+      `Prototype document's ${chalk.bold('servers')} should have as minimum one entry`
+    );
+  }
+
+  if (prototypeDocument.security && !Array.isArray(prototypeDocument.security)) {
+    throw new Error(`Prototype document's ${chalk.bold('security')} must be an array`);
+  }
+
+  if (prototypeDocument.security && prototypeDocument.security.length === 0) {
+    throw new Error(
+      `Prototype document's ${chalk.bold('security')} should have as minimum one entry`
+    );
+  }
+
   if (prototypeDocument.tags && !Array.isArray(prototypeDocument.tags)) {
     throw new Error(`Prototype document's ${chalk.bold('tags')} must be an array`);
+  }
+
+  if (prototypeDocument.tags && prototypeDocument.tags.length === 0) {
+    throw new Error(`Prototype document's ${chalk.bold('tags')} should have as minimum one entry`);
   }
 
   if (prototypeDocument.security && !prototypeDocument.components?.securitySchemes) {

--- a/packages/kbn-openapi-bundler/tests/bundler/result_overrides/add_tags.test.ts
+++ b/packages/kbn-openapi-bundler/tests/bundler/result_overrides/add_tags.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createOASDocument } from '../../create_oas_document';
+import { bundleSpecs } from '../bundle_specs';
+
+describe('OpenAPI Bundler - assign a tag', () => {
+  it('adds tags when nothing is set', async () => {
+    const spec1 = createOASDocument({
+      paths: {
+        '/api/some_api': {
+          get: {
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const spec2 = createOASDocument({
+      paths: {
+        '/api/another_api': {
+          get: {
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const [bundledSpec] = Object.values(
+      await bundleSpecs(
+        {
+          1: spec1,
+          2: spec2,
+        },
+        {
+          prototypeDocument: {
+            tags: [
+              {
+                name: 'Some Tag',
+                description: 'Some tag description',
+              },
+              {
+                name: 'Another Tag',
+                description: 'Another tag description',
+              },
+            ],
+          },
+        }
+      )
+    );
+
+    expect(bundledSpec.paths['/api/some_api']?.get?.tags).toEqual(['Some Tag', 'Another Tag']);
+    expect(bundledSpec.paths['/api/another_api']?.get?.tags).toEqual(['Some Tag', 'Another Tag']);
+    expect(bundledSpec.tags).toEqual([
+      {
+        name: 'Some Tag',
+        description: 'Some tag description',
+      },
+      {
+        name: 'Another Tag',
+        description: 'Another tag description',
+      },
+    ]);
+  });
+
+  it('adds tags to existing tags', async () => {
+    const spec1 = createOASDocument({
+      paths: {
+        '/api/some_api': {
+          get: {
+            tags: ['Local tag'],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const spec2 = createOASDocument({
+      paths: {
+        '/api/another_api': {
+          get: {
+            tags: ['Global tag'],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      tags: [{ name: 'Global tag', description: 'Global tag description' }],
+    });
+
+    const [bundledSpec] = Object.values(
+      await bundleSpecs(
+        {
+          1: spec1,
+          2: spec2,
+        },
+        {
+          prototypeDocument: {
+            tags: [
+              {
+                name: 'Some Tag',
+                description: 'Some tag description',
+              },
+              {
+                name: 'Another Tag',
+                description: 'Another tag description',
+              },
+            ],
+          },
+        }
+      )
+    );
+
+    expect(bundledSpec.paths['/api/some_api']?.get?.tags).toEqual([
+      'Some Tag',
+      'Another Tag',
+      'Local tag',
+    ]);
+    expect(bundledSpec.paths['/api/another_api']?.get?.tags).toEqual([
+      'Some Tag',
+      'Another Tag',
+      'Global tag',
+    ]);
+    expect(bundledSpec.tags).toEqual([
+      {
+        name: 'Some Tag',
+        description: 'Some tag description',
+      },
+      {
+        name: 'Another Tag',
+        description: 'Another tag description',
+      },
+      { name: 'Global tag', description: 'Global tag description' },
+    ]);
+  });
+});

--- a/packages/kbn-openapi-bundler/tests/merger/result_overrides/add_tags.test.ts
+++ b/packages/kbn-openapi-bundler/tests/merger/result_overrides/add_tags.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createOASDocument } from '../../create_oas_document';
+import { mergeSpecs } from '../merge_specs';
+
+describe('OpenAPI Bundler - assign a tag', () => {
+  it('adds tags when nothing is set', async () => {
+    const spec1 = createOASDocument({
+      paths: {
+        '/api/some_api': {
+          get: {
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const spec2 = createOASDocument({
+      paths: {
+        '/api/another_api': {
+          get: {
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const [mergedSpec] = Object.values(
+      await mergeSpecs(
+        {
+          1: spec1,
+          2: spec2,
+        },
+        {
+          prototypeDocument: {
+            tags: [
+              {
+                name: 'Some Tag',
+                description: 'Some tag description',
+              },
+              {
+                name: 'Another Tag',
+                description: 'Another tag description',
+              },
+            ],
+          },
+        }
+      )
+    );
+
+    expect(mergedSpec.paths['/api/some_api']?.get?.tags).toEqual(['Some Tag', 'Another Tag']);
+    expect(mergedSpec.paths['/api/another_api']?.get?.tags).toEqual(['Some Tag', 'Another Tag']);
+    expect(mergedSpec.tags).toEqual([
+      {
+        name: 'Some Tag',
+        description: 'Some tag description',
+      },
+      {
+        name: 'Another Tag',
+        description: 'Another tag description',
+      },
+    ]);
+  });
+
+  it('adds tags to existing tags', async () => {
+    const spec1 = createOASDocument({
+      paths: {
+        '/api/some_api': {
+          get: {
+            tags: ['Local tag'],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const spec2 = createOASDocument({
+      paths: {
+        '/api/another_api': {
+          get: {
+            tags: ['Global tag'],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      tags: [{ name: 'Global tag', description: 'Global tag description' }],
+    });
+
+    const [mergedSpec] = Object.values(
+      await mergeSpecs(
+        {
+          1: spec1,
+          2: spec2,
+        },
+        {
+          prototypeDocument: {
+            tags: [
+              {
+                name: 'Some Tag',
+                description: 'Some tag description',
+              },
+              {
+                name: 'Another Tag',
+                description: 'Another tag description',
+              },
+            ],
+          },
+        }
+      )
+    );
+
+    expect(mergedSpec.paths['/api/some_api']?.get?.tags).toEqual([
+      'Some Tag',
+      'Another Tag',
+      'Local tag',
+    ]);
+    expect(mergedSpec.paths['/api/another_api']?.get?.tags).toEqual([
+      'Some Tag',
+      'Another Tag',
+      'Global tag',
+    ]);
+    expect(mergedSpec.tags).toEqual([
+      {
+        name: 'Some Tag',
+        description: 'Some tag description',
+      },
+      {
+        name: 'Another Tag',
+        description: 'Another tag description',
+      },
+      { name: 'Global tag', description: 'Global tag description' },
+    ]);
+  });
+});

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list/create_endpoint_list.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list/create_endpoint_list.schema.yaml
@@ -10,8 +10,6 @@ paths:
       operationId: CreateEndpointList
       summary: Creates an endpoint list
       description: Creates an endpoint list or does nothing if the list already exists
-      tags:
-        - Endpoint exceptions API
       responses:
         200:
           description: Successful response

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list_item/create_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list_item/create_endpoint_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       x-codegen-enabled: true
       operationId: CreateEndpointListItem
       summary: Creates an endpoint list item
-      tags:
-        - Endpoint exceptions API
       requestBody:
         description: Exception list item's properties
         required: true

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/delete_endpoint_list_item/delete_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/delete_endpoint_list_item/delete_endpoint_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       x-codegen-enabled: true
       operationId: DeleteEndpointListItem
       summary: Deletes an endpoint list item
-      tags:
-        - Endpoint exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/find_endpoint_list_item/find_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/find_endpoint_list_item/find_endpoint_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       x-codegen-enabled: true
       operationId: FindEndpointListItems
       summary: Finds endpoint list items
-      tags:
-        - Endpoint exceptions API
       parameters:
         - name: filter
           in: query

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       x-codegen-enabled: true
       operationId: ReadEndpointListItem
       summary: Reads an endpoint list item
-      tags:
-        - Endpoint exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/update_endpoint_list_item/update_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/update_endpoint_list_item/update_endpoint_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       x-codegen-enabled: true
       operationId: UpdateEndpointListItem
       summary: Updates an endpoint list item
-      tags:
-        - Endpoint exceptions API
       requestBody:
         description: Exception list item's properties
         required: true

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -49,8 +49,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Creates an endpoint list
-      tags:
-        - Endpoint exceptions API
   /api/endpoint_list/items:
     delete:
       operationId: DeleteEndpointListItem
@@ -107,8 +105,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Deletes an endpoint list item
-      tags:
-        - Endpoint exceptions API
     get:
       operationId: ReadEndpointListItem
       parameters:
@@ -166,8 +162,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Reads an endpoint list item
-      tags:
-        - Endpoint exceptions API
     post:
       operationId: CreateEndpointListItem
       requestBody:
@@ -244,8 +238,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Creates an endpoint list item
-      tags:
-        - Endpoint exceptions API
     put:
       operationId: UpdateEndpointListItem
       requestBody:
@@ -327,8 +319,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Updates an endpoint list item
-      tags:
-        - Endpoint exceptions API
   /api/endpoint_list/items/_find:
     get:
       operationId: FindEndpointListItems
@@ -433,8 +423,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Finds endpoint list items
-      tags:
-        - Endpoint exceptions API
 components:
   schemas:
     EndpointList:

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -49,8 +49,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Creates an endpoint list
-      tags:
-        - Endpoint exceptions API
   /api/endpoint_list/items:
     delete:
       operationId: DeleteEndpointListItem
@@ -107,8 +105,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Deletes an endpoint list item
-      tags:
-        - Endpoint exceptions API
     get:
       operationId: ReadEndpointListItem
       parameters:
@@ -166,8 +162,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Reads an endpoint list item
-      tags:
-        - Endpoint exceptions API
     post:
       operationId: CreateEndpointListItem
       requestBody:
@@ -244,8 +238,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Creates an endpoint list item
-      tags:
-        - Endpoint exceptions API
     put:
       operationId: UpdateEndpointListItem
       requestBody:
@@ -327,8 +319,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Updates an endpoint list item
-      tags:
-        - Endpoint exceptions API
   /api/endpoint_list/items/_find:
     get:
       operationId: FindEndpointListItems
@@ -433,8 +423,6 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
       summary: Finds endpoint list items
-      tags:
-        - Endpoint exceptions API
 components:
   schemas:
     EndpointList:

--- a/packages/kbn-securitysolution-exceptions-common/api/create_exception_list/create_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/create_exception_list/create_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateExceptionList
       x-codegen-enabled: true
       summary: Creates an exception list
-      tags:
-        - Exceptions API
       requestBody:
         description: Exception list's properties
         required: true

--- a/packages/kbn-securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/create_exception_list_item/create_exception_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateExceptionListItem
       x-codegen-enabled: true
       summary: Creates an exception list item
-      tags:
-        - Exceptions API
       requestBody:
         description: Exception list item's properties
         required: true

--- a/packages/kbn-securitysolution-exceptions-common/api/create_rule_exceptions/create_rule_exceptions.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/create_rule_exceptions/create_rule_exceptions.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateRuleExceptionListItems
       x-codegen-enabled: true
       summary: Creates rule exception list items
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: path

--- a/packages/kbn-securitysolution-exceptions-common/api/create_shared_exceptions_list/create_shared_exceptions_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/create_shared_exceptions_list/create_shared_exceptions_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateSharedExceptionList
       x-codegen-enabled: true
       summary: Creates a shared exception list
-      tags:
-        - Exceptions API
       requestBody:
         required: true
         content:

--- a/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list/delete_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list/delete_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: DeleteExceptionList
       x-codegen-enabled: true
       summary: Deletes an exception list
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list_item/delete_exception_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/delete_exception_list_item/delete_exception_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: DeleteExceptionListItem
       x-codegen-enabled: true
       summary: Deletes an exception list item
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/duplicate_exception_list/duplicate_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/duplicate_exception_list/duplicate_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: DuplicateExceptionList
       x-codegen-enabled: true
       summary: Duplicates an exception list
-      tags:
-        - Exceptions API
       parameters:
         - name: list_id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/export_exception_list/export_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/export_exception_list/export_exception_list.schema.yaml
@@ -10,8 +10,6 @@ paths:
       x-codegen-enabled: true
       summary: Exports an exception list
       description: Exports an exception list and its associated items to an .ndjson file
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/find_exception_list/find_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/find_exception_list/find_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: FindExceptionLists
       x-codegen-enabled: true
       summary: Finds exception lists
-      tags:
-        - Exceptions API
       parameters:
         - name: filter
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/find_exception_list_item/find_exception_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/find_exception_list_item/find_exception_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: FindExceptionListItems
       x-codegen-enabled: true
       summary: Finds exception list items
-      tags:
-        - Exceptions API
       parameters:
         - name: list_id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/import_exceptions/import_exceptions.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/import_exceptions/import_exceptions.schema.yaml
@@ -10,8 +10,6 @@ paths:
       x-codegen-enabled: true
       summary: Imports an exception list
       description: Imports an exception list and associated items
-      tags:
-        - Exceptions API
       requestBody:
         required: true
         content:

--- a/packages/kbn-securitysolution-exceptions-common/api/read_exception_list/read_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/read_exception_list/read_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetExceptionList
       x-codegen-enabled: true
       summary: Retrieves an exception list using its `id` or `list_id` field
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/read_exception_list_item/read_exception_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/read_exception_list_item/read_exception_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetExceptionListItem
       x-codegen-enabled: true
       summary: Gets an exception list item
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/summary_exception_list/summary_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/summary_exception_list/summary_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetExceptionListSummary
       x-codegen-enabled: true
       summary: Retrieves an exception list summary
-      tags:
-        - Exceptions API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-exceptions-common/api/update_exception_list/update_exception_list.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/update_exception_list/update_exception_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: UpdateExceptionList
       x-codegen-enabled: true
       summary: Updates an exception list
-      tags:
-        - Exceptions API
       requestBody:
         description: Exception list's properties
         required: true

--- a/packages/kbn-securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/api/update_exception_list_item/update_exception_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: UpdateExceptionListItem
       x-codegen-enabled: true
       summary: Updates an exception list item
-      tags:
-        - Exceptions API
       requestBody:
         description: Exception list item's properties
         required: true

--- a/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -75,6 +75,7 @@ paths:
           description: Internal server error response
       summary: Creates rule exception list items
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists:
     delete:
@@ -139,6 +140,7 @@ paths:
           description: Internal server error response
       summary: Deletes an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     get:
       operationId: GetExceptionList
@@ -202,6 +204,7 @@ paths:
           description: Internal server error response
       summary: Retrieves an exception list using its `id` or `list_id` field
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     post:
       operationId: CreateExceptionList
@@ -279,6 +282,7 @@ paths:
           description: Internal server error response
       summary: Creates an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     put:
       operationId: UpdateExceptionList
@@ -359,6 +363,7 @@ paths:
           description: Internal server error response
       summary: Updates an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_duplicate:
     post:
@@ -428,6 +433,7 @@ paths:
           description: Internal server error response
       summary: Duplicates an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_export:
     post:
@@ -508,6 +514,7 @@ paths:
           description: Internal server error response
       summary: Exports an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_find:
     get:
@@ -628,6 +635,7 @@ paths:
           description: Internal server error response
       summary: Finds exception lists
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_import:
     post:
@@ -744,6 +752,7 @@ paths:
           description: Internal server error response
       summary: Imports an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/items:
     delete:
@@ -808,6 +817,7 @@ paths:
           description: Internal server error response
       summary: Deletes an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     get:
       operationId: GetExceptionListItem
@@ -871,6 +881,7 @@ paths:
           description: Internal server error response
       summary: Gets an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     post:
       operationId: CreateExceptionListItem
@@ -958,6 +969,7 @@ paths:
           description: Internal server error response
       summary: Creates an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     put:
       operationId: UpdateExceptionListItem
@@ -1049,6 +1061,7 @@ paths:
           description: Internal server error response
       summary: Updates an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/items/_find:
     get:
@@ -1185,6 +1198,7 @@ paths:
           description: Internal server error response
       summary: Finds exception list items
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/summary:
     get:
@@ -1268,6 +1282,7 @@ paths:
           description: Internal server error response
       summary: Retrieves an exception list summary
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exceptions/shared:
     post:
@@ -1327,6 +1342,7 @@ paths:
           description: Internal server error response
       summary: Creates a shared exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
 components:
   schemas:
@@ -1852,3 +1868,9 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: >-
+      Exceptions API allows you to manage detection rule exceptions to prevent a
+      rule from generating an alert from incoming events even when the rule's
+      other criteria are met.
+    name: Security Solution Exceptions API

--- a/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -76,7 +76,6 @@ paths:
       summary: Creates rule exception list items
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists:
     delete:
       operationId: DeleteExceptionList
@@ -141,7 +140,6 @@ paths:
       summary: Deletes an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     get:
       operationId: GetExceptionList
       parameters:
@@ -205,7 +203,6 @@ paths:
       summary: Retrieves an exception list using its `id` or `list_id` field
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     post:
       operationId: CreateExceptionList
       requestBody:
@@ -283,7 +280,6 @@ paths:
       summary: Creates an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     put:
       operationId: UpdateExceptionList
       requestBody:
@@ -364,7 +360,6 @@ paths:
       summary: Updates an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_duplicate:
     post:
       operationId: DuplicateExceptionList
@@ -434,7 +429,6 @@ paths:
       summary: Duplicates an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_export:
     post:
       description: Exports an exception list and its associated items to an .ndjson file
@@ -515,7 +509,6 @@ paths:
       summary: Exports an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_find:
     get:
       operationId: FindExceptionLists
@@ -636,7 +629,6 @@ paths:
       summary: Finds exception lists
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_import:
     post:
       description: Imports an exception list and associated items
@@ -753,7 +745,6 @@ paths:
       summary: Imports an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/items:
     delete:
       operationId: DeleteExceptionListItem
@@ -818,7 +809,6 @@ paths:
       summary: Deletes an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     get:
       operationId: GetExceptionListItem
       parameters:
@@ -882,7 +872,6 @@ paths:
       summary: Gets an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     post:
       operationId: CreateExceptionListItem
       requestBody:
@@ -970,7 +959,6 @@ paths:
       summary: Creates an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     put:
       operationId: UpdateExceptionListItem
       requestBody:
@@ -1062,7 +1050,6 @@ paths:
       summary: Updates an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/items/_find:
     get:
       operationId: FindExceptionListItems
@@ -1199,7 +1186,6 @@ paths:
       summary: Finds exception list items
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/summary:
     get:
       operationId: GetExceptionListSummary
@@ -1283,7 +1269,6 @@ paths:
       summary: Retrieves an exception list summary
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exceptions/shared:
     post:
       operationId: CreateSharedExceptionList
@@ -1343,7 +1328,6 @@ paths:
       summary: Creates a shared exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
 components:
   schemas:
     CreateExceptionListItemComment:

--- a/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -75,6 +75,7 @@ paths:
           description: Internal server error response
       summary: Creates rule exception list items
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists:
     delete:
@@ -139,6 +140,7 @@ paths:
           description: Internal server error response
       summary: Deletes an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     get:
       operationId: GetExceptionList
@@ -202,6 +204,7 @@ paths:
           description: Internal server error response
       summary: Retrieves an exception list using its `id` or `list_id` field
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     post:
       operationId: CreateExceptionList
@@ -279,6 +282,7 @@ paths:
           description: Internal server error response
       summary: Creates an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     put:
       operationId: UpdateExceptionList
@@ -359,6 +363,7 @@ paths:
           description: Internal server error response
       summary: Updates an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_duplicate:
     post:
@@ -428,6 +433,7 @@ paths:
           description: Internal server error response
       summary: Duplicates an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_export:
     post:
@@ -508,6 +514,7 @@ paths:
           description: Internal server error response
       summary: Exports an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_find:
     get:
@@ -628,6 +635,7 @@ paths:
           description: Internal server error response
       summary: Finds exception lists
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/_import:
     post:
@@ -744,6 +752,7 @@ paths:
           description: Internal server error response
       summary: Imports an exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/items:
     delete:
@@ -808,6 +817,7 @@ paths:
           description: Internal server error response
       summary: Deletes an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     get:
       operationId: GetExceptionListItem
@@ -871,6 +881,7 @@ paths:
           description: Internal server error response
       summary: Gets an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     post:
       operationId: CreateExceptionListItem
@@ -958,6 +969,7 @@ paths:
           description: Internal server error response
       summary: Creates an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
     put:
       operationId: UpdateExceptionListItem
@@ -1049,6 +1061,7 @@ paths:
           description: Internal server error response
       summary: Updates an exception list item
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/items/_find:
     get:
@@ -1185,6 +1198,7 @@ paths:
           description: Internal server error response
       summary: Finds exception list items
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exception_lists/summary:
     get:
@@ -1268,6 +1282,7 @@ paths:
           description: Internal server error response
       summary: Retrieves an exception list summary
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
   /api/exceptions/shared:
     post:
@@ -1327,6 +1342,7 @@ paths:
           description: Internal server error response
       summary: Creates a shared exception list
       tags:
+        - Security Solution Exceptions API
         - Exceptions API
 components:
   schemas:
@@ -1852,3 +1868,9 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: >-
+      Exceptions API allows you to manage detection rule exceptions to prevent a
+      rule from generating an alert from incoming events even when the rule's
+      other criteria are met.
+    name: Security Solution Exceptions API

--- a/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -76,7 +76,6 @@ paths:
       summary: Creates rule exception list items
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists:
     delete:
       operationId: DeleteExceptionList
@@ -141,7 +140,6 @@ paths:
       summary: Deletes an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     get:
       operationId: GetExceptionList
       parameters:
@@ -205,7 +203,6 @@ paths:
       summary: Retrieves an exception list using its `id` or `list_id` field
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     post:
       operationId: CreateExceptionList
       requestBody:
@@ -283,7 +280,6 @@ paths:
       summary: Creates an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     put:
       operationId: UpdateExceptionList
       requestBody:
@@ -364,7 +360,6 @@ paths:
       summary: Updates an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_duplicate:
     post:
       operationId: DuplicateExceptionList
@@ -434,7 +429,6 @@ paths:
       summary: Duplicates an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_export:
     post:
       description: Exports an exception list and its associated items to an .ndjson file
@@ -515,7 +509,6 @@ paths:
       summary: Exports an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_find:
     get:
       operationId: FindExceptionLists
@@ -636,7 +629,6 @@ paths:
       summary: Finds exception lists
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/_import:
     post:
       description: Imports an exception list and associated items
@@ -753,7 +745,6 @@ paths:
       summary: Imports an exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/items:
     delete:
       operationId: DeleteExceptionListItem
@@ -818,7 +809,6 @@ paths:
       summary: Deletes an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     get:
       operationId: GetExceptionListItem
       parameters:
@@ -882,7 +872,6 @@ paths:
       summary: Gets an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     post:
       operationId: CreateExceptionListItem
       requestBody:
@@ -970,7 +959,6 @@ paths:
       summary: Creates an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
     put:
       operationId: UpdateExceptionListItem
       requestBody:
@@ -1062,7 +1050,6 @@ paths:
       summary: Updates an exception list item
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/items/_find:
     get:
       operationId: FindExceptionListItems
@@ -1199,7 +1186,6 @@ paths:
       summary: Finds exception list items
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exception_lists/summary:
     get:
       operationId: GetExceptionListSummary
@@ -1283,7 +1269,6 @@ paths:
       summary: Retrieves an exception list summary
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
   /api/exceptions/shared:
     post:
       operationId: CreateSharedExceptionList
@@ -1343,7 +1328,6 @@ paths:
       summary: Creates a shared exception list
       tags:
         - Security Solution Exceptions API
-        - Exceptions API
 components:
   schemas:
     CreateExceptionListItemComment:

--- a/packages/kbn-securitysolution-exceptions-common/scripts/openapi_bundle.js
+++ b/packages/kbn-securitysolution-exceptions-common/scripts/openapi_bundle.js
@@ -27,6 +27,13 @@ const ROOT = resolve(__dirname, '..');
           description:
             "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
         },
+        tags: [
+          {
+            name: 'Security Solution Exceptions API',
+            description:
+              "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
+          },
+        ],
       },
     },
   });
@@ -45,6 +52,13 @@ const ROOT = resolve(__dirname, '..');
           description:
             "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
         },
+        tags: [
+          {
+            name: 'Security Solution Exceptions API',
+            description:
+              "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
+          },
+        ],
       },
     },
   });

--- a/packages/kbn-securitysolution-lists-common/api/create_list/create_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/create_list/create_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateList
       x-codegen-enabled: true
       summary: Creates a list
-      tags:
-        - List API
       requestBody:
         description: List's properties
         required: true

--- a/packages/kbn-securitysolution-lists-common/api/create_list_index/create_list_index.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/create_list_index/create_list_index.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateListIndex
       x-codegen-enabled: true
       summary: Creates necessary list data streams
-      tags:
-        - List API
       responses:
         200:
           description: Successful response

--- a/packages/kbn-securitysolution-lists-common/api/create_list_item/create_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/create_list_item/create_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: CreateListItem
       x-codegen-enabled: true
       summary: Creates a list item
-      tags:
-        - List item API
       requestBody:
         description: List item's properties
         required: true

--- a/packages/kbn-securitysolution-lists-common/api/delete_list/delete_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/delete_list/delete_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: DeleteList
       x-codegen-enabled: true
       summary: Deletes a list
-      tags:
-        - List API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/delete_list_index/delete_list_index.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/delete_list_index/delete_list_index.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: DeleteListIndex
       x-codegen-enabled: true
       summary: Deletes list data streams
-      tags:
-        - List API
       responses:
         200:
           description: Successful response

--- a/packages/kbn-securitysolution-lists-common/api/delete_list_item/delete_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/delete_list_item/delete_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: DeleteListItem
       x-codegen-enabled: true
       summary: Deletes a list item
-      tags:
-        - List item API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/export_list_item/export_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/export_list_item/export_list_item.schema.yaml
@@ -10,8 +10,6 @@ paths:
       x-codegen-enabled: true
       summary: Exports list items
       description: Exports list item values from the specified list
-      tags:
-        - List items Import/Export API
       parameters:
         - name: list_id
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/find_list/find_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/find_list/find_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: FindLists
       x-codegen-enabled: true
       summary: Finds lists
-      tags:
-        - List API
       parameters:
         - name: page
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/find_list_item/find_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/find_list_item/find_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: FindListItems
       x-codegen-enabled: true
       summary: Finds list items
-      tags:
-        - List API
       parameters:
         - name: list_id
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/get_list_privileges/get_list_privileges.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/get_list_privileges/get_list_privileges.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetListPrivileges
       x-codegen-enabled: true
       summary: Gets list privileges
-      tags:
-        - List API
       responses:
         200:
           description: Successful response

--- a/packages/kbn-securitysolution-lists-common/api/import_list_item/import_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/import_list_item/import_list_item.schema.yaml
@@ -13,8 +13,6 @@ paths:
         Imports a list of items from a `.txt` or `.csv` file. The maximum file size is 9 million bytes.
 
         You can import items to a new or existing list.
-      tags:
-        - List items Import/Export API
       requestBody:
         required: true
         content:

--- a/packages/kbn-securitysolution-lists-common/api/patch_list/patch_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/patch_list/patch_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: PatchList
       x-codegen-enabled: true
       summary: Patches a list
-      tags:
-        - List API
       requestBody:
         description: List's properties
         required: true

--- a/packages/kbn-securitysolution-lists-common/api/patch_list_item/patch_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/patch_list_item/patch_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: PatchListItem
       x-codegen-enabled: true
       summary: Patches a list item
-      tags:
-        - List item API
       requestBody:
         description: List item's properties
         required: true

--- a/packages/kbn-securitysolution-lists-common/api/read_list/read_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/read_list/read_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetList
       x-codegen-enabled: true
       summary: Retrieves a list using its id field
-      tags:
-        - List API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/read_list_index/read_list_index.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/read_list_index/read_list_index.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetListIndex
       x-codegen-enabled: true
       summary: Get list data stream existence status
-      tags:
-        - List API
       responses:
         200:
           description: Successful response

--- a/packages/kbn-securitysolution-lists-common/api/read_list_item/read_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/read_list_item/read_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: GetListItem
       x-codegen-enabled: true
       summary: Gets a list item
-      tags:
-        - List item API
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-lists-common/api/update_list/update_list.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/update_list/update_list.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: UpdateList
       x-codegen-enabled: true
       summary: Updates a list
-      tags:
-        - List API
       requestBody:
         description: List's properties
         required: true

--- a/packages/kbn-securitysolution-lists-common/api/update_list_item/update_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/api/update_list_item/update_list_item.schema.yaml
@@ -9,8 +9,6 @@ paths:
       operationId: UpdateListItem
       x-codegen-enabled: true
       summary: Updates a list item
-      tags:
-        - List item API
       requestBody:
         description: List item's properties
         required: true

--- a/packages/kbn-securitysolution-lists-common/docs/openapi/ess/security_solution_lists_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/docs/openapi/ess/security_solution_lists_api_2023_10_31.bundled.schema.yaml
@@ -74,7 +74,7 @@ paths:
           description: Internal server error response
       summary: Deletes a list
       tags:
-        - List API
+        - Security Solution Lists API
     get:
       operationId: GetList
       parameters:
@@ -125,7 +125,7 @@ paths:
           description: Internal server error response
       summary: Retrieves a list using its id field
       tags:
-        - List API
+        - Security Solution Lists API
     patch:
       operationId: PatchList
       requestBody:
@@ -192,7 +192,7 @@ paths:
           description: Internal server error response
       summary: Patches a list
       tags:
-        - List API
+        - Security Solution Lists API
     post:
       operationId: CreateList
       requestBody:
@@ -266,7 +266,7 @@ paths:
           description: Internal server error response
       summary: Creates a list
       tags:
-        - List API
+        - Security Solution Lists API
     put:
       operationId: UpdateList
       requestBody:
@@ -335,7 +335,7 @@ paths:
           description: Internal server error response
       summary: Updates a list
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/_find:
     get:
       operationId: FindLists
@@ -448,7 +448,7 @@ paths:
           description: Internal server error response
       summary: Finds lists
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/index:
     delete:
       operationId: DeleteListIndex
@@ -498,7 +498,7 @@ paths:
           description: Internal server error response
       summary: Deletes list data streams
       tags:
-        - List API
+        - Security Solution Lists API
     get:
       operationId: GetListIndex
       responses:
@@ -550,7 +550,7 @@ paths:
           description: Internal server error response
       summary: Get list data stream existence status
       tags:
-        - List API
+        - Security Solution Lists API
     post:
       operationId: CreateListIndex
       responses:
@@ -599,7 +599,7 @@ paths:
           description: Internal server error response
       summary: Creates necessary list data streams
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/items:
     delete:
       operationId: DeleteListItem
@@ -680,7 +680,7 @@ paths:
           description: Internal server error response
       summary: Deletes a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     get:
       operationId: GetListItem
       parameters:
@@ -747,7 +747,7 @@ paths:
           description: Internal server error response
       summary: Gets a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     patch:
       operationId: PatchListItem
       requestBody:
@@ -818,7 +818,7 @@ paths:
           description: Internal server error response
       summary: Patches a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     post:
       operationId: CreateListItem
       requestBody:
@@ -890,7 +890,7 @@ paths:
           description: Internal server error response
       summary: Creates a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     put:
       operationId: UpdateListItem
       requestBody:
@@ -953,7 +953,7 @@ paths:
           description: Internal server error response
       summary: Updates a list item
       tags:
-        - List item API
+        - Security Solution Lists API
   /api/lists/items/_export:
     post:
       description: Exports list item values from the specified list
@@ -1008,7 +1008,7 @@ paths:
           description: Internal server error response
       summary: Exports list items
       tags:
-        - List items Import/Export API
+        - Security Solution Lists API
   /api/lists/items/_find:
     get:
       operationId: FindListItems
@@ -1127,7 +1127,7 @@ paths:
           description: Internal server error response
       summary: Finds list items
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/items/_import:
     post:
       description: >
@@ -1234,7 +1234,7 @@ paths:
           description: Internal server error response
       summary: Imports list items
       tags:
-        - List items Import/Export API
+        - Security Solution Lists API
   /api/lists/privileges:
     get:
       operationId: GetListPrivileges
@@ -1284,7 +1284,7 @@ paths:
           description: Internal server error response
       summary: Gets list privileges
       tags:
-        - List API
+        - Security Solution Lists API
 components:
   schemas:
     FindListItemsCursor:
@@ -1520,3 +1520,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: 'Lists API allows you to manage lists of keywords, IPs or IP ranges items.'
+    name: Security Solution Lists API

--- a/packages/kbn-securitysolution-lists-common/docs/openapi/serverless/security_solution_lists_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/docs/openapi/serverless/security_solution_lists_api_2023_10_31.bundled.schema.yaml
@@ -74,7 +74,7 @@ paths:
           description: Internal server error response
       summary: Deletes a list
       tags:
-        - List API
+        - Security Solution Lists API
     get:
       operationId: GetList
       parameters:
@@ -125,7 +125,7 @@ paths:
           description: Internal server error response
       summary: Retrieves a list using its id field
       tags:
-        - List API
+        - Security Solution Lists API
     patch:
       operationId: PatchList
       requestBody:
@@ -192,7 +192,7 @@ paths:
           description: Internal server error response
       summary: Patches a list
       tags:
-        - List API
+        - Security Solution Lists API
     post:
       operationId: CreateList
       requestBody:
@@ -266,7 +266,7 @@ paths:
           description: Internal server error response
       summary: Creates a list
       tags:
-        - List API
+        - Security Solution Lists API
     put:
       operationId: UpdateList
       requestBody:
@@ -335,7 +335,7 @@ paths:
           description: Internal server error response
       summary: Updates a list
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/_find:
     get:
       operationId: FindLists
@@ -448,7 +448,7 @@ paths:
           description: Internal server error response
       summary: Finds lists
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/index:
     delete:
       operationId: DeleteListIndex
@@ -498,7 +498,7 @@ paths:
           description: Internal server error response
       summary: Deletes list data streams
       tags:
-        - List API
+        - Security Solution Lists API
     get:
       operationId: GetListIndex
       responses:
@@ -550,7 +550,7 @@ paths:
           description: Internal server error response
       summary: Get list data stream existence status
       tags:
-        - List API
+        - Security Solution Lists API
     post:
       operationId: CreateListIndex
       responses:
@@ -599,7 +599,7 @@ paths:
           description: Internal server error response
       summary: Creates necessary list data streams
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/items:
     delete:
       operationId: DeleteListItem
@@ -680,7 +680,7 @@ paths:
           description: Internal server error response
       summary: Deletes a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     get:
       operationId: GetListItem
       parameters:
@@ -747,7 +747,7 @@ paths:
           description: Internal server error response
       summary: Gets a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     patch:
       operationId: PatchListItem
       requestBody:
@@ -818,7 +818,7 @@ paths:
           description: Internal server error response
       summary: Patches a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     post:
       operationId: CreateListItem
       requestBody:
@@ -890,7 +890,7 @@ paths:
           description: Internal server error response
       summary: Creates a list item
       tags:
-        - List item API
+        - Security Solution Lists API
     put:
       operationId: UpdateListItem
       requestBody:
@@ -953,7 +953,7 @@ paths:
           description: Internal server error response
       summary: Updates a list item
       tags:
-        - List item API
+        - Security Solution Lists API
   /api/lists/items/_export:
     post:
       description: Exports list item values from the specified list
@@ -1008,7 +1008,7 @@ paths:
           description: Internal server error response
       summary: Exports list items
       tags:
-        - List items Import/Export API
+        - Security Solution Lists API
   /api/lists/items/_find:
     get:
       operationId: FindListItems
@@ -1127,7 +1127,7 @@ paths:
           description: Internal server error response
       summary: Finds list items
       tags:
-        - List API
+        - Security Solution Lists API
   /api/lists/items/_import:
     post:
       description: >
@@ -1234,7 +1234,7 @@ paths:
           description: Internal server error response
       summary: Imports list items
       tags:
-        - List items Import/Export API
+        - Security Solution Lists API
   /api/lists/privileges:
     get:
       operationId: GetListPrivileges
@@ -1284,7 +1284,7 @@ paths:
           description: Internal server error response
       summary: Gets list privileges
       tags:
-        - List API
+        - Security Solution Lists API
 components:
   schemas:
     FindListItemsCursor:
@@ -1520,3 +1520,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: 'Lists API allows you to manage lists of keywords, IPs or IP ranges items.'
+    name: Security Solution Lists API

--- a/packages/kbn-securitysolution-lists-common/scripts/openapi_bundle.js
+++ b/packages/kbn-securitysolution-lists-common/scripts/openapi_bundle.js
@@ -26,6 +26,13 @@ const ROOT = resolve(__dirname, '..');
           title: 'Security Solution Lists API (Elastic Cloud Serverless)',
           description: 'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
         },
+        tags: [
+          {
+            name: 'Security Solution Lists API',
+            description:
+              'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
+          },
+        ],
       },
     },
   });
@@ -43,6 +50,13 @@ const ROOT = resolve(__dirname, '..');
           title: 'Security Solution Lists API (Elastic Cloud and self-hosted)',
           description: 'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
         },
+        tags: [
+          {
+            name: 'Security Solution Lists API',
+            description:
+              'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
+          },
+        ],
       },
     },
   });

--- a/x-pack/packages/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/packages/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -65,6 +65,7 @@ paths:
           description: Generic Error
       summary: Applies a bulk action to multiple anonymization fields
       tags:
+        - Security AI Assistant API
         - Bulk API
   /api/security_ai_assistant/anonymization_fields/_find:
     get:
@@ -150,6 +151,7 @@ paths:
           description: Generic Error
       summary: Finds anonymization fields that match the given query.
       tags:
+        - Security AI Assistant API
         - AnonymizationFields API
   /api/security_ai_assistant/chat/complete:
     post:
@@ -184,6 +186,7 @@ paths:
           description: Generic Error
       summary: Creates a model response for the given chat conversation.
       tags:
+        - Security AI Assistant API
         - Chat Complete API
   /api/security_ai_assistant/current_user/conversations:
     post:
@@ -217,6 +220,7 @@ paths:
           description: Generic Error
       summary: Create a conversation
       tags:
+        - Security AI Assistant API
         - Conversation API
   /api/security_ai_assistant/current_user/conversations/_find:
     get:
@@ -302,6 +306,7 @@ paths:
           description: Generic Error
       summary: Finds conversations that match the given query.
       tags:
+        - Security AI Assistant API
         - Conversations API
   '/api/security_ai_assistant/current_user/conversations/{id}':
     delete:
@@ -336,6 +341,7 @@ paths:
           description: Generic Error
       summary: Deletes a single conversation using the `id` field.
       tags:
+        - Security AI Assistant API
         - Conversation API
     get:
       description: Read a single conversation
@@ -369,6 +375,7 @@ paths:
           description: Generic Error
       summary: Read a single conversation
       tags:
+        - Security AI Assistant API
         - Conversations API
     put:
       description: Update a single conversation
@@ -408,6 +415,7 @@ paths:
           description: Generic Error
       summary: Update a conversation
       tags:
+        - Security AI Assistant API
         - Conversation API
   /api/security_ai_assistant/prompts/_bulk_action:
     post:
@@ -463,6 +471,7 @@ paths:
           description: Generic Error
       summary: Applies a bulk action to multiple prompts
       tags:
+        - Security AI Assistant API
         - Bulk API
   /api/security_ai_assistant/prompts/_find:
     get:
@@ -548,6 +557,7 @@ paths:
           description: Generic Error
       summary: Finds prompts that match the given query.
       tags:
+        - Security AI Assistant API
         - Prompts API
 components:
   schemas:
@@ -1222,3 +1232,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: Manage and interact with Security Assistant resources.
+    name: Security AI Assistant API

--- a/x-pack/packages/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/packages/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -65,6 +65,7 @@ paths:
           description: Generic Error
       summary: Applies a bulk action to multiple anonymization fields
       tags:
+        - Security AI Assistant API
         - Bulk API
   /api/security_ai_assistant/anonymization_fields/_find:
     get:
@@ -150,6 +151,7 @@ paths:
           description: Generic Error
       summary: Finds anonymization fields that match the given query.
       tags:
+        - Security AI Assistant API
         - AnonymizationFields API
   /api/security_ai_assistant/chat/complete:
     post:
@@ -184,6 +186,7 @@ paths:
           description: Generic Error
       summary: Creates a model response for the given chat conversation.
       tags:
+        - Security AI Assistant API
         - Chat Complete API
   /api/security_ai_assistant/current_user/conversations:
     post:
@@ -217,6 +220,7 @@ paths:
           description: Generic Error
       summary: Create a conversation
       tags:
+        - Security AI Assistant API
         - Conversation API
   /api/security_ai_assistant/current_user/conversations/_find:
     get:
@@ -302,6 +306,7 @@ paths:
           description: Generic Error
       summary: Finds conversations that match the given query.
       tags:
+        - Security AI Assistant API
         - Conversations API
   '/api/security_ai_assistant/current_user/conversations/{id}':
     delete:
@@ -336,6 +341,7 @@ paths:
           description: Generic Error
       summary: Deletes a single conversation using the `id` field.
       tags:
+        - Security AI Assistant API
         - Conversation API
     get:
       description: Read a single conversation
@@ -369,6 +375,7 @@ paths:
           description: Generic Error
       summary: Read a single conversation
       tags:
+        - Security AI Assistant API
         - Conversations API
     put:
       description: Update a single conversation
@@ -408,6 +415,7 @@ paths:
           description: Generic Error
       summary: Update a conversation
       tags:
+        - Security AI Assistant API
         - Conversation API
   /api/security_ai_assistant/prompts/_bulk_action:
     post:
@@ -463,6 +471,7 @@ paths:
           description: Generic Error
       summary: Applies a bulk action to multiple prompts
       tags:
+        - Security AI Assistant API
         - Bulk API
   /api/security_ai_assistant/prompts/_find:
     get:
@@ -548,6 +557,7 @@ paths:
           description: Generic Error
       summary: Finds prompts that match the given query.
       tags:
+        - Security AI Assistant API
         - Prompts API
 components:
   schemas:
@@ -1222,3 +1232,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: Manage and interact with Security Assistant resources.
+    name: Security AI Assistant API

--- a/x-pack/packages/kbn-elastic-assistant-common/scripts/openapi/bundle.js
+++ b/x-pack/packages/kbn-elastic-assistant-common/scripts/openapi/bundle.js
@@ -26,6 +26,12 @@ const ELASTIC_ASSISTANT_ROOT = resolve(__dirname, '../..');
           title: 'Security AI Assistant API (Elastic Cloud Serverless)',
           description: 'Manage and interact with Security Assistant resources.',
         },
+        tags: [
+          {
+            name: 'Security AI Assistant API',
+            description: 'Manage and interact with Security Assistant resources.',
+          },
+        ],
       },
     },
   });
@@ -43,6 +49,12 @@ const ELASTIC_ASSISTANT_ROOT = resolve(__dirname, '../..');
           title: 'Security AI Assistant API (Elastic Cloud & self-hosted)',
           description: 'Manage and interact with Security Assistant resources.',
         },
+        tags: [
+          {
+            name: 'Security AI Assistant API',
+            description: 'Manage and interact with Security Assistant resources.',
+          },
+        ],
       },
     },
   });

--- a/x-pack/plugins/osquery/docs/openapi/ess/osquery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/osquery/docs/openapi/ess/osquery_api_2023_10_31.bundled.schema.yaml
@@ -28,6 +28,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Find live queries
+      tags:
+        - Security Solution Osquery API
     post:
       operationId: OsqueryCreateLiveQuery
       requestBody:
@@ -44,6 +46,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Create a live query
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/live_queries/{id}':
     get:
       operationId: OsqueryGetLiveQueryDetails
@@ -66,6 +70,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get live query details
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/live_queries/{id}/results/{actionId}':
     get:
       operationId: OsqueryGetLiveQueryResults
@@ -93,6 +99,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get live query results
+      tags:
+        - Security Solution Osquery API
   /api/osquery/packs:
     get:
       operationId: OsqueryFindPacks
@@ -110,6 +118,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Find packs
+      tags:
+        - Security Solution Osquery API
     post:
       operationId: OsqueryCreatePacks
       requestBody:
@@ -126,6 +136,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Create a packs
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/packs/{id}':
     delete:
       operationId: OsqueryDeletePacks
@@ -143,6 +155,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Delete packs
+      tags:
+        - Security Solution Osquery API
     get:
       operationId: OsqueryGetPacksDetails
       parameters:
@@ -159,6 +173,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get packs details
+      tags:
+        - Security Solution Osquery API
     put:
       operationId: OsqueryUpdatePacks
       parameters:
@@ -181,6 +197,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Update packs
+      tags:
+        - Security Solution Osquery API
   /api/osquery/saved_queries:
     get:
       operationId: OsqueryFindSavedQueries
@@ -198,6 +216,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Find saved queries
+      tags:
+        - Security Solution Osquery API
     post:
       operationId: OsqueryCreateSavedQuery
       requestBody:
@@ -214,6 +234,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Create a saved query
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/saved_queries/{id}':
     delete:
       operationId: OsqueryDeleteSavedQuery
@@ -231,6 +253,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Delete saved query
+      tags:
+        - Security Solution Osquery API
     get:
       operationId: OsqueryGetSavedQueryDetails
       parameters:
@@ -247,6 +271,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get saved query details
+      tags:
+        - Security Solution Osquery API
     put:
       operationId: OsqueryUpdateSavedQuery
       parameters:
@@ -269,6 +295,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Update saved query
+      tags:
+        - Security Solution Osquery API
 components:
   schemas:
     ArrayQueries:
@@ -588,3 +616,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: 'Run live queries, manage packs and saved queries.'
+    name: Security Solution Osquery API

--- a/x-pack/plugins/osquery/docs/openapi/serverless/osquery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/osquery/docs/openapi/serverless/osquery_api_2023_10_31.bundled.schema.yaml
@@ -28,6 +28,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Find live queries
+      tags:
+        - Security Solution Osquery API
     post:
       operationId: OsqueryCreateLiveQuery
       requestBody:
@@ -44,6 +46,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Create a live query
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/live_queries/{id}':
     get:
       operationId: OsqueryGetLiveQueryDetails
@@ -66,6 +70,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get live query details
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/live_queries/{id}/results/{actionId}':
     get:
       operationId: OsqueryGetLiveQueryResults
@@ -93,6 +99,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get live query results
+      tags:
+        - Security Solution Osquery API
   /api/osquery/packs:
     get:
       operationId: OsqueryFindPacks
@@ -110,6 +118,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Find packs
+      tags:
+        - Security Solution Osquery API
     post:
       operationId: OsqueryCreatePacks
       requestBody:
@@ -126,6 +136,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Create a packs
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/packs/{id}':
     delete:
       operationId: OsqueryDeletePacks
@@ -143,6 +155,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Delete packs
+      tags:
+        - Security Solution Osquery API
     get:
       operationId: OsqueryGetPacksDetails
       parameters:
@@ -159,6 +173,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get packs details
+      tags:
+        - Security Solution Osquery API
     put:
       operationId: OsqueryUpdatePacks
       parameters:
@@ -181,6 +197,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Update packs
+      tags:
+        - Security Solution Osquery API
   /api/osquery/saved_queries:
     get:
       operationId: OsqueryFindSavedQueries
@@ -198,6 +216,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Find saved queries
+      tags:
+        - Security Solution Osquery API
     post:
       operationId: OsqueryCreateSavedQuery
       requestBody:
@@ -214,6 +234,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Create a saved query
+      tags:
+        - Security Solution Osquery API
   '/api/osquery/saved_queries/{id}':
     delete:
       operationId: OsqueryDeleteSavedQuery
@@ -231,6 +253,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Delete saved query
+      tags:
+        - Security Solution Osquery API
     get:
       operationId: OsqueryGetSavedQueryDetails
       parameters:
@@ -247,6 +271,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Get saved query details
+      tags:
+        - Security Solution Osquery API
     put:
       operationId: OsqueryUpdateSavedQuery
       parameters:
@@ -269,6 +295,8 @@ paths:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
       summary: Update saved query
+      tags:
+        - Security Solution Osquery API
 components:
   schemas:
     ArrayQueries:
@@ -588,3 +616,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: 'Run live queries, manage packs and saved queries.'
+    name: Security Solution Osquery API

--- a/x-pack/plugins/osquery/scripts/openapi/bundle.js
+++ b/x-pack/plugins/osquery/scripts/openapi/bundle.js
@@ -25,6 +25,12 @@ const ELASTIC_ASSISTANT_ROOT = resolve(__dirname, '../..');
           title: 'Security Solution Osquery API (Elastic Cloud Serverless)',
           description: 'Run live queries, manage packs and saved queries.',
         },
+        tags: [
+          {
+            name: 'Security Solution Osquery API',
+            description: 'Run live queries, manage packs and saved queries.',
+          },
+        ],
       },
     },
   });
@@ -40,6 +46,12 @@ const ELASTIC_ASSISTANT_ROOT = resolve(__dirname, '../..');
           title: 'Security Solution Osquery API (Elastic Cloud and self-hosted)',
           description: 'Run live queries, manage packs and saved queries.',
         },
+        tags: [
+          {
+            name: 'Security Solution Osquery API',
+            description: 'Run live queries, manage packs and saved queries.',
+          },
+        ],
       },
     },
   });

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -55,6 +55,7 @@ paths:
           description: Internal server error response
       summary: Delete an alerts index
       tags:
+        - Security Solution Detections API
         - Alert index API
     get:
       operationId: GetAlertsIndex
@@ -100,6 +101,7 @@ paths:
           description: Internal server error response
       summary: Gets the alert index name if it exists
       tags:
+        - Security Solution Detections API
         - Alert index API
     post:
       operationId: CreateAlertsIndex
@@ -141,6 +143,7 @@ paths:
           description: Internal server error response
       summary: Create an alerts index
       tags:
+        - Security Solution Detections API
         - Alert index API
   /api/detection_engine/privileges:
     get:
@@ -183,6 +186,7 @@ paths:
           description: Internal server error response
       summary: Returns user privileges for the Kibana space
       tags:
+        - Security Solution Detections API
         - Privileges API
   /api/detection_engine/rules:
     delete:
@@ -210,6 +214,7 @@ paths:
           description: Indicates a successful call.
       summary: Delete a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     get:
       description: Retrieve a detection rule using the `rule_id` or `id` field.
@@ -236,6 +241,7 @@ paths:
           description: Indicates a successful call.
       summary: Retrieve a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     patch:
       description: >-
@@ -257,6 +263,7 @@ paths:
           description: Indicates a successful call.
       summary: Patch a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     post:
       description: Create a new detection rule.
@@ -276,6 +283,7 @@ paths:
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     put:
       description: >
@@ -301,6 +309,7 @@ paths:
           description: Indicates a successful call.
       summary: Update a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
@@ -339,6 +348,7 @@ paths:
           description: OK
       summary: Apply a bulk action to detection rules
       tags:
+        - Security Solution Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_create:
     post:
@@ -363,6 +373,7 @@ paths:
           description: Indicates a successful call.
       summary: Create multiple detection rules
       tags:
+        - Security Solution Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_delete:
     delete:
@@ -414,6 +425,7 @@ paths:
           description: Internal server error response
       summary: Delete multiple detection rules
       tags:
+        - Security Solution Detections API
         - Bulk API
     post:
       deprecated: true
@@ -463,6 +475,7 @@ paths:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error response
       tags:
+        - Security Solution Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_update:
     patch:
@@ -489,6 +502,7 @@ paths:
           description: Indicates a successful call.
       summary: Patch multiple detection rules
       tags:
+        - Security Solution Detections API
         - Bulk API
     put:
       deprecated: true
@@ -520,6 +534,7 @@ paths:
           description: Indicates a successful call.
       summary: Update multiple detection rules
       tags:
+        - Security Solution Detections API
         - Bulk API
   /api/detection_engine/rules/_export:
     post:
@@ -583,6 +598,7 @@ paths:
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
+        - Security Solution Detections API
         - Import/Export API
   /api/detection_engine/rules/_find:
     get:
@@ -657,6 +673,7 @@ paths:
           description: Successful response
       summary: List all detection rules
       tags:
+        - Security Solution Detections API
         - Rules API
   /api/detection_engine/rules/_import:
     post:
@@ -771,6 +788,7 @@ paths:
           description: Indicates a successful call.
       summary: Import detection rules
       tags:
+        - Security Solution Detections API
         - Import/Export API
   /api/detection_engine/rules/prepackaged:
     put:
@@ -808,6 +826,7 @@ paths:
           description: Indicates a successful call
       summary: Install prebuilt detection rules and Timelines
       tags:
+        - Security Solution Detections API
         - Prebuilt Rules API
   /api/detection_engine/rules/prepackaged/_status:
     get:
@@ -866,6 +885,7 @@ paths:
           description: Indicates a successful call
       summary: Retrieve the status of prebuilt detection rules and Timelines
       tags:
+        - Security Solution Detections API
         - Prebuilt Rules API
   /api/detection_engine/rules/preview:
     post:
@@ -945,6 +965,7 @@ paths:
           description: Internal server error response
       summary: Preview rule alerts generated on specified time range
       tags:
+        - Security Solution Detections API
         - Rule preview API
   /api/detection_engine/signals/assignees:
     post:
@@ -975,6 +996,8 @@ paths:
         '400':
           description: Invalid request.
       summary: Assign and unassign users from detection alerts
+      tags:
+        - Security Solution Detections API
   /api/detection_engine/signals/finalize_migration:
     post:
       description: >
@@ -1032,6 +1055,7 @@ paths:
           description: Internal server error response
       summary: Finalize detection alert migrations
       tags:
+        - Security Solution Detections API
         - Alerts migration API
   /api/detection_engine/signals/migration:
     delete:
@@ -1099,6 +1123,7 @@ paths:
           description: Internal server error response
       summary: Clean up detection alert migrations
       tags:
+        - Security Solution Detections API
         - Alerts migration API
     post:
       description: >
@@ -1165,6 +1190,7 @@ paths:
           description: Internal server error response
       summary: Initiate a detection alert migration
       tags:
+        - Security Solution Detections API
         - Alerts migration API
   /api/detection_engine/signals/migration_status:
     post:
@@ -1222,6 +1248,7 @@ paths:
           description: Internal server error response
       summary: Retrieve the status of detection alert migrations
       tags:
+        - Security Solution Detections API
         - Alerts migration API
   /api/detection_engine/signals/search:
     post:
@@ -1294,6 +1321,7 @@ paths:
           description: Internal server error response
       summary: Find and/or aggregate detection alerts
       tags:
+        - Security Solution Detections API
         - Alerts API
   /api/detection_engine/signals/status:
     post:
@@ -1341,6 +1369,7 @@ paths:
           description: Internal server error response
       summary: Set a detection alert status
       tags:
+        - Security Solution Detections API
         - Alerts API
   /api/detection_engine/signals/tags:
     post:
@@ -1397,6 +1426,7 @@ paths:
           description: Internal server error response
       summary: Add and remove detection alert tags
       tags:
+        - Security Solution Detections API
         - Alerts API
   /api/detection_engine/tags:
     get:
@@ -1411,6 +1441,7 @@ paths:
           description: Indicates a successful call
       summary: List all detection rule tags
       tags:
+        - Security Solution Detections API
         - Tags API
 components:
   schemas:
@@ -6926,3 +6957,9 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: >-
+      You can create rules that automatically turn events and external alerts
+      sent to Elastic Security into detection alerts. These alerts are displayed
+      on the Detections page.
+    name: Security Solution Detections API

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -28,6 +28,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Actions List schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action_log/{agent_id}':
     get:
       operationId: EndpointGetActionAuditLog
@@ -50,6 +52,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get action audit log schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action_status:
     get:
       operationId: EndpointGetActionsStatus
@@ -70,6 +74,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Actions status schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action/{action_id}':
     get:
       operationId: EndpointGetActionsDetails
@@ -87,6 +93,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Action details schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action/{action_id}/file/{file_id}/download`':
     get:
       operationId: EndpointFileDownload
@@ -104,6 +112,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: File Download schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action/{action_id}/file/{file_id}`':
     get:
       operationId: EndpointFileInfo
@@ -121,6 +131,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: File Info schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/execute:
     post:
       operationId: EndpointExecuteAction
@@ -138,6 +150,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Execute Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/get_file:
     post:
       operationId: EndpointGetFileAction
@@ -155,6 +169,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get File Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/isolate:
     post:
       operationId: EndpointIsolateHostAction
@@ -183,6 +199,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Isolate host Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/kill_process:
     post:
       operationId: EndpointKillProcessAction
@@ -200,6 +218,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Kill process Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/running_procs:
     post:
       operationId: EndpointGetRunningProcessesAction
@@ -228,6 +248,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Running Processes Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/scan:
     post:
       operationId: EndpointScanAction
@@ -245,6 +267,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Scan Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/state:
     get:
       operationId: EndpointGetActionsState
@@ -256,6 +280,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Action State schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/suspend_process:
     post:
       operationId: EndpointSuspendProcessAction
@@ -273,6 +299,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Suspend process Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/unisolate:
     post:
       operationId: EndpointUnisolateHostAction
@@ -301,6 +329,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Unisolate host Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/upload:
     post:
       operationId: EndpointUploadAction
@@ -318,6 +348,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Upload Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/isolate:
     post:
       operationId: EndpointIsolateRedirect
@@ -354,6 +386,8 @@ paths:
                 example: /api/endpoint/action/isolate
                 type: string
       summary: Permanently redirects to a new location
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/metadata:
     get:
       operationId: GetEndpointMetadataList
@@ -371,6 +405,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Metadata List schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/metadata/{id}':
     get:
       operationId: GetEndpointMetadata
@@ -391,6 +427,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Metadata schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/metadata/transforms:
     get:
       operationId: GetEndpointMetadataTransform
@@ -402,6 +440,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Metadata Transform schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/policy_response:
     get:
       operationId: GetPolicyResponse
@@ -422,6 +462,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Policy Response schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/policy/summaries:
     get:
       operationId: GetAgentPolicySummary
@@ -445,6 +487,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Agent Policy Summary schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/protection_updates_note/{package_policy_id}':
     get:
       operationId: GetProtectionUpdatesNote
@@ -462,6 +506,8 @@ paths:
                 $ref: '#/components/schemas/ProtectionUpdatesNoteResponse'
           description: OK
       summary: Get Protection Updates Note schema
+      tags:
+        - Security Solution Endpoint Management API
     post:
       operationId: CreateUpdateProtectionUpdatesNote
       parameters:
@@ -487,6 +533,8 @@ paths:
                 $ref: '#/components/schemas/ProtectionUpdatesNoteResponse'
           description: OK
       summary: Create Update Protection Updates Note schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/suggestions/{suggestion_type}':
     post:
       operationId: GetEndpointSuggestions
@@ -521,6 +569,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get suggestions
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/unisolate:
     post:
       operationId: EndpointUnisolateRedirect
@@ -557,6 +607,8 @@ paths:
                 example: /api/endpoint/action/unisolate
                 type: string
       summary: Permanently redirects to a new location
+      tags:
+        - Security Solution Endpoint Management API
 components:
   schemas:
     AgentId:
@@ -935,3 +987,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: Interact with and manage endpoints running the Elastic Defend integration.
+    name: Security Solution Endpoint Management API

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -42,6 +42,8 @@ paths:
         '400':
           description: Invalid request
       summary: Delete Criticality Record
+      tags:
+        - Security Solution Entity Analytics API
     get:
       operationId: GetAssetCriticalityRecord
       parameters:
@@ -70,6 +72,8 @@ paths:
         '404':
           description: Criticality record not found
       summary: Get Criticality Record
+      tags:
+        - Security Solution Entity Analytics API
     post:
       operationId: CreateAssetCriticalityRecord
       requestBody:
@@ -98,6 +102,8 @@ paths:
         '400':
           description: Invalid request
       summary: Create Criticality Record
+      tags:
+        - Security Solution Entity Analytics API
   /api/asset_criticality/bulk:
     post:
       operationId: BulkUpsertAssetCriticalityRecords
@@ -153,6 +159,8 @@ paths:
       summary: >-
         Bulk upsert asset criticality data, creating or updating records as
         needed
+      tags:
+        - Security Solution Entity Analytics API
   /api/asset_criticality/list:
     post:
       operationId: FindAssetCriticalityRecords
@@ -226,6 +234,8 @@ paths:
                   - total
           description: Bulk upload successful
       summary: 'List asset criticality data, filtering and sorting as needed'
+      tags:
+        - Security Solution Entity Analytics API
 components:
   schemas:
     AssetCriticalityBulkUploadErrorItem:
@@ -304,3 +314,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: ''
+    name: Security Solution Entity Analytics API

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -51,6 +51,7 @@ paths:
           description: Indicates the note was successfully deleted.
       summary: Deletes a note from a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     get:
       description: Gets notes
@@ -96,6 +97,7 @@ paths:
           description: Indicates the requested notes were returned.
       summary: Get all notes for a given document.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     patch:
       operationId: PersistNoteRoute
@@ -159,6 +161,7 @@ paths:
           description: Indicates the note was successfully created.
       summary: Persists a note to a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/pinned_event:
     patch:
@@ -207,6 +210,7 @@ paths:
           description: Indicate the event was successfully pinned in the timeline.
       summary: Persists a pinned event to a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline:
     delete:
@@ -251,6 +255,7 @@ paths:
           description: Indicates the timeline was successfully deleted.
       summary: Deletes one or more timelines or timeline templates.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     get:
       operationId: GetTimeline
@@ -287,6 +292,7 @@ paths:
         Get an existing saved timeline or timeline template. This API is used to
         retrieve an existing saved timeline or timeline template.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     patch:
       description: >-
@@ -354,6 +360,7 @@ paths:
             a draft timeline.
       summary: Updates an existing timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     post:
       operationId: CreateTimelines
@@ -422,6 +429,7 @@ paths:
           description: Indicates that there was an error in the timeline creation.
       summary: Creates a new timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_draft:
     get:
@@ -486,6 +494,7 @@ paths:
         Retrieves the draft timeline for the current user. If the user does not
         have a draft timeline, an empty timeline is returned.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     post:
       description: >
@@ -559,6 +568,7 @@ paths:
             timelineId.
       summary: Retrieves a draft timeline or timeline template.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_export:
     post:
@@ -604,6 +614,7 @@ paths:
           description: Indicates that the export size limit was exceeded
       summary: Exports timelines as an NDJSON file
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_favorite:
     patch:
@@ -665,6 +676,7 @@ paths:
             the favorite status.
       summary: Persists a given users favorite status of a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_import:
     post:
@@ -754,6 +766,7 @@ paths:
           description: Indicates the import of timelines was unsuccessful.
       summary: Imports timelines.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_prepackaged:
     post:
@@ -811,6 +824,7 @@ paths:
             unsuccessful.
       summary: Installs prepackaged timelines.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/resolve:
     get:
@@ -850,6 +864,7 @@ paths:
           description: The (template) timeline was not found
       summary: Get an existing saved timeline or timeline template.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timelines:
     get:
@@ -954,6 +969,7 @@ paths:
         This API is used to retrieve a list of existing saved timelines or
         timeline templates.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
 components:
   schemas:
@@ -1473,3 +1489,8 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: >-
+      You can create Timelines and Timeline templates via the API, as well as
+      import new Timelines from an ndjson file.
+    name: Security Solution Timeline API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -55,6 +55,7 @@ paths:
           description: Internal server error response
       summary: Returns user privileges for the Kibana space
       tags:
+        - Security Solution Detections API
         - Privileges API
   /api/detection_engine/rules:
     delete:
@@ -82,6 +83,7 @@ paths:
           description: Indicates a successful call.
       summary: Delete a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     get:
       description: Retrieve a detection rule using the `rule_id` or `id` field.
@@ -108,6 +110,7 @@ paths:
           description: Indicates a successful call.
       summary: Retrieve a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     patch:
       description: >-
@@ -129,6 +132,7 @@ paths:
           description: Indicates a successful call.
       summary: Patch a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     post:
       description: Create a new detection rule.
@@ -148,6 +152,7 @@ paths:
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
     put:
       description: >
@@ -173,6 +178,7 @@ paths:
           description: Indicates a successful call.
       summary: Update a detection rule
       tags:
+        - Security Solution Detections API
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
@@ -211,6 +217,7 @@ paths:
           description: OK
       summary: Apply a bulk action to detection rules
       tags:
+        - Security Solution Detections API
         - Bulk API
   /api/detection_engine/rules/_export:
     post:
@@ -274,6 +281,7 @@ paths:
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
+        - Security Solution Detections API
         - Import/Export API
   /api/detection_engine/rules/_find:
     get:
@@ -348,6 +356,7 @@ paths:
           description: Successful response
       summary: List all detection rules
       tags:
+        - Security Solution Detections API
         - Rules API
   /api/detection_engine/rules/_import:
     post:
@@ -462,6 +471,7 @@ paths:
           description: Indicates a successful call.
       summary: Import detection rules
       tags:
+        - Security Solution Detections API
         - Import/Export API
   /api/detection_engine/rules/preview:
     post:
@@ -541,6 +551,7 @@ paths:
           description: Internal server error response
       summary: Preview rule alerts generated on specified time range
       tags:
+        - Security Solution Detections API
         - Rule preview API
   /api/detection_engine/signals/assignees:
     post:
@@ -571,6 +582,8 @@ paths:
         '400':
           description: Invalid request.
       summary: Assign and unassign users from detection alerts
+      tags:
+        - Security Solution Detections API
   /api/detection_engine/signals/search:
     post:
       description: Find and/or aggregate detection alerts that match the given query.
@@ -642,6 +655,7 @@ paths:
           description: Internal server error response
       summary: Find and/or aggregate detection alerts
       tags:
+        - Security Solution Detections API
         - Alerts API
   /api/detection_engine/signals/status:
     post:
@@ -689,6 +703,7 @@ paths:
           description: Internal server error response
       summary: Set a detection alert status
       tags:
+        - Security Solution Detections API
         - Alerts API
   /api/detection_engine/signals/tags:
     post:
@@ -745,6 +760,7 @@ paths:
           description: Internal server error response
       summary: Add and remove detection alert tags
       tags:
+        - Security Solution Detections API
         - Alerts API
   /api/detection_engine/tags:
     get:
@@ -759,6 +775,7 @@ paths:
           description: Indicates a successful call
       summary: List all detection rule tags
       tags:
+        - Security Solution Detections API
         - Tags API
 components:
   schemas:
@@ -6087,3 +6104,9 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: >-
+      You can create rules that automatically turn events and external alerts
+      sent to Elastic Security into detection alerts. These alerts are displayed
+      on the Detections page.
+    name: Security Solution Detections API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -28,6 +28,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Actions List schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action_log/{agent_id}':
     get:
       operationId: EndpointGetActionAuditLog
@@ -50,6 +52,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get action audit log schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action_status:
     get:
       operationId: EndpointGetActionsStatus
@@ -70,6 +74,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Actions status schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action/{action_id}':
     get:
       operationId: EndpointGetActionsDetails
@@ -87,6 +93,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Action details schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action/{action_id}/file/{file_id}/download`':
     get:
       operationId: EndpointFileDownload
@@ -104,6 +112,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: File Download schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/action/{action_id}/file/{file_id}`':
     get:
       operationId: EndpointFileInfo
@@ -121,6 +131,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: File Info schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/execute:
     post:
       operationId: EndpointExecuteAction
@@ -138,6 +150,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Execute Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/get_file:
     post:
       operationId: EndpointGetFileAction
@@ -155,6 +169,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get File Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/isolate:
     post:
       operationId: EndpointIsolateHostAction
@@ -183,6 +199,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Isolate host Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/kill_process:
     post:
       operationId: EndpointKillProcessAction
@@ -200,6 +218,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Kill process Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/running_procs:
     post:
       operationId: EndpointGetRunningProcessesAction
@@ -228,6 +248,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Running Processes Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/scan:
     post:
       operationId: EndpointScanAction
@@ -245,6 +267,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Scan Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/state:
     get:
       operationId: EndpointGetActionsState
@@ -256,6 +280,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Action State schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/suspend_process:
     post:
       operationId: EndpointSuspendProcessAction
@@ -273,6 +299,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Suspend process Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/unisolate:
     post:
       operationId: EndpointUnisolateHostAction
@@ -301,6 +329,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Unisolate host Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/action/upload:
     post:
       operationId: EndpointUploadAction
@@ -318,6 +348,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Upload Action
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/metadata:
     get:
       operationId: GetEndpointMetadataList
@@ -335,6 +367,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Metadata List schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/metadata/{id}':
     get:
       operationId: GetEndpointMetadata
@@ -355,6 +389,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Metadata schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/metadata/transforms:
     get:
       operationId: GetEndpointMetadataTransform
@@ -366,6 +402,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Metadata Transform schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/policy_response:
     get:
       operationId: GetPolicyResponse
@@ -386,6 +424,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Policy Response schema
+      tags:
+        - Security Solution Endpoint Management API
   /api/endpoint/policy/summaries:
     get:
       operationId: GetAgentPolicySummary
@@ -409,6 +449,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get Agent Policy Summary schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/protection_updates_note/{package_policy_id}':
     get:
       operationId: GetProtectionUpdatesNote
@@ -426,6 +468,8 @@ paths:
                 $ref: '#/components/schemas/ProtectionUpdatesNoteResponse'
           description: OK
       summary: Get Protection Updates Note schema
+      tags:
+        - Security Solution Endpoint Management API
     post:
       operationId: CreateUpdateProtectionUpdatesNote
       parameters:
@@ -451,6 +495,8 @@ paths:
                 $ref: '#/components/schemas/ProtectionUpdatesNoteResponse'
           description: OK
       summary: Create Update Protection Updates Note schema
+      tags:
+        - Security Solution Endpoint Management API
   '/api/endpoint/suggestions/{suggestion_type}':
     post:
       operationId: GetEndpointSuggestions
@@ -485,6 +531,8 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
           description: OK
       summary: Get suggestions
+      tags:
+        - Security Solution Endpoint Management API
 components:
   schemas:
     AgentId:
@@ -863,3 +911,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: Interact with and manage endpoints running the Elastic Defend integration.
+    name: Security Solution Endpoint Management API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -42,6 +42,8 @@ paths:
         '400':
           description: Invalid request
       summary: Delete Criticality Record
+      tags:
+        - Security Solution Entity Analytics API
     get:
       operationId: GetAssetCriticalityRecord
       parameters:
@@ -70,6 +72,8 @@ paths:
         '404':
           description: Criticality record not found
       summary: Get Criticality Record
+      tags:
+        - Security Solution Entity Analytics API
     post:
       operationId: CreateAssetCriticalityRecord
       requestBody:
@@ -98,6 +102,8 @@ paths:
         '400':
           description: Invalid request
       summary: Create Criticality Record
+      tags:
+        - Security Solution Entity Analytics API
   /api/asset_criticality/bulk:
     post:
       operationId: BulkUpsertAssetCriticalityRecords
@@ -153,6 +159,8 @@ paths:
       summary: >-
         Bulk upsert asset criticality data, creating or updating records as
         needed
+      tags:
+        - Security Solution Entity Analytics API
   /api/asset_criticality/list:
     post:
       operationId: FindAssetCriticalityRecords
@@ -226,6 +234,8 @@ paths:
                   - total
           description: Bulk upload successful
       summary: 'List asset criticality data, filtering and sorting as needed'
+      tags:
+        - Security Solution Entity Analytics API
 components:
   schemas:
     AssetCriticalityBulkUploadErrorItem:
@@ -304,3 +314,6 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: ''
+    name: Security Solution Entity Analytics API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -51,6 +51,7 @@ paths:
           description: Indicates the note was successfully deleted.
       summary: Deletes a note from a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     get:
       description: Gets notes
@@ -96,6 +97,7 @@ paths:
           description: Indicates the requested notes were returned.
       summary: Get all notes for a given document.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     patch:
       operationId: PersistNoteRoute
@@ -159,6 +161,7 @@ paths:
           description: Indicates the note was successfully created.
       summary: Persists a note to a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/pinned_event:
     patch:
@@ -207,6 +210,7 @@ paths:
           description: Indicate the event was successfully pinned in the timeline.
       summary: Persists a pinned event to a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline:
     delete:
@@ -251,6 +255,7 @@ paths:
           description: Indicates the timeline was successfully deleted.
       summary: Deletes one or more timelines or timeline templates.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     get:
       operationId: GetTimeline
@@ -287,6 +292,7 @@ paths:
         Get an existing saved timeline or timeline template. This API is used to
         retrieve an existing saved timeline or timeline template.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     patch:
       description: >-
@@ -354,6 +360,7 @@ paths:
             a draft timeline.
       summary: Updates an existing timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     post:
       operationId: CreateTimelines
@@ -422,6 +429,7 @@ paths:
           description: Indicates that there was an error in the timeline creation.
       summary: Creates a new timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_draft:
     get:
@@ -486,6 +494,7 @@ paths:
         Retrieves the draft timeline for the current user. If the user does not
         have a draft timeline, an empty timeline is returned.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
     post:
       description: >
@@ -559,6 +568,7 @@ paths:
             timelineId.
       summary: Retrieves a draft timeline or timeline template.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_export:
     post:
@@ -604,6 +614,7 @@ paths:
           description: Indicates that the export size limit was exceeded
       summary: Exports timelines as an NDJSON file
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_favorite:
     patch:
@@ -665,6 +676,7 @@ paths:
             the favorite status.
       summary: Persists a given users favorite status of a timeline.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_import:
     post:
@@ -754,6 +766,7 @@ paths:
           description: Indicates the import of timelines was unsuccessful.
       summary: Imports timelines.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/_prepackaged:
     post:
@@ -811,6 +824,7 @@ paths:
             unsuccessful.
       summary: Installs prepackaged timelines.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timeline/resolve:
     get:
@@ -850,6 +864,7 @@ paths:
           description: The (template) timeline was not found
       summary: Get an existing saved timeline or timeline template.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
   /api/timelines:
     get:
@@ -954,6 +969,7 @@ paths:
         This API is used to retrieve a list of existing saved timelines or
         timeline templates.
       tags:
+        - Security Solution Timeline API
         - 'access:securitySolution'
 components:
   schemas:
@@ -1473,3 +1489,8 @@ components:
       type: http
 security:
   - BasicAuth: []
+tags:
+  - description: >-
+      You can create Timelines and Timeline templates via the API, as well as
+      import new Timelines from an ndjson file.
+    name: Security Solution Timeline API

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_detections.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_detections.js
@@ -26,6 +26,13 @@ const ROOT = resolve(__dirname, '../..');
           description:
             'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
         },
+        tags: [
+          {
+            name: 'Security Solution Detections API',
+            description:
+              'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
+          },
+        ],
       },
     },
   });
@@ -44,6 +51,13 @@ const ROOT = resolve(__dirname, '../..');
           description:
             'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
         },
+        tags: [
+          {
+            name: 'Security Solution Detections API',
+            description:
+              'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
+          },
+        ],
       },
     },
   });

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_endpoint_management.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_endpoint_management.js
@@ -25,6 +25,13 @@ const ROOT = resolve(__dirname, '../..');
           title: 'Security Solution Endpoint Management API (Elastic Cloud Serverless)',
           description: 'Interact with and manage endpoints running the Elastic Defend integration.',
         },
+        tags: [
+          {
+            name: 'Security Solution Endpoint Management API',
+            description:
+              'Interact with and manage endpoints running the Elastic Defend integration.',
+          },
+        ],
       },
     },
   });
@@ -42,6 +49,13 @@ const ROOT = resolve(__dirname, '../..');
           title: 'Security Solution Endpoint Management API (Elastic Cloud and self-hosted)',
           description: 'Interact with and manage endpoints running the Elastic Defend integration.',
         },
+        tags: [
+          {
+            name: 'Security Solution Endpoint Management API',
+            description:
+              'Interact with and manage endpoints running the Elastic Defend integration.',
+          },
+        ],
       },
     },
   });

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_entity_analytics.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_entity_analytics.js
@@ -25,6 +25,12 @@ const ROOT = resolve(__dirname, '../..');
           title: 'Security Solution Entity Analytics API (Elastic Cloud Serverless)',
           description: '',
         },
+        tags: [
+          {
+            name: 'Security Solution Entity Analytics API',
+            description: '',
+          },
+        ],
       },
     },
   });
@@ -42,6 +48,12 @@ const ROOT = resolve(__dirname, '../..');
           title: 'Security Solution Entity Analytics API (Elastic Cloud and self-hosted)',
           description: '',
         },
+        tags: [
+          {
+            name: 'Security Solution Entity Analytics API',
+            description: '',
+          },
+        ],
       },
     },
   });

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_timeline.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_timeline.js
@@ -26,6 +26,13 @@ const ROOT = resolve(__dirname, '../..');
           description:
             'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
         },
+        tags: [
+          {
+            name: 'Security Solution Timeline API',
+            description:
+              'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
+          },
+        ],
       },
     },
   });
@@ -44,6 +51,13 @@ const ROOT = resolve(__dirname, '../..');
           description:
             'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
         },
+        tags: [
+          {
+            name: 'Security Solution Timeline API',
+            description:
+              'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
+          },
+        ],
       },
     },
   });


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/183375

## Summary

This PR implements functionality assigning a provided tag to OpenAPI `Operation object`s in the result bundle. Specified tag is also added as the only root level OpenAPI tag. This approach allows to produce domain bundles having a single tag assigned. At the next step domain bundles are merged together into single Kibana bundle where tags will allow to properly display grouping at Bump.sh (API reference documentation platform).

## Details

Bump.sh (our new API reference documentation platform) uses OpenAPI tags for grouping API endpoints. It supports only one tag per endpoint.

This PR facilitates preparation of Kibana OpenAPI bundle to be uploaded to Bump.sh by implementing functionality assigning a provided tag to OpenAPI `Operation object`s in the result domain bundles. It's implemented by providing an optional configuration option `assignTag` whose format is OpenAPI Tag Object. When `assignTag` isn't specified the bundler merges existing tags.

## Example

Consider the following bundling configuration

```js
const { bundle } = require('@kbn/openapi-bundler');

bundle({
  // ...
  options: {
    assignTag: {
      name: 'Some Domain API tag name',
      description: 'Some Domain API description',
      externalDocs: {
        url: 'https://some-external-documentation-url',
        description: 'External documentation description',
    }
  },
});
```

and source OpenAPI specs

**spec1.schema.yaml**
```yaml
openapi: 3.0.3
info:
  title: Spec1
  version: '2023-10-31'
paths:
  /api/some_api:
    get:
      tags: ['Some local tag']
      responses:
        200:
          content:
            'application/json':
              schema:
                type: string
```

**spec2.schema.yaml**
```yaml
openapi: 3.0.3
info:
  title: Spec2
  version: '2023-10-31'
paths:
  /api/some_api:
    post:
      tags: ['Some global tag']
      responses:
        200:
          content:
            'application/json':
              schema:
                type: string
tags:
  - name: Some global tag
```

**spec2.schema.yaml**
```yaml
openapi: 3.0.3
info:
  title: Spec3
  version: '2023-10-31'
paths:
  /api/another_api:
    get:
      responses:
        200:
          content:
            'application/json':
              schema:
                type: string
```

After bundling above OpenAPI specs with the provided bundling script we'll get the following

**domain-bundle.schema.yaml**
```yaml
openapi: 3.0.3
info:
  title: Bundled document
  version: '2023-10-31'
paths:
  /api/some_api:
    get:
      tags: ['Some Domain API tag name']
      responses:
        200:
          content:
            'application/json':
              schema:
                type: string
    post:
      tags: ['Some Domain API tag name']
      responses:
        200:
          content:
            'application/json':
              schema:
                type: string
  /api/another_api:
    get:
      tags: ['Some Domain API tag name']
      responses:
        200:
          content:
            'application/json':
              schema:
                type: string
tags:
  - name: Some Domain API tag name
    description: Some Domain API description
    externalDocs:
      url: 'https://some-external-documentation-url'
      description: External documentation description
```