### PR TITLE
[Index management] Unskip api_integration tests for inference endpoints

### DIFF
--- a/x-pack/test/api_integration/apis/management/index_management/inference_endpoints.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/inference_endpoints.ts
@@ -20,9 +20,7 @@ export default function ({ getService }: FtrProviderContext) {
   const service = 'elser';
   const modelId = '.elser_model_2';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/189333
-  // Failing: See https://github.com/elastic/kibana/issues/189333
-  describe.skip('Inference endpoints', function () {
+  describe('Inference endpoints', function () {
     after(async () => {
       try {
         log.debug(`Deleting underlying trained model`);
@@ -56,7 +54,7 @@ export default function ({ getService }: FtrProviderContext) {
         inferenceEndpoints.some(
           (endpoint: InferenceAPIConfigResponse) => endpoint.inference_id === inferenceId
         )
-      ).to.be(true);
+      ).to.eql(true, `${inferenceId} not found in the GET _inference/_all response`);
     });
     it('can delete inference endpoint', async () => {
       log.debug(`Deleting inference endpoint`);

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/inference_endpoints.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/inference_endpoints.ts
@@ -26,8 +26,7 @@ export default function ({ getService }: FtrProviderContext) {
   let roleAuthc: RoleCredentials;
   let internalReqHeader: InternalRequestHeader;
 
-  // FLAKY: https://github.com/elastic/kibana/issues/189464
-  describe.skip('Inference endpoints', function () {
+  describe('Inference endpoints', function () {
     before(async () => {
       roleAuthc = await svlUserManager.createM2mApiKeyWithRoleScope('admin');
       internalReqHeader = svlCommonApi.getInternalRequestHeader();
@@ -67,7 +66,7 @@ export default function ({ getService }: FtrProviderContext) {
         inferenceEndpoints.some(
           (endpoint: InferenceAPIConfigResponse) => endpoint.inference_id === inferenceId
         )
-      ).to.be(true);
+      ).to.eql(true, `${inferenceId} not found in the GET _inference/_all response`);
     });
     it('can delete inference endpoint', async () => {
       log.debug(`Deleting inference endpoint`);


### PR DESCRIPTION
## Summary

Recently Elasticsearch GET all inference endpoints api response format was changed in [PR](https://github.com/elastic/elasticsearch/pull/111366) causing the api integration tests to fail.  These tests were skipped in https://github.com/elastic/kibana/issues/189333#issuecomment-2254814105 and https://github.com/elastic/kibana/pull/189466

The [frontend route changes](https://github.com/elastic/kibana/pull/189545) required for these api integration tests to succeed has been merged and is [backported to 8.15](https://github.com/elastic/kibana/pull/189642). 

In this PR, we are un skipping these tests.  

### Test reports
Tested this changes serverless changes locally using qaf tool against cloud deployment and ran FTR tests for both serverless & stateful version. 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->