### PR TITLE
[Embeddable Rebuild] [Links] Fix small bugs

### DIFF
--- a/src/plugins/links/public/editor/open_editor_flyout.tsx
+++ b/src/plugins/links/public/editor/open_editor_flyout.tsx
@@ -62,7 +62,7 @@ export async function openEditorFlyout({
       ? parentDashboard.savedObjectId.value
       : undefined;
 
-  return new Promise<LinksRuntimeState | undefined>((resolve, reject) => {
+  return new Promise<LinksRuntimeState | undefined>((resolve) => {
     const flyoutId = `linksEditorFlyout-${uuidv4()}`;
 
     const closeEditorFlyout = (editorFlyout: OverlayRef) => {
@@ -116,7 +116,7 @@ export async function openEditorFlyout({
     };
 
     const onCancel = () => {
-      reject();
+      resolve(undefined);
       closeEditorFlyout(editorFlyout);
     };
 
@@ -148,8 +148,5 @@ export async function openEditorFlyout({
     if (overlayTracker) {
       overlayTracker.openOverlay(editorFlyout);
     }
-  }).catch(() => {
-    // on reject (i.e. on cancel), don't do anything
-    return undefined;
   });
 }

--- a/src/plugins/links/public/editor/open_editor_flyout.tsx
+++ b/src/plugins/links/public/editor/open_editor_flyout.tsx
@@ -62,7 +62,7 @@ export async function openEditorFlyout({
       ? parentDashboard.savedObjectId.value
       : undefined;
 
-  return new Promise((resolve, reject) => {
+  return new Promise<LinksRuntimeState | undefined>((resolve, reject) => {
     const flyoutId = `linksEditorFlyout-${uuidv4()}`;
 
     const closeEditorFlyout = (editorFlyout: OverlayRef) => {
@@ -148,5 +148,8 @@ export async function openEditorFlyout({
     if (overlayTracker) {
       overlayTracker.openOverlay(editorFlyout);
     }
+  }).catch(() => {
+    // on reject (i.e. on cancel), don't do anything
+    return undefined;
   });
 }

--- a/src/plugins/links/public/editor/open_link_editor_flyout.tsx
+++ b/src/plugins/links/public/editor/open_link_editor_flyout.tsx
@@ -49,14 +49,14 @@ export async function openLinkEditorFlyout({
     });
   };
 
-  return new Promise<UnorderedLink | undefined>((resolve, reject) => {
+  return new Promise<UnorderedLink | undefined>((resolve) => {
     const onSave = async (newLink: UnorderedLink) => {
       resolve(newLink);
       await unmountFlyout();
     };
 
     const onCancel = async () => {
-      reject();
+      resolve(undefined);
       await unmountFlyout();
     };
 
@@ -71,8 +71,5 @@ export async function openLinkEditorFlyout({
       </KibanaRenderContextProvider>,
       ref.current
     );
-  }).catch(() => {
-    // on reject (i.e. on cancel), just return the original list of links
-    return undefined;
   });
 }

--- a/src/plugins/links/public/embeddable/links_embeddable.test.tsx
+++ b/src/plugins/links/public/embeddable/links_embeddable.test.tsx
@@ -153,6 +153,7 @@ describe('getLinksEmbeddableFactory', () => {
       savedObjectId: '123',
       title: 'my links',
       description: 'just a few links',
+      hidePanelTitles: false,
     } as LinksSerializedState;
 
     const expectedRuntimeState = {
@@ -163,6 +164,7 @@ describe('getLinksEmbeddableFactory', () => {
       description: 'just a few links',
       title: 'my links',
       savedObjectId: '123',
+      hidePanelTitles: false,
     };
 
     let parent: LinksParentApi;
@@ -210,7 +212,7 @@ describe('getLinksEmbeddableFactory', () => {
             savedObjectId: '123',
             title: 'my links',
             description: 'just a few links',
-            hidePanelTitles: undefined,
+            hidePanelTitles: false,
           },
           references: [],
         });
@@ -238,7 +240,7 @@ describe('getLinksEmbeddableFactory', () => {
           rawState: {
             title: 'my links',
             description: 'just a few links',
-            hidePanelTitles: undefined,
+            hidePanelTitles: false,
             attributes: {
               description: 'some links',
               title: 'links 001',
@@ -261,6 +263,7 @@ describe('getLinksEmbeddableFactory', () => {
       },
       description: 'just a few links',
       title: 'my links',
+      hidePanelTitles: true,
     } as LinksSerializedState;
 
     const expectedRuntimeState = {
@@ -271,6 +274,7 @@ describe('getLinksEmbeddableFactory', () => {
       description: 'just a few links',
       title: 'my links',
       savedObjectId: undefined,
+      hidePanelTitles: true,
     };
 
     let parent: LinksParentApi;
@@ -315,7 +319,7 @@ describe('getLinksEmbeddableFactory', () => {
           rawState: {
             title: 'my links',
             description: 'just a few links',
-            hidePanelTitles: undefined,
+            hidePanelTitles: true,
             attributes: {
               links: getLinks(),
               layout: 'horizontal',
@@ -356,7 +360,7 @@ describe('getLinksEmbeddableFactory', () => {
             savedObjectId: '333',
             title: 'my links',
             description: 'just a few links',
-            hidePanelTitles: undefined,
+            hidePanelTitles: true,
           },
           references: [],
         });

--- a/src/plugins/links/public/embeddable/links_embeddable.tsx
+++ b/src/plugins/links/public/embeddable/links_embeddable.tsx
@@ -129,7 +129,6 @@ export const getLinksEmbeddableFactory = () => {
           },
           serializeState: async (): Promise<SerializedPanelState<LinksSerializedState>> => {
             if (savedObjectId$.value !== undefined) {
-              console.log(serializeTitles());
               const linksByReferenceState: LinksByReferenceSerializedState = {
                 savedObjectId: savedObjectId$.value,
                 ...serializeTitles(),

--- a/src/plugins/links/public/embeddable/links_embeddable.tsx
+++ b/src/plugins/links/public/embeddable/links_embeddable.tsx
@@ -94,6 +94,7 @@ export const getLinksEmbeddableFactory = () => {
       return {
         title,
         description,
+        hidePanelTitles,
         links: resolvedLinks,
         layout: attributesWithInjectedIds.layout,
         defaultPanelTitle: attributesWithInjectedIds.title,

--- a/src/plugins/links/public/embeddable/links_embeddable.tsx
+++ b/src/plugins/links/public/embeddable/links_embeddable.tsx
@@ -71,7 +71,7 @@ export const getLinksEmbeddableFactory = () => {
     deserializeState: async (serializedState) => {
       // Clone the state to avoid an object not extensible error when injecting references
       const state = cloneDeep(serializedState.rawState);
-      const { title, description } = serializedState.rawState;
+      const { title, description, hidePanelTitles } = serializedState.rawState;
 
       if (linksSerializeStateIsByReference(state)) {
         const linksSavedObject = await linksClient.get(state.savedObjectId);
@@ -80,6 +80,7 @@ export const getLinksEmbeddableFactory = () => {
           ...runtimeState,
           title,
           description,
+          hidePanelTitles,
         };
       }
 
@@ -128,6 +129,7 @@ export const getLinksEmbeddableFactory = () => {
           },
           serializeState: async (): Promise<SerializedPanelState<LinksSerializedState>> => {
             if (savedObjectId$.value !== undefined) {
+              console.log(serializeTitles());
               const linksByReferenceState: LinksByReferenceSerializedState = {
                 savedObjectId: savedObjectId$.value,
                 ...serializeTitles(),

--- a/src/plugins/links/public/embeddable/links_embeddable.tsx
+++ b/src/plugins/links/public/embeddable/links_embeddable.tsx
@@ -175,21 +175,18 @@ export const getLinksEmbeddableFactory = () => {
             savedObjectId$.next(undefined);
           },
           onEdit: async () => {
-            try {
-              const { openEditorFlyout } = await import('../editor/open_editor_flyout');
-              const newState = await openEditorFlyout({
-                initialState: api.snapshotRuntimeState(),
-                parentDashboard: parentApi,
-              });
-              if (newState) {
-                links$.next(newState.links);
-                layout$.next(newState.layout);
-                defaultPanelTitle.next(newState.defaultPanelTitle);
-                defaultPanelDescription.next(newState.defaultPanelDescription);
-                savedObjectId$.next(newState.savedObjectId);
-              }
-            } catch {
-              // do nothing, user cancelled
+            const { openEditorFlyout } = await import('../editor/open_editor_flyout');
+            const newState = await openEditorFlyout({
+              initialState: api.snapshotRuntimeState(),
+              parentDashboard: parentApi,
+            });
+
+            if (newState) {
+              links$.next(newState.links);
+              layout$.next(newState.layout);
+              defaultPanelTitle.next(newState.defaultPanelTitle);
+              defaultPanelDescription.next(newState.defaultPanelDescription);
+              savedObjectId$.next(newState.savedObjectId);
             }
           },
         },


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/189445

## Summary

As a follow up to https://github.com/elastic/kibana/pull/178670, this PR fixes two small bugs with the links panel that were introduced in that PR:
1. The editor no longer throws an unnecessary error on cancel:

    https://github.com/user-attachments/assets/666d856d-f1aa-46b2-a764-1731cce49a57

2. The `hidePanelTitles` attribute is now passed to the embeddable as expected:


     https://github.com/user-attachments/assets/92a95a89-d853-4bce-b6dc-9b22d89182da


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
