### PR TITLE
[Embeddable Rebuild] [Controls] Fix range slider state on field change

### DIFF
--- a/examples/controls_example/public/react_controls/control_group/selections_manager.ts
+++ b/examples/controls_example/public/react_controls/control_group/selections_manager.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, filter, Subscription } from 'rxjs';
 import deepEqual from 'fast-deep-equal';
 import { Filter } from '@kbn/es-query';
 import { combineCompatibleChildrenApis } from '@kbn/presentation-containers';
@@ -54,7 +54,9 @@ export function initSelectionsManager(
         'filters$',
         apiPublishesFilters,
         []
-      ).subscribe((newFilters) => unpublishedFilters$.next(newFilters))
+      ).subscribe((newFilters) => {
+        unpublishedFilters$.next(newFilters);
+      })
     );
 
     subscriptions.push(
@@ -89,11 +91,11 @@ export function initSelectionsManager(
         controlGroupApi.autoApplySelections$,
         unpublishedFilters$,
         unpublishedTimeslice$,
-      ]).subscribe(([autoApplySelections]) => {
-        if (autoApplySelections) {
+      ])
+        .pipe(filter(([autoApplySelections]) => autoApplySelections))
+        .subscribe(() => {
           applySelections();
-        }
-      })
+        })
     );
   });
 

--- a/examples/controls_example/public/react_controls/control_group/selections_manager.ts
+++ b/examples/controls_example/public/react_controls/control_group/selections_manager.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { BehaviorSubject, combineLatest, filter, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
 import deepEqual from 'fast-deep-equal';
 import { Filter } from '@kbn/es-query';
 import { combineCompatibleChildrenApis } from '@kbn/presentation-containers';
@@ -54,9 +54,7 @@ export function initSelectionsManager(
         'filters$',
         apiPublishesFilters,
         []
-      ).subscribe((newFilters) => {
-        unpublishedFilters$.next(newFilters);
-      })
+      ).subscribe((newFilters) => unpublishedFilters$.next(newFilters))
     );
 
     subscriptions.push(
@@ -91,11 +89,11 @@ export function initSelectionsManager(
         controlGroupApi.autoApplySelections$,
         unpublishedFilters$,
         unpublishedTimeslice$,
-      ])
-        .pipe(filter(([autoApplySelections]) => autoApplySelections))
-        .subscribe(() => {
+      ]).subscribe(([autoApplySelections]) => {
+        if (autoApplySelections) {
           applySelections();
-        })
+        }
+      })
     );
   });
 

--- a/examples/controls_example/public/react_controls/data_controls/initialize_data_control.ts
+++ b/examples/controls_example/public/react_controls/data_controls/initialize_data_control.ts
@@ -27,6 +27,10 @@ export const initializeDataControl = <EditorState extends object = {}>(
   controlId: string,
   controlType: string,
   state: DefaultDataControlState,
+  /**
+   * `This state manager` should only include the state that the data control editor is
+   * responsible for managing
+   */
   editorStateManager: ControlStateManager<EditorState>,
   controlGroup: ControlGroupApi,
   services: {

--- a/examples/controls_example/public/react_controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/examples/controls_example/public/react_controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -66,13 +66,12 @@ export const getRangesliderControlFactory = (
         value$.next(nextValue);
       }
 
-      const dataControl = initializeDataControl<Pick<RangesliderControlState, 'step' | 'value'>>(
+      const dataControl = initializeDataControl<Pick<RangesliderControlState, 'step'>>(
         uuid,
         RANGE_SLIDER_CONTROL_TYPE,
         initialState,
         {
           step: step$,
-          value: value$,
         },
         controlGroupApi,
         services


### PR DESCRIPTION
## Summary

The range slider `value` was getting overwritten by the old value on edit after the field name changed because we were passing in `value` as part of the editor state manager - so, this resulted in the following when editing a range slider with a defined `value` (for the sake of clarity, let's say `value = [100, 200]`.
1. Change the field name to another number field (keeping it as a range slider control) and save your changes
2. On save, the editor loops through the provided state manager key by key and updates the control
3. The `fieldName` key is hit first because of the order of spread, so this gets updated - which triggers the `fieldChangedSubscription` and sets `value` to `undefined`
4. The `value` key gets hit afterward, which still has the old `[100, 200]` value because we don't clear up the dirty state - so, the editor calls `value$.next([100, 200])`
5. The edited control now has the same selection as the old control :fire:

We should only add state to the editor state manager **that the editor can change** - and since `value` is never changed via the editor, removing this from the state manager fixes the above situation. I've added a comment to hopefully clarify this.

### How to test
1. Create a range slider control and make a value change on it
2. Edit that control and pick a different data view and/or field - keep it as a range slider control!
3. The value selected at step 1 **should be cleared**

### Before

https://github.com/user-attachments/assets/e6700538-deda-4196-8f52-c5446fa06518



### After


https://github.com/user-attachments/assets/be47fb2c-ecbf-4274-8beb-82a7e5462874



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
