### PR TITLE
[APM][ECO] renaming log error rate to log error %

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/entities/charts/log_error_rate_chart.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/entities/charts/log_error_rate_chart.tsx
@@ -68,7 +68,7 @@ export function LogErrorRateChart({ height }: { height: number }) {
       type: 'linemark',
       color: currentPeriodColor,
       title: i18n.translate('xpack.apm.logs.chart.logsErrorRate', {
-        defaultMessage: 'Log Error Rate',
+        defaultMessage: 'Log Error %',
       }),
     },
   ];
@@ -80,7 +80,7 @@ export function LogErrorRateChart({ height }: { height: number }) {
           <EuiTitle size="xs">
             <h2>
               {i18n.translate('xpack.apm.logErrorRate', {
-                defaultMessage: 'Log error rate',
+                defaultMessage: 'Log error %',
               })}
             </h2>
           </EuiTitle>

--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/get_service_columns.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/get_service_columns.tsx
@@ -224,7 +224,7 @@ export function getServiceColumns({
       name: (
         <ColumnHeader
           label={i18n.translate('xpack.apm.multiSignal.servicesTable.logErrorRate', {
-            defaultMessage: 'Log error rate',
+            defaultMessage: 'Log error %',
           })}
           formula={getMetricsFormula(ChartMetricType.LOG_ERROR_RATE)}
           toolTip={


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/189354

<img width="188" alt="Screenshot 2024-08-01 at 09 28 47" src="https://github.com/user-attachments/assets/9be41354-6c26-4752-bcb6-22c6226cf6b6">
<img width="608" alt="Screenshot 2024-08-01 at 09 30 00" src="https://github.com/user-attachments/assets/11e83898-5d0a-4a99-8174-fa6e46705e7a">
