### PR TITLE
[8.15] [Custom threshold] Respect query:allowLeadingWildcards in optional query filter (#189488)

### DIFF
--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/custom_threshold_executor.test.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/custom_threshold_executor.test.ts
@@ -964,7 +964,7 @@ describe('The custom threshold alert type', () => {
         stateResult2
       );
       expect(stateResult3.missingGroups).toEqual([{ key: 'b', bucketKey: { groupBy0: 'b' } }]);
-      expect(mockedEvaluateRule.mock.calls[2][9]).toEqual([
+      expect(mockedEvaluateRule.mock.calls[2][10]).toEqual([
         { bucketKey: { groupBy0: 'b' }, key: 'b' },
       ]);
     });

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
@@ -18,6 +18,7 @@ import { RecoveredActionGroup } from '@kbn/alerting-plugin/common';
 import { IBasePath, Logger } from '@kbn/core/server';
 import { AlertsClientError, RuleExecutorOptions } from '@kbn/alerting-plugin/server';
 import { getEvaluationValues, getThreshold } from './lib/get_values';
+import { getEsQueryConfig } from '../../../utils/get_es_query_config';
 import { AlertsLocatorParams, getAlertDetailsUrl } from '../../../../common';
 import { getViewInAppUrl } from '../../../../common/custom_threshold_rule/get_view_in_app_url';
 import { ObservabilityConfig } from '../../..';
@@ -94,7 +95,7 @@ export const createCustomThresholdExecutor = ({
       executionId,
     });
 
-    const { searchSourceClient, alertsClient } = services;
+    const { searchSourceClient, alertsClient, uiSettingsClient } = services;
 
     if (!alertsClient) {
       throw new AlertsClientError();
@@ -134,6 +135,7 @@ export const createCustomThresholdExecutor = ({
 
     // Calculate initial start and end date with no time window, as each criterion has its own time window
     const { dateStart, dateEnd } = getTimeRange();
+    const esQueryConfig = await getEsQueryConfig(uiSettingsClient);
     const alertResults = await evaluateRule(
       services.scopedClusterClient.asCurrentUser,
       params as EvaluatedRuleParams,
@@ -143,6 +145,7 @@ export const createCustomThresholdExecutor = ({
       alertOnGroupDisappear,
       logger,
       { end: dateEnd, start: dateStart },
+      esQueryConfig,
       state.lastRunTimestamp,
       previousMissingGroups
     );

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/check_missing_group.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/check_missing_group.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { ElasticsearchClient } from '@kbn/core/server';
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { EsQueryConfig } from '@kbn/es-query';
 import type { Logger } from '@kbn/logging';
 import { isString, get, identity } from 'lodash';
 import {
@@ -30,6 +31,7 @@ export const checkMissingGroups = async (
   searchConfiguration: SearchConfigurationType,
   logger: Logger,
   timeframe: { start: number; end: number },
+  esQueryConfig: EsQueryConfig,
   missingGroups: MissingGroupsRecord[] = []
 ): Promise<MissingGroupsRecord[]> => {
   if (missingGroups.length === 0) {
@@ -52,8 +54,10 @@ export const checkMissingGroups = async (
       currentTimeFrame,
       timeFieldName,
       searchConfiguration,
+      esQueryConfig,
       groupByQueries
     );
+
     return [
       { index: indexPattern },
       {

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/evaluate_rule.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/evaluate_rule.ts
@@ -6,7 +6,8 @@
  */
 
 import moment from 'moment';
-import { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import { EsQueryConfig } from '@kbn/es-query';
 import type { Logger } from '@kbn/logging';
 import { getIntervalInSeconds } from '../../../../../common/utils/get_interval_in_seconds';
 import {
@@ -43,6 +44,7 @@ export const evaluateRule = async <Params extends EvaluatedRuleParams = Evaluate
   alertOnGroupDisappear: boolean,
   logger: Logger,
   timeframe: { start: string; end: string },
+  esQueryConfig: EsQueryConfig,
   lastPeriodEnd?: number,
   missingGroups: MissingGroupsRecord[] = []
 ): Promise<Array<Record<string, Evaluation>>> => {
@@ -70,6 +72,7 @@ export const evaluateRule = async <Params extends EvaluatedRuleParams = Evaluate
         timeFieldName,
         groupBy,
         searchConfiguration,
+        esQueryConfig,
         compositeSize,
         alertOnGroupDisappear,
         calculatedTimerange,
@@ -86,6 +89,7 @@ export const evaluateRule = async <Params extends EvaluatedRuleParams = Evaluate
         searchConfiguration,
         logger,
         calculatedTimerange,
+        esQueryConfig,
         missingGroups
       );
 

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/get_data.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/get_data.ts
@@ -7,9 +7,10 @@
 
 import { SearchResponse, AggregationsAggregate } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core/server';
+import type { EsQueryConfig } from '@kbn/es-query';
 import type { Logger } from '@kbn/logging';
 import { EcsFieldsResponse } from '@kbn/rule-registry-plugin/common/search_strategy';
-import {
+import type {
   CustomMetricExpressionParams,
   SearchConfigurationType,
 } from '../../../../../common/custom_threshold_rule/types';
@@ -104,6 +105,7 @@ export const getData = async (
   timeFieldName: string,
   groupBy: string | undefined | string[],
   searchConfiguration: SearchConfigurationType,
+  esQueryConfig: EsQueryConfig,
   compositeSize: number,
   alertOnGroupDisappear: boolean,
   timeframe: { start: number; end: number },
@@ -163,6 +165,7 @@ export const getData = async (
           timeFieldName,
           groupBy,
           searchConfiguration,
+          esQueryConfig,
           compositeSize,
           alertOnGroupDisappear,
           timeframe,
@@ -205,6 +208,7 @@ export const getData = async (
       compositeSize,
       alertOnGroupDisappear,
       searchConfiguration,
+      esQueryConfig,
       lastPeriodEnd,
       groupBy,
       afterKey,

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/metric_query.test.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/metric_query.test.ts
@@ -42,6 +42,11 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
       query: '',
     },
   };
+  const esQueryConfig = {
+    allowLeadingWildcards: false,
+    queryStringOptions: {},
+    ignoreFilterIfFieldNotInIndex: false,
+  };
 
   const groupBy = 'host.doggoname';
   const timeFieldName = 'mockedTimeFieldName';
@@ -58,6 +63,7 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
       100,
       true,
       searchConfiguration,
+      esQueryConfig,
       void 0,
       groupBy
     );
@@ -114,6 +120,7 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
       100,
       true,
       currentSearchConfiguration,
+      esQueryConfig,
       void 0,
       groupBy
     );
@@ -225,6 +232,7 @@ describe("The Metric Threshold Alert's getElasticsearchMetricQuery", () => {
       100,
       true,
       currentSearchConfiguration,
+      esQueryConfig,
       void 0,
       groupBy
     );

--- a/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/metric_query.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/rules/custom_threshold/lib/metric_query.ts
@@ -7,7 +7,7 @@
 
 import moment from 'moment';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { Filter } from '@kbn/es-query';
+import type { EsQueryConfig, Filter } from '@kbn/es-query';
 import {
   Aggregators,
   CustomMetricExpressionParams,
@@ -52,6 +52,7 @@ export const createBoolQuery = (
   timeframe: { start: number; end: number },
   timeFieldName: string,
   searchConfiguration: SearchConfigurationType,
+  esQueryConfig: EsQueryConfig,
   additionalQueries: QueryDslQueryContainer[] = []
 ) => {
   const rangeQuery: QueryDslQueryContainer = {
@@ -64,7 +65,7 @@ export const createBoolQuery = (
   };
   const filters = QueryDslQueryContainerToFilter([rangeQuery, ...additionalQueries]);
 
-  return getSearchConfigurationBoolQuery(searchConfiguration, filters);
+  return getSearchConfigurationBoolQuery(searchConfiguration, filters, esQueryConfig);
 };
 
 export const getElasticsearchMetricQuery = (
@@ -74,6 +75,7 @@ export const getElasticsearchMetricQuery = (
   compositeSize: number,
   alertOnGroupDisappear: boolean,
   searchConfiguration: SearchConfigurationType,
+  esQueryConfig: EsQueryConfig,
   lastPeriodEnd?: number,
   groupBy?: string | string[],
   afterKey?: Record<string, string>,
@@ -204,7 +206,7 @@ export const getElasticsearchMetricQuery = (
     aggs.groupings.composite.after = afterKey;
   }
 
-  const query = createBoolQuery(timeframe, timeFieldName, searchConfiguration);
+  const query = createBoolQuery(timeframe, timeFieldName, searchConfiguration, esQueryConfig);
 
   return {
     track_total_hits: true,

--- a/x-pack/plugins/observability_solution/observability/server/utils/get_es_query_config.test.ts
+++ b/x-pack/plugins/observability_solution/observability/server/utils/get_es_query_config.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-server-mocks';
+import { getEsQueryConfig } from './get_es_query_config';
+
+describe('getEsQueryConfig', () => {
+  const uiSettingsClient = uiSettingsServiceMock.createClient();
+
+  it('should get the es query config correctly', async () => {
+    const settings = await getEsQueryConfig(uiSettingsClient);
+
+    expect(settings).toEqual({
+      allowLeadingWildcards: false,
+      ignoreFilterIfFieldNotInIndex: false,
+      queryStringOptions: false,
+    });
+  });
+});

--- a/x-pack/plugins/observability_solution/observability/server/utils/get_es_query_config.ts
+++ b/x-pack/plugins/observability_solution/observability/server/utils/get_es_query_config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IUiSettingsClient } from '@kbn/core/server';
+import { UI_SETTINGS } from '@kbn/data-plugin/server';
+
+export async function getEsQueryConfig(uiSettings: IUiSettingsClient) {
+  const allowLeadingWildcards = await uiSettings.get(UI_SETTINGS.QUERY_ALLOW_LEADING_WILDCARDS);
+  const queryStringOptions = await uiSettings.get(UI_SETTINGS.QUERY_STRING_OPTIONS);
+  const ignoreFilterIfFieldNotInIndex = await uiSettings.get(
+    UI_SETTINGS.COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX
+  );
+
+  return {
+    allowLeadingWildcards,
+    queryStringOptions,
+    ignoreFilterIfFieldNotInIndex,
+  };
+}

--- a/x-pack/plugins/observability_solution/observability/tsconfig.json
+++ b/x-pack/plugins/observability_solution/observability/tsconfig.json
@@ -102,6 +102,7 @@
     "@kbn/react-kibana-mount",
     "@kbn/core-chrome-browser",
     "@kbn/navigation-plugin",
+    "@kbn/core-ui-settings-server-mocks",
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Custom threshold] Respect query:allowLeadingWildcards in optional query filter (#189488)](https://github.com/elastic/kibana/pull/189488)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2024-07-31T13:29:04Z","message":"[Custom threshold] Respect query:allowLeadingWildcards in optional query filter (#189488)\n\nPartially fixes.   #189072\r\n\r\n## Summary\r\n\r\nIn this PR, we pass the `query:allowLeadingWildcards` for the optional\r\nfilter to the custom threshold (specifically\r\n`getSearchConfigurationBoolQuery` function that generates the related ES\r\nQuery).\r\n\r\n|Before|After|\r\n|----|---|\r\n\r\n|![image](https://github.com/user-attachments/assets/74f25ffe-516d-437f-90eb-a9a4c1dfc184)|![image](https://github.com/user-attachments/assets/a0190f81-d137-4b75-95f2-7358ece99468)|\r\n\r\n#### Rule\r\n\r\n<img\r\nsrc=\"https://github.com/user-attachments/assets/70d2de37-2285-450f-88bf-45aa88954019\"\r\nwidth=500 />\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5219a1f14d1af812624282e59170503d8a071bd4","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-management","Feature: Custom threshold","v8.16.0"],"number":189488,"url":"https://github.com/elastic/kibana/pull/189488","mergeCommit":{"message":"[Custom threshold] Respect query:allowLeadingWildcards in optional query filter (#189488)\n\nPartially fixes.   #189072\r\n\r\n## Summary\r\n\r\nIn this PR, we pass the `query:allowLeadingWildcards` for the optional\r\nfilter to the custom threshold (specifically\r\n`getSearchConfigurationBoolQuery` function that generates the related ES\r\nQuery).\r\n\r\n|Before|After|\r\n|----|---|\r\n\r\n|![image](https://github.com/user-attachments/assets/74f25ffe-516d-437f-90eb-a9a4c1dfc184)|![image](https://github.com/user-attachments/assets/a0190f81-d137-4b75-95f2-7358ece99468)|\r\n\r\n#### Rule\r\n\r\n<img\r\nsrc=\"https://github.com/user-attachments/assets/70d2de37-2285-450f-88bf-45aa88954019\"\r\nwidth=500 />\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5219a1f14d1af812624282e59170503d8a071bd4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/189488","number":189488,"mergeCommit":{"message":"[Custom threshold] Respect query:allowLeadingWildcards in optional query filter (#189488)\n\nPartially fixes.   #189072\r\n\r\n## Summary\r\n\r\nIn this PR, we pass the `query:allowLeadingWildcards` for the optional\r\nfilter to the custom threshold (specifically\r\n`getSearchConfigurationBoolQuery` function that generates the related ES\r\nQuery).\r\n\r\n|Before|After|\r\n|----|---|\r\n\r\n|![image](https://github.com/user-attachments/assets/74f25ffe-516d-437f-90eb-a9a4c1dfc184)|![image](https://github.com/user-attachments/assets/a0190f81-d137-4b75-95f2-7358ece99468)|\r\n\r\n#### Rule\r\n\r\n<img\r\nsrc=\"https://github.com/user-attachments/assets/70d2de37-2285-450f-88bf-45aa88954019\"\r\nwidth=500 />\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5219a1f14d1af812624282e59170503d8a071bd4"}}]}] BACKPORT-->