### PR TITLE
[Search] [Playground] Omit question from session state 

### DIFF
--- a/x-pack/plugins/search_playground/public/providers/form_provider.test.tsx
+++ b/x-pack/plugins/search_playground/public/providers/form_provider.test.tsx
@@ -130,6 +130,8 @@ describe('FormProvider', () => {
 
     act(() => {
       setValue(ChatFormFields.prompt, 'New prompt');
+      // omit question from the session state
+      setValue(ChatFormFields.question, 'dont save me');
     });
 
     await waitFor(() => {

--- a/x-pack/plugins/search_playground/public/providers/form_provider.tsx
+++ b/x-pack/plugins/search_playground/public/providers/form_provider.tsx
@@ -36,7 +36,10 @@ const getLocalSession = (storage: Storage): PartialChatForm => {
   }
 };
 
-const setLocalSession = (state: PartialChatForm, storage: Storage) => {
+const setLocalSession = (formState: PartialChatForm, storage: Storage) => {
+  // omit question from the session state
+  const { question, ...state } = formState;
+
   storage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state));
 };
 

--- a/x-pack/test/functional/page_objects/search_playground_page.ts
+++ b/x-pack/test/functional/page_objects/search_playground_page.ts
@@ -47,6 +47,12 @@ export function SearchPlaygroundPageProvider({ getService }: FtrProviderContext)
           },
         });
       },
+
+      async expectInSession(key: string, value: string | undefined): Promise<void> {
+        const session = (await browser.getLocalStorageItem(SESSION_KEY)) || '{}';
+        const state = JSON.parse(session);
+        expect(state[key]).to.be(value);
+      },
     },
     PlaygroundStartChatPage: {
       async expectPlaygroundStartChatPageComponentsToExist() {
@@ -149,6 +155,20 @@ export function SearchPlaygroundPageProvider({ getService }: FtrProviderContext)
 
         await testSubjects.existOrFail('editContextPanel');
         await testSubjects.existOrFail('summarizationPanel');
+      },
+
+      async updatePrompt(prompt: string) {
+        await testSubjects.setValue('instructionsPrompt', prompt);
+      },
+
+      async updateQuestion(question: string) {
+        await testSubjects.setValue('questionInput', question);
+      },
+
+      async expectQuestionInputToBeEmpty() {
+        const questionInput = await testSubjects.find('questionInput');
+        const question = await questionInput.getAttribute('value');
+        expect(question).to.be.empty();
       },
 
       async sendQuestion() {

--- a/x-pack/test_serverless/functional/test_suites/search/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index.ts
@@ -11,20 +11,20 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless search UI', function () {
     this.tags(['esGate']);
 
-    // loadTestFile(require.resolve('./landing_page'));
-    // loadTestFile(require.resolve('./connectors/connectors_overview'));
-    // loadTestFile(require.resolve('./default_dataview'));
-    // loadTestFile(require.resolve('./navigation'));
-    // loadTestFile(require.resolve('./pipelines'));
-    // loadTestFile(require.resolve('./cases/attachment_framework'));
-    // loadTestFile(require.resolve('./dashboards/build_dashboard'));
-    // loadTestFile(require.resolve('./dashboards/import_dashboard'));
-    // loadTestFile(require.resolve('./advanced_settings'));
-    // loadTestFile(require.resolve('./rules/rule_details'));
-    // loadTestFile(require.resolve('./console_notebooks'));
+    loadTestFile(require.resolve('./landing_page'));
+    loadTestFile(require.resolve('./connectors/connectors_overview'));
+    loadTestFile(require.resolve('./default_dataview'));
+    loadTestFile(require.resolve('./navigation'));
+    loadTestFile(require.resolve('./pipelines'));
+    loadTestFile(require.resolve('./cases/attachment_framework'));
+    loadTestFile(require.resolve('./dashboards/build_dashboard'));
+    loadTestFile(require.resolve('./dashboards/import_dashboard'));
+    loadTestFile(require.resolve('./advanced_settings'));
+    loadTestFile(require.resolve('./rules/rule_details'));
+    loadTestFile(require.resolve('./console_notebooks'));
     loadTestFile(require.resolve('./search_playground/playground_overview'));
 
-    // loadTestFile(require.resolve('./ml'));
-    // loadTestFile(require.resolve('./search_homepage'));
+    loadTestFile(require.resolve('./ml'));
+    loadTestFile(require.resolve('./search_homepage'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/search/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index.ts
@@ -11,20 +11,20 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless search UI', function () {
     this.tags(['esGate']);
 
-    loadTestFile(require.resolve('./landing_page'));
-    loadTestFile(require.resolve('./connectors/connectors_overview'));
-    loadTestFile(require.resolve('./default_dataview'));
-    loadTestFile(require.resolve('./navigation'));
-    loadTestFile(require.resolve('./pipelines'));
-    loadTestFile(require.resolve('./cases/attachment_framework'));
-    loadTestFile(require.resolve('./dashboards/build_dashboard'));
-    loadTestFile(require.resolve('./dashboards/import_dashboard'));
-    loadTestFile(require.resolve('./advanced_settings'));
-    loadTestFile(require.resolve('./rules/rule_details'));
-    loadTestFile(require.resolve('./console_notebooks'));
+    // loadTestFile(require.resolve('./landing_page'));
+    // loadTestFile(require.resolve('./connectors/connectors_overview'));
+    // loadTestFile(require.resolve('./default_dataview'));
+    // loadTestFile(require.resolve('./navigation'));
+    // loadTestFile(require.resolve('./pipelines'));
+    // loadTestFile(require.resolve('./cases/attachment_framework'));
+    // loadTestFile(require.resolve('./dashboards/build_dashboard'));
+    // loadTestFile(require.resolve('./dashboards/import_dashboard'));
+    // loadTestFile(require.resolve('./advanced_settings'));
+    // loadTestFile(require.resolve('./rules/rule_details'));
+    // loadTestFile(require.resolve('./console_notebooks'));
     loadTestFile(require.resolve('./search_playground/playground_overview'));
 
-    loadTestFile(require.resolve('./ml'));
-    loadTestFile(require.resolve('./search_homepage'));
+    // loadTestFile(require.resolve('./ml'));
+    // loadTestFile(require.resolve('./search_homepage'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/search/search_playground/playground_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/search_playground/playground_overview.ts
@@ -192,6 +192,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             'You are a fireman in london that helps answering question-answering tasks.'
           );
         });
+
+        it("saves a session to localstorage when it's updated", async () => {
+          await pageObjects.searchPlayground.session.setSession();
+          await browser.refresh();
+          await pageObjects.searchPlayground.PlaygroundChatPage.navigateToChatPage();
+          await pageObjects.searchPlayground.PlaygroundChatPage.updatePrompt("You're a doctor");
+          await pageObjects.searchPlayground.PlaygroundChatPage.updateQuestion('i have back pain');
+          await pageObjects.searchPlayground.session.expectInSession('prompt', "You're a doctor");
+          await pageObjects.searchPlayground.session.expectInSession('question', undefined);
+        });
       });
 
       after(async () => {


### PR DESCRIPTION
## Summary

Bug within session persistence where it may persist the question into form state which in turn gets persisted into localstorage. This change omits the question from the session state. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

