### PR TITLE
[Logs UI] Fix missing `share` service in shared component fly-out

### DIFF
--- a/x-pack/plugins/observability_solution/logs_shared/public/components/log_stream/log_stream.tsx
+++ b/x-pack/plugins/observability_solution/logs_shared/public/components/log_stream/log_stream.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
+import type { HttpStart } from '@kbn/core-http-browser';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { buildEsQuery, Filter, Query } from '@kbn/es-query';
-import { JsonValue } from '@kbn/utility-types';
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
+import { JsonValue } from '@kbn/utility-types';
 import { noop } from 'lodash';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import usePrevious from 'react-use/lib/usePrevious';
 import { LogEntryCursor } from '../../../common/log_entry';
 import { defaultLogViewsStaticConfig, LogViewReference } from '../../../common/log_views';
@@ -20,12 +22,14 @@ import { useLogView } from '../../hooks/use_log_view';
 import { LogViewsClient } from '../../services/log_views';
 import { LogColumnRenderConfiguration } from '../../utils/log_column_render_configuration';
 import { useKibanaQuerySettings } from '../../utils/use_kibana_query_settings';
+import { useLogEntryFlyout } from '../logging/log_entry_flyout';
 import { ScrollableLogTextStreamView } from '../logging/log_text_stream';
 import { LogStreamErrorBoundary } from './log_stream_error_boundary';
-import { useLogEntryFlyout } from '../logging/log_entry_flyout';
 
 interface LogStreamPluginDeps {
   data: DataPublicPluginStart;
+  http: HttpStart;
+  share: SharePluginStart;
 }
 
 const PAGE_THRESHOLD = 2;
@@ -109,9 +113,9 @@ export const LogStreamContent = ({
   );
 
   const {
-    services: { http, data },
+    services: { http, data, share },
   } = useKibana<LogStreamPluginDeps>();
-  if (http == null || data == null) {
+  if (http == null || data == null || share == null) {
     throw new Error(
       `<LogStream /> cannot access kibana core services.
 

--- a/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_entry_flyout/log_entry_flyout.tsx
+++ b/x-pack/plugins/observability_solution/logs_shared/public/components/logging/log_entry_flyout/log_entry_flyout.tsx
@@ -42,7 +42,7 @@ export interface LogEntryFlyoutProps {
 export const useLogEntryFlyout = (logViewReference: LogViewReference) => {
   const flyoutRef = useRef<OverlayRef>();
   const {
-    services: { http, data, uiSettings, application, observabilityAIAssistant },
+    services: { http, data, share, uiSettings, application, observabilityAIAssistant },
     overlays: { openFlyout },
   } = useKibanaContextForPlugin();
 
@@ -55,6 +55,7 @@ export const useLogEntryFlyout = (logViewReference: LogViewReference) => {
       const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
         http,
         data,
+        share,
         uiSettings,
         application,
         observabilityAIAssistant,
@@ -71,14 +72,15 @@ export const useLogEntryFlyout = (logViewReference: LogViewReference) => {
       );
     },
     [
-      http,
-      data,
-      uiSettings,
       application,
-      openFlyout,
-      logViewReference,
       closeLogEntryFlyout,
+      data,
+      http,
+      logViewReference,
       observabilityAIAssistant,
+      openFlyout,
+      share,
+      uiSettings,
     ]
   );
 


### PR DESCRIPTION
## :memo: Summary

This ensures the `share` service is in the old log stream component's context when used outside of the Logs UI.

- :adhesive_bandage: fixes https://github.com/elastic/kibana/issues/189722

## :female_detective: Review notes

- Since the bug was only triggered when opening the fly-out, only usage sites what pass the prop `showFlyoutAction` should have been affected.

## Release note

Fix log stream fly-out when embedded in APM or the Infrastructure UI.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->