### PR TITLE
[Cloud Security] Fix Detection Rule flaky FTR

### DIFF
--- a/x-pack/test/cloud_security_posture_functional/pages/findings_alerts.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_alerts.ts
@@ -195,7 +195,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await testSubjects.click('csp:toast-success-link');
         await pageObjects.header.waitUntilLoadingHasFinished();
         const rulePageTitle = await testSubjects.find('header-page-title');
-        expect(await rulePageTitle.getVisibleText()).to.be(ruleName1);
+        // Rule page title is not immediately available, so we need to retry until it is
+        await retry.try(async () => {
+          expect(await rulePageTitle.getVisibleText()).to.be(ruleName1);
+        });
       });
     });
     describe('Rule details', () => {


### PR DESCRIPTION
## Summary

It closes https://github.com/elastic/kibana/issues/172312

This PR fixed the flaky FTR test by adding a retry method to the title checking.