### PR TITLE
[APM][ECO] Fix empty state alignment

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/no_entities_empty_state.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/no_entities_empty_state.tsx
@@ -29,8 +29,10 @@ import {
   AssociateServiceLogs,
   CollectServiceLogs,
 } from '../../../../shared/add_data_buttons/buttons';
+import { useBreakpoints } from '../../../../../hooks/use_breakpoints';
 
 export function NoEntitiesEmptyState() {
+  const { isLarge } = useBreakpoints();
   const { services } = useKibana<ApmPluginStartDeps & ApmServices>();
   const [userHasDismissedCallout, setUserHasDismissedCallout] = useLocalStorage(
     'apm.uiNewExperienceCallout',
@@ -50,6 +52,34 @@ export function NoEntitiesEmptyState() {
 
   return (
     <EuiFlexGroup direction="column">
+      {!userHasDismissedCallout && (
+        <EuiFlexItem>
+          <EuiCallOut
+            css={{ textAlign: 'left' }}
+            onDismiss={() => setUserHasDismissedCallout(true)}
+            title={i18n.translate('xpack.apm.noEntitiesEmptyState.callout.title', {
+              defaultMessage: 'Trying for the first time?',
+            })}
+          >
+            <p>
+              {i18n.translate('xpack.apm.noEntitiesEmptyState.description', {
+                defaultMessage:
+                  'It can take up to a couple of minutes for your services to show. Try refreshing the page in a minute. ',
+              })}
+            </p>
+            <EuiLink
+              external
+              target="_blank"
+              data-test-subj="apmNewExperienceEmptyStateLink"
+              href="https://ela.st/elastic-entity-model-first-time"
+            >
+              {i18n.translate('xpack.apm.noEntitiesEmptyState.learnMore.link', {
+                defaultMessage: 'Learn more',
+              })}
+            </EuiLink>
+          </EuiCallOut>
+        </EuiFlexItem>
+      )}
       <EuiFlexItem>
         <EuiEmptyPrompt
           hasShadow={false}
@@ -63,7 +93,7 @@ export function NoEntitiesEmptyState() {
               })}
             </h2>
           }
-          layout="horizontal"
+          layout={isLarge ? 'vertical' : 'horizontal'}
           color="plain"
           body={
             <>
@@ -105,35 +135,6 @@ export function NoEntitiesEmptyState() {
                   }}
                 />
               </EuiFlexGroup>
-
-              {!userHasDismissedCallout && (
-                <EuiFlexItem>
-                  <EuiCallOut
-                    css={{ textAlign: 'left' }}
-                    onDismiss={() => setUserHasDismissedCallout(true)}
-                    title={i18n.translate('xpack.apm.noEntitiesEmptyState.callout.title', {
-                      defaultMessage: 'Trying for the first time?',
-                    })}
-                  >
-                    <p>
-                      {i18n.translate('xpack.apm.noEntitiesEmptyState.description', {
-                        defaultMessage:
-                          'It can take up to a couple of minutes for your services to show. Try refreshing the page in a minute. ',
-                      })}
-                    </p>
-                    <EuiLink
-                      external
-                      target="_blank"
-                      data-test-subj="apmNewExperienceEmptyStateLink"
-                      href="https://ela.st/elastic-entity-model-first-time"
-                    >
-                      {i18n.translate('xpack.apm.noEntitiesEmptyState.learnMore.link', {
-                        defaultMessage: 'Learn more',
-                      })}
-                    </EuiLink>
-                  </EuiCallOut>
-                </EuiFlexItem>
-              )}
             </EuiFlexGroup>
           }
         />

--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/no_entities_empty_state.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_inventory/multi_signal_inventory/table/no_entities_empty_state.tsx
@@ -64,7 +64,7 @@ export function NoEntitiesEmptyState() {
             <p>
               {i18n.translate('xpack.apm.noEntitiesEmptyState.description', {
                 defaultMessage:
-                  'It can take up to a couple of minutes for your services to show. Try refreshing the page in a minute. ',
+                  'It can take up to a couple of minutes for your services to show. Try refreshing the page in a minute.',
               })}
             </p>
             <EuiLink


### PR DESCRIPTION
## Summary
closes https://github.com/elastic/observability-dev/issues/3779

1. Move the callout to the top
2. Fix the overflow in smaller screen

Note: The horizontal layout is EUI issue which will be fixed 


Summarize your PR. If it involves visual changes include a screenshot or gif.

### Before

![image](https://github.com/user-attachments/assets/f8c49092-15fc-4cc1-8789-c8abb67e7b0f)

### After
 

https://github.com/user-attachments/assets/0fcf7d3d-9bba-4d05-8034-274efbb8b338

