### PR TITLE
[ES|QL] Implement `OrderExpression` for `SORT` command arguments

### DIFF
--- a/packages/kbn-esql-ast/src/__tests__/ast_parser.commands.test.ts
+++ b/packages/kbn-esql-ast/src/__tests__/ast_parser.commands.test.ts
@@ -169,8 +169,16 @@ describe('commands', () => {
           name: 'sort',
           args: [
             {
-              type: 'literal',
-              value: 1,
+              type: 'function',
+              name: 'order-expression',
+              order: '',
+              nulls: '',
+              args: [
+                {
+                  type: 'literal',
+                  value: 1,
+                },
+              ],
             },
           ],
         },

--- a/packages/kbn-esql-ast/src/__tests__/ast_parser.sort.test.ts
+++ b/packages/kbn-esql-ast/src/__tests__/ast_parser.sort.test.ts
@@ -10,11 +10,38 @@ import { getAstAndSyntaxErrors as parse } from '../ast_parser';
 
 describe('SORT', () => {
   describe('correctly formatted', () => {
-    // Un-skip one https://github.com/elastic/kibana/issues/189491 fixed.
-    it.skip('example from documentation', () => {
+    it('sorting order without modifiers', () => {
+      const text = `FROM employees | SORT height`;
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'sort',
+          args: [
+            {
+              type: 'function',
+              subtype: 'postfix-unary-expression',
+              name: 'order-expression',
+              order: '',
+              nulls: '',
+              args: [
+                {
+                  type: 'column',
+                  name: 'height',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('with order modifier "DESC"', () => {
       const text = `
         FROM employees
-        | KEEP first_name, last_name, height
         | SORT height DESC
         `;
       const { ast, errors } = parse(text);
@@ -22,22 +49,61 @@ describe('SORT', () => {
       expect(errors.length).toBe(0);
       expect(ast).toMatchObject([
         {},
-        {},
         {
           type: 'command',
           name: 'sort',
           args: [
             {
-              type: 'column',
-              name: 'height',
+              type: 'function',
+              subtype: 'postfix-unary-expression',
+              name: 'order-expression',
+              order: 'DESC',
+              nulls: '',
+              args: [
+                {
+                  type: 'column',
+                  name: 'height',
+                },
+              ],
             },
           ],
         },
       ]);
     });
 
-    // Un-skip once https://github.com/elastic/kibana/issues/189491 fixed.
-    it.skip('can parse various sorting columns with options', () => {
+    it('with nulls modifier "NULLS LAST"', () => {
+      const text = `
+        FROM employees
+        | SORT height NULLS LAST
+        `;
+      const { ast, errors } = parse(text);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'sort',
+          args: [
+            {
+              type: 'function',
+              subtype: 'postfix-unary-expression',
+              name: 'order-expression',
+              order: '',
+              nulls: 'NULLS LAST',
+              args: [
+                {
+                  type: 'column',
+                  name: 'height',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse various sorting columns with options', () => {
       const text =
         'FROM a | SORT a, b ASC, c DESC, d NULLS FIRST, e NULLS LAST, f ASC NULLS FIRST, g DESC NULLS LAST';
       const { ast, errors } = parse(text);
@@ -50,32 +116,71 @@ describe('SORT', () => {
           name: 'sort',
           args: [
             {
-              type: 'column',
-              name: 'a',
+              type: 'function',
+              subtype: 'postfix-unary-expression',
+              name: 'order-expression',
+              order: '',
+              nulls: '',
+              args: [
+                {
+                  type: 'column',
+                  name: 'a',
+                },
+              ],
             },
             {
-              type: 'column',
-              name: 'b',
+              order: 'ASC',
+              nulls: '',
+              args: [
+                {
+                  name: 'b',
+                },
+              ],
             },
             {
-              type: 'column',
-              name: 'c',
+              order: 'DESC',
+              nulls: '',
+              args: [
+                {
+                  name: 'c',
+                },
+              ],
             },
             {
-              type: 'column',
-              name: 'd',
+              order: '',
+              nulls: 'NULLS FIRST',
+              args: [
+                {
+                  name: 'd',
+                },
+              ],
             },
             {
-              type: 'column',
-              name: 'e',
+              order: '',
+              nulls: 'NULLS LAST',
+              args: [
+                {
+                  name: 'e',
+                },
+              ],
             },
             {
-              type: 'column',
-              name: 'f',
+              order: 'ASC',
+              nulls: 'NULLS FIRST',
+              args: [
+                {
+                  name: 'f',
+                },
+              ],
             },
             {
-              type: 'column',
-              name: 'g',
+              order: 'DESC',
+              nulls: 'NULLS LAST',
+              args: [
+                {
+                  name: 'g',
+                },
+              ],
             },
           ],
         },

--- a/packages/kbn-esql-ast/src/ast_factory.ts
+++ b/packages/kbn-esql-ast/src/ast_factory.ts
@@ -51,7 +51,7 @@ import {
   visitDissect,
   visitGrok,
   collectBooleanExpression,
-  visitOrderExpression,
+  visitOrderExpressions,
   getPolicyName,
   getMatchField,
   getEnrichClauses,
@@ -219,7 +219,7 @@ export class AstListener implements ESQLParserListener {
   exitSortCommand(ctx: SortCommandContext) {
     const command = createCommand('sort', ctx);
     this.ast.push(command);
-    command.args.push(...visitOrderExpression(ctx.orderExpression_list()));
+    command.args.push(...visitOrderExpressions(ctx.orderExpression_list()));
   }
 
   /**

--- a/packages/kbn-esql-ast/src/ast_helpers.ts
+++ b/packages/kbn-esql-ast/src/ast_helpers.ts
@@ -38,6 +38,7 @@ import type {
   ESQLNumericLiteralType,
   FunctionSubtype,
   ESQLNumericLiteral,
+  ESQLOrderExpression,
 } from './types';
 
 export function nonNullable<T>(v: T): v is NonNullable<T> {
@@ -216,6 +217,26 @@ export function createFunction<Subtype extends FunctionSubtype>(
   }
   return node;
 }
+
+export const createOrderExpression = (
+  ctx: ParserRuleContext,
+  arg: ESQLAstItem,
+  order: ESQLOrderExpression['order'],
+  nulls: ESQLOrderExpression['nulls']
+) => {
+  const orderExpression: ESQLOrderExpression = createFunction(
+    'order-expression',
+    ctx,
+    undefined,
+    'postfix-unary-expression'
+  ) as ESQLOrderExpression;
+
+  orderExpression.args = [arg];
+  orderExpression.order = order;
+  orderExpression.nulls = nulls;
+
+  return orderExpression;
+};
 
 function walkFunctionStructure(
   args: ESQLAstItem[],

--- a/packages/kbn-esql-ast/src/types.ts
+++ b/packages/kbn-esql-ast/src/types.ts
@@ -115,9 +115,15 @@ export interface ESQLUnaryExpression extends ESQLFunction<'unary-expression'> {
   args: [ESQLAstItem];
 }
 
-export interface ESQLPostfixUnaryExpression extends ESQLFunction<'postfix-unary-expression'> {
+export interface ESQLPostfixUnaryExpression<Name extends string = string>
+  extends ESQLFunction<'postfix-unary-expression', Name> {
   subtype: 'postfix-unary-expression';
   args: [ESQLAstItem];
+}
+
+export interface ESQLOrderExpression extends ESQLPostfixUnaryExpression<'order-expression'> {
+  order: '' | 'ASC' | 'DESC';
+  nulls: '' | 'NULLS FIRST' | 'NULLS LAST';
 }
 
 export interface ESQLBinaryExpression


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/189491


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
