### PR TITLE
[POC][Security-in-core] First-class Route Authorization

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -255,6 +255,7 @@ export class CoreKibanaRequest<
         true, // some places in LP call KibanaRequest.from(request) manually. remove fallback to true before v8
       access: this.getAccess(request),
       tags: request.route?.settings?.tags || [],
+      authz: ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.authz,
       timeout: {
         payload: payloadTimeout,
         idleSocket: socketTimeout === 0 ? undefined : socketTimeout,

--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -255,7 +255,7 @@ export class CoreKibanaRequest<
         true, // some places in LP call KibanaRequest.from(request) manually. remove fallback to true before v8
       access: this.getAccess(request),
       tags: request.route?.settings?.tags || [],
-      authz: ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.authz,
+      security: ((request.route?.settings as RouteOptions)?.app as KibanaRouteOptions)?.security,
       timeout: {
         payload: payloadTimeout,
         idleSocket: socketTimeout === 0 ? undefined : socketTimeout,

--- a/packages/core/http/core-http-router-server-internal/src/request.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.ts
@@ -136,6 +136,8 @@ export class CoreKibanaRequest<
   public readonly httpVersion: string;
   /** {@inheritDoc KibanaRequest.protocol} */
   public readonly protocol: HttpProtocol;
+  /** {@inheritDoc KibanaRequest.authzResult} */
+  public readonly authzResult: any;
 
   /** @internal */
   protected readonly [requestSymbol]!: Request;
@@ -158,6 +160,7 @@ export class CoreKibanaRequest<
     this.id = appState?.requestId ?? uuidv4();
     this.uuid = appState?.requestUuid ?? uuidv4();
     this.rewrittenUrl = appState?.rewrittenUrl;
+    this.authzResult = appState?.authzResult;
 
     this.url = request.url ?? new URL('https://fake-request/url');
     this.headers = isRealReq ? deepFreeze({ ...request.headers }) : request.headers;
@@ -203,6 +206,7 @@ export class CoreKibanaRequest<
         isAuthenticated: this.auth.isAuthenticated,
       },
       route: this.route,
+      authzResult: this.authzResult,
     };
   }
 

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -171,9 +171,13 @@ export interface AuthzDisabled {
 }
 
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
+export interface RouteAuthc {
+  enabled: boolean | 'optional';
+  reason?: string;
+}
 export interface RouteSecurity {
   authz: RouteAuthz;
-  authRequired?: boolean;
+  authc?: RouteAuthc;
 }
 
 /** @internal */

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -28,6 +28,7 @@ import type {
 } from '@kbn/core-http-server';
 import { isZod } from '@kbn/zod';
 import { validBodyOutput, getRequestValidation } from '@kbn/core-http-server';
+import type { RouteSecurity } from '@kbn/core-http-server';
 import { RouteValidator } from './validator';
 import { CoreVersionedRouter } from './versioned_router';
 import { CoreKibanaRequest } from './request';
@@ -150,35 +151,6 @@ export type InternalRegistrar<M extends Method, C extends RequestHandlerContextB
   handler: RequestHandler<P, Q, B, C, M>,
   internalOpts?: InternalRegistrarOptions
 ) => ReturnType<RouteRegistrar<M, C>>;
-
-type Privilege = string;
-
-interface PrivilegeSet {
-  anyRequired?: Privilege[];
-  allRequired?: Privilege[];
-  offering?: string;
-}
-
-type Privileges = Array<Privilege | PrivilegeSet>;
-
-export interface AuthzEnabled {
-  requiredPrivileges: Privileges;
-}
-
-export interface AuthzDisabled {
-  enabled: false;
-  reason: string;
-}
-
-export type RouteAuthz = AuthzEnabled | AuthzDisabled;
-export interface RouteAuthc {
-  enabled: boolean | 'optional';
-  reason?: string;
-}
-export interface RouteSecurity {
-  authz: RouteAuthz;
-  authc?: RouteAuthc;
-}
 
 /** @internal */
 export interface InternalRouterRoute extends RouterRoute {

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -171,11 +171,15 @@ export interface AuthzDisabled {
 }
 
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
+export interface RouteSecurity {
+  authz: RouteAuthz;
+  authRequired?: boolean;
+}
 
 /** @internal */
 export interface InternalRouterRoute extends RouterRoute {
   readonly isVersioned: boolean;
-  readonly authz?: RouteAuthz;
+  readonly security?: RouteSecurity;
 }
 
 /** @internal */
@@ -225,7 +229,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
           method,
           path: getRouteFullPath(this.routerPath, route.path),
           options: validOptions(method, route),
-          authz: route.authz,
+          security: route.security,
           /** Below is added for introspection */
           validationSchemas: route.validate,
           isVersioned: internalOptions.isVersioned,

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -166,7 +166,10 @@ export interface AuthzEnabled {
   passThrough?: boolean;
 }
 
-export type AuthzDisabled = false;
+export interface AuthzDisabled {
+  enabled: false;
+  reason: string;
+}
 
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
 

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -154,6 +154,12 @@ export type InternalRegistrar<M extends Method, C extends RequestHandlerContextB
 /** @internal */
 export interface InternalRouterRoute extends RouterRoute {
   readonly isVersioned: boolean;
+  readonly authz?:
+    | false
+    | {
+        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
+        passThrough?: boolean;
+      };
 }
 
 /** @internal */
@@ -192,6 +198,10 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
         route = prepareRouteConfigValidation(route);
         const routeSchemas = routeSchemasFromRouteConfig(route, method);
 
+        if (route.authz) {
+          console.log(route.authz, route.path);
+        }
+
         this.routes.push({
           handler: async (req, responseToolkit) =>
             await this.handle({
@@ -203,6 +213,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
           method,
           path: getRouteFullPath(this.routerPath, route.path),
           options: validOptions(method, route),
+          authz: route.authz,
           /** Below is added for introspection */
           validationSchemas: route.validate,
           isVersioned: internalOptions.isVersioned,

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -163,7 +163,6 @@ type Privileges = Array<Privilege | PrivilegeSet>;
 
 export interface AuthzEnabled {
   requiredPrivileges: Privileges;
-  passThrough?: boolean;
 }
 
 export interface AuthzDisabled {

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -699,7 +699,7 @@ export class HttpServer {
     const kibanaRouteOptions: KibanaRouteOptions = {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),
       access: route.options.access ?? 'internal',
-      authz: route.authz,
+      security: route.security,
     };
     // Log HTTP API target consumer.
     optionsLogger.debug(

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -696,10 +696,6 @@ export class HttpServer {
     const { authRequired, tags, body = {}, timeout } = route.options;
     const { accepts: allow, override, maxBytes, output, parse } = body;
 
-    // if (route.path === '/internal/security/roles/{spaceId}') {
-    //   console.log(route);
-    // }
-
     const kibanaRouteOptions: KibanaRouteOptions = {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),
       access: route.options.access ?? 'internal',
@@ -712,10 +708,6 @@ export class HttpServer {
       }]`
     );
 
-    if (route.authz) {
-      console.log('route authz', route.authz);
-    }
-
     this.server!.route({
       handler: route.handler,
       method: route.method,
@@ -724,7 +716,7 @@ export class HttpServer {
         // ext: {
         //   onPostAuth: {
         //     method(request, h) {
-        //       // check authz here ?
+        //       // After moving authz to core, check it here ?
 
         //       return h.continue;
         //     },

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -696,9 +696,14 @@ export class HttpServer {
     const { authRequired, tags, body = {}, timeout } = route.options;
     const { accepts: allow, override, maxBytes, output, parse } = body;
 
+    // if (route.path === '/internal/security/roles/{spaceId}') {
+    //   console.log(route);
+    // }
+
     const kibanaRouteOptions: KibanaRouteOptions = {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),
       access: route.options.access ?? 'internal',
+      authz: route.authz,
     };
     // Log HTTP API target consumer.
     optionsLogger.debug(
@@ -707,11 +712,24 @@ export class HttpServer {
       }]`
     );
 
+    if (route.authz) {
+      console.log('route authz', route.authz);
+    }
+
     this.server!.route({
       handler: route.handler,
       method: route.method,
       path: route.path,
       options: {
+        // ext: {
+        //   onPostAuth: {
+        //     method(request, h) {
+        //       // check authz here ?
+
+        //       return h.continue;
+        //     },
+        //   },
+        // },
         auth: this.getAuthOption(authRequired),
         app: kibanaRouteOptions,
         tags: tags ? Array.from(tags) : undefined,

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -295,6 +295,7 @@ export class HttpService
                   title: 'Kibana HTTP APIs',
                   version: '0.0.0', // TODO get a better version here
                   filters: { pathStartsWith, excludePathsMatching, access, version },
+                  buildFlavour: this.env.packageInfo.buildFlavor,
                 });
                 return h.response(result);
               } catch (e) {

--- a/packages/core/http/core-http-server-internal/src/lifecycle/on_post_auth.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle/on_post_auth.ts
@@ -21,6 +21,7 @@ import {
   CoreKibanaRequest,
   lifecycleResponseFactory,
 } from '@kbn/core-http-router-server-internal';
+import { deepFreeze } from '@kbn/std';
 
 const postAuthResult = {
   next(): OnPostAuthResult {
@@ -51,7 +52,17 @@ export function adoptToHapiOnPostAuthFormat(fn: OnPostAuthHandler, log: Logger) 
       if (isKibanaResponse(result)) {
         return hapiResponseAdapter.handle(result);
       }
+
       if (postAuthResult.isNext(result)) {
+        if (result.authzResult) {
+          Object.defineProperty(request.app, 'authzResult', {
+            value: deepFreeze(result.authzResult),
+            configurable: false,
+            writable: false,
+            enumerable: false,
+          });
+        }
+
         return responseToolkit.continue;
       }
 

--- a/packages/core/http/core-http-server/index.ts
+++ b/packages/core/http/core-http-server/index.ts
@@ -106,6 +106,9 @@ export type {
   RouteValidatorFullConfigResponse,
   LazyValidator,
   RouteAccess,
+  AuthzDisabled,
+  AuthzEnabled,
+  RouteAuthz,
 } from './src/router';
 export {
   validBodyOutput,

--- a/packages/core/http/core-http-server/index.ts
+++ b/packages/core/http/core-http-server/index.ts
@@ -26,6 +26,7 @@ export type {
   AuthToolkit,
   OnPostAuthHandler,
   OnPostAuthNextResult,
+  OnPostAuthAuthzResult,
   OnPostAuthToolkit,
   OnPostAuthResult,
   OnPreAuthHandler,

--- a/packages/core/http/core-http-server/index.ts
+++ b/packages/core/http/core-http-server/index.ts
@@ -110,6 +110,10 @@ export type {
   AuthzDisabled,
   AuthzEnabled,
   RouteAuthz,
+  RouteAuthc,
+  AuthcDisabled,
+  AuthcEnabled,
+  RouteSecurity,
 } from './src/router';
 export {
   validBodyOutput,

--- a/packages/core/http/core-http-server/src/lifecycle/index.ts
+++ b/packages/core/http/core-http-server/src/lifecycle/index.ts
@@ -24,6 +24,7 @@ export type {
   OnPostAuthNextResult,
   OnPostAuthToolkit,
   OnPostAuthResult,
+  OnPostAuthAuthzResult,
 } from './on_post_auth';
 export { OnPostAuthResultType } from './on_post_auth';
 

--- a/packages/core/http/core-http-server/src/lifecycle/on_post_auth.ts
+++ b/packages/core/http/core-http-server/src/lifecycle/on_post_auth.ts
@@ -20,6 +20,7 @@ export enum OnPostAuthResultType {
  */
 export interface OnPostAuthNextResult {
   type: OnPostAuthResultType.next;
+  authzResult?: Record<string, boolean>;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/lifecycle/on_post_auth.ts
+++ b/packages/core/http/core-http-server/src/lifecycle/on_post_auth.ts
@@ -13,6 +13,7 @@ import type { IKibanaResponse, KibanaRequest, LifecycleResponseFactory } from '.
  */
 export enum OnPostAuthResultType {
   next = 'next',
+  authzResult = 'authzResult',
 }
 
 /**
@@ -20,13 +21,17 @@ export enum OnPostAuthResultType {
  */
 export interface OnPostAuthNextResult {
   type: OnPostAuthResultType.next;
-  authzResult?: Record<string, boolean>;
+}
+
+export interface OnPostAuthAuthzResult {
+  type: OnPostAuthResultType.authzResult;
+  authzResult: Record<string, boolean>;
 }
 
 /**
  * @public
  */
-export type OnPostAuthResult = OnPostAuthNextResult;
+export type OnPostAuthResult = OnPostAuthNextResult | OnPostAuthAuthzResult;
 
 /**
  * @public

--- a/packages/core/http/core-http-server/src/router/index.ts
+++ b/packages/core/http/core-http-server/src/router/index.ts
@@ -54,7 +54,15 @@ export type {
   RouteAccess,
 } from './route';
 export { validBodyOutput } from './route';
-export type { AuthzDisabled, AuthzEnabled, RouteAuthz } from './route';
+export type {
+  AuthzDisabled,
+  AuthzEnabled,
+  RouteAuthz,
+  RouteAuthc,
+  AuthcDisabled,
+  AuthcEnabled,
+  RouteSecurity,
+} from './route';
 export type {
   RouteValidationFunction,
   RouteValidationResultFactory,

--- a/packages/core/http/core-http-server/src/router/index.ts
+++ b/packages/core/http/core-http-server/src/router/index.ts
@@ -54,6 +54,7 @@ export type {
   RouteAccess,
 } from './route';
 export { validBodyOutput } from './route';
+export type { AuthzDisabled, AuthzEnabled, RouteAuthz } from './route';
 export type {
   RouteValidationFunction,
   RouteValidationResultFactory,

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -12,7 +12,7 @@ import type { Observable } from 'rxjs';
 import type { RecursiveReadonly } from '@kbn/utility-types';
 import type { HttpProtocol } from '../http_contract';
 import type { IKibanaSocket } from './socket';
-import type { RouteMethod, RouteConfigOptions, RouteAuthz, RouteSecurity } from './route';
+import type { RouteMethod, RouteConfigOptions, RouteSecurity } from './route';
 import type { Headers } from './headers';
 
 /**
@@ -32,6 +32,7 @@ export interface KibanaRequestState extends RequestApplicationState {
   requestUuid: string;
   rewrittenUrl?: URL;
   traceId?: string;
+  authzResult?: Record<string, boolean>;
   measureElu?: () => void;
 }
 
@@ -137,7 +138,7 @@ export interface KibanaRequest<
    */
   readonly isFakeRequest: boolean;
 
-  readonly authzResult?: any;
+  readonly authzResult?: Record<string, boolean>;
 
   /**
    * An internal request has access to internal routes.

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -12,7 +12,7 @@ import type { Observable } from 'rxjs';
 import type { RecursiveReadonly } from '@kbn/utility-types';
 import type { HttpProtocol } from '../http_contract';
 import type { IKibanaSocket } from './socket';
-import type { RouteMethod, RouteConfigOptions } from './route';
+import type { RouteMethod, RouteConfigOptions, RouteAuthz } from './route';
 import type { Headers } from './headers';
 
 /**
@@ -21,12 +21,7 @@ import type { Headers } from './headers';
 export interface KibanaRouteOptions extends RouteOptionsApp {
   xsrfRequired: boolean;
   access: 'internal' | 'public';
-  authz?:
-    | false
-    | {
-        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
-        passThrough?: boolean;
-      };
+  authz?: RouteAuthz;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -12,7 +12,7 @@ import type { Observable } from 'rxjs';
 import type { RecursiveReadonly } from '@kbn/utility-types';
 import type { HttpProtocol } from '../http_contract';
 import type { IKibanaSocket } from './socket';
-import type { RouteMethod, RouteConfigOptions, RouteAuthz } from './route';
+import type { RouteMethod, RouteConfigOptions, RouteAuthz, RouteSecurity } from './route';
 import type { Headers } from './headers';
 
 /**
@@ -21,7 +21,7 @@ import type { Headers } from './headers';
 export interface KibanaRouteOptions extends RouteOptionsApp {
   xsrfRequired: boolean;
   access: 'internal' | 'public';
-  authz?: RouteAuthz;
+  security?: RouteSecurity;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -21,6 +21,12 @@ import type { Headers } from './headers';
 export interface KibanaRouteOptions extends RouteOptionsApp {
   xsrfRequired: boolean;
   access: 'internal' | 'public';
+  authz?:
+    | false
+    | {
+        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
+        passThrough?: boolean;
+      };
 }
 
 /**
@@ -135,6 +141,8 @@ export interface KibanaRequest<
    * Even if the API facade is the same, fake requests have some stubbed functionalities.
    */
   readonly isFakeRequest: boolean;
+
+  authzResponse?: any;
 
   /**
    * An internal request has access to internal routes.

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -137,7 +137,7 @@ export interface KibanaRequest<
    */
   readonly isFakeRequest: boolean;
 
-  authzResponse?: any;
+  readonly authzResult?: any;
 
   /**
    * An internal request has access to internal routes.

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -32,6 +32,25 @@ export type SafeRouteMethod = 'get' | 'options';
  */
 export type RouteMethod = SafeRouteMethod | DestructiveRouteMethod;
 
+type Privilege = string;
+
+interface PrivilegeSet {
+  anyRequired?: Privilege[];
+  allRequired?: Privilege[];
+  offering?: string;
+}
+
+type Privileges = Array<Privilege | PrivilegeSet>;
+
+export interface AuthzEnabled {
+  requiredPrivileges: Privileges;
+  passThrough?: boolean;
+}
+
+export type AuthzDisabled = false;
+
+export type RouteAuthz = AuthzEnabled | AuthzDisabled;
+
 /**
  * The set of supported parseable Content-Types
  * @public
@@ -210,12 +229,7 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
   /**
    * The required capabilities to access this route.
    */
-  authz?:
-    | false
-    | {
-        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
-        passThrough?: boolean;
-      };
+  authz?: RouteAuthz;
 }
 
 /**
@@ -296,15 +310,7 @@ export interface RouteConfig<P, Q, B, Method extends RouteMethod> {
    */
   validate: RouteValidator<P, Q, B> | (() => RouteValidator<P, Q, B>) | false;
 
-  authz?:
-    | false
-    | {
-        /**
-         * The required capabilities to access this route.
-         */
-        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
-        passThrough?: boolean;
-      };
+  authz?: RouteAuthz;
 
   /**
    * Additional route options {@link RouteConfigOptions}.

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -51,15 +51,20 @@ export interface AuthzDisabled {
   reason: string;
 }
 
-export interface RouteAuthc {
-  enabled: boolean | 'optional';
-  reason?: string;
+export interface AuthcEnabled {
+  enabled: true | 'optional';
 }
 
+export interface AuthcDisabled {
+  enabled: false;
+  reason: string;
+}
+
+export type RouteAuthc = AuthcEnabled | AuthcDisabled;
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
 export interface RouteSecurity {
   authz: RouteAuthz;
-  authRequired?: RouteAuthc;
+  authc?: RouteAuthc;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -52,6 +52,10 @@ export interface AuthzDisabled {
 }
 
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
+export interface RouteSecurity {
+  authz: RouteAuthz;
+  authRequired?: boolean;
+}
 
 /**
  * The set of supported parseable Content-Types
@@ -231,7 +235,7 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
   /**
    * The required capabilities to access this route.
    */
-  authz?: RouteAuthz;
+  security?: RouteSecurity;
 }
 
 /**
@@ -312,7 +316,7 @@ export interface RouteConfig<P, Q, B, Method extends RouteMethod> {
    */
   validate: RouteValidator<P, Q, B> | (() => RouteValidator<P, Q, B>) | false;
 
-  authz?: RouteAuthz;
+  security?: RouteSecurity;
 
   /**
    * Additional route options {@link RouteConfigOptions}.

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -206,6 +206,16 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
    * @remarks This will be surfaced in OAS documentation.
    */
   deprecated?: boolean;
+
+  /**
+   * The required capabilities to access this route.
+   */
+  authz?:
+    | false
+    | {
+        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
+        passThrough?: boolean;
+      };
 }
 
 /**
@@ -285,6 +295,16 @@ export interface RouteConfig<P, Q, B, Method extends RouteMethod> {
    * ```
    */
   validate: RouteValidator<P, Q, B> | (() => RouteValidator<P, Q, B>) | false;
+
+  authz?:
+    | false
+    | {
+        /**
+         * The required capabilities to access this route.
+         */
+        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
+        passThrough?: boolean;
+      };
 
   /**
    * Additional route options {@link RouteConfigOptions}.

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -47,7 +47,10 @@ export interface AuthzEnabled {
   passThrough?: boolean;
 }
 
-export type AuthzDisabled = false;
+export interface AuthzDisabled {
+  enabled: false;
+  reason: string;
+}
 
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
 

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -51,10 +51,15 @@ export interface AuthzDisabled {
   reason: string;
 }
 
+export interface RouteAuthc {
+  enabled: boolean | 'optional';
+  reason?: string;
+}
+
 export type RouteAuthz = AuthzEnabled | AuthzDisabled;
 export interface RouteSecurity {
   authz: RouteAuthz;
-  authRequired?: boolean;
+  authRequired?: RouteAuthc;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -44,7 +44,6 @@ type Privileges = Array<Privilege | PrivilegeSet>;
 
 export interface AuthzEnabled {
   requiredPrivileges: Privileges;
-  passThrough?: boolean;
 }
 
 export interface AuthzDisabled {

--- a/packages/core/http/core-http-server/src/router/router.ts
+++ b/packages/core/http/core-http-server/src/router/router.ts
@@ -124,6 +124,12 @@ export interface RouterRoute {
   method: RouteMethod;
   path: string;
   options: RouteConfigOptions<RouteMethod>;
+  authz?:
+    | false
+    | {
+        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
+        passThrough?: boolean;
+      };
   /**
    * @note if providing a function to lazily load your validation schemas assume
    *       that the function will only be called once.

--- a/packages/core/http/core-http-server/src/router/router.ts
+++ b/packages/core/http/core-http-server/src/router/router.ts
@@ -12,7 +12,7 @@ import type { VersionedRouter } from '../versioning';
 import type { RouteConfig, RouteMethod } from './route';
 import type { RequestHandler, RequestHandlerWrapper } from './request_handler';
 import type { RequestHandlerContextBase } from './request_handler_context';
-import type { RouteConfigOptions, RouteAuthz } from './route';
+import type { RouteConfigOptions, RouteSecurity } from './route';
 import { RouteValidator } from './route_validator';
 
 /**
@@ -124,7 +124,7 @@ export interface RouterRoute {
   method: RouteMethod;
   path: string;
   options: RouteConfigOptions<RouteMethod>;
-  authz?: RouteAuthz;
+  security?: RouteSecurity;
   /**
    * @note if providing a function to lazily load your validation schemas assume
    *       that the function will only be called once.

--- a/packages/core/http/core-http-server/src/router/router.ts
+++ b/packages/core/http/core-http-server/src/router/router.ts
@@ -12,7 +12,7 @@ import type { VersionedRouter } from '../versioning';
 import type { RouteConfig, RouteMethod } from './route';
 import type { RequestHandler, RequestHandlerWrapper } from './request_handler';
 import type { RequestHandlerContextBase } from './request_handler_context';
-import type { RouteConfigOptions } from './route';
+import type { RouteConfigOptions, RouteAuthz } from './route';
 import { RouteValidator } from './route_validator';
 
 /**
@@ -124,12 +124,7 @@ export interface RouterRoute {
   method: RouteMethod;
   path: string;
   options: RouteConfigOptions<RouteMethod>;
-  authz?:
-    | false
-    | {
-        requiredPrivileges: Array<string | { tier: string; privileges: string[] }>;
-        passThrough?: boolean;
-      };
+  authz?: RouteAuthz;
   /**
    * @note if providing a function to lazily load your validation schemas assume
    *       that the function will only be called once.

--- a/packages/kbn-eslint-config/.eslintrc.js
+++ b/packages/kbn-eslint-config/.eslintrc.js
@@ -278,6 +278,8 @@ module.exports = {
     '@kbn/eslint/no_this_in_property_initializers': 'error',
     '@kbn/eslint/no_unsafe_console': 'error',
     '@kbn/imports/no_unresolvable_imports': 'error',
+    // ESLINT Rule for security object in routes
+    // '@kbn/eslint/no_route_security_defined': 'error',
     '@kbn/imports/uniform_imports': 'error',
     '@kbn/imports/no_unused_imports': 'error',
     '@kbn/imports/no_boundary_crossing': 'error',

--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -18,5 +18,6 @@ module.exports = {
     no_constructor_args_in_property_initializers: require('./rules/no_constructor_args_in_property_initializers'),
     no_this_in_property_initializers: require('./rules/no_this_in_property_initializers'),
     no_unsafe_console: require('./rules/no_unsafe_console'),
+    no_route_security_defined: require('./rules/no_route_security_defined'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/no_route_security_defined.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_route_security_defined.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Automatically append security object after path if not defined within router methods',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const validMethods = ['get', 'put', 'delete', 'post'];
+        const callee = node.callee;
+        const securityObject = `
+          security: {
+            authz: {
+              enabled: false,
+              reason: 'This route is opted out from authorization',
+            },
+          },`;
+
+        if (
+          callee.type === 'MemberExpression' &&
+          callee.object.name === 'router' &&
+          validMethods.includes(callee.property.name)
+        ) {
+          const [routeConfig] = node.arguments;
+
+          if (routeConfig && routeConfig.type === 'ObjectExpression') {
+            const pathProperty = routeConfig.properties.find(
+              (property) => property.key && property.key.name === 'path'
+            );
+
+            const securityProperty = routeConfig.properties.find(
+              (property) => property.key && property.key.name === 'security'
+            );
+
+            if (!securityProperty) {
+              context.report({
+                node: routeConfig,
+                message: 'Security object is missing',
+                fix(fixer) {
+                  // Find the position to insert the security object
+                  const insertPosition = pathProperty.range[1];
+
+                  return fixer.insertTextAfterRange(
+                    [insertPosition, insertPosition + 1],
+                    `${securityObject}`
+                  );
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/kbn-eslint-plugin-eslint/rules/no_route_security_defined.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_route_security_defined.js
@@ -12,8 +12,8 @@ module.exports = {
     docs: {
       description:
         'Automatically append security object after path if not defined within router methods',
-      category: 'Best Practices',
-      recommended: false,
+      category: 'Security Best Practices',
+      recommended: true,
     },
     fixable: 'code',
     schema: [],

--- a/packages/kbn-eslint-plugin-eslint/rules/no_rule_security_defined.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_rule_security_defined.test.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const { RuleTester } = require('eslint');
+
+const rule = require('./no_route_security_defined');
+
+// Tests
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+ruleTester.run('append-security-object', rule, {
+  valid: [
+    {
+      code: `
+      router.get(
+        {
+          path: '/api/security/authz_poc/simple_privileges_example_1',
+          security: {
+            authz: {
+              enabled: false,
+              reason: 'This route is opted out from authorization ',
+            },
+          },
+          validate: false,
+        },
+        createLicensedRouteHandler(async (context, request, response) => {
+          try {
+            return response.ok({
+              body: {
+                authzResult: request.authzResult,
+              },
+            });
+          } catch (error) {
+            return response.customError(wrapIntoCustomErrorResponse(error));
+          }
+        })
+      );
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      router.get(
+        {
+          path: '/api/security/authz_poc/simple_privileges_example_1',
+          validate: false,
+        },
+        createLicensedRouteHandler(async (context, request, response) => {
+          try {
+            return response.ok({
+              body: {
+                authzResult: request.authzResult,
+              },
+            });
+          } catch (error) {
+            return response.customError(wrapIntoCustomErrorResponse(error));
+          }
+        })
+      );
+      `,
+      errors: [{ message: 'Security object is missing' }],
+      output: `
+      router.get(
+        {
+          path: '/api/security/authz_poc/simple_privileges_example_1',
+          security: {
+            authz: {
+              enabled: false,
+              reason: 'This route is opted out from authorization',
+            },
+          },
+          validate: false,
+        },
+        createLicensedRouteHandler(async (context, request, response) => {
+          try {
+            return response.ok({
+              body: {
+                authzResult: request.authzResult,
+              },
+            });
+          } catch (error) {
+            return response.customError(wrapIntoCustomErrorResponse(error));
+          }
+        })
+      );
+      `,
+    },
+  ],
+});

--- a/packages/kbn-router-to-openapispec/src/generate_oas.ts
+++ b/packages/kbn-router-to-openapispec/src/generate_oas.ts
@@ -31,18 +31,19 @@ export interface GenerateOpenApiDocumentOptions {
   docsUrl?: string;
   tags?: string[];
   filters?: GenerateOpenApiDocumentOptionsFilters;
+  buildFlavour: string;
 }
 
 export const generateOpenApiDocument = (
   appRouters: { routers: Router[]; versionedRouters: CoreVersionedRouter[] },
   opts: GenerateOpenApiDocumentOptions
 ): OpenAPIV3.Document => {
-  const { filters } = opts;
+  const { filters, buildFlavour } = opts;
   const converter = new OasConverter();
   const getOpId = createOperationIdCounter();
   const paths: OpenAPIV3.PathsObject = {};
   for (const router of appRouters.routers) {
-    const result = processRouter(router, converter, getOpId, filters);
+    const result = processRouter(router, converter, getOpId, buildFlavour, filters);
     Object.assign(paths, result.paths);
   }
   for (const router of appRouters.versionedRouters) {

--- a/packages/kbn-router-to-openapispec/src/process_router.ts
+++ b/packages/kbn-router-to-openapispec/src/process_router.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Router } from '@kbn/core-http-router-server-internal';
-import { getResponseValidation } from '@kbn/core-http-server';
+import { getResponseValidation, AuthzEnabled, AuthzDisabled } from '@kbn/core-http-server';
 import { ALLOWED_PUBLIC_VERSION as SERVERLESS_VERSION_2023_10_31 } from '@kbn/core-http-router-server-internal';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { OasConverter } from './oas_converter';
@@ -25,6 +25,89 @@ import {
 } from './util';
 import type { OperationIdCounter } from './operation_id_counter';
 import type { GenerateOpenApiDocumentOptionsFilters } from './generate_oas';
+
+interface PrivilegeGroupValue {
+  allRequired: string[];
+  anyRequired: string[];
+}
+
+interface PrivilegeGroups {
+  all: PrivilegeGroupValue;
+  serverless: PrivilegeGroupValue;
+  traditional: PrivilegeGroupValue;
+}
+
+const extractAuthzDescription = (route: InternalRouterRoute) => {
+  if (!route?.authz) {
+    return '';
+  }
+
+  if ((route.authz as AuthzDisabled).enabled === false) {
+    return `Route authz is disabled. ${(route.authz as AuthzDisabled).reason ?? ''}`;
+  }
+
+  const privileges = (route?.authz as AuthzEnabled).requiredPrivileges;
+  const offeringGroupedPrivileges = privileges.reduce<PrivilegeGroups>(
+    (groups, privilege) => {
+      if (typeof privilege === 'string') {
+        groups.all.allRequired.push(privilege);
+
+        return groups;
+      }
+      const group = (privilege.offering ?? 'all') as keyof PrivilegeGroups;
+
+      groups[group].allRequired.push(...(privilege.allRequired ?? []));
+      groups[group].anyRequired.push(...(privilege.anyRequired ?? []));
+
+      return groups;
+    },
+    {
+      all: { allRequired: [], anyRequired: [] },
+      serverless: { allRequired: [], anyRequired: [] },
+      traditional: { allRequired: [], anyRequired: [] },
+    }
+  );
+
+  const hasAnyOfferingPrivileges = (offering: string) =>
+    offeringGroupedPrivileges[offering as keyof PrivilegeGroups].allRequired.length ||
+    offeringGroupedPrivileges[offering as keyof PrivilegeGroups].anyRequired.length;
+
+  const getPrivilegesDescription = (allRequired: string[], anyRequired: string[]) => {
+    const allDescription = allRequired.length ? `ALL of [${allRequired.join(', ')}]` : '';
+    const anyDescription = anyRequired.length ? `ANY of [${anyRequired.join(' OR ')}]` : '';
+
+    return `${allDescription}${allDescription && anyDescription ? ' AND ' : ''}${anyDescription}`;
+  };
+
+  if (!hasAnyOfferingPrivileges('serverless') && !hasAnyOfferingPrivileges('traditional')) {
+    const { allRequired, anyRequired } = offeringGroupedPrivileges.all;
+
+    return `[Authz] Route required privileges: ${getPrivilegesDescription(
+      allRequired,
+      anyRequired
+    )}`;
+  }
+
+  const getDescriptionForOffering = (offering: string) => {
+    const allRequired = [
+      ...offeringGroupedPrivileges[offering as keyof PrivilegeGroups].allRequired,
+      ...offeringGroupedPrivileges.all.allRequired,
+    ];
+    const anyRequired = [
+      ...offeringGroupedPrivileges[offering as keyof PrivilegeGroups].anyRequired,
+      ...offeringGroupedPrivileges.all.anyRequired,
+    ];
+
+    return `Route required privileges for ${offering}: ${getPrivilegesDescription(
+      allRequired,
+      anyRequired
+    )}.\n`;
+  };
+
+  return `[Authz] ${getDescriptionForOffering('serverless')}${getDescriptionForOffering(
+    'traditional'
+  )}`;
+};
 
 export const processRouter = (
   appRouter: Router,
@@ -60,10 +143,13 @@ export const processRouter = (
         parameters.push(...pathObjects, ...queryObjects);
       }
 
+      const authzDescription = extractAuthzDescription(route);
+      const description = `${route.options.description ?? ''}${authzDescription}`;
+
       const operation: OpenAPIV3.OperationObject = {
         summary: route.options.summary ?? '',
         tags: route.options.tags ? extractTags(route.options.tags) : [],
-        ...(route.options.description ? { description: route.options.description } : {}),
+        description,
         ...(route.options.deprecated ? { deprecated: route.options.deprecated } : {}),
         requestBody: !!validationSchemas?.body
           ? {

--- a/packages/kbn-router-to-openapispec/src/process_router.ts
+++ b/packages/kbn-router-to-openapispec/src/process_router.ts
@@ -37,7 +37,7 @@ interface PrivilegeGroups {
   traditional: PrivilegeGroupValue;
 }
 
-const extractAuthzDescription = (route: InternalRouterRoute) => {
+const extractAuthzDescription = (route: InternalRouterRoute, currentOffering: string) => {
   if (!route?.security?.authz || (route.security.authz as AuthzDisabled).enabled === false) {
     return '';
   }
@@ -94,21 +94,17 @@ const extractAuthzDescription = (route: InternalRouterRoute) => {
       ...offeringGroupedPrivileges.all.anyRequired,
     ];
 
-    return `Route required privileges for ${offering}: ${getPrivilegesDescription(
-      allRequired,
-      anyRequired
-    )}.\n`;
+    return `Route required privileges for: ${getPrivilegesDescription(allRequired, anyRequired)}.`;
   };
 
-  return `[Authz] ${getDescriptionForOffering('serverless')}${getDescriptionForOffering(
-    'traditional'
-  )}`;
+  return `[Authz] ${getDescriptionForOffering(currentOffering)}`;
 };
 
 export const processRouter = (
   appRouter: Router,
   converter: OasConverter,
   getOpId: OperationIdCounter,
+  buildFlavour: string,
   filters?: GenerateOpenApiDocumentOptionsFilters
 ) => {
   const paths: OpenAPIV3.PathsObject = {};
@@ -139,7 +135,7 @@ export const processRouter = (
         parameters.push(...pathObjects, ...queryObjects);
       }
 
-      const authzDescription = extractAuthzDescription(route);
+      const authzDescription = extractAuthzDescription(route, buildFlavour);
       const description = `${route.options.description ?? ''}${authzDescription}`;
 
       const operation: OpenAPIV3.OperationObject = {

--- a/packages/kbn-router-to-openapispec/src/process_router.ts
+++ b/packages/kbn-router-to-openapispec/src/process_router.ts
@@ -38,15 +38,15 @@ interface PrivilegeGroups {
 }
 
 const extractAuthzDescription = (route: InternalRouterRoute) => {
-  if (!route?.authz) {
+  if (!route?.security?.authz) {
     return '';
   }
 
-  if ((route.authz as AuthzDisabled).enabled === false) {
-    return `Route authz is disabled. ${(route.authz as AuthzDisabled).reason ?? ''}`;
+  if ((route.security.authz as AuthzDisabled).enabled === false) {
+    return `Route authz is disabled. ${(route.security?.authz as AuthzDisabled).reason ?? ''}`;
   }
 
-  const privileges = (route?.authz as AuthzEnabled).requiredPrivileges;
+  const privileges = (route?.security?.authz as AuthzEnabled).requiredPrivileges;
   const offeringGroupedPrivileges = privileges.reduce<PrivilegeGroups>(
     (groups, privilege) => {
       if (typeof privilege === 'string') {

--- a/packages/kbn-router-to-openapispec/src/process_router.ts
+++ b/packages/kbn-router-to-openapispec/src/process_router.ts
@@ -38,12 +38,8 @@ interface PrivilegeGroups {
 }
 
 const extractAuthzDescription = (route: InternalRouterRoute) => {
-  if (!route?.security?.authz) {
+  if (!route?.security?.authz || (route.security.authz as AuthzDisabled).enabled === false) {
     return '';
-  }
-
-  if ((route.security.authz as AuthzDisabled).enabled === false) {
-    return `Route authz is disabled. ${(route.security?.authz as AuthzDisabled).reason ?? ''}`;
   }
 
   const privileges = (route?.security?.authz as AuthzEnabled).requiredPrivileges;

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -236,7 +236,7 @@ export type {
 } from '@kbn/core-http-server';
 export type { IExternalUrlPolicy } from '@kbn/core-http-common';
 
-export { validBodyOutput } from '@kbn/core-http-server';
+export { validBodyOutput, OnPostAuthResultType } from '@kbn/core-http-server';
 export type { AuthzDisabled, AuthzEnabled, RouteAuthz } from '@kbn/core-http-server';
 
 export type {

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -237,6 +237,7 @@ export type {
 export type { IExternalUrlPolicy } from '@kbn/core-http-common';
 
 export { validBodyOutput } from '@kbn/core-http-server';
+export type { AuthzDisabled, AuthzEnabled, RouteAuthz } from '@kbn/core-http-server';
 
 export type {
   HttpResourcesRenderOptions,

--- a/x-pack/plugins/security/common/constants.ts
+++ b/x-pack/plugins/security/common/constants.ts
@@ -102,3 +102,10 @@ export const SESSION_ROUTE = '/internal/security/session';
  * Allowed image file types for uploading an image as avatar
  */
 export const IMAGE_FILE_TYPES = ['image/svg+xml', 'image/jpeg', 'image/png', 'image/gif'];
+
+export enum ApiActionPermission {
+  ManageSpaces = 'manageSpaces',
+  TaskManager = 'taskManager',
+  Features = 'features',
+  DecryptedTelemetry = 'decryptedTelemetry',
+}

--- a/x-pack/plugins/security/server/authorization/actions/api.ts
+++ b/x-pack/plugins/security/server/authorization/actions/api.ts
@@ -16,6 +16,7 @@ export class ApiActions implements ApiActionsType {
     this.prefix = `api:`;
   }
 
+  // From this
   public get(operation: string) {
     if (!operation || !isString(operation)) {
       throw new Error('operation is required and must be a string');

--- a/x-pack/plugins/security/server/authorization/api_authorization.ts
+++ b/x-pack/plugins/security/server/authorization/api_authorization.ts
@@ -23,67 +23,9 @@ export function initAPIAuthorization(
 
     const authz = request.route.options.authz;
 
-    const checkAuthz = async (apiActions: string[]) => {
-      const checkPrivileges = checkPrivilegesDynamicallyWithRequest(request);
-      const checkPrivilegesResponse = await checkPrivileges({ kibana: apiActions });
-      const kibanaPrivileges: Record<string, boolean> = {};
-
-      if (authz) {
-        for (const kbPrivilege of checkPrivilegesResponse.privileges.kibana) {
-          kibanaPrivileges[kbPrivilege.privilege.replace('api:', '')] = kbPrivilege.authorized;
-        }
-
-        for (const requiredPrivilege of authz.requiredPrivileges) {
-          if (typeof requiredPrivilege === 'string' && !kibanaPrivileges[requiredPrivilege]) {
-            logger.warn(
-              `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
-            );
-            return response.forbidden();
-          }
-
-          if (
-            typeof requiredPrivilege === 'object' &&
-            (!requiredPrivilege.offering || requiredPrivilege.offering === buildFlavor)
-          ) {
-            const allRequired = requiredPrivilege.allRequired ?? [];
-            const anyRequired = requiredPrivilege.anyRequired ?? [];
-
-            if (
-              !allRequired.every((privilege) => kibanaPrivileges[privilege]) &&
-              !anyRequired.some((privilege) => kibanaPrivileges[privilege])
-            ) {
-              logger.warn(
-                `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
-              );
-              return response.forbidden();
-            }
-          }
-        }
-
-        if (authz?.passThrough) {
-          Object.defineProperty(request, 'authzResponse', {
-            value: deepFreeze(checkPrivilegesResponse.privileges.kibana),
-            enumerable: false,
-            configurable: false,
-            writable: false,
-          });
-        }
-
-        return toolkit.next();
-      }
-
-      // we've actually authorized the request
-      if (checkPrivilegesResponse.hasAllRequested) {
-        logger.debug(`User authorized for "${request.url.pathname}${request.url.search}"`);
-        return toolkit.next();
-      }
-
-      logger.warn(
-        `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
-      );
-      return response.forbidden();
-    };
-
+    /**
+     * Please note, that this code was intended for POC demo purposes only and is not production-ready.
+     */
     if (authz) {
       const requiredPrivileges = authz.requiredPrivileges.flatMap((privilegeEntry) => {
         if (typeof privilegeEntry === 'string') {
@@ -101,7 +43,51 @@ export function initAPIAuthorization(
       });
       const apiActions = requiredPrivileges.map((permission) => actions.api.get(permission));
 
-      return await checkAuthz(apiActions);
+      const checkPrivileges = checkPrivilegesDynamicallyWithRequest(request);
+      const checkPrivilegesResponse = await checkPrivileges({ kibana: apiActions });
+      const kibanaPrivileges: Record<string, boolean> = {};
+
+      for (const kbPrivilege of checkPrivilegesResponse.privileges.kibana) {
+        kibanaPrivileges[kbPrivilege.privilege.replace('api:', '')] = kbPrivilege.authorized;
+      }
+
+      for (const requiredPrivilege of authz.requiredPrivileges) {
+        if (typeof requiredPrivilege === 'string' && !kibanaPrivileges[requiredPrivilege]) {
+          logger.warn(
+            `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
+          );
+          return response.forbidden();
+        }
+
+        if (
+          typeof requiredPrivilege === 'object' &&
+          (!requiredPrivilege.offering || requiredPrivilege.offering === buildFlavor)
+        ) {
+          const allRequired = requiredPrivilege.allRequired ?? [];
+          const anyRequired = requiredPrivilege.anyRequired ?? [];
+
+          if (
+            !allRequired.every((privilege) => kibanaPrivileges[privilege]) &&
+            !anyRequired.some((privilege) => kibanaPrivileges[privilege])
+          ) {
+            logger.warn(
+              `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
+            );
+            return response.forbidden();
+          }
+        }
+      }
+
+      if (authz.passThrough) {
+        Object.defineProperty(request, 'authzResponse', {
+          value: deepFreeze(checkPrivilegesResponse.privileges.kibana),
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        });
+      }
+
+      return toolkit.next();
     }
 
     const tags = request.route.options.tags;
@@ -115,6 +101,18 @@ export function initAPIAuthorization(
 
     const apiActions = actionTags.map((tag) => actions.api.get(tag.substring(tagPrefix.length)));
 
-    return await checkAuthz(apiActions);
+    const checkPrivileges = checkPrivilegesDynamicallyWithRequest(request);
+    const checkPrivilegesResponse = await checkPrivileges({ kibana: apiActions });
+
+    // we've actually authorized the request
+    if (checkPrivilegesResponse.hasAllRequested) {
+      logger.debug(`User authorized for "${request.url.pathname}${request.url.search}"`);
+      return toolkit.next();
+    }
+
+    logger.warn(
+      `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
+    );
+    return response.forbidden();
   });
 }

--- a/x-pack/plugins/security/server/authorization/api_authorization.ts
+++ b/x-pack/plugins/security/server/authorization/api_authorization.ts
@@ -7,16 +7,62 @@
 
 import type { HttpServiceSetup, Logger } from '@kbn/core/server';
 import type { AuthorizationServiceSetup } from '@kbn/security-plugin-types-server';
+import { deepFreeze } from '@kbn/std';
 
 export function initAPIAuthorization(
   http: HttpServiceSetup,
   { actions, checkPrivilegesDynamicallyWithRequest, mode }: AuthorizationServiceSetup,
+  buildFlavor: string,
   logger: Logger
 ) {
   http.registerOnPostAuth(async (request, response, toolkit) => {
     // if we aren't using RBAC for this request, just continue
     if (!mode.useRbacForRequest(request)) {
       return toolkit.next();
+    }
+
+    const authz = request.route.options.authz;
+
+    const checkAuthz = async (apiActions: string[]) => {
+      const checkPrivileges = checkPrivilegesDynamicallyWithRequest(request);
+      const checkPrivilegesResponse = await checkPrivileges({ kibana: apiActions });
+
+      if (authz && authz?.passThrough) {
+        Object.defineProperty(request, 'authzResponse', {
+          value: deepFreeze(checkPrivilegesResponse),
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        });
+      }
+
+      // we've actually authorized the request
+      if (checkPrivilegesResponse.hasAllRequested) {
+        logger.debug(`User authorized for "${request.url.pathname}${request.url.search}"`);
+        return toolkit.next();
+      }
+
+      logger.warn(
+        `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
+      );
+      return response.forbidden();
+    };
+
+    if (authz) {
+      const requiredPrivileges = authz.requiredPrivileges.flatMap((privilegeEntry) => {
+        if (typeof privilegeEntry === 'string') {
+          return privilegeEntry;
+        }
+
+        if (typeof privilegeEntry === 'object' && privilegeEntry.tier === buildFlavor) {
+          return privilegeEntry.privileges;
+        }
+
+        return [];
+      });
+      const apiActions = requiredPrivileges.map((permission) => actions.api.get(permission));
+
+      return await checkAuthz(apiActions);
     }
 
     const tags = request.route.options.tags;
@@ -29,18 +75,7 @@ export function initAPIAuthorization(
     }
 
     const apiActions = actionTags.map((tag) => actions.api.get(tag.substring(tagPrefix.length)));
-    const checkPrivileges = checkPrivilegesDynamicallyWithRequest(request);
-    const checkPrivilegesResponse = await checkPrivileges({ kibana: apiActions });
 
-    // we've actually authorized the request
-    if (checkPrivilegesResponse.hasAllRequested) {
-      logger.debug(`User authorized for "${request.url.pathname}${request.url.search}"`);
-      return toolkit.next();
-    }
-
-    logger.warn(
-      `User not authorized for "${request.url.pathname}${request.url.search}": responding with 403`
-    );
-    return response.forbidden();
+    return await checkAuthz(apiActions);
   });
 }

--- a/x-pack/plugins/security/server/authorization/api_authorization.ts
+++ b/x-pack/plugins/security/server/authorization/api_authorization.ts
@@ -109,7 +109,7 @@ export function initAPIAuthorization(
         }
       }
 
-      return { type: OnPostAuthResultType.next, authzResult: kibanaPrivileges };
+      return { type: OnPostAuthResultType.authzResult, authzResult: kibanaPrivileges };
     }
 
     const tags = request.route.options.tags;

--- a/x-pack/plugins/security/server/authorization/api_authorization.ts
+++ b/x-pack/plugins/security/server/authorization/api_authorization.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { OnPostAuthResultType } from '@kbn/core/server';
 import type {
   AuthzDisabled,
   AuthzEnabled,
@@ -13,7 +14,6 @@ import type {
   RouteAuthz,
 } from '@kbn/core/server';
 import type { AuthorizationServiceSetup } from '@kbn/security-plugin-types-server';
-import { deepFreeze } from '@kbn/std';
 
 const isAuthzDisabled = (authz?: RouteAuthz): authz is AuthzDisabled => {
   return (authz as AuthzDisabled)?.enabled === false;
@@ -109,14 +109,7 @@ export function initAPIAuthorization(
         }
       }
 
-      Object.defineProperty(request, 'authzResult', {
-        value: deepFreeze(kibanaPrivileges),
-        enumerable: false,
-        configurable: false,
-        writable: false,
-      });
-
-      return toolkit.next();
+      return { type: OnPostAuthResultType.next, authzResult: kibanaPrivileges };
     }
 
     const tags = request.route.options.tags;

--- a/x-pack/plugins/security/server/authorization/api_authorization.ts
+++ b/x-pack/plugins/security/server/authorization/api_authorization.ts
@@ -32,15 +32,15 @@ export function initAPIAuthorization(
     }
 
     // @ts-ignore
-    if (isAuthzDisabled(request.route.options.authz)) {
+    if (isAuthzDisabled(request.route.options.security?.authz)) {
       logger.warn(
-        `Route authz is disabled for ${request.url.pathname}${request.url.search}": ${request.route.options.authz.reason}`
+        `Route authz is disabled for ${request.url.pathname}${request.url.search}": ${request.route.options.security.authz.reason}`
       );
 
       return toolkit.next();
     }
 
-    const authz = request.route.options.authz as AuthzEnabled;
+    const authz = request.route.options.security?.authz as AuthzEnabled;
 
     /**
      * Please note, that this code was intended for POC demo purposes only and is not production-ready.

--- a/x-pack/plugins/security/server/authorization/authorization_service.tsx
+++ b/x-pack/plugins/security/server/authorization/authorization_service.tsx
@@ -70,6 +70,8 @@ interface AuthorizationServiceSetupParams {
   getCurrentUser(request: KibanaRequest): AuthenticatedUser | null;
 
   customBranding: CustomBrandingSetup;
+
+  buildFlavor: string;
 }
 
 interface AuthorizationServiceStartParams {
@@ -107,6 +109,7 @@ export class AuthorizationService {
     getSpacesService,
     getCurrentUser,
     customBranding,
+    buildFlavor,
   }: AuthorizationServiceSetupParams): AuthorizationServiceSetupInternal {
     this.logger = loggers.get('authorization');
     this.applicationName = `${APPLICATION_PREFIX}${kibanaIndexName}`;
@@ -166,7 +169,7 @@ export class AuthorizationService {
       }
     );
 
-    initAPIAuthorization(http, authz, loggers.get('api-authorization'));
+    initAPIAuthorization(http, authz, buildFlavor, loggers.get('api-authorization'));
     initAppAuthorization(http, authz, loggers.get('app-authorization'), features);
 
     http.registerOnPreResponse(async (request, preResponse, toolkit) => {

--- a/x-pack/plugins/security/server/plugin.ts
+++ b/x-pack/plugins/security/server/plugin.ts
@@ -284,6 +284,7 @@ export class SecurityPlugin
       features,
       getCurrentUser,
       customBranding: core.customBranding,
+      buildFlavor: this.initializerContext.env.packageInfo.buildFlavor,
     });
 
     this.userProfileService.setup({ authz: this.authorizationSetup, license });

--- a/x-pack/plugins/security/server/routes/authorization/index.ts
+++ b/x-pack/plugins/security/server/routes/authorization/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { defineAuthzPOCRoutes } from './poc_examples';
 import { definePrivilegesRoutes } from './privileges';
 import { resetSessionPageRoutes } from './reset_session_page';
 import { defineRolesRoutes } from './roles';
@@ -14,6 +15,7 @@ import type { RouteDefinitionParams } from '..';
 export function defineAuthorizationRoutes(params: RouteDefinitionParams) {
   // The reset session endpoint is registered with httpResources and should remain public in serverless
   resetSessionPageRoutes(params);
+  defineAuthzPOCRoutes(params);
 
   // By default, in the serverless environment privileges and permissions are managed internally and only
   // exposed to users and administrators via control plane UI, however, we will allow these routes to be registered

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/index.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { defineOfferingPrivilegesExampleRoutes } from './offering_privileges';
+import { defineSimplePrivilegesExampleRoutes } from './simple_privileges';
+import type { RouteDefinitionParams } from '../..';
+
+export function defineAuthzPOCRoutes(params: RouteDefinitionParams) {
+  defineSimplePrivilegesExampleRoutes(params);
+  defineOfferingPrivilegesExampleRoutes(params);
+}

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/offering_privileges.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/offering_privileges.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteDefinitionParams } from '../..';
+import { ApiActionPermission } from '../../../../common/constants';
+import { wrapIntoCustomErrorResponse } from '../../../errors';
+import { createLicensedRouteHandler } from '../../licensed_route_handler';
+
+export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitionParams) {
+  /**
+   * Requires both ManageSpaces AND TaskManager privileges for serverless.
+   * Requires only TaskManager privilege for traditional.
+   *
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/offering_privileges_example_1
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/offering_privileges_example_1',
+      authz: {
+        requiredPrivileges: [
+          {
+            offering: 'serverless',
+            allRequired: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+          },
+          {
+            offering: 'traditional',
+            allRequired: [ApiActionPermission.TaskManager],
+          },
+        ],
+        // passes the authzResult to the handler
+        passThrough: true,
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+  /**
+   * Requires both ManageSpaces AND TaskManager AND ANY of (Features OR DecryptedTelemetry) privileges for serverless.
+   * Requires ANY TaskManager OR ManageSpaces privilege for traditional.
+   *
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/offering_privileges_example_2
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/offering_privileges_example_2',
+      authz: {
+        requiredPrivileges: [
+          {
+            offering: 'serverless',
+            allRequired: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+            anyRequired: [ApiActionPermission.Features, ApiActionPermission.DecryptedTelemetry],
+          },
+          {
+            offering: 'traditional',
+            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.ManageSpaces],
+          },
+        ],
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            // authzResult was not passed to the handler, so it is not available here
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+  /**
+   * Requires TaskManager AND ANY of (Features OR DecryptedTelemetry) privileges for serverless.
+   * Requires only TaskManager privilege for traditional.
+   *
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/offering_privileges_example_3
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/offering_privileges_example_3',
+      authz: {
+        requiredPrivileges: [
+          ApiActionPermission.TaskManager,
+          {
+            offering: 'serverless',
+            anyRequired: [ApiActionPermission.Features, ApiActionPermission.DecryptedTelemetry],
+          },
+        ],
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            // authzResult was not passed to the handler, so it is not available here
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/offering_privileges.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/offering_privileges.ts
@@ -21,17 +21,19 @@ export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitio
   router.get(
     {
       path: '/api/security/authz_poc/offering_privileges_example_1',
-      authz: {
-        requiredPrivileges: [
-          {
-            offering: 'serverless',
-            allRequired: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
-          },
-          {
-            offering: 'traditional',
-            allRequired: [ApiActionPermission.TaskManager],
-          },
-        ],
+      security: {
+        authz: {
+          requiredPrivileges: [
+            {
+              offering: 'serverless',
+              allRequired: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+            },
+            {
+              offering: 'traditional',
+              allRequired: [ApiActionPermission.TaskManager],
+            },
+          ],
+        },
       },
       validate: false,
     },
@@ -57,19 +59,22 @@ export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitio
   router.get(
     {
       path: '/api/security/authz_poc/offering_privileges_example_2',
-      authz: {
-        requiredPrivileges: [
-          {
-            offering: 'serverless',
-            allRequired: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
-            anyRequired: [ApiActionPermission.Features, ApiActionPermission.DecryptedTelemetry],
-          },
-          {
-            offering: 'traditional',
-            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.ManageSpaces],
-          },
-        ],
+      security: {
+        authz: {
+          requiredPrivileges: [
+            {
+              offering: 'serverless',
+              allRequired: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+              anyRequired: [ApiActionPermission.Features, ApiActionPermission.DecryptedTelemetry],
+            },
+            {
+              offering: 'traditional',
+              anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.ManageSpaces],
+            },
+          ],
+        },
       },
+
       validate: false,
     },
     createLicensedRouteHandler(async (context, request, response) => {
@@ -94,14 +99,16 @@ export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitio
   router.get(
     {
       path: '/api/security/authz_poc/offering_privileges_example_3',
-      authz: {
-        requiredPrivileges: [
-          ApiActionPermission.TaskManager,
-          {
-            offering: 'serverless',
-            anyRequired: [ApiActionPermission.Features, ApiActionPermission.DecryptedTelemetry],
-          },
-        ],
+      security: {
+        authz: {
+          requiredPrivileges: [
+            ApiActionPermission.TaskManager,
+            {
+              offering: 'serverless',
+              anyRequired: [ApiActionPermission.Features, ApiActionPermission.DecryptedTelemetry],
+            },
+          ],
+        },
       },
       validate: false,
     },

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/offering_privileges.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/offering_privileges.ts
@@ -32,8 +32,6 @@ export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitio
             allRequired: [ApiActionPermission.TaskManager],
           },
         ],
-        // passes the authzResult to the handler
-        passThrough: true,
       },
       validate: false,
     },
@@ -78,7 +76,6 @@ export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitio
       try {
         return response.ok({
           body: {
-            // authzResult was not passed to the handler, so it is not available here
             authzResult: request.authzResult,
           },
         });
@@ -112,7 +109,6 @@ export function defineOfferingPrivilegesExampleRoutes({ router }: RouteDefinitio
       try {
         return response.ok({
           body: {
-            // authzResult was not passed to the handler, so it is not available here
             authzResult: request.authzResult,
           },
         });

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/simple_privileges.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/simple_privileges.ts
@@ -12,6 +12,31 @@ import { createLicensedRouteHandler } from '../../licensed_route_handler';
 
 export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionParams) {
   /**
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/authz_disabled
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/authz_disabled',
+      authz: {
+        enabled: false,
+        reason: 'This route is opted out from authorization for demo purposes',
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+  /**
    * Requires both ManageSpaces AND TaskManager privileges.
    *
    * Check OAS authz description generated
@@ -22,8 +47,6 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
       path: '/api/security/authz_poc/simple_privileges_example_1',
       authz: {
         requiredPrivileges: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
-        // passes the authzResult to the handler
-        passThrough: true,
       },
       validate: false,
     },
@@ -62,7 +85,6 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
       try {
         return response.ok({
           body: {
-            // authzResult was not passed to the handler, so it is not available here
             authzResult: request.authzResult,
           },
         });
@@ -93,7 +115,6 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
       try {
         return response.ok({
           body: {
-            // authzResult was not passed to the handler, so it is not available here
             authzResult: request.authzResult,
           },
         });

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/simple_privileges.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/simple_privileges.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteDefinitionParams } from '../..';
+import { ApiActionPermission } from '../../../../common/constants';
+import { wrapIntoCustomErrorResponse } from '../../../errors';
+import { createLicensedRouteHandler } from '../../licensed_route_handler';
+
+export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionParams) {
+  /**
+   * Requires both ManageSpaces AND TaskManager privileges.
+   *
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/simple_privileges_example_1
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/simple_privileges_example_1',
+      authz: {
+        requiredPrivileges: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+        // passes the authzResult to the handler
+        passThrough: true,
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+  /**
+   * Requires ManageSpaces AND ANY of (TaskManager OR Features) privileges.
+   *
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/simple_privileges_example_2
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/simple_privileges_example_2',
+      authz: {
+        requiredPrivileges: [
+          ApiActionPermission.ManageSpaces,
+          {
+            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
+          },
+        ],
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            // authzResult was not passed to the handler, so it is not available here
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+  /**
+   * Requires ANY of (TaskManager OR Features) privileges.
+   *
+   * Check OAS authz description generated
+   * GET /api/oas?pathStartsWith=/api/security/authz_poc/simple_privileges_example_3
+   */
+  router.get(
+    {
+      path: '/api/security/authz_poc/simple_privileges_example_3',
+      authz: {
+        requiredPrivileges: [
+          {
+            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
+          },
+        ],
+      },
+      validate: false,
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      try {
+        return response.ok({
+          body: {
+            // authzResult was not passed to the handler, so it is not available here
+            authzResult: request.authzResult,
+          },
+        });
+      } catch (error) {
+        return response.customError(wrapIntoCustomErrorResponse(error));
+      }
+    })
+  );
+}

--- a/x-pack/plugins/security/server/routes/authorization/poc_examples/simple_privileges.ts
+++ b/x-pack/plugins/security/server/routes/authorization/poc_examples/simple_privileges.ts
@@ -18,9 +18,11 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
   router.get(
     {
       path: '/api/security/authz_poc/authz_disabled',
-      authz: {
-        enabled: false,
-        reason: 'This route is opted out from authorization for demo purposes',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
       },
       validate: false,
     },
@@ -45,8 +47,10 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
   router.get(
     {
       path: '/api/security/authz_poc/simple_privileges_example_1',
-      authz: {
-        requiredPrivileges: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+      security: {
+        authz: {
+          requiredPrivileges: [ApiActionPermission.ManageSpaces, ApiActionPermission.TaskManager],
+        },
       },
       validate: false,
     },
@@ -71,13 +75,15 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
   router.get(
     {
       path: '/api/security/authz_poc/simple_privileges_example_2',
-      authz: {
-        requiredPrivileges: [
-          ApiActionPermission.ManageSpaces,
-          {
-            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
-          },
-        ],
+      security: {
+        authz: {
+          requiredPrivileges: [
+            ApiActionPermission.ManageSpaces,
+            {
+              anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
+            },
+          ],
+        },
       },
       validate: false,
     },
@@ -102,12 +108,14 @@ export function defineSimplePrivilegesExampleRoutes({ router }: RouteDefinitionP
   router.get(
     {
       path: '/api/security/authz_poc/simple_privileges_example_3',
-      authz: {
-        requiredPrivileges: [
-          {
-            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
-          },
-        ],
+      security: {
+        authz: {
+          requiredPrivileges: [
+            {
+              anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
+            },
+          ],
+        },
       },
       validate: false,
     },

--- a/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
@@ -30,7 +30,6 @@ export function defineGetAllRolesBySpaceRoutes({
             anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
           },
         ],
-        passThrough: true,
       },
       validate: {
         params: schema.object({ spaceId: schema.string({ minLength: 1 }) }),

--- a/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
@@ -27,8 +27,7 @@ export function defineGetAllRolesBySpaceRoutes({
         requiredPrivileges: [
           ApiActionPermission.ManageSpaces,
           {
-            tier: 'serverless',
-            privileges: [ApiActionPermission.TaskManager],
+            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
           },
         ],
         passThrough: true,

--- a/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
@@ -7,7 +7,7 @@
 import { schema } from '@kbn/config-schema';
 
 import type { RouteDefinitionParams } from '../..';
-import { ALL_SPACES_ID } from '../../../../common/constants';
+import { ALL_SPACES_ID, ApiActionPermission } from '../../../../common/constants';
 import { compareRolesByName, transformElasticsearchRoleToRole } from '../../../authorization';
 import { wrapIntoCustomErrorResponse } from '../../../errors';
 import { createLicensedRouteHandler } from '../../licensed_route_handler';
@@ -23,8 +23,15 @@ export function defineGetAllRolesBySpaceRoutes({
   router.get(
     {
       path: '/internal/security/roles/{spaceId}',
-      options: {
-        tags: ['access:manageSpaces'],
+      authz: {
+        requiredPrivileges: [
+          ApiActionPermission.ManageSpaces,
+          {
+            tier: 'serverless',
+            privileges: [ApiActionPermission.TaskManager],
+          },
+        ],
+        passThrough: true,
       },
       validate: {
         params: schema.object({ spaceId: schema.string({ minLength: 1 }) }),

--- a/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/get_all_by_space.ts
@@ -23,13 +23,15 @@ export function defineGetAllRolesBySpaceRoutes({
   router.get(
     {
       path: '/internal/security/roles/{spaceId}',
-      authz: {
-        requiredPrivileges: [
-          ApiActionPermission.ManageSpaces,
-          {
-            anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
-          },
-        ],
+      security: {
+        authz: {
+          requiredPrivileges: [
+            ApiActionPermission.ManageSpaces,
+            {
+              anyRequired: [ApiActionPermission.TaskManager, ApiActionPermission.Features],
+            },
+          ],
+        },
       },
       validate: {
         params: schema.object({ spaceId: schema.string({ minLength: 1 }) }),


### PR DESCRIPTION
## Summary
This PR demonstrates proposed changes for First-class Route Authorization initiative. It includes:
- Security configuration with `authz` property at route definition level.
- Updates required for the `http.registerOnPostAuth` hook and router configuration.
- Demo routes with various `authz` configurations.
- OAS generated examples.
- Draft eslint autofixer.

## Demo routes
There are several demo routes located under `plugins/security/server/routes/authorization/poc_examples` which demonstrate simple and complex route for authorization, demo routes return `authzResult` check in response body.
For each route there is an automatically generated description which is appended to OAS.

### Example
Request
```http
GET /api/security/authz_poc/simple_privileges_example_1
```

Response body
```json
{
  "authzResult": {
    "manageSpaces": true,
    "taskManager": true
  }
}
```

OAS with authz description
```http
GET /api/oas?pathStartsWith=/api/security/authz_poc/simple_privileges_example_1
```

Response body should include the following description
```json
"description": "[Authz] Route required privileges: ALL of [manageSpaces, taskManager]"
```








