### PR TITLE
fix(es-setup): retry docker pull on "connection refused"

### DIFF
--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -9,6 +9,7 @@ import chalk from 'chalk';
 import execa from 'execa';
 import fs from 'fs';
 import Fsp from 'fs/promises';
+import pRetry from 'p-retry';
 import { resolve, basename, join } from 'path';
 import { Client, ClientOptions, HttpConnection } from '@elastic/elasticsearch';
 
@@ -390,16 +391,30 @@ export async function maybeCreateDockerNetwork(log: ToolingLog) {
 export async function maybePullDockerImage(log: ToolingLog, image: string) {
   log.info(chalk.bold(`Checking for image: ${image}`));
 
-  await execa('docker', ['pull', image], {
-    // inherit is required to show Docker pull output
-    stdio: ['ignore', 'inherit', 'pipe'],
-  }).catch(({ message }) => {
-    const errorMessage = `Error pulling image. This is likely an issue authenticating with ${DOCKER_REGISTRY}.
+  await pRetry(
+    async () => {
+      await execa('docker', ['pull', image], {
+        // inherit is required to show Docker pull output
+        stdio: ['ignore', 'inherit', 'pipe'],
+      }).catch(({ message }) => {
+        const errorMessage = `Error pulling image. This is likely an issue authenticating with ${DOCKER_REGISTRY}.
 Visit ${chalk.bold.cyan('https://docker-auth.elastic.co/github_auth')} to login.
 
 ${message}`;
-    throw createCliError(errorMessage);
-  });
+        throw createCliError(errorMessage);
+      });
+    },
+    {
+      retries: 2,
+      onFailedAttempt: (error) => {
+        // Only retry if `connection refused` is found in the error message.
+        if (!error?.message?.includes('connection refused')) {
+          throw error;
+        }
+      },
+    }
+  );
+  // TODO: Retry here on "connection refused"
 }
 
 /**

--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -414,7 +414,6 @@ ${message}`;
       },
     }
   );
-  // TODO: Retry here on "connection refused"
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves #188968
Resolves #188967
Resolves #188966
Resolves #188965
Resolves #188964
Resolves #188963
Resolves #188962
Resolves #176855
Resolves #176854
Resolves #176853
Resolves #176852
Resolves #176851
Resolves #176850
Resolves #176849
Resolves #176848
Resolves #176847
Resolves #176846
Resolves #176845
Resolves #176844
Resolves #176843
Resolves #176842
Resolves #176841
Resolves #167291
Resolves #167290
Resolves #167289
Resolves #167288
Resolves #167287
Resolves #167286
Resolves #167285 
Resolves #167284 
Resolves #167283 
Resolves #167282 
Resolves #167281 
Resolves #167280 
Resolves #167279
Resolves #167278 
Resolves #167277 
Resolves #167276 
Resolves #167275 
Resolves #167274 
Resolves #167273 
Resolves #167272 
Resolves #167268 
Resolves #167267
Resolves #167266 
Resolves #167265 
Resolves #167264 
Resolves #167263 
Resolves #167262 
Resolves #167261 
Resolves #167260 
Resolves #167259
Resolves #167258 
Resolves #167257 


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
