### PR TITLE
[Visualize] Do not display a toast about missing provider when error is displayed

### DIFF
--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -527,20 +527,27 @@ export class VisualizeEmbeddable
   }
 
   private renderError(error: ErrorLike | string) {
+    const { core } = this.deps.start();
     if (isFallbackDataView(this.vis.data.indexPattern)) {
       return (
-        <VisualizationMissedSavedObjectError
-          renderMode={this.input.renderMode ?? 'view'}
-          savedObjectMeta={{
-            savedObjectType: this.vis.data.savedSearchId ? 'search' : DATA_VIEW_SAVED_OBJECT_TYPE,
-          }}
-          application={getApplication()}
-          message={typeof error === 'string' ? error : error.message}
-        />
+        <KibanaRenderContextProvider {...core}>
+          <VisualizationMissedSavedObjectError
+            renderMode={this.input.renderMode ?? 'view'}
+            savedObjectMeta={{
+              savedObjectType: this.vis.data.savedSearchId ? 'search' : DATA_VIEW_SAVED_OBJECT_TYPE,
+            }}
+            application={getApplication()}
+            message={typeof error === 'string' ? error : error.message}
+          />
+        </KibanaRenderContextProvider>
       );
     }
 
-    return <VisualizationError error={error} />;
+    return (
+      <KibanaRenderContextProvider {...core}>
+        <VisualizationError error={error} />
+      </KibanaRenderContextProvider>
+    );
   }
 
   public destroy() {


### PR DESCRIPTION
## Summary

To reproduce:
1. Trigger an error on visualize visualization on the dashboard. A quick way of doing it would be just to import this saved object, that creates a visualization on a dataview that doesn't exist.
2. This toast appears:
<img width="1142" alt="Screenshot 2024-08-05 at 11 44 48" src="https://github.com/user-attachments/assets/e6d945f6-a53d-403e-a898-77f76de5494b">


[test_toast_bug.json](https://github.com/user-attachments/files/16493961/test_toast_bug.json)


This PR fixes it (doesn't display the toast). Should we backport? 🤔 