### PR TITLE
[Entity Analytics] Improve response body for asset criticality delete route

### DIFF
--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/delete_asset_criticality.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/delete_asset_criticality.gen.ts
@@ -16,7 +16,7 @@
 
 import { z } from 'zod';
 
-import { IdField } from './common.gen';
+import { IdField, AssetCriticalityRecord } from './common.gen';
 
 export type DeleteAssetCriticalityRecordRequestQuery = z.infer<
   typeof DeleteAssetCriticalityRecordRequestQuery
@@ -38,3 +38,14 @@ export const DeleteAssetCriticalityRecordRequestQuery = z.object({
 export type DeleteAssetCriticalityRecordRequestQueryInput = z.input<
   typeof DeleteAssetCriticalityRecordRequestQuery
 >;
+
+export type DeleteAssetCriticalityRecordResponse = z.infer<
+  typeof DeleteAssetCriticalityRecordResponse
+>;
+export const DeleteAssetCriticalityRecordResponse = z.object({
+  /**
+   * If the record was deleted. If false the record did not exist.
+   */
+  deleted: z.boolean(),
+  record: AssetCriticalityRecord.optional(),
+});

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/delete_asset_criticality.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/asset_criticality/delete_asset_criticality.schema.yaml
@@ -33,5 +33,17 @@ paths:
       responses:
         '200':
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                    description: If the record was deleted. If false the record did not exist.
+                  record:
+                    $ref: './common.schema.yaml#/components/schemas/AssetCriticalityRecord'
+                required:
+                  - deleted
         '400':
           description: Invalid request

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -38,6 +38,20 @@ paths:
             type: string
       responses:
         '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    description: >-
+                      If the record was deleted. If false the record did not
+                      exist.
+                    type: boolean
+                  record:
+                    $ref: '#/components/schemas/AssetCriticalityRecord'
+                required:
+                  - deleted
           description: Successful response
         '400':
           description: Invalid request

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -38,6 +38,20 @@ paths:
             type: string
       responses:
         '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    description: >-
+                      If the record was deleted. If false the record did not
+                      exist.
+                    type: boolean
+                  record:
+                    $ref: '#/components/schemas/AssetCriticalityRecord'
+                required:
+                  - deleted
           description: Successful response
         '400':
           description: Invalid request


### PR DESCRIPTION
While doing the API docs I noticed the asset criticality delete route did not return a response body, and returned a very ugly 404 if you attempted to delete something which didnt exist...


```
{"message":"{\"_index\":\".asset-criticality.asset-criticality-default\",\"_id\":\"host.name:my_host\",\"_version\":1,\"result\":\"not_found\",\"_shards\":{\"total\":2,\"successful\":1,\"failed\":0},\"_seq_no\":0,\"_primary_term\":1}","full_error":"{\"name\":\"ResponseError\",\"message\":\"{\\\"_index\\\":\\\".asset-criticality.asset-criticality-default\\\",\\\"_id\\\":\\\"host.name:my_host\\\",\\\"_version\\\":1,\\\"result\\\":\\\"not_found\\\",\\\"_shards\\\":{\\\"total\\\":2,\\\"successful\\\":1,\\\"failed\\\":0},\\\"_seq_no\\\":0,\\\"_primary_term\\\":1}\"}","status_code":404}%
```

I have now made it so that we return a boolean for if the record was deleted or not (`false` if the record didnt exist) and we also return the record that was deleted if it was, e.g...

```
{
    "deleted": true,
    "record": {
        "id_field": "host.name",
        "id_value": "my_host",
        "criticality_level": "medium_impact",
        "@timestamp": "2024-08-05T09:42:11.240Z"
    }
}
```

And if the record didnt exist...


```
{
    "deleted": false,
}
```