### PR TITLE
[Fleet] Allow `traces` to be added to the `monitoring_enabled` array in Agent policies

### DIFF
--- a/x-pack/plugins/fleet/common/constants/epm.ts
+++ b/x-pack/plugins/fleet/common/constants/epm.ts
@@ -93,6 +93,7 @@ export const agentAssetTypes = {
 export const dataTypes = {
   Logs: 'logs',
   Metrics: 'metrics',
+  Traces: 'traces',
 } as const;
 
 // currently identical but may be a subset or otherwise different some day

--- a/x-pack/plugins/fleet/common/services/generate_new_agent_policy.test.ts
+++ b/x-pack/plugins/fleet/common/services/generate_new_agent_policy.test.ts
@@ -15,7 +15,7 @@ describe('generateNewAgentPolicyWithDefaults', () => {
       name: '',
       description: '',
       namespace: 'default',
-      monitoring_enabled: ['logs', 'metrics'],
+      monitoring_enabled: ['logs', 'metrics', 'traces'],
       inactivity_timeout: 1209600,
       is_protected: false,
     });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -491,7 +491,7 @@ describe('When on the package policy create page', () => {
       expect(sendCreateAgentPolicy as jest.MockedFunction<any>).toHaveBeenCalledWith(
         {
           description: '',
-          monitoring_enabled: ['logs', 'metrics'],
+          monitoring_enabled: ['logs', 'metrics', 'traces'],
           name: 'Agent policy 2',
           namespace: 'default',
           inactivity_timeout: 1209600,
@@ -526,7 +526,7 @@ describe('When on the package policy create page', () => {
         expect(sendCreateAgentPolicy as jest.MockedFunction<any>).toHaveBeenCalledWith(
           {
             description: '',
-            monitoring_enabled: ['logs', 'metrics'],
+            monitoring_enabled: ['logs', 'metrics', 'traces'],
             name: 'Agent policy 2',
             namespace: 'default',
             inactivity_timeout: 1209600,
@@ -826,7 +826,7 @@ describe('When on the package policy create page', () => {
         expect(sendGetOneAgentPolicy).not.toHaveBeenCalled();
         expect(sendCreateAgentPolicy).toHaveBeenCalledWith(
           expect.objectContaining({
-            monitoring_enabled: ['logs', 'metrics'],
+            monitoring_enabled: ['logs', 'metrics', 'traces'],
             name: 'Agent policy 1',
           }),
           { withSysMonitoring: true }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
@@ -541,7 +541,7 @@ describe('edit package policy page', () => {
       expect(sendCreateAgentPolicy as jest.MockedFunction<any>).toHaveBeenCalledWith(
         {
           description: '',
-          monitoring_enabled: ['logs', 'metrics'],
+          monitoring_enabled: ['logs', 'metrics', 'traces'],
           name: 'Agent policy 2',
           namespace: 'default',
           inactivity_timeout: 1209600,

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
@@ -32,7 +32,7 @@ describe('Fleet index patterns', () => {
     it('should call updateObjectsSpaces with the correct params', async () => {
       const result = await makeManagedIndexPatternsGlobal(mockSoClient);
 
-      for (const pattern of ['logs-*', 'metrics-*', 'traces-*']) {
+      for (const pattern of ['logs-*', 'metrics-*']) {
         expect(mockSoClient.updateObjectsSpaces).toHaveBeenCalledWith(
           [{ id: pattern, type: 'index-pattern' }],
           ['*'],

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
@@ -32,7 +32,7 @@ describe('Fleet index patterns', () => {
     it('should call updateObjectsSpaces with the correct params', async () => {
       const result = await makeManagedIndexPatternsGlobal(mockSoClient);
 
-      for (const pattern of ['logs-*', 'metrics-*']) {
+      for (const pattern of ['logs-*', 'metrics-*', 'traces-*']) {
         expect(mockSoClient.updateObjectsSpaces).toHaveBeenCalledWith(
           [{ id: pattern, type: 'index-pattern' }],
           ['*'],
@@ -40,7 +40,7 @@ describe('Fleet index patterns', () => {
         );
       }
 
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
     });
 
     it('handles errors from updateObjectsSpaces', async () => {

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
@@ -40,7 +40,7 @@ describe('Fleet index patterns', () => {
         );
       }
 
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(2);
     });
 
     it('handles errors from updateObjectsSpaces', async () => {

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -14,7 +14,7 @@ const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
 
 export const indexPatternTypes = Object.values(dataTypes)
   // we don't want to add traces-* as a new global data view
-  .filter(dataType => dataType === dataTypes.Traces);
+  .filter((dataType) => dataType === dataTypes.Traces);
 
 export function getIndexPatternSavedObjects() {
   return indexPatternTypes.map((indexPatternType) => ({

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -12,7 +12,7 @@ import { appContextService } from '../../..';
 import { getPackageSavedObjects } from '../../packages/get';
 const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
 
-export const indexPatternTypes = [dataTypes.Logs, dataTypes.Metrics]
+export const indexPatternTypes = [dataTypes.Logs, dataTypes.Metrics];
 
 export function getIndexPatternSavedObjects() {
   return indexPatternTypes.map((indexPatternType) => ({

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -12,9 +12,7 @@ import { appContextService } from '../../..';
 import { getPackageSavedObjects } from '../../packages/get';
 const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
 
-export const indexPatternTypes = Object.values(dataTypes)
-  // we don't want to add traces-* as a new global data view
-  .filter((dataType) => dataType === dataTypes.Traces);
+export const indexPatternTypes = [dataTypes.Logs, dataTypes.Metrics]
 
 export function getIndexPatternSavedObjects() {
   return indexPatternTypes.map((indexPatternType) => ({

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -14,7 +14,7 @@ const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
 
 export const indexPatternTypes = Object.values(dataTypes)
   // we don't want to add traces-* as a new global data view
-  .filter(dataType => dataType == dataTypes.Traces);
+  .filter(dataType => dataType === dataTypes.Traces);
 
 export function getIndexPatternSavedObjects() {
   return indexPatternTypes.map((indexPatternType) => ({

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -12,7 +12,9 @@ import { appContextService } from '../../..';
 import { getPackageSavedObjects } from '../../packages/get';
 const INDEX_PATTERN_SAVED_OBJECT_TYPE = 'index-pattern';
 
-export const indexPatternTypes = Object.values(dataTypes);
+export const indexPatternTypes = Object.values(dataTypes)
+  // we don't want to add traces-* as a new global data view
+  .filter(dataType => dataType == dataTypes.Traces);
 
 export function getIndexPatternSavedObjects() {
   return indexPatternTypes.map((indexPatternType) => ({

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -56,7 +56,7 @@ export const AgentPolicyBaseSchema = {
   }),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
-      schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])
+      schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics), schema.literal(dataTypes.Traces)])
     )
   ),
   keep_monitoring_alive: schema.maybe(schema.boolean({ defaultValue: false })),

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -56,7 +56,11 @@ export const AgentPolicyBaseSchema = {
   }),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
-      schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics), schema.literal(dataTypes.Traces)])
+      schema.oneOf([
+        schema.literal(dataTypes.Logs),
+        schema.literal(dataTypes.Metrics),
+        schema.literal(dataTypes.Traces),
+      ])
     )
   ),
   keep_monitoring_alive: schema.maybe(schema.boolean({ defaultValue: false })),

--- a/x-pack/test/functional/apps/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/test/functional/apps/observability_logs_explorer/data_source_selector.ts
@@ -15,7 +15,7 @@ const initialPackageMap = {
 };
 const initialPackagesTexts = Object.values(initialPackageMap);
 
-const expectedDataViews = ['logs-*', 'logstash-*', 'metrics-*', 'traces-*'];
+const expectedDataViews = ['logs-*', 'logstash-*', 'metrics-*'];
 const sortedExpectedDataViews = expectedDataViews.slice().sort();
 
 const uncategorized = ['logs-gaming-*', 'logs-manufacturing-*', 'logs-retail-*'];

--- a/x-pack/test/functional/apps/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/test/functional/apps/observability_logs_explorer/data_source_selector.ts
@@ -15,7 +15,7 @@ const initialPackageMap = {
 };
 const initialPackagesTexts = Object.values(initialPackageMap);
 
-const expectedDataViews = ['logs-*', 'logstash-*', 'metrics-*'];
+const expectedDataViews = ['logs-*', 'logstash-*', 'metrics-*', 'traces-*'];
 const sortedExpectedDataViews = expectedDataViews.slice().sort();
 
 const uncategorized = ['logs-gaming-*', 'logs-manufacturing-*', 'logs-retail-*'];

--- a/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
@@ -15,7 +15,7 @@ const initialPackageMap = {
 };
 const initialPackagesTexts = Object.values(initialPackageMap);
 
-const expectedDataViews = ['logs-*', 'metrics-*', 'traces-*'];
+const expectedDataViews = ['logs-*', 'metrics-*'];
 const sortedExpectedDataViews = expectedDataViews.slice().sort();
 
 const uncategorized = ['logs-gaming-*', 'logs-manufacturing-*', 'logs-retail-*'];

--- a/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
@@ -636,9 +636,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               .getDataViewsContextMenu()
               .then((menu) => PageObjects.observabilityLogsExplorer.getPanelEntries(menu));
 
-            expect(await menuEntries[0].getVisibleText()).to.be(sortedExpectedDataViews[2]);
-            expect(await menuEntries[1].getVisibleText()).to.be(sortedExpectedDataViews[1]);
-            expect(await menuEntries[2].getVisibleText()).to.be(sortedExpectedDataViews[0]);
+            expect(await menuEntries[0].getVisibleText()).to.be(sortedExpectedDataViews[1]);
+            expect(await menuEntries[1].getVisibleText()).to.be(sortedExpectedDataViews[0]);
           });
 
           // Test back ascending order
@@ -650,7 +649,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
             expect(await menuEntries[0].getVisibleText()).to.be(sortedExpectedDataViews[0]);
             expect(await menuEntries[1].getVisibleText()).to.be(sortedExpectedDataViews[1]);
-            expect(await menuEntries[2].getVisibleText()).to.be(sortedExpectedDataViews[2]);
           });
         });
 

--- a/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
@@ -15,7 +15,7 @@ const initialPackageMap = {
 };
 const initialPackagesTexts = Object.values(initialPackageMap);
 
-const expectedDataViews = ['logs-*', 'metrics-*'];
+const expectedDataViews = ['logs-*', 'metrics-*', 'traces-*'];
 const sortedExpectedDataViews = expectedDataViews.slice().sort();
 
 const uncategorized = ['logs-gaming-*', 'logs-manufacturing-*', 'logs-retail-*'];

--- a/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/observability_logs_explorer/data_source_selector.ts
@@ -636,8 +636,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
               .getDataViewsContextMenu()
               .then((menu) => PageObjects.observabilityLogsExplorer.getPanelEntries(menu));
 
-            expect(await menuEntries[0].getVisibleText()).to.be(sortedExpectedDataViews[1]);
-            expect(await menuEntries[1].getVisibleText()).to.be(sortedExpectedDataViews[0]);
+            expect(await menuEntries[0].getVisibleText()).to.be(sortedExpectedDataViews[2]);
+            expect(await menuEntries[1].getVisibleText()).to.be(sortedExpectedDataViews[1]);
+            expect(await menuEntries[2].getVisibleText()).to.be(sortedExpectedDataViews[0]);
           });
 
           // Test back ascending order
@@ -649,6 +650,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
             expect(await menuEntries[0].getVisibleText()).to.be(sortedExpectedDataViews[0]);
             expect(await menuEntries[1].getVisibleText()).to.be(sortedExpectedDataViews[1]);
+            expect(await menuEntries[2].getVisibleText()).to.be(sortedExpectedDataViews[2]);
           });
         });
 


### PR DESCRIPTION
## Summary

This PR modifies the Agent policy schema to allow `traces` to be added to the `monitoring_enabled` array.
