### PR TITLE
[KibanaErrorBoundary] Log the error that was caught

### DIFF
--- a/packages/shared-ux/error_boundary/src/services/error_boundary_services.test.tsx
+++ b/packages/shared-ux/error_boundary/src/services/error_boundary_services.test.tsx
@@ -17,6 +17,7 @@ import { BadComponent } from '../../mocks';
 describe('<KibanaErrorBoundaryProvider>', () => {
   let analytics: KibanaErrorBoundaryProviderDeps['analytics'];
   beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     analytics = analyticsServiceMock.createAnalyticsServiceStart();
   });
 

--- a/packages/shared-ux/error_boundary/src/services/error_service.test.ts
+++ b/packages/shared-ux/error_boundary/src/services/error_service.test.ts
@@ -9,6 +9,10 @@
 import { KibanaErrorService } from './error_service';
 
 describe('KibanaErrorBoundary Error Service', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   const mockDeps = {
     analytics: { reportEvent: jest.fn() },
   };

--- a/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
+++ b/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
@@ -19,6 +19,7 @@ import { errorMessageStrings as strings } from './message_strings';
 describe('<KibanaErrorBoundary>', () => {
   let services: KibanaErrorBoundaryServices;
   beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     services = getServicesMock();
   });
 

--- a/packages/shared-ux/error_boundary/src/ui/error_boundary.tsx
+++ b/packages/shared-ux/error_boundary/src/ui/error_boundary.tsx
@@ -42,6 +42,9 @@ class ErrorBoundaryInternal extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('Error caught by Kibana React Error Boundary'); // eslint-disable-line no-console
+    console.error(error); // eslint-disable-line no-console
+
     const { name, isFatal } = this.props.services.errorService.registerError(error, errorInfo);
     this.setState(() => {
       return { error, errorInfo, componentName: name, isFatal };


### PR DESCRIPTION
Log the error that was caught to the console, so developers can interact with the stack trace messages.

Addresses https://github.com/elastic/kibana/pull/168754#issuecomment-2268523404