### PR TITLE
unskip unsaved changes tests

### DIFF
--- a/packages/presentation/presentation_containers/interfaces/unsaved_changes/children_unsaved_changes.test.ts
+++ b/packages/presentation/presentation_containers/interfaces/unsaved_changes/children_unsaved_changes.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { BehaviorSubject, skip } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { childrenUnsavedChanges$, DEBOUNCE_TIME } from './children_unsaved_changes';
 import { waitFor } from '@testing-library/react';
 
@@ -59,7 +59,7 @@ describe('childrenUnsavedChanges$', () => {
         interval: DEBOUNCE_TIME + 1,
       }
     );
-    
+
     child1Api.unsavedChanges.next({
       key1: 'modified value',
     });
@@ -116,7 +116,7 @@ describe('childrenUnsavedChanges$', () => {
         interval: DEBOUNCE_TIME + 1,
       }
     );
-    
+
     subscription.unsubscribe();
   });
 });

--- a/packages/presentation/presentation_containers/interfaces/unsaved_changes/children_unsaved_changes.test.ts
+++ b/packages/presentation/presentation_containers/interfaces/unsaved_changes/children_unsaved_changes.test.ts
@@ -8,10 +8,9 @@
 
 import { BehaviorSubject, skip } from 'rxjs';
 import { childrenUnsavedChanges$, DEBOUNCE_TIME } from './children_unsaved_changes';
+import { waitFor } from '@testing-library/react';
 
-// Failing: See https://github.com/elastic/kibana/issues/189823
-// FLAKY: https://github.com/elastic/kibana/issues/189822
-describe.skip('childrenUnsavedChanges$', () => {
+describe('childrenUnsavedChanges$', () => {
   const child1Api = {
     unsavedChanges: new BehaviorSubject<object | undefined>(undefined),
     resetUnsavedChanges: () => undefined,
@@ -35,40 +34,64 @@ describe.skip('childrenUnsavedChanges$', () => {
 
   test('should emit on subscribe', async () => {
     const subscription = childrenUnsavedChanges$(children$).subscribe(onFireMock);
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_TIME + 1));
 
-    expect(onFireMock).toHaveBeenCalledTimes(1);
-    const childUnsavedChanges = onFireMock.mock.calls[0][0];
-    expect(childUnsavedChanges).toBeUndefined();
+    await waitFor(
+      () => {
+        expect(onFireMock).toHaveBeenCalledTimes(1);
+        const childUnsavedChanges = onFireMock.mock.calls[0][0];
+        expect(childUnsavedChanges).toBeUndefined();
+      },
+      {
+        interval: DEBOUNCE_TIME + 1,
+      }
+    );
 
     subscription.unsubscribe();
   });
 
   test('should emit when child has new unsaved changes', async () => {
-    const subscription = childrenUnsavedChanges$(children$).pipe(skip(1)).subscribe(onFireMock);
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_TIME + 1));
-    expect(onFireMock).toHaveBeenCalledTimes(0);
-
+    const subscription = childrenUnsavedChanges$(children$).subscribe(onFireMock);
+    await waitFor(
+      () => {
+        expect(onFireMock).toHaveBeenCalledTimes(1);
+      },
+      {
+        interval: DEBOUNCE_TIME + 1,
+      }
+    );
+    
     child1Api.unsavedChanges.next({
       key1: 'modified value',
     });
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_TIME + 1));
 
-    expect(onFireMock).toHaveBeenCalledTimes(1);
-    const childUnsavedChanges = onFireMock.mock.calls[0][0];
-    expect(childUnsavedChanges).toEqual({
-      child1: {
-        key1: 'modified value',
+    await waitFor(
+      () => {
+        expect(onFireMock).toHaveBeenCalledTimes(2);
+        const childUnsavedChanges = onFireMock.mock.calls[1][0];
+        expect(childUnsavedChanges).toEqual({
+          child1: {
+            key1: 'modified value',
+          },
+        });
       },
-    });
+      {
+        interval: DEBOUNCE_TIME + 1,
+      }
+    );
 
     subscription.unsubscribe();
   });
 
   test('should emit when children changes', async () => {
-    const subscription = childrenUnsavedChanges$(children$).pipe(skip(1)).subscribe(onFireMock);
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_TIME + 1));
-    expect(onFireMock).toHaveBeenCalledTimes(0);
+    const subscription = childrenUnsavedChanges$(children$).subscribe(onFireMock);
+    await waitFor(
+      () => {
+        expect(onFireMock).toHaveBeenCalledTimes(1);
+      },
+      {
+        interval: DEBOUNCE_TIME + 1,
+      }
+    );
 
     // add child
     children$.next({
@@ -78,16 +101,22 @@ describe.skip('childrenUnsavedChanges$', () => {
         resetUnsavedChanges: () => undefined,
       },
     });
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_TIME + 1));
 
-    expect(onFireMock).toHaveBeenCalledTimes(1);
-    const childUnsavedChanges = onFireMock.mock.calls[0][0];
-    expect(childUnsavedChanges).toEqual({
-      child3: {
-        key1: 'modified value',
+    await waitFor(
+      () => {
+        expect(onFireMock).toHaveBeenCalledTimes(2);
+        const childUnsavedChanges = onFireMock.mock.calls[1][0];
+        expect(childUnsavedChanges).toEqual({
+          child3: {
+            key1: 'modified value',
+          },
+        });
       },
-    });
-
+      {
+        interval: DEBOUNCE_TIME + 1,
+      }
+    );
+    
     subscription.unsubscribe();
   });
 });

--- a/packages/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.test.ts
+++ b/packages/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.test.ts
@@ -12,14 +12,14 @@ import {
   initializeUnsavedChanges,
 } from './initialize_unsaved_changes';
 import { PublishesUnsavedChanges, StateComparators } from '@kbn/presentation-publishing';
+import { waitFor } from '@testing-library/react';
 
 interface TestState {
   key1: string;
   key2: string;
 }
 
-// Failing: See https://github.com/elastic/kibana/issues/189811
-describe.skip('unsavedChanges api', () => {
+describe('unsavedChanges api', () => {
   const lastSavedState = {
     key1: 'original key1 value',
     key2: 'original key2 value',
@@ -47,33 +47,42 @@ describe.skip('unsavedChanges api', () => {
 
   test('should have unsaved changes when state changes', async () => {
     key1$.next('modified key1 value');
-    await new Promise((resolve) => setTimeout(resolve, COMPARATOR_SUBJECTS_DEBOUNCE + 1));
-    expect(api?.unsavedChanges.value).toEqual({
-      key1: 'modified key1 value',
-    });
+    await waitFor(
+      () =>
+        expect(api?.unsavedChanges.value).toEqual({
+          key1: 'modified key1 value',
+        }),
+      {
+        interval: COMPARATOR_SUBJECTS_DEBOUNCE + 1,
+      }
+    );
   });
 
   test('should have no unsaved changes after save', async () => {
     key1$.next('modified key1 value');
-    await new Promise((resolve) => setTimeout(resolve, COMPARATOR_SUBJECTS_DEBOUNCE + 1));
-    expect(api?.unsavedChanges.value).not.toBeUndefined();
+    await waitFor(() => expect(api?.unsavedChanges.value).not.toBeUndefined(), {
+      interval: COMPARATOR_SUBJECTS_DEBOUNCE + 1,
+    });
 
     // trigger save
     parentApi.saveNotification$.next();
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(api?.unsavedChanges.value).toBeUndefined();
+    await waitFor(() => expect(api?.unsavedChanges.value).toBeUndefined(), {
+      interval: COMPARATOR_SUBJECTS_DEBOUNCE + 1,
+    });
   });
 
   test('should have no unsaved changes after reset', async () => {
     key1$.next('modified key1 value');
-    await new Promise((resolve) => setTimeout(resolve, COMPARATOR_SUBJECTS_DEBOUNCE + 1));
-    expect(api?.unsavedChanges.value).not.toBeUndefined();
+    await waitFor(() => expect(api?.unsavedChanges.value).not.toBeUndefined(), {
+      interval: COMPARATOR_SUBJECTS_DEBOUNCE + 1,
+    });
 
     // trigger reset
     api?.resetUnsavedChanges();
 
-    await new Promise((resolve) => setTimeout(resolve, COMPARATOR_SUBJECTS_DEBOUNCE + 1));
-    expect(api?.unsavedChanges.value).toBeUndefined();
+    await waitFor(() => expect(api?.unsavedChanges.value).toBeUndefined(), {
+      interval: COMPARATOR_SUBJECTS_DEBOUNCE + 1,
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/189811, https://github.com/elastic/kibana/issues/189823, and https://github.com/elastic/kibana/issues/189822

PR attempts resolves flaky tests by putting expects in `waitFor`