### PR TITLE
[ci] Fix sonarqube scan

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-sonarqube.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-sonarqube.yml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-kibana-sonarqube
+  description: Run a SonarQube scan
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/kibana-sonarqube
+spec:
+  type: buildkite-pipeline
+  owner: group:kibana-operations
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / sonarqube
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+      repository: elastic/kibana
+      provider_settings:
+        trigger_mode: none
+      schedules:
+        daily:
+          branch: main
+          cronline: "@daily"
+      pipeline_file: ".buildkite/pipelines/sonarqube.yml"
+      teams:
+        kibana-operations:
+         access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -44,3 +44,4 @@ spec:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-pointer-compression.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-sonarqube.yml

--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -23,12 +23,14 @@ if [[ -d /opt/local-ssd/buildkite ]]; then
   mkdir -p "$TMPDIR"
 fi
 
-KIBANA_PKG_BRANCH="$(jq -r .branch "$KIBANA_DIR/package.json")"
-export KIBANA_PKG_BRANCH
-export KIBANA_BASE_BRANCH="$KIBANA_PKG_BRANCH"
+if command -v jq >/dev/null 2>&1; then
+  KIBANA_PKG_BRANCH="$(jq -r .branch "$KIBANA_DIR/package.json")"
+  export KIBANA_PKG_BRANCH
+  export KIBANA_BASE_BRANCH="$KIBANA_PKG_BRANCH"
 
-KIBANA_PKG_VERSION="$(jq -r .version "$KIBANA_DIR/package.json")"
-export KIBANA_PKG_VERSION
+  KIBANA_PKG_VERSION="$(jq -r .version "$KIBANA_DIR/package.json")"
+  export KIBANA_PKG_VERSION
+fi
 
 # Detects and exports the final target branch when using a merge queue
 if [[ "${BUILDKITE_BRANCH:-}" == "gh-readonly-queue"* ]]; then

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -113,6 +113,9 @@ spec:
     metadata:
       name: kibana / sonarqube
     spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       repository: elastic/kibana
       provider_settings:
         trigger_mode: none

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -93,42 +93,5 @@ spec:
   lifecycle: production
   system: control-plane
 
----
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
-apiVersion: backstage.io/v1alpha1
-kind: Resource
-metadata:
-  name: buildkite-pipeline-kibana-sonarqube
-  description: Run a SonarQube scan
-  links:
-    - title: Pipeline
-      url: https://buildkite.com/elastic/kibana-sonarqube
-spec:
-  type: buildkite-pipeline
-  owner: group:kibana-operations
-  system: buildkite
-  implementation:
-    apiVersion: buildkite.elastic.dev/v1
-    kind: Pipeline
-    metadata:
-      name: kibana / sonarqube
-    spec:
-      env:
-        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-      repository: elastic/kibana
-      provider_settings:
-        trigger_mode: none
-      schedules:
-        daily:
-          branch: main
-          cronline: "@daily"
-      pipeline_file: ".buildkite/pipelines/sonarqube.yml"
-      teams:
-        kibana-operations:
-         access_level: MANAGE_BUILD_AND_READ
-        everyone:
-          access_level: READ_ONLY
-
 # Please avoid creating new kibana pipelines in this file to avoid bloating.
 # Instead, create a new file in the pipeline-resource-definitions directory, and wire it in through the locations.yml file.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -50,3 +50,4 @@ sonar.exclusions=\
   src/dev/**/*
 
 sonar.javascript.node.maxspace=8192
+sonar.log.level = DEBUG

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -50,4 +50,3 @@ sonar.exclusions=\
   src/dev/**/*
 
 sonar.javascript.node.maxspace=8192
-sonar.log.level = DEBUG

--- a/x-pack/plugins/observability_solution/infra/server/routes/ip_to_hostname.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/ip_to_hostname.ts
@@ -52,10 +52,10 @@ export const initIpToHostName = ({ framework }: InfraBackendLibs) => {
         }
         const hostDoc = first(hits.hits)!;
         return response.ok({ body: { host: hostDoc._source.host.name } });
-      } catch ({ statusCode = 500, message = 'Unknown error occurred' }) {
+      } catch (error) {
         return response.customError({
-          statusCode,
-          body: { message },
+          statusCode: error.statusCode || 500,
+          body: { message: error.message || 'Unknown error occurred' },
         });
       }
     }


### PR DESCRIPTION
jq isn't installed on the container running a scan.  It isn't needed, so this wraps the statement in an `if binary exists`. block

This also enables slack notifications on failure.

https://buildkite.com/elastic/kibana-sonarqube/builds/224