### PR TITLE
[Security Solution] [Security assistant] [Attack discovery] Fixes Select a connector placeholder issue

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/connector_selector/index.test.tsx
@@ -7,9 +7,10 @@
 
 import React from 'react';
 import { ConnectorSelector } from '.';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { TestProviders } from '../../mock/test_providers/test_providers';
 import { mockActionTypes, mockConnectors } from '../../mock/connectors';
+import * as i18n from '../translations';
 
 const onConnectorSelectionChange = jest.fn();
 const setIsOpen = jest.fn();
@@ -106,5 +107,29 @@ describe('Connector selector', () => {
     expect(onConnectorSelectionChange).toHaveBeenCalledWith(newConnector);
     expect(mockRefetchConnectors).toHaveBeenCalled();
     expect(setIsOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('renders the expected placeholder when selectedConnectorId is undefined', () => {
+    render(
+      <TestProviders>
+        <ConnectorSelector {...defaultProps} selectedConnectorId={undefined} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('connector-selector')).toHaveTextContent(
+      i18n.INLINE_CONNECTOR_PLACEHOLDER
+    );
+  });
+
+  it('does NOT render the placeholder when selectedConnectorId is defined', () => {
+    render(
+      <TestProviders>
+        <ConnectorSelector {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('connector-selector')).not.toHaveTextContent(
+      i18n.INLINE_CONNECTOR_PLACEHOLDER
+    );
   });
 });

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -6,11 +6,13 @@
  */
 
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSuperSelect, EuiText } from '@elastic/eui';
+import { css } from '@emotion/css';
 import React, { Suspense, useCallback, useMemo, useState } from 'react';
 
 import { ActionConnector, ActionType } from '@kbn/triggers-actions-ui-plugin/public';
 
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
+import { euiThemeVars } from '@kbn/ui-theme';
 import { some } from 'lodash';
 import type { AttackDiscoveryStats } from '@kbn/elastic-assistant-common';
 import { AttackDiscoveryStatusIndicator } from './attack_discovery_status_indicator';
@@ -22,6 +24,13 @@ import { getActionTypeTitle, getGenAiConfig } from '../helpers';
 import { AddConnectorModal } from '../add_connector_modal';
 
 export const ADD_NEW_CONNECTOR = 'ADD_NEW_CONNECTOR';
+
+const placeholderCss = css`
+  .euiSuperSelectControl__placeholder {
+    color: ${euiThemeVars.euiColorPrimary};
+    margin-right: ${euiThemeVars.euiSizeXS};
+  }
+`;
 
 interface Props {
   isDisabled?: boolean;
@@ -187,6 +196,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
         ) : (
           <EuiSuperSelect
             aria-label={i18n.CONNECTOR_SELECTOR_TITLE}
+            className={placeholderCss}
             compressed={true}
             data-test-subj="connector-selector"
             disabled={localIsDisabled}
@@ -195,6 +205,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
             onChange={onChange}
             options={allConnectorOptions}
             valueOfSelected={selectedConnectorId}
+            placeholder={i18n.INLINE_CONNECTOR_PLACEHOLDER}
             popoverProps={{ panelMinWidth: 400, anchorPosition: 'downRight' }}
           />
         )}

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/translations.ts
@@ -52,7 +52,7 @@ export const ADD_CONNECTOR = i18n.translate(
 export const INLINE_CONNECTOR_PLACEHOLDER = i18n.translate(
   'xpack.elasticAssistant.assistant.connectors.connectorSelectorInline.connectorPlaceholder',
   {
-    defaultMessage: 'Select a Connector',
+    defaultMessage: 'Select a connector',
   }
 );
 


### PR DESCRIPTION
## [Security Solution] [Security assistant] [Attack discovery] Fixes `Select a connector` placeholder issue

This PR fixes an issue in the Security assistant and Attack discovery where the `Select a connector` text is not displayed, per the _before_ and _after_ screenshots below:

### Before

| Before<br>Security Assistant                                                                                   | Before<br>Attack discovery                                                                                  |
|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| ![security_assistant_before](https://github.com/user-attachments/assets/83f23c12-c0a1-4d05-a211-51a07bd7e716) | ![attack_discovery_before](https://github.com/user-attachments/assets/7ebb9cca-5be5-4148-b874-bef396ea4207) |

_Above: Before the fix, the Security Assistant and Attack discovery do NOT display the `Select a connector` placeholder_

### After

| After<br>Security Assistant                                                                                   | After<br>Attack discovery                                                                                  |
|--------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
| ![security_assistant_after](https://github.com/user-attachments/assets/e4df27a7-e9e7-4e9f-bbce-016d869ffd7b) | ![attack_discovery_after](https://github.com/user-attachments/assets/6f9be05f-18d9-4461-86ef-cc2bf0870a44) |

_Above: After the fix, the Security Assistant and Attack discovery display the `Select a connector` placeholder_

## Desk Testing

Note: The reproduction steps will add (one at a time) a total of three preconfigured connectors to reproduce / test the fix.

Reproduction steps:

1) Add **just ONE** preconfigured Gen AI connector, i.e. `GPT-4o`, to `config/kibana.dev.yml`

**IMPORTANT**: There MUST be **a total of only ONE** preconfigured connector.

2) Clear Kibana local storage in your browser, then close all Kibana tabs

3) Start a new (development) instance of Elasticsearch:

```sh
yarn es snapshot -E path.data=/Users/$USERNAME/data-2024-08-05a
```

4) Start a local (development) instance of Kibana:

```
yarn start --no-base-path
````

5) Login to Kibana as the `elastic` user

6) Navigate to Stack Management > License Management and start a 30 day trial

7) Navigate to Security > Attack discovery

**Expected results:**

- The preconfigured connector is automatically selected in the Attack discovery page

8) Click the `AI Assistant` button

**Expected result:**

- The preconfigured connector is automatically selected in the Assistant

9) Refresh the page again

**Expected results**

- The connector is still selected in the Attack discovery page
- The connector is still selected in the Security Assistant

10) Clear Kibana local storage via the browser's `Application` tab in dev tools

11) Refresh the page

**Expected results**

- Once again, the connector is still selected in the Attack discovery page
- Yet again, the connector is still selected in the Security Assistant

12) Add a 2nd preconfigured connector, i.e. `Claude Sonnet 3.5 (Bedrock)` to `config/kibana.dev.yml`

13) Refresh the browser after Kibana server restarts

**Expected results**

- The `Select a connector` text appears in the header of the Attack discovery page, because there are now two connectors available (the user must explicitly select one to save selection to local storage), as illustrated by the screenshot below: ![attack_discovery_after](https://github.com/user-attachments/assets/6f9be05f-18d9-4461-86ef-cc2bf0870a44)

- The previously selected (1st) connector is still selected in the Security assistant, because it was persisted with the Welcome conversation

**Actual results**

- The `Select a connector` text does NOT appear in the header of the Attack discovery page, as illustrated by the screenshot below: ![attack_discovery_before](https://github.com/user-attachments/assets/7ebb9cca-5be5-4148-b874-bef396ea4207)

14) Select the 2nd connector in the Attack discovery page

15) Select the 2nd connector in the Security assistant for the `Welcome connection`

16) Refresh the page

**Expected results**

- The 2nd connector is still selected in Attack discovery
- The 2nd connector is still selected in the Security assistant

17) Edit `config/kibana.dev.yml` such that:

A) The 2nd connector is commented out

B) A new 3rd connector (e.g. `Gemini`) is added to the configuration

`A` and `B` above ensures that:

- The previously valid connector selected in both Attack discovery and the Security assistant will NOT be valid, because it was removed
- Any business logic that selects a single connector if it's available will still find TWO connectors (the 1st and 3rd), and thus it MUST NOT pick one automatically

18) After kibana server finishes restarting, refresh the browser

**Expected results**

- The Attack discovery page displays `Select a connector` in the header, because the 2nd connector was deleted, so only the 1st and 3rd are available
- The Security assistant displays `Select a connector` in the header, because the 2nd connector was deleted, so only the 1st and 3rd are available, as illustrated by the screenshot below:

![security_assistant_after](https://github.com/user-attachments/assets/e4df27a7-e9e7-4e9f-bbce-016d869ffd7b)

**Actual results**

- In Attack discovery, the `Select a connector` text does NOT appear in the header
- In the Security assistant, the `Select a connector` text does NOT appear, as illustrated by the screenshot below: ![security_assistant_before](https://github.com/user-attachments/assets/83f23c12-c0a1-4d05-a211-51a07bd7e716)

19) Select the 3rd connector (i.e. `Gemini`) in Attack discovery

20) Also select the 3rd connector (i.e. `Gemini`) in the Security assistant

21) Refresh the page

**Expected results**

- The 3rd connector is selected in Attack discovery
- The 3rd connector is selected in the Security assistant


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->