### PR TITLE
fix(es-setup): retry docker pull on "i/o timeout"

### DIFF
--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -382,7 +382,11 @@ export async function maybeCreateDockerNetwork(log: ToolingLog) {
   log.indent(-4);
 }
 
-const RETRYABLE_DOCKER_PULL_ERROR_MESSAGES = ['connection refused', 'i/o timeout'];
+const RETRYABLE_DOCKER_PULL_ERROR_MESSAGES = [
+  'connection refused',
+  'i/o timeout',
+  'Client.Timeout',
+];
 
 /**
  *

--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -382,6 +382,8 @@ export async function maybeCreateDockerNetwork(log: ToolingLog) {
   log.indent(-4);
 }
 
+const RETRYABLE_DOCKER_PULL_ERROR_MESSAGES = ['connection refused', 'i/o timeout'];
+
 /**
  *
  * Pull a Docker image if needed. Ensures latest image.
@@ -407,8 +409,12 @@ ${message}`;
     {
       retries: 2,
       onFailedAttempt: (error) => {
-        // Only retry if `connection refused` is found in the error message.
-        if (!error?.message?.includes('connection refused')) {
+        // Only retry if retryable error messages are found in the error message.
+        if (
+          RETRYABLE_DOCKER_PULL_ERROR_MESSAGES.every(
+            (msg) => !error?.message?.includes('connection refused')
+          )
+        ) {
           throw error;
         }
       },


### PR DESCRIPTION
## Summary

Adding another retriable scenario to https://github.com/elastic/kibana/pull/189815

Resolves #188968
Resolves #188967
Resolves #188966
Resolves #188965
Resolves #188964
Resolves #188963
Resolves #188962
Resolves #176855
Resolves #176854
Resolves #176853
Resolves #176852
Resolves #176851
Resolves #176850
Resolves #176849
Resolves #176848
Resolves #176847
Resolves #176846
Resolves #176845
Resolves #176844
Resolves #176843
Resolves #176842
Resolves #176841
Resolves #167291
Resolves #167290
Resolves #167289
Resolves #167288
Resolves #167287
Resolves #167286
Resolves #167285 
Resolves #167284 
Resolves #167283 
Resolves #167282 
Resolves #167281 
Resolves #167280 
Resolves #167279
Resolves #167278 
Resolves #167277 
Resolves #167276 
Resolves #167275 
Resolves #167274 
Resolves #167273 
Resolves #167272 
Resolves #167268 
Resolves #167267
Resolves #167266 
Resolves #167265 
Resolves #167264 
Resolves #167263 
Resolves #167262 
Resolves #167261 
Resolves #167260 
Resolves #167259
Resolves #167258 
Resolves #167257 

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
