### PR TITLE
[eem] fix delete indices

### DIFF
--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/delete_index.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/delete_index.ts
@@ -15,13 +15,11 @@ export async function deleteIndices(
   logger: Logger
 ) {
   try {
-    const response = await esClient.indices.resolveIndex({
-      name: `${generateHistoryIndexName(definition)}.*,${generateLatestIndexName(definition)}`,
-    });
-    const indices = response.indices.map((doc) => doc.name);
-    if (indices.length) {
-      await esClient.indices.delete({ index: indices, ignore_unavailable: true });
-    }
+    const indices = [
+      `${generateHistoryIndexName(definition)}.*`,
+      generateLatestIndexName(definition),
+    ];
+    await esClient.indices.delete({ index: indices, ignore_unavailable: true });
   } catch (e) {
     logger.error(`Unable to remove entity definition index [${definition.id}}]`);
     throw e;


### PR DESCRIPTION
resolve index fails when latest index does not exist and we only need one call to delete indices api anyway