### PR TITLE
[Security solution] Create new class instance for each use of LangChain chat model

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/graph.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/graph.ts
@@ -41,8 +41,7 @@ interface GetDefaultAssistantGraphParams {
   agentRunnable: AgentRunnableSequence;
   dataClients?: AssistantDataClients;
   conversationId?: string;
-  getLlmInstance: () => BaseChatModel;
-  llm: BaseChatModel;
+  createLlmInstance: () => BaseChatModel;
   logger: Logger;
   tools: StructuredTool[];
   responseLanguage: string;
@@ -61,8 +60,7 @@ export const getDefaultAssistantGraph = ({
   agentRunnable,
   conversationId,
   dataClients,
-  getLlmInstance,
-  llm,
+  createLlmInstance,
   logger,
   responseLanguage,
   tools,
@@ -106,7 +104,6 @@ export const getDefaultAssistantGraph = ({
 
     // Default node parameters
     const nodeParams: NodeParamsBase = {
-      model: llm,
       logger,
     };
 
@@ -131,6 +128,7 @@ export const getDefaultAssistantGraph = ({
     const generateChatTitleNode = (state: AgentState) =>
       generateChatTitle({
         ...nodeParams,
+        model: createLlmInstance(),
         state,
         responseLanguage,
       });
@@ -154,7 +152,7 @@ export const getDefaultAssistantGraph = ({
     const respondNode = (state: AgentState) =>
       respond({
         ...nodeParams,
-        llm: getLlmInstance(),
+        model: createLlmInstance(),
         state,
       });
     const shouldContinueEdge = (state: AgentState) => shouldContinue({ ...nodeParams, state });

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
@@ -57,7 +57,16 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
   const logger = parentLogger.get('defaultAssistantGraph');
   const isOpenAI = llmType === 'openai';
   const llmClass = getLlmClass(llmType, bedrockChatEnabled);
-  const getLlmInstance = () =>
+
+  /**
+   * Creates a new instance of llmClass.
+   *
+   * This function ensures that a new llmClass instance is created every time it is called.
+   * This is necessary to avoid any potential side effects from shared state. By always
+   * creating a new instance, we prevent other uses of llm from binding and changing
+   * the state unintentionally. For this reason, never assign this value to a variable (ex const llm = createLlmInstance())
+   */
+  const createLlmInstance = () =>
     new llmClass({
       actionsClient,
       connectorId,
@@ -76,8 +85,6 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
       maxRetries: 0,
     });
 
-  const llm = getLlmInstance();
-
   const anonymizationFieldsRes =
     await dataClients?.anonymizationFieldsDataClient?.findDocuments<EsAnonymizationFieldsSchema>({
       perPage: 1000,
@@ -93,7 +100,7 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
   const modelExists = await esStore.isModelInstalled();
 
   // Create a chain that uses the ELSER backed ElasticsearchStore, override k=10 for esql query generation for now
-  const chain = RetrievalQAChain.fromLLM(getLlmInstance(), esStore.asRetriever(10));
+  const chain = RetrievalQAChain.fromLLM(createLlmInstance(), esStore.asRetriever(10));
 
   // Check if KB is available
   const isEnabledKnowledgeBase = (await dataClients?.kbDataClient?.isModelDeployed()) ?? false;
@@ -106,7 +113,6 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
     esClient,
     isEnabledKnowledgeBase,
     kbDataClient: dataClients?.kbDataClient,
-    llm,
     logger,
     modelExists,
     onNewReplacements,
@@ -116,26 +122,26 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
   };
 
   const tools: StructuredTool[] = assistantTools.flatMap(
-    (tool) => tool.getTool(assistantToolParams) ?? []
+    (tool) => tool.getTool({ ...assistantToolParams, llm: createLlmInstance() }) ?? []
   );
 
   const agentRunnable = isOpenAI
     ? await createOpenAIFunctionsAgent({
-        llm,
+        llm: createLlmInstance(),
         tools,
         prompt: openAIFunctionAgentPrompt,
         streamRunnable: isStream,
       })
     : llmType && ['bedrock', 'gemini'].includes(llmType) && bedrockChatEnabled
     ? await createToolCallingAgent({
-        llm,
+        llm: createLlmInstance(),
         tools,
         prompt:
           llmType === 'bedrock' ? bedrockToolCallingAgentPrompt : geminiToolCallingAgentPrompt,
         streamRunnable: isStream,
       })
     : await createStructuredChatAgent({
-        llm,
+        llm: createLlmInstance(),
         tools,
         prompt: structuredChatAgentPrompt,
         streamRunnable: isStream,
@@ -147,9 +153,8 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
     agentRunnable,
     conversationId,
     dataClients,
-    llm,
     // we need to pass it like this or streaming does not work for bedrock
-    getLlmInstance,
+    createLlmInstance,
     logger,
     tools,
     responseLanguage,

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/nodes/generate_chat_title.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/nodes/generate_chat_title.ts
@@ -7,6 +7,7 @@
 import { StringOutputParser } from '@langchain/core/output_parsers';
 
 import { ChatPromptTemplate } from '@langchain/core/prompts';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { AgentState, NodeParamsBase } from '../types';
 
 export const GENERATE_CHAT_TITLE_PROMPT = (responseLanguage: string) =>
@@ -25,6 +26,7 @@ export const GENERATE_CHAT_TITLE_PROMPT = (responseLanguage: string) =>
 export interface GenerateChatTitleParams extends NodeParamsBase {
   responseLanguage: string;
   state: AgentState;
+  model: BaseChatModel;
 }
 
 export const GENERATE_CHAT_TITLE_NODE = 'generateChatTitle';

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/nodes/respond.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/nodes/respond.ts
@@ -11,7 +11,7 @@ import { AGENT_NODE_TAG } from './run_agent';
 import { AgentState } from '../types';
 
 export const RESPOND_NODE = 'respond';
-export const respond = async ({ llm, state }: { llm: BaseChatModel; state: AgentState }) => {
+export const respond = async ({ model, state }: { model: BaseChatModel; state: AgentState }) => {
   if (state?.agentOutcome && 'returnValues' in state.agentOutcome) {
     const userMessage = [
       'user',
@@ -21,7 +21,7 @@ export const respond = async ({ llm, state }: { llm: BaseChatModel; state: Agent
     Do not verify, confirm or anything else. Just reply with the same content as provided above.`,
     ] as [StringWithAutocomplete<'user'>, string];
 
-    const responseMessage = await llm
+    const responseMessage = await model
       // use AGENT_NODE_TAG to identify as agent node for stream parsing
       .withConfig({ runName: 'Summarizer', tags: [AGENT_NODE_TAG] })
       .invoke([userMessage]);

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/types.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/types.ts
@@ -7,7 +7,6 @@
 
 import { BaseMessage } from '@langchain/core/messages';
 import { AgentAction, AgentFinish, AgentStep } from '@langchain/core/agents';
-import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { Logger } from '@kbn/logging';
 import { ConversationResponse } from '@kbn/elastic-assistant-common';
 
@@ -25,5 +24,4 @@ export interface AgentState extends AgentStateBase {
 
 export interface NodeParamsBase {
   logger: Logger;
-  model: BaseChatModel;
 }


### PR DESCRIPTION
## Summary

Follow up from https://github.com/elastic/kibana/pull/189810
Related to https://github.com/elastic/kibana/issues/189771

We need to create a new class instance for each use of any LangChain chat model. This is necessary to avoid any potential side effects from shared state and a variety of bugs. 

1. Renames `getLlmInstance` to `createLlmInstance`
2. Adds a comment to explain to always create a new instance of the LLM class and to never assign it to a variable.
3. Removes anywhere `llmClass` was assigned to a variable (`llm`) and instead always calls `createLlmInstance()`

### Tests

| `ESQLKnowledgeBaseTool`  | `AlertsCountTool` | `OpenAndAcknowledgedAlertsTool` | Alert Summary |
| ------------- | ------------- | ------------- | ------------- |
| [Azure 4o](https://smith.langchain.com/public/440604f1-5111-490c-af13-aa6ba18c465b/r)  | [Azure 4o](https://smith.langchain.com/public/99ec8f0b-c902-4023-88b1-7c682a1ccf5f/r)  | [Azure 4o](https://smith.langchain.com/public/535af375-ebe3-44e2-8f0c-f6c077141522/r)  | [Azure 4o](https://smith.langchain.com/public/699eb81e-40dc-4fe1-bef2-2ec09f7aaa1a/r)  |
| [Gemini Pro 1.5](https://smith.langchain.com/public/8f30f077-6310-4c80-a8ac-9db0e39238ed/r)  | [Gemini Pro 1.5](https://smith.langchain.com/public/8e005f2b-b066-4812-bbdc-ee4513259e8d/r)  | [Gemini Pro 1.5](https://smith.langchain.com/public/3147a20b-7040-4e98-8351-abf792204953/r)  | [Gemini Pro 1.5](https://smith.langchain.com/public/766a8563-d16c-4ab6-9e84-b2e93f5c2fbc/r)  |
| [Sonnet 3.5](https://smith.langchain.com/public/99283545-a788-43e3-8e91-0b04351f0cfa/r)  | [Sonnet 3.5](https://smith.langchain.com/public/5d8a3c9b-6a98-4a8d-ada7-cff259a9feff/r)  | [Sonnet 3.5](https://smith.langchain.com/public/b33a4f1f-91e9-4a20-b602-a072a64b3646/r)  | [Sonnet 3.5](https://smith.langchain.com/public/a585c7ef-a108-402a-b7b3-da45badb9419/r)  |

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->