### PR TITLE
Revert "Remove border on default, filled toolbar button"

### DIFF
--- a/packages/shared-ux/button_toolbar/src/buttons/toolbar_button/toolbar_button.styles.ts
+++ b/packages/shared-ux/button_toolbar/src/buttons/toolbar_button/toolbar_button.styles.ts
@@ -18,7 +18,8 @@ export const ToolbarButtonStyles = ({ euiTheme }: UseEuiTheme) => {
     default: {
       // style declaration carried over from https://github.com/elastic/kibana/blob/v8.10.4/src/plugins/kibana_react/public/toolbar_button/toolbar_button.scss
       // informed by issue https://github.com/elastic/eui/issues/4730
-      border: 'none',
+      borderStyle: 'solid',
+      border: euiTheme.border.thin,
       borderColor: euiTheme.border.color,
     },
     emptyButton: {


### PR DESCRIPTION
Reverts elastic/kibana#189832

Turns out it won't be quite this simple. This broke the toolbar buttons in Lens.

![CleanShot 2024-08-06 at 14 48 52@2x](https://github.com/user-attachments/assets/9513a3e0-0b51-4211-a6d2-736da6169965)
