### PR TITLE
[APM][Settings][Custom Links] Prevent initial error when adding filters

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.test.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect'; // for the 'toBeInTheDocument' matcher
+import { SuggestionsSelect } from '../../../../shared/suggestions_select';
+import { FiltersSection } from './filters_section';
+import { Filter } from '../../../../../../common/custom_link/custom_link_types';
+import { DEFAULT_OPTION } from './helper';
+import { FILTER_OPTIONS } from '../../../../../../common/custom_link/custom_link_filter_options';
+
+jest.mock('../../../../shared/suggestions_select', () => ({
+  SuggestionsSelect: jest.fn(() => <div />),
+}));
+
+type SuggestionsSelectMock = jest.MockedFunction<typeof SuggestionsSelect>;
+
+describe('FiltersSection', () => {
+  it('should pass the correct fieldName prop to SuggestionsSelect', () => {
+    const filters: Filter[] = [
+      { key: '', value: '' },
+      { key: FILTER_OPTIONS[0], value: '' },
+    ];
+
+    render(<FiltersSection filters={filters} onChangeFilters={() => {}} />);
+
+    filters.forEach((filter, idx) => {
+      const fieldName = filter.key !== '' ? filter.key : DEFAULT_OPTION.value;
+
+      expect((SuggestionsSelect as SuggestionsSelectMock).mock.calls[idx][0]).toEqual(
+        expect.objectContaining({
+          fieldName,
+        })
+      );
+    });
+  });
+});

--- a/x-pack/plugins/observability_solution/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
@@ -76,49 +76,52 @@ export function FiltersSection({
         const filterId = `filter-${idx}`;
         const selectOptions = getSelectOptions(filters, key);
         return (
-          <EuiFlexGroup key={filterId} gutterSize="s" alignItems="center">
-            <EuiFlexItem>
-              <EuiSelect
-                data-test-subj={filterId}
-                id={filterId}
-                fullWidth
-                options={selectOptions}
-                value={key}
-                prepend={i18n.translate('xpack.apm.settings.customLink.flyout.filters.prepend', {
-                  defaultMessage: 'Field',
-                })}
-                onChange={(e) =>
-                  // set value to empty string to reset value when new field is selected
-                  onChangeFilter(e.target.value as FilterKey, '', idx)
-                }
-                isInvalid={!isEmpty(value) && (isEmpty(key) || key === DEFAULT_OPTION.value)}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <SuggestionsSelect
-                key={key}
-                dataTestSubj={`${key}.value`}
-                fieldName={key !== '' ? key : DEFAULT_OPTION.value}
-                placeholder={i18n.translate(
-                  'xpack.apm.settings.customLink.flyOut.filters.defaultOption.value',
-                  { defaultMessage: 'Value' }
-                )}
-                onChange={(selectedValue) => onChangeFilter(key, selectedValue as string, idx)}
-                defaultValue={value}
-                isInvalid={!isEmpty(key) && isEmpty(value)}
-                start={moment().subtract(24, 'h').toISOString()}
-                end={moment().toISOString()}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                data-test-subj="apmCustomLinkFiltersSectionButton"
-                iconType="trash"
-                onClick={() => onRemoveFilter(idx)}
-                disabled={!value && !key && filters.length === 1}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <React.Fragment key={filterId}>
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem>
+                <EuiSelect
+                  data-test-subj={filterId}
+                  id={filterId}
+                  fullWidth
+                  options={selectOptions}
+                  value={key}
+                  prepend={i18n.translate('xpack.apm.settings.customLink.flyout.filters.prepend', {
+                    defaultMessage: 'Field',
+                  })}
+                  onChange={(e) =>
+                    // set value to empty string to reset value when new field is selected
+                    onChangeFilter(e.target.value as FilterKey, '', idx)
+                  }
+                  isInvalid={!isEmpty(value) && (isEmpty(key) || key === DEFAULT_OPTION.value)}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <SuggestionsSelect
+                  key={key}
+                  dataTestSubj={`${key}.value`}
+                  fieldName={key !== '' ? key : DEFAULT_OPTION.value}
+                  placeholder={i18n.translate(
+                    'xpack.apm.settings.customLink.flyOut.filters.defaultOption.value',
+                    { defaultMessage: 'Value' }
+                  )}
+                  onChange={(selectedValue) => onChangeFilter(key, selectedValue as string, idx)}
+                  defaultValue={value}
+                  isInvalid={!isEmpty(key) && isEmpty(value)}
+                  start={moment().subtract(24, 'h').toISOString()}
+                  end={moment().toISOString()}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  data-test-subj="apmCustomLinkFiltersSectionButton"
+                  iconType="trash"
+                  onClick={() => onRemoveFilter(idx)}
+                  disabled={!value && !key && filters.length === 1}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+          </React.Fragment>
         );
       })}
 

--- a/x-pack/plugins/observability_solution/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/settings/custom_link/create_edit_custom_link_flyout/filters_section.tsx
@@ -98,7 +98,7 @@ export function FiltersSection({
               <SuggestionsSelect
                 key={key}
                 dataTestSubj={`${key}.value`}
-                fieldName={key}
+                fieldName={key !== '' ? key : DEFAULT_OPTION.value}
                 placeholder={i18n.translate(
                   'xpack.apm.settings.customLink.flyOut.filters.defaultOption.value',
                   { defaultMessage: 'Value' }

--- a/x-pack/plugins/observability_solution/infra/public/components/ml/anomaly_detection/job_setup_screen.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/ml/anomaly_detection/job_setup_screen.tsx
@@ -223,12 +223,12 @@ export const JobSetupScreen = (props: Props) => {
             />
             <EuiSpacer />
             {setupStatus.reasons.map((errorMessage, i) => (
-              <>
-                <EuiCallOut key={i} color="danger" iconType="warning" title={errorCalloutTitle}>
+              <React.Fragment key={i}>
+                <EuiCallOut color="danger" iconType="warning" title={errorCalloutTitle}>
                   <EuiCode transparentBackground>{errorMessage}</EuiCode>
                 </EuiCallOut>
                 <EuiSpacer />
-              </>
+              </React.Fragment>
             ))}
             <EuiButton data-test-subj="infraJobSetupScreenTryAgainButton" fill onClick={createJobs}>
               <FormattedMessage


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/171079

|Scenario|Before|After|
|-|-|-|
|Click "Create custom link"|<img src="https://github.com/user-attachments/assets/c8cfa241-7d47-46bd-83dc-34e69de30308" width="280"/>|<img src="https://github.com/user-attachments/assets/fc5c6cd3-da9d-40df-b158-3e7b2fc056f7" width="280"/>|
|Click "Add new filter"|<img src="https://github.com/user-attachments/assets/0d1edf79-38e9-4101-af43-7a987670c8c5" width="280"/>|<img src="https://github.com/user-attachments/assets/2c529c74-fcf8-4380-a14c-79826393523c" width="280"/>|

### Extra
A React warning for missing unique key introduced in [this PR](https://github.com/elastic/kibana/pull/189627) has been fixed in [this commit](https://github.com/elastic/kibana/commit/5e2a2771d5182ca6c099774d20e911a65138b243).