### PR TITLE
[ES|QL][Discover] Adds an explanatory tooltip in the navigation switch

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.test.ts
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.test.ts
@@ -46,6 +46,7 @@ test('getTopNavLinks result', () => {
         "label": "Try ES|QL",
         "run": [Function],
         "testId": "select-text-based-language-btn",
+        "tooltip": "ES|QL is Elastic's powerful new piped query language.",
       },
       Object {
         "description": "New Search",
@@ -110,6 +111,7 @@ test('getTopNavLinks result for ES|QL mode', () => {
         "label": "Switch to classic",
         "run": [Function],
         "testId": "switch-to-dataviews",
+        "tooltip": "Switch to KQL or Lucene syntax.",
       },
       Object {
         "description": "New Search",

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -81,6 +81,11 @@ export const getTopNavLinks = ({
     iconType: 'editorRedo',
     fill: false,
     color: 'text',
+    tooltip: isEsqlMode
+      ? undefined
+      : i18n.translate('discover.localMenu.esqlTooltipLabel', {
+          defaultMessage: 'Try our new query language',
+        }),
     run: () => {
       if (dataView) {
         if (isEsqlMode) {

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -82,9 +82,11 @@ export const getTopNavLinks = ({
     fill: false,
     color: 'text',
     tooltip: isEsqlMode
-      ? undefined
+      ? i18n.translate('discover.localMenu.switchToClassicTooltipLabel', {
+          defaultMessage: 'Switch to KQL or Lucene syntax.',
+        })
       : i18n.translate('discover.localMenu.esqlTooltipLabel', {
-          defaultMessage: 'Try our new query language',
+          defaultMessage: `ES|QL is Elastic's powerful new piped query language.`,
         }),
     run: () => {
       if (dataView) {


### PR DESCRIPTION
## Summary

<img width="836" alt="image" src="https://github.com/user-attachments/assets/06e1154d-60c1-476f-bb57-1c5f9bfced77">

<img width="802" alt="image" src="https://github.com/user-attachments/assets/fa2ac700-4908-4ccd-a4bf-0ba30c292975">
