### PR TITLE
[maps] Revert "Revert of fix EMS vector file manifest is loaded in Discover

### DIFF
--- a/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/setup.ts
@@ -8,7 +8,6 @@
 import type { ExpressionsSetup } from '@kbn/expressions-plugin/public';
 import type { CoreSetup, CoreStart } from '@kbn/core/public';
 import type { LensPublicSetup } from '@kbn/lens-plugin/public';
-import type { FileLayer } from '@elastic/ems-client';
 import type { MapsPluginStartDependencies } from '../../plugin';
 import { getExpressionFunction } from './expression_function';
 import { getExpressionRenderer } from './expression_renderer';
@@ -27,22 +26,10 @@ export function setupLensChoroplethChart(
   lens.registerVisualization(async () => {
     const [coreStart, plugins]: [CoreStart, MapsPluginStartDependencies, unknown] =
       await coreSetup.getStartServices();
-    const { getEmsFileLayers } = await import('../../util');
     const { getVisualization } = await import('./visualization');
-
-    let emsFileLayers: FileLayer[] = [];
-    try {
-      emsFileLayers = await getEmsFileLayers();
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Lens region map setup is unable to access administrative boundaries from Elastic Maps Service (EMS). To avoid unnecessary EMS requests, set 'map.includeElasticMapsService: false' in 'kibana.yml'. For more details please visit ${coreStart.docLinks.links.maps.connectToEms}`
-      );
-    }
 
     return getVisualization({
       theme: coreStart.theme,
-      emsFileLayers,
       paletteService: await plugins.charts.palettes.getPalettes(),
     });
   });

--- a/x-pack/plugins/maps/public/lens/choropleth_chart/suggestions_lazy.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/suggestions_lazy.ts
@@ -28,7 +28,7 @@ export function getSuggestionsLazy(
   suggestionRequest: SuggestionRequest<ChoroplethChartState>
 ): Array<VisualizationSuggestion<ChoroplethChartState>> {
   if (!promise) {
-    promise = new Promise((resolve, reject) => {
+    promise = new Promise((resolve) => {
       Promise.all([import('./suggestions'), import('../../util')])
         .then(async ([{ getSuggestions }, { getEmsFileLayers }]) => {
           getSuggestionsActual = getSuggestions;
@@ -42,7 +42,7 @@ export function getSuggestionsLazy(
           }
           resolve();
         })
-        .catch(reject);
+        .catch(resolve);
     });
     return [];
   }

--- a/x-pack/plugins/maps/public/lens/choropleth_chart/suggestions_lazy.ts
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/suggestions_lazy.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SuggestionRequest, VisualizationSuggestion } from '@kbn/lens-plugin/public';
+import type { FileLayer } from '@elastic/ems-client';
+import type { ChoroplethChartState } from './types';
+
+let emsFileLayers: FileLayer[] | undefined;
+let getSuggestionsActual:
+  | ((
+      suggestionRequest: SuggestionRequest<ChoroplethChartState>,
+      emsFileLayers: FileLayer[]
+    ) => Array<VisualizationSuggestion<ChoroplethChartState>>)
+  | undefined;
+let promise: undefined | Promise<void>;
+
+/**
+ * Avoid loading file layers during plugin setup
+ * Instead, load file layers when getSuggestions is called
+ * Since getSuggestions is sync, the trade off is that
+ * getSuggestions will return no suggestions until file layers load
+ */
+export function getSuggestionsLazy(
+  suggestionRequest: SuggestionRequest<ChoroplethChartState>
+): Array<VisualizationSuggestion<ChoroplethChartState>> {
+  if (!promise) {
+    promise = new Promise((resolve, reject) => {
+      Promise.all([import('./suggestions'), import('../../util')])
+        .then(async ([{ getSuggestions }, { getEmsFileLayers }]) => {
+          getSuggestionsActual = getSuggestions;
+          try {
+            emsFileLayers = await getEmsFileLayers();
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Lens region map is unable to access administrative boundaries from Elastic Maps Service (EMS). To avoid unnecessary EMS requests, set 'map.includeElasticMapsService: false' in 'kibana.yml'.`
+            );
+          }
+          resolve();
+        })
+        .catch(reject);
+    });
+    return [];
+  }
+
+  return emsFileLayers && getSuggestionsActual
+    ? getSuggestionsActual(suggestionRequest, emsFileLayers)
+    : [];
+}


### PR DESCRIPTION
Re-instate https://github.com/elastic/kibana/pull/189550. PR makes one small clean-up in that getSuggestionsLazy promise will not reject when modules fail to load.

https://github.com/elastic/kibana/pull/189984 confirmed that [the fix did](https://github.com/elastic/kibana/pull/189550) had a large impact on performance. 