### PR TITLE
[Security Solution][Entity details] - move code to get url link to flyout folder

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_actions.test.tsx
@@ -14,13 +14,11 @@ import { useAssistant } from '../hooks/use_assistant';
 import { mockGetFieldsData } from '../../shared/mocks/mock_get_fields_data';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
 import { TestProvidersComponent } from '../../../../common/mock';
-import { useGetAlertDetailsFlyoutLink } from '../../../../timelines/components/side_panel/event_details/use_get_alert_details_flyout_link';
+import { useGetFlyoutLink } from '../hooks/use_get_flyout_link';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../hooks/use_assistant');
-jest.mock(
-  '../../../../timelines/components/side_panel/event_details/use_get_alert_details_flyout_link'
-);
+jest.mock('../hooks/use_get_flyout_link');
 
 jest.mock('@elastic/eui', () => ({
   ...jest.requireActual('@elastic/eui'),
@@ -53,7 +51,7 @@ describe('<HeaderAction />', () => {
 
   beforeEach(() => {
     window.location.search = '?';
-    jest.mocked(useGetAlertDetailsFlyoutLink).mockReturnValue(alertUrl);
+    jest.mocked(useGetFlyoutLink).mockReturnValue(alertUrl);
     jest.mocked(useAssistant).mockReturnValue({ showAssistant: true, promptContextId: '' });
   });
 
@@ -65,7 +63,7 @@ describe('<HeaderAction />', () => {
     });
 
     it('should not render share button in the title if alert is missing url info', () => {
-      jest.mocked(useGetAlertDetailsFlyoutLink).mockReturnValue(null);
+      jest.mocked(useGetFlyoutLink).mockReturnValue(null);
       const { queryByTestId } = renderHeaderActions(mockContextValue);
       expect(queryByTestId(SHARE_BUTTON_TEST_ID)).not.toBeInTheDocument();
     });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_actions.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_actions.tsx
@@ -10,7 +10,7 @@ import React, { memo } from 'react';
 import { EuiButtonIcon, EuiCopy, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { NewChatByTitle } from '@kbn/elastic-assistant';
-import { useGetAlertDetailsFlyoutLink } from '../../../../timelines/components/side_panel/event_details/use_get_alert_details_flyout_link';
+import { useGetFlyoutLink } from '../hooks/use_get_flyout_link';
 import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
 import { useAssistant } from '../hooks/use_assistant';
 import {
@@ -27,9 +27,9 @@ export const HeaderActions: VFC = memo(() => {
   const { dataFormattedForFieldBrowser, eventId, indexName } = useDocumentDetailsContext();
   const { isAlert, timestamp } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
 
-  const alertDetailsLink = useGetAlertDetailsFlyoutLink({
-    _id: eventId,
-    _index: indexName,
+  const alertDetailsLink = useGetFlyoutLink({
+    eventId,
+    indexName,
     timestamp,
   });
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_flyout_is_expandable.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_flyout_is_expandable.ts
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { getField, getFieldArray } from '../../shared/utils';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from '../../shared/hooks/use_get_fields_data';
 import { getRowRenderer } from '../../../../timelines/components/timeline/body/renderers/get_row_renderer';
 import { defaultRowRenderers } from '../../../../timelines/components/timeline/body/renderers';
 import { isEcsAllowedValue } from '../utils/event_utils';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_flyout_link.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_flyout_link.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useGetFlyoutLink } from './use_get_flyout_link';
+import { useGetAppUrl } from '@kbn/security-solution-navigation';
+import { ALERT_DETAILS_REDIRECT_PATH } from '../../../../../common/constants';
+
+jest.mock('@kbn/security-solution-navigation');
+
+const eventId = 'eventId';
+const indexName = 'indexName';
+const timestamp = 'timestamp';
+
+describe('useGetFlyoutLink', () => {
+  it('should return url', () => {
+    (useGetAppUrl as jest.Mock).mockReturnValue({
+      getAppUrl: (data: { path: string }) => data.path,
+    });
+
+    const hookResult = renderHook(() =>
+      useGetFlyoutLink({
+        eventId,
+        indexName,
+        timestamp,
+      })
+    );
+
+    const origin = 'http://localhost';
+    const path = `${ALERT_DETAILS_REDIRECT_PATH}/${eventId}?index=${indexName}&timestamp=${timestamp}`;
+    expect(hookResult.result.current).toBe(`${origin}${path}`);
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_flyout_link.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_flyout_link.ts
@@ -11,19 +11,36 @@ import { DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 import { buildAlertDetailPath } from '../../../../../common/utils/alert_detail_path';
 import { useAppUrl } from '../../../../common/lib/kibana/hooks';
 
-// TODO: MOVE TO FLYOUT FOLDER - https://github.com/elastic/security-team/issues/7462
-export const useGetAlertDetailsFlyoutLink = ({
-  _id,
-  _index,
-  timestamp,
-}: {
-  _id: string;
-  _index: string;
+export interface UseGetFlyoutLinkProps {
+  /**
+   * Id of the document
+   */
+  eventId: string;
+  /**
+   * Name of the index used in the parent's page
+   */
+  indexName: string;
+  /**
+   * Timestamp of the document
+   */
   timestamp: string;
-}) => {
+}
+
+/**
+ * Hook to get the link to the alert details page
+ */
+export const useGetFlyoutLink = ({
+  eventId,
+  indexName,
+  timestamp,
+}: UseGetFlyoutLinkProps): string | null => {
   const { getAppUrl } = useAppUrl();
-  const alertDetailPath = buildAlertDetailPath({ alertId: _id, index: _index, timestamp });
-  const isPreviewAlert = _index.includes(DEFAULT_PREVIEW_INDEX);
+  const alertDetailPath = buildAlertDetailPath({
+    alertId: eventId,
+    index: indexName,
+    timestamp,
+  });
+  const isPreviewAlert = indexName.includes(DEFAULT_PREVIEW_INDEX);
 
   // getAppUrl accounts for the users selected space
   const alertDetailsLink = useMemo(() => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_process_data.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_process_data.ts
@@ -7,7 +7,7 @@
 
 import { useMemo } from 'react';
 import { ALERT_RULE_NAME, ALERT_RULE_UUID } from '@kbn/rule-data-utils';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from '../../shared/hooks/use_get_fields_data';
 import { getField } from '../../shared/utils';
 import { useDocumentDetailsContext } from '../../shared/context';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.test.tsx
@@ -10,7 +10,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import type { UseSessionPreviewParams } from './use_session_preview';
 import { useSessionPreview } from './use_session_preview';
 import type { SessionViewConfig } from '@kbn/securitysolution-data-table/common/types';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from '../../shared/hooks/use_get_fields_data';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
 import { mockFieldData, mockGetFieldsData } from '../../shared/mocks/mock_get_fields_data';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.ts
@@ -7,7 +7,7 @@
 
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
 import type { SessionViewConfig } from '@kbn/securitysolution-data-table/common/types';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from '../../shared/hooks/use_get_fields_data';
 import { getField } from '../../shared/utils';
 import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/context.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/context.tsx
@@ -15,7 +15,7 @@ import { FlyoutLoading } from '../../shared/components/flyout_loading';
 import type { SearchHit } from '../../../../common/search_strategy';
 import { useBasicDataFromDetailsData } from './hooks/use_basic_data_from_details_data';
 import type { DocumentDetailsProps } from './types';
-import type { GetFieldsData } from '../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './hooks/use_get_fields_data';
 import { useRuleWithFallback } from '../../../detection_engine/rule_management/logic/use_rule_with_fallback';
 
 export interface DocumentDetailsContext {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
@@ -13,13 +13,13 @@ import { useSpaceId } from '../../../../common/hooks/use_space_id';
 import { useRouteSpy } from '../../../../common/utils/route/use_route_spy';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useTimelineEventsDetails } from '../../../../timelines/containers/details';
-import { useGetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import { useGetFieldsData } from './use_get_fields_data';
 
 jest.mock('../../../../common/hooks/use_space_id');
 jest.mock('../../../../common/utils/route/use_route_spy');
 jest.mock('../../../../sourcerer/containers');
 jest.mock('../../../../timelines/containers/details');
-jest.mock('../../../../common/hooks/use_get_fields_data');
+jest.mock('./use_get_fields_data');
 
 const eventId = 'eventId';
 const indexName = 'indexName';
@@ -35,7 +35,7 @@ describe('useEventDetails', () => {
       indexPattern: {},
     });
     (useTimelineEventsDetails as jest.Mock).mockReturnValue([false, [], {}, {}, jest.fn()]);
-    jest.mocked(useGetFieldsData).mockReturnValue((field: string) => field);
+    jest.mocked(useGetFieldsData).mockReturnValue({ getFieldsData: (field: string) => field });
 
     hookResult = renderHook(() => useEventDetails({ eventId, indexName }));
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
@@ -8,7 +8,7 @@
 import type { RenderHookResult } from '@testing-library/react-hooks';
 import { renderHook } from '@testing-library/react-hooks';
 import type { UseEventDetailsParams, UseEventDetailsResult } from './use_event_details';
-import { useEventDetails } from './use_event_details';
+import { getAlertIndexAlias, useEventDetails } from './use_event_details';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
 import { useRouteSpy } from '../../../../common/utils/route/use_route_spy';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
@@ -23,6 +23,26 @@ jest.mock('./use_get_fields_data');
 
 const eventId = 'eventId';
 const indexName = 'indexName';
+
+describe('getAlertIndexAlias', () => {
+  it('should handle default alert index', () => {
+    expect(getAlertIndexAlias('.internal.alerts-security.alerts')).toEqual(
+      '.alerts-security.alerts-default'
+    );
+  });
+
+  it('should handle default preview index', () => {
+    expect(getAlertIndexAlias('.internal.preview.alerts-security.alerts')).toEqual(
+      '.preview.alerts-security.alerts-default'
+    );
+  });
+
+  it('should handle non default space id', () => {
+    expect(getAlertIndexAlias('.internal.preview.alerts-security.alerts', 'test')).toEqual(
+      '.preview.alerts-security.alerts-test'
+    );
+  });
+});
 
 describe('useEventDetails', () => {
   let hookResult: RenderHookResult<UseEventDetailsParams, UseEventDetailsResult>;

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.ts
@@ -9,16 +9,31 @@ import type { BrowserFields, TimelineEventsDetailsItem } from '@kbn/timelines-pl
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
 import type { DataViewBase } from '@kbn/es-query';
+import { DEFAULT_ALERTS_INDEX, DEFAULT_PREVIEW_INDEX } from '../../../../../common/constants';
 import type { RunTimeMappings } from '../../../../../common/api/search_strategy';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
-import { getAlertIndexAlias } from '../../../../timelines/components/side_panel/event_details/helpers';
 import { useRouteSpy } from '../../../../common/utils/route/use_route_spy';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useTimelineEventsDetails } from '../../../../timelines/containers/details';
-import { useGetFieldsData } from '../../../../common/hooks/use_get_fields_data';
 import type { SearchHit } from '../../../../../common/search_strategy';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './use_get_fields_data';
+import { useGetFieldsData } from './use_get_fields_data';
+
+/**
+ * The referenced alert _index in the flyout uses the `.internal.` such as `.internal.alerts-security.alerts-spaceId` in the alert page flyout and .internal.preview.alerts-security.alerts-spaceId` in the rule creation preview flyout,
+ * but we always want to use their respective aliase indices rather than accessing their backing .internal. indices.
+ */
+export const getAlertIndexAlias = (
+  index: string,
+  spaceId: string = 'default'
+): string | undefined => {
+  if (index.startsWith(`.internal${DEFAULT_ALERTS_INDEX}`)) {
+    return `${DEFAULT_ALERTS_INDEX}-${spaceId}`;
+  } else if (index.startsWith(`.internal${DEFAULT_PREVIEW_INDEX}`)) {
+    return `${DEFAULT_PREVIEW_INDEX}-${spaceId}`;
+  }
+};
 
 export interface UseEventDetailsParams {
   /**
@@ -90,7 +105,7 @@ export const useEventDetails = ({
       runtimeMappings: sourcererDataView?.sourcererDataView?.runtimeFieldMap as RunTimeMappings,
       skip: !eventId,
     });
-  const getFieldsData = useGetFieldsData(searchHit?.fields);
+  const { getFieldsData } = useGetFieldsData({ fieldsData: searchHit?.fields });
 
   return {
     browserFields: sourcererDataView.browserFields,

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_get_fields_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_get_fields_data.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
+import { mockSearchHit } from '../mocks/mock_search_hit';
+import type { UseGetFieldsDataParams, UseGetFieldsDataResult } from './use_get_fields_data';
+import { useGetFieldsData } from './use_get_fields_data';
+
+const fieldsData = {
+  ...mockSearchHit.fields,
+  field: ['value'],
+};
+
+describe('useGetFieldsData', () => {
+  let hookResult: RenderHookResult<UseGetFieldsDataParams, UseGetFieldsDataResult>;
+
+  it('should return the value for a field', () => {
+    hookResult = renderHook(() => useGetFieldsData({ fieldsData }));
+
+    const getFieldsData = hookResult.result.current.getFieldsData;
+    expect(getFieldsData('field')).toEqual(['value']);
+    expect(getFieldsData('wrong_field')).toEqual(undefined);
+  });
+
+  it('should handle undefined', () => {
+    hookResult = renderHook(() => useGetFieldsData({ fieldsData: undefined }));
+
+    const getFieldsData = hookResult.result.current.getFieldsData;
+    expect(getFieldsData('field')).toEqual(undefined);
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './use_get_fields_data';
 import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { ANCESTOR_ID } from '../constants/field_names';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_same_source_event.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_same_source_event.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './use_get_fields_data';
 import { ANCESTOR_ID } from '../constants/field_names';
 import { getField } from '../utils';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_session.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_session.ts
@@ -6,7 +6,7 @@
  */
 
 import { ENTRY_LEADER_ENTITY_ID } from '../constants/field_names';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './use_get_fields_data';
 import { getField } from '../utils';
 
 export interface UseShowRelatedAlertsBySessionParams {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_cases.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_cases.ts
@@ -7,7 +7,7 @@
 
 import { APP_ID } from '../../../../../common';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './use_get_fields_data';
 import { getField } from '../utils';
 
 export interface UseShowRelatedCasesParams {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_suppressed_alerts.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_suppressed_alerts.ts
@@ -6,7 +6,7 @@
  */
 
 import { ALERT_SUPPRESSION_DOCS_COUNT } from '@kbn/rule-data-utils';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from './use_get_fields_data';
 
 export interface ShowSuppressedAlertsParams {
   /**

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/mocks/mock_get_fields_data.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/mocks/mock_get_fields_data.ts
@@ -12,7 +12,7 @@ import {
   ALERT_SUPPRESSION_DOCS_COUNT,
 } from '@kbn/rule-data-utils';
 import { EventKind } from '../constants/event_kinds';
-import type { GetFieldsData } from '../../../../common/hooks/use_get_fields_data';
+import type { GetFieldsData } from '../hooks/use_get_fields_data';
 
 export const mockFieldData: Record<string, string[]> = {
   [ALERT_SEVERITY]: ['low'],


### PR DESCRIPTION
## Summary

This PR continues the effort in removing all old flyout components, hooks and utils functions. It moves all the code related to retrieving the url to share from the old event_details folder to the alert details expandable flyout folder

The goal of this PR is to:
- move the code and update the imports
- add unit tests if they were not present

The purpose of the PR was never to full refactor the code, so things that aren't necessarily super clean might still be present.

**_No UI changes should be visible whatsoever!_**

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

https://github.com/elastic/security-team/issues/7462