### PR TITLE
[ES|QL] Rename the params in ?t_start ?t_end

### DIFF
--- a/packages/kbn-esql-ast/src/walker/walker.test.ts
+++ b/packages/kbn-esql-ast/src/walker/walker.test.ts
@@ -801,13 +801,13 @@ describe('Walker.params()', () => {
         type: 'literal',
         literalType: 'param',
         paramType: 'named',
-        value: 'start',
+        value: 't_start',
       },
       {
         type: 'literal',
         literalType: 'param',
         paramType: 'named',
-        value: 'end',
+        value: 't_end',
       },
     ]);
   });

--- a/packages/kbn-esql-ast/src/walker/walker.test.ts
+++ b/packages/kbn-esql-ast/src/walker/walker.test.ts
@@ -791,7 +791,8 @@ describe('Walker.params()', () => {
   });
 
   test('can collect all params from grouping functions', () => {
-    const query = 'ROW x=1, time=2024-07-10 | stats z = avg(x) by bucket(time, 20, ?start,?end)';
+    const query =
+      'ROW x=1, time=2024-07-10 | stats z = avg(x) by bucket(time, 20, ?t_start,?t_end)';
     const { ast } = getAstAndSyntaxErrors(query);
     const params = Walker.params(ast);
 

--- a/packages/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
+++ b/packages/kbn-esql-utils/src/utils/get_initial_esql_query.test.ts
@@ -96,7 +96,7 @@ describe('getInitialESQLQuery', () => {
     ] as DataView['fields'];
     const dataView = getDataView('logs*', fields, '@custom_timestamp');
     expect(getInitialESQLQuery(dataView)).toBe(
-      'FROM logs* | WHERE @custom_timestamp >= ?start AND @custom_timestamp <= ?end | LIMIT 10'
+      'FROM logs* | WHERE @custom_timestamp >= ?t_start AND @custom_timestamp <= ?t_end | LIMIT 10'
     );
   });
 });

--- a/packages/kbn-esql-utils/src/utils/get_initial_esql_query.ts
+++ b/packages/kbn-esql-utils/src/utils/get_initial_esql_query.ts
@@ -18,7 +18,7 @@ export function getInitialESQLQuery(dataView: DataView): string {
   const timeFieldName = dataView?.timeFieldName;
   const filterByTimeParams =
     !hasAtTimestampField && timeFieldName
-      ? ` | WHERE ${timeFieldName} >= ?start AND ${timeFieldName} <= ?end`
+      ? ` | WHERE ${timeFieldName} >= ?t_start AND ${timeFieldName} <= ?t_end`
       : '';
   return `FROM ${dataView.getIndexPattern()}${filterByTimeParams} | LIMIT 10`;
 }

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -150,10 +150,12 @@ describe('esql query helpers', () => {
     });
 
     it('should return the time field if there is at least one time param', () => {
-      expect(getTimeFieldFromESQLQuery('from a | eval b = 1 | where time >= ?start')).toBe('time');
+      expect(getTimeFieldFromESQLQuery('from a | eval b = 1 | where time >= ?t_start')).toBe(
+        'time'
+      );
     });
 
-    it('should return undefined if there is one named param but is not ?start or ?end', () => {
+    it('should return undefined if there is one named param but is not ?t_start or ?t_end', () => {
       expect(
         getTimeFieldFromESQLQuery('from a | eval b = 1 | where time >= ?late')
       ).toBeUndefined();
@@ -161,14 +163,14 @@ describe('esql query helpers', () => {
 
     it('should return undefined if there is one named param but is used without a time field', () => {
       expect(
-        getTimeFieldFromESQLQuery('from a | eval b = DATE_TRUNC(1 day, ?start)')
+        getTimeFieldFromESQLQuery('from a | eval b = DATE_TRUNC(1 day, ?t_start)')
       ).toBeUndefined();
     });
 
     it('should return the time field if there is at least one time param in the bucket function', () => {
       expect(
         getTimeFieldFromESQLQuery(
-          'from a | stats meow = avg(bytes) by bucket(event.timefield, 200, ?start, ?end)'
+          'from a | stats meow = avg(bytes) by bucket(event.timefield, 200, ?t_start, ?t_end)'
         )
       ).toBe('event.timefield');
     });

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -69,7 +69,9 @@ export const getTimeFieldFromESQLQuery = (esql: string) => {
   });
 
   const params = Walker.params(ast);
-  const timeNamedParam = params.find((param) => param.value === 'start' || param.value === 'end');
+  const timeNamedParam = params.find(
+    (param) => param.value === 't_start' || param.value === 't_end'
+  );
   if (!timeNamedParam || !functions.length) {
     return undefined;
   }

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -56,7 +56,7 @@ export function removeDropCommandsFromESQLQuery(esql?: string): string {
 }
 
 /**
- * When the ?start and ?end params are used, we want to retrieve the timefield from the query.
+ * When the ?t_start and ?t_end params are used, we want to retrieve the timefield from the query.
  * @param esql:string
  * @returns string
  */

--- a/packages/kbn-esql-utils/src/utils/run_query.test.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.test.ts
@@ -20,7 +20,7 @@ describe('getStartEndParams', () => {
     const query = 'FROM foo | where time > ?t_start';
     const params = getStartEndParams(query, time);
     expect(params).toHaveLength(1);
-    expect(params[0]).toHaveProperty('start');
+    expect(params[0]).toHaveProperty('t_start');
   });
 
   it('should return an array with the end param if exists at the query', () => {
@@ -28,7 +28,7 @@ describe('getStartEndParams', () => {
     const query = 'FROM foo | where time < ?t_end';
     const params = getStartEndParams(query, time);
     expect(params).toHaveLength(1);
-    expect(params[0]).toHaveProperty('end');
+    expect(params[0]).toHaveProperty('t_end');
   });
 
   it('should return an array with the end and start params if exist at the query', () => {
@@ -36,7 +36,7 @@ describe('getStartEndParams', () => {
     const query = 'FROM foo | where time < ?t_end amd time > ?t_start';
     const params = getStartEndParams(query, time);
     expect(params).toHaveLength(2);
-    expect(params[0]).toHaveProperty('start');
-    expect(params[1]).toHaveProperty('end');
+    expect(params[0]).toHaveProperty('t_start');
+    expect(params[1]).toHaveProperty('t_end');
   });
 });

--- a/packages/kbn-esql-utils/src/utils/run_query.test.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.test.ts
@@ -17,7 +17,7 @@ describe('getStartEndParams', () => {
 
   it('should return an array with the start param if exists at the query', () => {
     const time = { from: 'Jul 5, 2024 @ 08:03:56.849', to: 'Jul 5, 2024 @ 10:03:56.849' };
-    const query = 'FROM foo | where time > ?start';
+    const query = 'FROM foo | where time > ?t_start';
     const params = getStartEndParams(query, time);
     expect(params).toHaveLength(1);
     expect(params[0]).toHaveProperty('start');
@@ -25,7 +25,7 @@ describe('getStartEndParams', () => {
 
   it('should return an array with the end param if exists at the query', () => {
     const time = { from: 'Jul 5, 2024 @ 08:03:56.849', to: 'Jul 5, 2024 @ 10:03:56.849' };
-    const query = 'FROM foo | where time < ?end';
+    const query = 'FROM foo | where time < ?t_end';
     const params = getStartEndParams(query, time);
     expect(params).toHaveLength(1);
     expect(params[0]).toHaveProperty('end');
@@ -33,7 +33,7 @@ describe('getStartEndParams', () => {
 
   it('should return an array with the end and start params if exist at the query', () => {
     const time = { from: 'Jul 5, 2024 @ 08:03:56.849', to: 'Jul 5, 2024 @ 10:03:56.849' };
-    const query = 'FROM foo | where time < ?end amd time > ?start';
+    const query = 'FROM foo | where time < ?t_end amd time > ?t_start';
     const params = getStartEndParams(query, time);
     expect(params).toHaveLength(2);
     expect(params[0]).toHaveProperty('start');

--- a/packages/kbn-esql-utils/src/utils/run_query.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.ts
@@ -26,10 +26,10 @@ export const getStartEndParams = (query: string, time?: TimeRange) => {
     };
     const namedParams = [];
     if (timeParams?.start) {
-      namedParams.push({ start: timeParams.start });
+      namedParams.push({ t_start: timeParams.start });
     }
     if (timeParams?.end) {
-      namedParams.push({ end: timeParams.end });
+      namedParams.push({ t_end: timeParams.end });
     }
     return namedParams;
   }

--- a/packages/kbn-esql-utils/src/utils/run_query.ts
+++ b/packages/kbn-esql-utils/src/utils/run_query.ts
@@ -14,11 +14,11 @@ import { esFieldTypeToKibanaFieldType } from '@kbn/field-types';
 import type { ESQLColumn, ESQLSearchResponse, ESQLSearchParams } from '@kbn/es-types';
 import { lastValueFrom } from 'rxjs';
 
-export const hasStartEndParams = (query: string) => /\?start|\?end/i.test(query);
+export const hasStartEndParams = (query: string) => /\?t_start|\?t_end/i.test(query);
 
 export const getStartEndParams = (query: string, time?: TimeRange) => {
-  const startNamedParams = /\?start/i.test(query);
-  const endNamedParams = /\?end/i.test(query);
+  const startNamedParams = /\?t_start/i.test(query);
+  const endNamedParams = /\?t_end/i.test(query);
   if (time && (startNamedParams || endNamedParams)) {
     const timeParams = {
       start: startNamedParams ? dateMath.parse(time.from)?.toISOString() : undefined,

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -29,7 +29,7 @@ const allFunctions = statsAggregationFunctionDefinitions
   .concat(evalFunctionDefinitions)
   .concat(groupingFunctionDefinitions);
 
-export const TIME_SYSTEM_PARAMS = ['?start', '?end'];
+export const TIME_SYSTEM_PARAMS = ['?t_start', '?t_end'];
 
 export const TRIGGER_SUGGESTION_COMMAND = {
   title: 'Trigger Suggestion Dialog',

--- a/packages/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.params.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.params.test.ts
@@ -23,16 +23,16 @@ test('should allow param inside agg function argument', async () => {
 test('allow params in WHERE command expressions', async () => {
   const { validate } = await setup();
 
-  const res1 = await validate('FROM index | WHERE textField >= ?start');
+  const res1 = await validate('FROM index | WHERE textField >= ?t_start');
   const res2 = await validate(`
     FROM index
-      | WHERE textField >= ?start
+      | WHERE textField >= ?t_start
       | WHERE textField <= ?0
       | WHERE textField == ?
   `);
   const res3 = await validate(`
     FROM index
-      | WHERE textField >= ?start
+      | WHERE textField >= ?t_start
         AND textField <= ?0
         AND textField == ?
   `);

--- a/src/plugins/discover/public/application/main/state_management/utils/get_esql_data_view.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/utils/get_esql_data_view.test.ts
@@ -32,7 +32,7 @@ describe('getEsqlDataView', () => {
   });
 
   it('returns an adhoc dataview if it is adhoc with named params and query index pattern is the same as the dataview index pattern', async () => {
-    const query = { esql: 'from data-view-ad-hoc-title | where time >= ?start' };
+    const query = { esql: 'from data-view-ad-hoc-title | where time >= ?t_start' };
     const dataView = await getEsqlDataView(query, dataViewAdHocNoAtTimestamp, services);
     expect(dataView.timeFieldName).toBe('time');
   });

--- a/test/functional/apps/discover/esql/_esql_view.ts
+++ b/test/functional/apps/discover/esql/_esql_view.ts
@@ -113,11 +113,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(false);
       });
 
-      it('should render the histogram for indices with no @timestamp field when the ?start, ?end params are in the query', async function () {
+      it('should render the histogram for indices with no @timestamp field when the ?t_start, ?t_end params are in the query', async function () {
         await PageObjects.discover.selectTextBaseLang();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
-        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?start and timestamp <= ?end`;
+        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?t_start and timestamp <= ?t_end`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');

--- a/x-pack/plugins/lens/public/datasources/text_based/utils.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/utils.test.ts
@@ -291,7 +291,7 @@ describe('Text based languages utils', () => {
       const expressionsMock = expressionsPluginMock.createStartContract();
       const updatedState = await getStateFromAggregateQuery(
         state,
-        { esql: 'FROM my-fake-index-pattern | WHERE time <= ?end' },
+        { esql: 'FROM my-fake-index-pattern | WHERE time <= ?t_end' },
         {
           ...dataViewsMock,
           getIdsWithTitle: jest.fn().mockReturnValue(
@@ -361,7 +361,7 @@ describe('Text based languages utils', () => {
             errors: [],
             index: '4',
             query: {
-              esql: 'FROM my-fake-index-pattern | WHERE time <= ?end',
+              esql: 'FROM my-fake-index-pattern | WHERE time <= ?t_end',
             },
             timeField: 'time',
           },

--- a/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/esql/_esql_view.ts
@@ -114,11 +114,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(false);
       });
 
-      it('should render the histogram for indices with no @timestamp field when the ?start, ?end params are in the query', async function () {
+      it('should render the histogram for indices with no @timestamp field when the ?t_start, ?t_end params are in the query', async function () {
         await PageObjects.discover.selectTextBaseLang();
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
-        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?start and timestamp <= ?end`;
+        const testQuery = `from kibana_sample_data_flights | limit 10 | where timestamp >= ?t_start and timestamp <= ?t_end`;
 
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');


### PR DESCRIPTION
## Summary

Renames the variables from `?start` to `?t_start` and `?end` to `?t_end`

Naming is hard so bare with us 😅 (I think this will be the last change)
