### PR TITLE
[ResponseOps][Cases] Fix custom fields and push button flaky tests

### DIFF
--- a/x-pack/plugins/cases/public/components/custom_fields/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/index.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
@@ -17,8 +17,7 @@ import { MAX_CUSTOM_FIELDS_PER_CASE } from '../../../common/constants';
 import { CustomFields } from '.';
 import * as i18n from './translations';
 
-// FLAKY: https://github.com/elastic/kibana/issues/176805
-describe.skip('CustomFields', () => {
+describe('CustomFields', () => {
   let appMockRender: AppMockRenderer;
 
   const props = {
@@ -68,7 +67,9 @@ describe.skip('CustomFields', () => {
 
     userEvent.click(await screen.findByTestId('add-custom-field'));
 
-    expect(props.handleAddCustomField).toBeCalled();
+    await waitFor(() => {
+      expect(props.handleAddCustomField).toBeCalled();
+    });
   });
 
   it('calls handleEditCustomField on edit option click', async () => {
@@ -80,13 +81,9 @@ describe.skip('CustomFields', () => {
       await screen.findByTestId(`${customFieldsConfigurationMock[0].key}-custom-field-edit`)
     );
 
-    expect(props.handleEditCustomField).toBeCalledWith(customFieldsConfigurationMock[0].key);
-  });
-
-  it('shows the experimental badge', async () => {
-    appMockRender.render(<CustomFields {...props} />);
-
-    expect(await screen.findByTestId('case-experimental-badge')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(props.handleEditCustomField).toBeCalledWith(customFieldsConfigurationMock[0].key);
+    });
   });
 
   it('shows error when custom fields reaches the limit', async () => {

--- a/x-pack/plugins/cases/public/components/edit_connector/push_button.test.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/push_button.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { AppMockRenderer } from '../../common/mock';
@@ -36,39 +36,42 @@ describe('PushButton ', () => {
   it('renders the button without tooltip', async () => {
     appMockRender.render(<PushButton {...defaultProps} />);
 
-    expect(screen.getByTestId('push-to-external-service')).toBeInTheDocument();
+    expect(await screen.findByTestId('push-to-external-service')).toBeInTheDocument();
     expect(screen.queryByTestId('push-button-tooltip')).not.toBeInTheDocument();
   });
 
   it('renders the correct label when the connector has not been pushed', async () => {
     appMockRender.render(<PushButton {...defaultProps} />);
 
-    expect(screen.getByText('Push as My SN connector incident')).toBeInTheDocument();
+    expect(await screen.findByText('Push as My SN connector incident')).toBeInTheDocument();
   });
 
   it('renders the correct label when the connector has been pushed', async () => {
     appMockRender.render(<PushButton {...defaultProps} hasBeenPushed={true} />);
 
-    expect(screen.getByText('Update My SN connector incident')).toBeInTheDocument();
+    expect(await screen.findByText('Update My SN connector incident')).toBeInTheDocument();
   });
 
   it('pushed correctly', async () => {
     appMockRender.render(<PushButton {...defaultProps} />);
 
-    userEvent.click(screen.getByTestId('push-to-external-service'));
-    expect(pushToService).toHaveBeenCalled();
+    userEvent.click(await screen.findByTestId('push-to-external-service'));
+    
+    await waitFor(() => {
+      expect(pushToService).toHaveBeenCalled();
+    });
   });
 
   it('disables the button', async () => {
     appMockRender.render(<PushButton {...defaultProps} disabled={true} />);
 
-    expect(screen.getByTestId('push-to-external-service')).toBeDisabled();
+    expect(await screen.findByTestId('push-to-external-service')).toBeDisabled();
   });
 
   it('shows the tooltip context correctly', async () => {
     appMockRender.render(<PushButton {...defaultProps} showTooltip={true} />);
 
-    userEvent.hover(screen.getByTestId('push-to-external-service'));
+    userEvent.hover(await screen.findByTestId('push-to-external-service'));
 
     expect(await screen.findByText('My SN connector incident is up to date')).toBeInTheDocument();
     expect(await screen.findByText('No update is required')).toBeInTheDocument();
@@ -83,7 +86,7 @@ describe('PushButton ', () => {
       />
     );
 
-    userEvent.hover(screen.getByTestId('push-to-external-service'));
+    userEvent.hover(await screen.findByTestId('push-to-external-service'));
 
     expect(await screen.findByText('My title')).toBeInTheDocument();
     expect(await screen.findByText('My desc')).toBeInTheDocument();

--- a/x-pack/plugins/cases/public/components/edit_connector/push_button.test.tsx
+++ b/x-pack/plugins/cases/public/components/edit_connector/push_button.test.tsx
@@ -56,7 +56,7 @@ describe('PushButton ', () => {
     appMockRender.render(<PushButton {...defaultProps} />);
 
     userEvent.click(await screen.findByTestId('push-to-external-service'));
-    
+
     await waitFor(() => {
       expect(pushToService).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/176805

Updated `getBy` to `findBy` and added `await waitFor` for method calls.

Updated `push_button.test.tsx` as this [build fail](https://buildkite.com/elastic/kibana-on-merge/builds/42597#018e3daf-4e91-4e2e-8d51-83800ad109b1) had both tests failing in it.