### PR TITLE
[Managed content] Fix flaky tests

### DIFF
--- a/x-pack/test/functional/apps/managed_content/managed_content.ts
+++ b/x-pack/test/functional/apps/managed_content/managed_content.ts
@@ -26,8 +26,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const listingTable = getService('listingTable');
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/177551
-  describe.skip('Managed Content', () => {
+  describe('Managed Content', () => {
     before(async () => {
       esArchiver.load('x-pack/test/functional/es_archives/logstash_functional');
       kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/managed_content');
@@ -55,7 +54,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('lens', async () => {
         await PageObjects.common.navigateToActualUrl(
           'lens',
-          'edit/managed-36db-4a3b-a4ba-7a64ab8f130b'
+          '/edit/managed-36db-4a3b-a4ba-7a64ab8f130b'
         );
 
         await PageObjects.lens.waitForVisualization('xyVisChart');
@@ -64,7 +63,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await PageObjects.common.navigateToActualUrl(
           'lens',
-          'edit/unmanaged-36db-4a3b-a4ba-7a64ab8f130b'
+          '/edit/unmanaged-36db-4a3b-a4ba-7a64ab8f130b'
         );
 
         await PageObjects.lens.waitForVisualization('xyVisChart');
@@ -72,11 +71,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await expectManagedContentSignifiers(false, 'lnsApp_saveButton');
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/178920
-      it.skip('discover', async () => {
+      it('discover', async () => {
         await PageObjects.common.navigateToActualUrl(
           'discover',
-          'view/managed-3d62-4113-ac7c-de2e20a68fbc'
+          '/view/managed-3d62-4113-ac7c-de2e20a68fbc'
         );
         await PageObjects.discover.waitForDiscoverAppOnScreen();
 
@@ -84,7 +82,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await PageObjects.common.navigateToActualUrl(
           'discover',
-          'view/unmanaged-3d62-4113-ac7c-de2e20a68fbc'
+          '/view/unmanaged-3d62-4113-ac7c-de2e20a68fbc'
         );
         await PageObjects.discover.waitForDiscoverAppOnScreen();
 
@@ -94,7 +92,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('visualize', async () => {
         await PageObjects.common.navigateToActualUrl(
           'visualize',
-          'edit/managed-feb9-4ba6-9538-1b8f67fb4f57'
+          '/edit/managed-feb9-4ba6-9538-1b8f67fb4f57'
         );
         await PageObjects.visChart.waitForVisualization();
 
@@ -102,7 +100,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await PageObjects.common.navigateToActualUrl(
           'visualize',
-          'edit/unmanaged-feb9-4ba6-9538-1b8f67fb4f57'
+          '/edit/unmanaged-feb9-4ba6-9538-1b8f67fb4f57'
         );
         await PageObjects.visChart.waitForVisualization();
 
@@ -112,7 +110,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('maps', async () => {
         await PageObjects.common.navigateToActualUrl(
           'maps',
-          'map/managed-d7ab-46eb-a807-8fed28ed8566'
+          '/map/managed-d7ab-46eb-a807-8fed28ed8566'
         );
         await PageObjects.maps.waitForLayerAddPanelClosed();
 
@@ -120,7 +118,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await PageObjects.common.navigateToActualUrl(
           'maps',
-          'map/unmanaged-d7ab-46eb-a807-8fed28ed8566'
+          '/map/unmanaged-d7ab-46eb-a807-8fed28ed8566'
         );
         await PageObjects.maps.waitForLayerAddPanelClosed();
 
@@ -147,20 +145,17 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    describe('managed panels in dashboards', () => {
+    // unskip with https://github.com/elastic/kibana/issues/190138 fix
+    describe.skip('managed panels in dashboards', () => {
       it('inlines panels when managed dashboard cloned', async () => {
         await PageObjects.common.navigateToActualUrl(
           'dashboard',
-          'view/c44c86f9-b105-4a9c-9a24-449a58a827f3',
-          // for some reason the URL didn't always match the expected, so I turned off this check
-          // URL doesn't matter as long as we get the dashboard app
-          { ensureCurrentUrl: false }
+          '/view/c44c86f9-b105-4a9c-9a24-449a58a827f3'
         );
 
         await PageObjects.dashboard.waitForRenderComplete();
 
         await PageObjects.dashboard.duplicateDashboard();
-
         await PageObjects.dashboard.waitForRenderComplete();
 
         await testSubjects.missingOrFail('embeddablePanelNotification-ACTION_LIBRARY_NOTIFICATION');
@@ -177,7 +172,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           { name: 'Managed map', type: 'map' },
           { name: 'Managed saved search', type: 'search' },
         ]);
-
         await testSubjects.missingOrFail('embeddablePanelNotification-ACTION_LIBRARY_NOTIFICATION');
 
         await dashboardAddPanel.addEmbeddables([


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/178920 Fixes https://github.com/elastic/kibana/issues/178712 Fixes https://github.com/elastic/kibana/issues/177551

The flakiness was caused by the redirect that was unnecessary (from `#edit/managed-36db-4a3b-a4ba-7a64ab8f130b`  to `#/edit/managed-36db-4a3b-a4ba-7a64ab8f130b`- sometimes the url would be compared before, sometimes after the redirect. This change adds the '/' inside the path so no redirect is happening.



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->