### PR TITLE
[7.17] Fix unknown product test flaky behavior (#148616)

### DIFF
--- a/src/core/server/elasticsearch/integration_tests/client.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/client.test.ts
@@ -88,6 +88,10 @@ describe('fake elasticsearch', () => {
     const kibanaPreboot = await kibanaServer.preboot();
     kibanaHttpServer = kibanaPreboot.http.server.listener; // Mind that we are using the prebootServer at this point because the migration gets hanging, while waiting for ES to be correct
     await kibanaServer.setup();
+    // give kibanaServer's status Observables enough time to bootstrap
+    // and emit a status after the initial "unavailable: Waiting for Elasticsearch"
+    // see https://github.com/elastic/kibana/issues/129754
+    await new Promise((resolve) => setTimeout(resolve, 500));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix unknown product test flaky behavior (#148616)](https://github.com/elastic/kibana/pull/148616)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2023-01-11T14:20:37Z","message":"Fix unknown product test flaky behavior (#148616)\n\nFixes https://github.com/elastic/kibana/issues/129754\r\n\r\nThe failing integration test is querying the `/api/status` endpoint\r\nbefore Kibana and ES are completely initialized, and thus, it is getting\r\na _unavailable: Waiting for Elasticsearch_ instead of the expected\r\n_critical_.\r\n\r\nThe proposed fix consists in awaiting a few milliseconds, in order to\r\ngive the `debounceTime` operators enough time to propagate the right\r\nstatus.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9f39b785620fbc42e30aea774e875bb3048eb2ae","branchLabelMapping":{"^v8.7.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","test-failure-flaky","backport:skip","v8.7.0"],"number":148616,"url":"https://github.com/elastic/kibana/pull/148616","mergeCommit":{"message":"Fix unknown product test flaky behavior (#148616)\n\nFixes https://github.com/elastic/kibana/issues/129754\r\n\r\nThe failing integration test is querying the `/api/status` endpoint\r\nbefore Kibana and ES are completely initialized, and thus, it is getting\r\na _unavailable: Waiting for Elasticsearch_ instead of the expected\r\n_critical_.\r\n\r\nThe proposed fix consists in awaiting a few milliseconds, in order to\r\ngive the `debounceTime` operators enough time to propagate the right\r\nstatus.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9f39b785620fbc42e30aea774e875bb3048eb2ae"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.7.0","labelRegex":"^v8.7.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/148616","number":148616,"mergeCommit":{"message":"Fix unknown product test flaky behavior (#148616)\n\nFixes https://github.com/elastic/kibana/issues/129754\r\n\r\nThe failing integration test is querying the `/api/status` endpoint\r\nbefore Kibana and ES are completely initialized, and thus, it is getting\r\na _unavailable: Waiting for Elasticsearch_ instead of the expected\r\n_critical_.\r\n\r\nThe proposed fix consists in awaiting a few milliseconds, in order to\r\ngive the `debounceTime` operators enough time to propagate the right\r\nstatus.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9f39b785620fbc42e30aea774e875bb3048eb2ae"}}]}] BACKPORT-->