### PR TITLE
[FTR] Anonymous login

### DIFF
--- a/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
+++ b/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
@@ -133,11 +133,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       await PageObjects.security.loginSelector.login('anonymous', 'anonymous1');
 
-      await security.user.delete('anonymous_user');
-
       // We need to make sure that both path and hash are respected.
       const currentURL = parse(await browser.getCurrentUrl());
       expect(currentURL.pathname).to.eql('/app/management/security/users');
+
+      await security.user.delete('anonymous_user');
     });
 
     it('can login after `Unauthorized` error after request authentication preserving original URL', async () => {

--- a/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
+++ b/x-pack/test/security_functional/tests/login_selector/basic_functionality.ts
@@ -132,6 +132,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         full_name: 'Guest',
       });
       await PageObjects.security.loginSelector.login('anonymous', 'anonymous1');
+
       await security.user.delete('anonymous_user');
 
       // We need to make sure that both path and hash are respected.


### PR DESCRIPTION
## Summary

Moved `anonymous_user` deletion after the URL check. If we delete `anonymous_user` it automatically terminates the session which can lead to flakiness, since we performed URL check after user deletion.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

__Fixes: https://github.com/elastic/kibana/issues/111377__
