### PR TITLE
[CI] Archive kibana-fips-ftr-errors

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -19,12 +19,12 @@ spec:
       description: Run Kibana FIPS smoke tests
     spec:
       env:
-        SLACK_NOTIFICATIONS_CHANNEL: "#kibana-fips-ftr-errors"
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "true"
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       repository: elastic/kibana
       branch_configuration: main
       default_branch: main
-      pipeline_file: ".buildkite/pipelines/fips.yml"
+      pipeline_file: '.buildkite/pipelines/fips.yml'
       provider_settings:
         trigger_mode: none
       schedules:


### PR DESCRIPTION
## Summary

The [FIPS smoke test pipeline](https://buildkite.com/elastic/kibana-fips/builds?branch=main) has been stable, so we can move it back to `#kibana-operations-alerts` and archive the old, specific channel.