### PR TITLE
[7.17] Flaky #96947

### DIFF
--- a/test/functional/apps/saved_objects_management/edit_saved_object.ts
+++ b/test/functional/apps/saved_objects_management/edit_saved_object.ts
@@ -14,7 +14,7 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
-  const PageObjects = getPageObjects(['common', 'settings', 'savedObjects']);
+  const PageObjects = getPageObjects(['common', 'header', 'settings', 'savedObjects']);
   const browser = getService('browser');
   const find = getService('find');
 
@@ -55,6 +55,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await button.click();
     // Allow some time for the transition/animations to occur before assuming the click is done
     await delay(100);
+    await PageObjects.header.waitUntilLoadingHasFinished();
   };
 
   describe('saved objects edition page', () => {


### PR DESCRIPTION
## Summary

Resolves #96947

The screenshot shows the elements there, but the page is still loading and the test code might still have old data to compare:
![image](https://github.com/user-attachments/assets/5a52dba9-1f19-4994-a32c-6b0e2bdccbed)

Waiting for the loading spinner to disappear before moving on with the tests.

Flaky test runner: ✅ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6725

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
