### PR TITLE
[8.14] fix(console): parsing --euiFixedHeadersOffset when it is calc() (#184362)

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/_variables.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_variables.scss
@@ -2,4 +2,4 @@ $embeddableConsoleBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorI
 $embeddableConsoleText: lighten(makeHighContrastColor($euiColorLightestShade, $embeddableConsoleBackground), 20%);
 $embeddableConsoleBorderColor: transparentize($euiColorGhost, .8);
 $embeddableConsoleInitialHeight: $euiSizeXXL;
-$embeddableConsoleMaxHeight: calc(100vh - var(--euiFixedHeadersOffset, 0));
+$embeddableConsoleMaxHeight: calc(100vh - var(--euiFixedHeadersOffset, 0) - $euiSize);

--- a/src/plugins/console/public/application/containers/embeddable/console_resize_button.test.ts
+++ b/src/plugins/console/public/application/containers/embeddable/console_resize_button.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EuiThemeComputed } from '@elastic/eui';
+import { getCurrentConsoleMaxSize } from './console_resize_button';
+
+describe('Console Resizing Tests', () => {
+  describe('getCurrentConsoleMaxSize', () => {
+    let windowSpy: jest.SpyInstance;
+    let mockHeaderOffset: string;
+    const mockBodyStyle = {
+      getPropertyValue: jest.fn().mockImplementation(() => mockHeaderOffset),
+    };
+    let mockTheme: EuiThemeComputed<{}>;
+    beforeEach(() => {
+      mockTheme = {
+        size: {
+          base: '16px',
+        },
+      } as unknown as EuiThemeComputed<{}>;
+      mockHeaderOffset = '48px';
+      windowSpy = jest.spyOn(window, 'window', 'get');
+      windowSpy.mockImplementation(() => ({
+        getComputedStyle: jest.fn().mockReturnValue(mockBodyStyle),
+        innerHeight: 1000,
+      }));
+    });
+    afterEach(() => {
+      windowSpy.mockRestore();
+    });
+
+    it('computes max size with base size offset', () => {
+      expect(getCurrentConsoleMaxSize(mockTheme)).toBe(936);
+    });
+    it('can handle failing to parse base size', () => {
+      mockTheme = {
+        size: {
+          base: undefined,
+        },
+      } as unknown as EuiThemeComputed<{}>;
+      expect(getCurrentConsoleMaxSize(mockTheme)).toBe(936);
+    });
+    it('can handle failing to parse header offset', () => {
+      mockHeaderOffset = 'calc(32px + 48px)';
+      expect(getCurrentConsoleMaxSize(mockTheme)).toBe(984);
+    });
+  });
+});

--- a/src/plugins/console/public/application/containers/embeddable/console_resize_button.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_resize_button.tsx
@@ -26,11 +26,26 @@ export interface EmbeddedConsoleResizeButtonProps {
   setConsoleHeight: React.Dispatch<React.SetStateAction<number>>;
 }
 
+const parseOrDefaultValue = (value: string, defaultValue: number): number => {
+  try {
+    const result = parseInt(value, 10);
+    if (!isNaN(result) && result >= 0) {
+      return result;
+    }
+  } catch {
+    // ignore bad values
+  }
+  return defaultValue;
+};
+
 export function getCurrentConsoleMaxSize(euiTheme: EuiThemeComputed<{}>) {
-  const euiBaseSize = parseInt(euiTheme.size.base, 10);
+  const euiBaseSize = parseOrDefaultValue(euiTheme.size.base, 16);
   const winHeight = window.innerHeight;
-  const bodyStyle = getComputedStyle(document.body);
-  const headerOffset = parseInt(bodyStyle.getPropertyValue('--euiFixedHeadersOffset') ?? '0px', 10);
+  const bodyStyle = window.getComputedStyle(document.body);
+  const headerOffset = parseOrDefaultValue(
+    bodyStyle.getPropertyValue('--euiFixedHeadersOffset') ?? '0px',
+    0
+  );
 
   // We leave a buffer of baseSize to allow room for the user to hover on the top border for resizing
   return Math.max(winHeight - headerOffset - euiBaseSize, CONSOLE_MIN_HEIGHT);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [fix(console): parsing --euiFixedHeadersOffset when it is calc() (#184362)](https://github.com/elastic/kibana/pull/184362)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2024-05-28T17:47:07Z","message":"fix(console): parsing --euiFixedHeadersOffset when it is calc() (#184362)\n\n## Summary\r\n\r\nFix console bug where parsing the `--euiFixedHeadersOffset` results in\r\nsetting the open console height to `NaNpx`.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"38d5784008886ecc953ece84efec5cefb68ca6fd","branchLabelMapping":{"^v8.15.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","backport:skip","v8.15.0"],"number":184362,"url":"https://github.com/elastic/kibana/pull/184362","mergeCommit":{"message":"fix(console): parsing --euiFixedHeadersOffset when it is calc() (#184362)\n\n## Summary\r\n\r\nFix console bug where parsing the `--euiFixedHeadersOffset` results in\r\nsetting the open console height to `NaNpx`.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"38d5784008886ecc953ece84efec5cefb68ca6fd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.15.0","labelRegex":"^v8.15.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/184362","number":184362,"mergeCommit":{"message":"fix(console): parsing --euiFixedHeadersOffset when it is calc() (#184362)\n\n## Summary\r\n\r\nFix console bug where parsing the `--euiFixedHeadersOffset` results in\r\nsetting the open console height to `NaNpx`.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"38d5784008886ecc953ece84efec5cefb68ca6fd"}}]}] BACKPORT-->