### PR TITLE
add custom matcher for run.ts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -426,5 +426,18 @@
       "labels": ["release_note:skip", "backport:all-open", "Team:Visualizations"],
       "enabled": true
     }
+  ],
+  "customManagers": [
+    {
+      "description": "Update Wolfi base image",
+      "customType": "regex",
+      "fileMatch": [
+        "^src/dev/build/tasks/os_packages/docker_generator/run\\.ts$"
+      ],
+      "matchStrings": [
+        "docker\\.elastic\\.co/wolfi/chainguard-base:(?<currentValue>[-a-zA-Z0-9.]+)?(?:@(?<currentDigest>sha256:[a-fA-F0-9]+))?"
+      ],
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

A custom matcher for chainguard updates.

https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/run.ts#L46