### PR TITLE
Docs: fix relative link

### DIFF
--- a/x-pack/plugins/stack_alerts/README.md
+++ b/x-pack/plugins/stack_alerts/README.md
@@ -20,4 +20,4 @@ export interface IService {
 
 Each Stack RuleType is described in it's own README:
 
-- index threshold: [`server/alert_types/index_threshold`](server/alert_types/index_threshold/README.md)
+- index threshold: [`server/rule_types/index_threshold`](server/rule_types/index_threshold/README.md)


### PR DESCRIPTION
Fix relative link to `index_threshold` README.

The link in `main` is outdated. ATM, clicking the `server/alert_types/index_threshold` link yields an embarrassing 
![Screenshot 2024-08-08 at 13 38 39](https://github.com/user-attachments/assets/cfbd4b03-55cd-4aaa-a4ea-eecef4766c6a)

At some point the README changed location. This PR updates the location to `server/rule_types/index_threshold`

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was fixed
