### PR TITLE
[CI] Increase Sonarqube Memory

### DIFF
--- a/.buildkite/pipelines/sonarqube.yml
+++ b/.buildkite/pipelines/sonarqube.yml
@@ -2,8 +2,8 @@ env:
   SKIP_NODE_SETUP: true
 
 steps:
-  - label: ":sonarqube: Continuous Code Inspection"
+  - label: ':sonarqube: Continuous Code Inspection'
     agents:
       image: docker.elastic.co/cloud-ci/sonarqube/buildkite-scanner:latest
-      memory: 16G
+      memory: 32G
     command: /scan-source-code.sh


### PR DESCRIPTION
## Summary

https://buildkite.com/elastic/kibana-sonarqube/builds/3#01913147-34c2-45f5-adc8-8da7fd3e7235/6-16877

I think we can double the memory for now, then pull it back as needed since the logs have the memory usage as the scanner is running.
