### PR TITLE
[Flaky #190197] Find random **available** port

### DIFF
--- a/packages/core/http/core-http-server-internal/src/https_redirect_server.test.ts
+++ b/packages/core/http/core-http-server-internal/src/https_redirect_server.test.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import * as net from 'node:net';
+
 jest.mock('fs', () => ({
   readFileSync: jest.fn(),
 }));
@@ -28,14 +30,34 @@ function getServerListener(httpServer: HttpsRedirectServer) {
   return (httpServer as any).server.listener;
 }
 
-beforeEach(() => {
+async function getRandomAvailablePort(opts: Chance.Options): Promise<number> {
+  while (true) {
+    const candidatePort = chance.integer(opts);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const svr = net.createServer();
+        svr.once('error', reject);
+        svr.listen({ host: '127.0.0.1', port: candidatePort }, () => {
+          svr.close(() => {
+            resolve();
+          });
+        });
+      });
+      return candidatePort;
+    } catch (err) {
+      // just keep trying to find another port
+    }
+  }
+}
+
+beforeEach(async () => {
   config = {
     host: '127.0.0.1',
     maxPayload: new ByteSizeValue(1024),
-    port: chance.integer({ min: 10000, max: 15000 }),
+    port: await getRandomAvailablePort({ min: 10000, max: 15000 }),
     ssl: {
       enabled: true,
-      redirectHttpFromPort: chance.integer({ min: 20000, max: 30000 }),
+      redirectHttpFromPort: await getRandomAvailablePort({ min: 20000, max: 30000 }),
     },
     cors: {
       enabled: false,
@@ -55,7 +77,7 @@ test('throws if SSL is not enabled', async () => {
       ...config,
       ssl: {
         enabled: false,
-        redirectHttpFromPort: chance.integer({ min: 20000, max: 30000 }),
+        redirectHttpFromPort: await getRandomAvailablePort({ min: 20000, max: 30000 }),
       },
     } as HttpConfig)
   ).rejects.toMatchSnapshot();


### PR DESCRIPTION
## Summary

Resolves #190197 

The test is randomly selecting a port to test against. There could be a possibility in which the port is used by something else during the test. This PR adds a check to the random generator to validate that the port is actually available.

NOTE: Being a Jest test (no integration), it could happen that 2 tests run at the same time, against the same _validated_ port. Let's hope that the new additional free-port validation reduces this race condition even more.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
