### PR TITLE
[Embeddable Rebuild] Fix managed dashboards and panels

### DIFF
--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -375,7 +375,11 @@ export class DiscoverPlugin
         const services = await getDiscoverServicesInternal();
         const initialState = await deserializeState({
           serializedState: {
-            rawState: { savedObjectId: savedObject.id },
+            rawState: savedObject.managed
+              ? {
+                  attributes: { ...savedObject.attributes, references: savedObject.references },
+                }
+              : { savedObjectId: savedObject.id },
             references: savedObject.references,
           },
           discoverServices: services,

--- a/src/plugins/links/public/lib/deserialize_from_library.ts
+++ b/src/plugins/links/public/lib/deserialize_from_library.ts
@@ -31,8 +31,8 @@ export const deserializeLinksSavedObject = async (
   return {
     links,
     layout,
-    savedObjectId: linksSavedObject.id,
-    defaultPanelTitle,
-    defaultPanelDescription,
+    ...(linksSavedObject.managed
+      ? {}
+      : { savedObjectId: linksSavedObject.id, defaultPanelTitle, defaultPanelDescription }),
   };
 };

--- a/x-pack/plugins/maps/public/react_embeddable/setup_map_embeddable.ts
+++ b/x-pack/plugins/maps/public/react_embeddable/setup_map_embeddable.ts
@@ -26,7 +26,9 @@ export function setupMapEmbeddable(embeddableSetup: EmbeddableSetup) {
     onAdd: (container, savedObject) => {
       container.addNewPanel({
         panelType: MAP_SAVED_OBJECT_TYPE,
-        initialState: { savedObjectId: savedObject.id },
+        initialState: savedObject.managed
+          ? { attributes: savedObject.attributes }
+          : { savedObjectId: savedObject.id },
       });
     },
     embeddableType: MAP_SAVED_OBJECT_TYPE,

--- a/x-pack/test/functional/apps/managed_content/managed_content.ts
+++ b/x-pack/test/functional/apps/managed_content/managed_content.ts
@@ -145,8 +145,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
     });
 
-    // unskip with https://github.com/elastic/kibana/issues/190138 fix
-    describe.skip('managed panels in dashboards', () => {
+    describe('managed panels in dashboards', () => {
       it('inlines panels when managed dashboard cloned', async () => {
         await PageObjects.common.navigateToActualUrl(
           'dashboard',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/190138

## Summary

This PR fixes two bugs related to managed saved objects that were introduced in the embeddable rebuild:
1. Previously, when managed dashboards  were duplicated, they were still referencing the original saved objects for **all** React embeddables (legacy embeddables were handled properly) - this allowed users to modify managed panels. Now, on duplicate of a managed dashboard, **all** panels, both React and legacy, are cloned by value.
2. When adding managed React embeddables from the library via the "Add from library" flyout, once again, we were adding a panel with the original SO reference - instead, we should always add managed panels by value, and this PR accomplishes that by adding the appropriate `managed` logic to each React embeddable. Unfortunately, because each embeddable handles their `onAdd` a bit differently, it was decided to just add the logic to each embeddable rather than making a more generic fix.

### How to Test:

Here's some sample saved objects:

- **Sample Managed Dashboard** (includes by-reference maps + saved search, from https://github.com/elastic/kibana/pull/176006):
  ```
  {"attributes":{"allowHidden":false,"fieldAttrs":"{}","fieldFormatMap":"{}","fields":"[]","name":"logstash-*","runtimeFieldMap":"{}","sourceFilters":"[]","timeFieldName":"@timestamp","title":"logstash-*"},"coreMigrationVersion":"8.8.0","created_at":"2024-02-01T22:06:58.824Z","id":"5f863f70-4728-4e8d-b441-db08f8c33b28","managed":false,"references":[],"type":"index-pattern","typeMigrationVersion":"8.0.0","updated_at":"2024-02-01T22:06:58.824Z","version":"WzQxNCwxXQ=="}
  {"attributes":{"description":"","kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"},"title":"Managed legacy visualization","uiStateJSON":"{}","version":1,"visState":"{\"title\":\"Legacy visualization\",\"type\":\"metrics\",\"aggs\":[],\"params\":{\"id\":\"1a14d0ad-0d74-4470-a189-8f040cddc1a1\",\"type\":\"timeseries\",\"series\":[{\"id\":\"daa8bbf7-86cc-4394-b249-be48da9f7351\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"palette\":{\"type\":\"palette\",\"name\":\"default\"},\"metrics\":[{\"id\":\"795375d9-1aa6-454d-9b23-687e69f3382c\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"default\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"override_index_pattern\":0,\"series_drop_last_bucket\":0}],\"time_field\":\"\",\"use_kibana_indexes\":true,\"interval\":\"\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"truncate_legend\":1,\"max_lines_legend\":1,\"show_grid\":1,\"tooltip_mode\":\"show_all\",\"drop_last_bucket\":0,\"index_pattern_ref_name\":\"metrics_0_index_pattern\"}}"},"coreMigrationVersion":"8.8.0","created_at":"2024-02-01T22:06:58.824Z","id":"managed-feb9-4ba6-9538-1b8f67fb4f57","managed":true,"references":[{"id":"5f863f70-4728-4e8d-b441-db08f8c33b28","name":"metrics_0_index_pattern","type":"index-pattern"}],"type":"visualization","typeMigrationVersion":"8.5.0","updated_at":"2024-02-01T22:06:58.824Z","version":"WzQxOSwxXQ=="}
  {"attributes":{"description":"","state":{"adHocDataViews":{},"datasourceStates":{"formBased":{"layers":{"e633b1af-3ab4-4bf5-8faa-fefde06c4a4a":{"columnOrder":["f2555a1a-6f93-43fd-bc63-acdfadd47729","d229daf9-9658-4579-99af-01d8adb2f25f"],"columns":{"d229daf9-9658-4579-99af-01d8adb2f25f":{"dataType":"number","isBucketed":false,"label":"Median of bytes","operationType":"median","params":{"emptyAsNull":true},"scale":"ratio","sourceField":"bytes"},"f2555a1a-6f93-43fd-bc63-acdfadd47729":{"dataType":"date","isBucketed":true,"label":"@timestamp","operationType":"date_histogram","params":{"dropPartials":false,"includeEmptyRows":true,"interval":"auto"},"scale":"interval","sourceField":"@timestamp"}},"incompleteColumns":{},"sampling":1}}},"indexpattern":{"layers":{}},"textBased":{"layers":{}}},"filters":[],"internalReferences":[],"query":{"language":"kuery","query":""},"visualization":{"axisTitlesVisibilitySettings":{"x":true,"yLeft":true,"yRight":true},"fittingFunction":"None","gridlinesVisibilitySettings":{"x":true,"yLeft":true,"yRight":true},"labelsOrientation":{"x":0,"yLeft":0,"yRight":0},"layers":[{"accessors":["d229daf9-9658-4579-99af-01d8adb2f25f"],"layerId":"e633b1af-3ab4-4bf5-8faa-fefde06c4a4a","layerType":"data","position":"top","seriesType":"bar_stacked","showGridlines":false,"xAccessor":"f2555a1a-6f93-43fd-bc63-acdfadd47729"}],"legend":{"isVisible":true,"position":"right"},"preferredSeriesType":"bar_stacked","tickLabelsVisibilitySettings":{"x":true,"yLeft":true,"yRight":true},"valueLabels":"hide"}},"title":"Managed lens vis","visualizationType":"lnsXY"},"coreMigrationVersion":"8.8.0","created_at":"2024-02-01T22:06:58.824Z","id":"managed-36db-4a3b-a4ba-7a64ab8f130b","managed":true,"references":[{"id":"5f863f70-4728-4e8d-b441-db08f8c33b28","name":"indexpattern-datasource-layer-e633b1af-3ab4-4bf5-8faa-fefde06c4a4a","type":"index-pattern"}],"type":"lens","typeMigrationVersion":"8.9.0","updated_at":"2024-02-01T22:06:58.824Z","version":"WzQxNSwxXQ=="}
  {"attributes":{"description":"","layerListJSON":"[{\"locale\":\"autoselect\",\"sourceDescriptor\":{\"type\":\"EMS_TMS\",\"isAutoSelect\":true,\"lightModeDefault\":\"road_map_desaturated\"},\"id\":\"5ff9c98e-e0d3-4aff-ac98-b33c191496b4\",\"label\":null,\"minZoom\":0,\"maxZoom\":24,\"alpha\":1,\"visible\":true,\"style\":{\"type\":\"EMS_VECTOR_TILE\",\"color\":\"\"},\"includeInFitToBounds\":true,\"type\":\"EMS_VECTOR_TILE\"}]","mapStateJSON":"{\"adHocDataViews\":[],\"zoom\":1.4,\"center\":{\"lon\":0,\"lat\":19.94277},\"timeFilters\":{\"from\":\"now-15m\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":true,\"interval\":60000},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"customIcons\":[],\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"keydownScrollZoom\":false,\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"showTimesliderToggleButton\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}","title":"Managed map","uiStateJSON":"{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"},"coreMigrationVersion":"8.8.0","created_at":"2024-02-01T22:06:58.824Z","id":"managed-d7ab-46eb-a807-8fed28ed8566","managed":true,"references":[],"type":"map","typeMigrationVersion":"8.4.0","updated_at":"2024-02-01T22:06:58.824Z","version":"WzQyMSwxXQ=="}
  {"attributes":{"columns":["@tags","clientip"],"description":"","grid":{},"hideChart":false,"isTextBasedQuery":false,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"agent.raw:\\\"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)\\\" \",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"},"sort":[["@timestamp","desc"]],"timeRestore":false,"title":"Managed saved search","usesAdHocDataView":false},"coreMigrationVersion":"8.8.0","created_at":"2024-02-01T22:06:58.824Z","id":"managed-3d62-4113-ac7c-de2e20a68fbc","managed":true,"references":[{"id":"5f863f70-4728-4e8d-b441-db08f8c33b28","name":"kibanaSavedObjectMeta.searchSourceJSON.index","type":"index-pattern"}],"type":"search","typeMigrationVersion":"8.0.0","updated_at":"2024-02-01T22:06:58.824Z","version":"WzQxNywxXQ=="}
  {"attributes":{"description":"","kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"},"optionsJSON":"{\"useMargins\":true,\"syncColors\":false,\"syncCursor\":true,\"syncTooltips\":false,\"hidePanelTitles\":false}","panelsJSON":"[{\"type\":\"visualization\",\"gridData\":{\"x\":0,\"y\":0,\"w\":24,\"h\":15,\"i\":\"536c52e4-ecf1-4cde-9323-cc1c3de1fdd2\"},\"panelIndex\":\"536c52e4-ecf1-4cde-9323-cc1c3de1fdd2\",\"embeddableConfig\":{\"enhancements\":{}},\"panelRefName\":\"panel_536c52e4-ecf1-4cde-9323-cc1c3de1fdd2\"},{\"type\":\"lens\",\"gridData\":{\"x\":24,\"y\":0,\"w\":24,\"h\":15,\"i\":\"f19bd0df-03e7-4181-9adf-e3b3b4c97e19\"},\"panelIndex\":\"f19bd0df-03e7-4181-9adf-e3b3b4c97e19\",\"embeddableConfig\":{\"enhancements\":{}},\"panelRefName\":\"panel_f19bd0df-03e7-4181-9adf-e3b3b4c97e19\"},{\"type\":\"map\",\"gridData\":{\"x\":0,\"y\":15,\"w\":24,\"h\":15,\"i\":\"26f25c71-2b7c-4540-8c1c-c003b5657978\"},\"panelIndex\":\"26f25c71-2b7c-4540-8c1c-c003b5657978\",\"embeddableConfig\":{\"mapCenter\":{\"lat\":19.94277,\"lon\":0,\"zoom\":1.4},\"mapBuffer\":{\"minLon\":-180,\"minLat\":-66.51326,\"maxLon\":180,\"maxLat\":66.51326},\"isLayerTOCOpen\":true,\"openTOCDetails\":[],\"hiddenLayers\":[],\"enhancements\":{}},\"panelRefName\":\"panel_26f25c71-2b7c-4540-8c1c-c003b5657978\"},{\"type\":\"search\",\"gridData\":{\"x\":24,\"y\":15,\"w\":24,\"h\":15,\"i\":\"d7e33257-de57-40cb-9171-3dd739dd1875\"},\"panelIndex\":\"d7e33257-de57-40cb-9171-3dd739dd1875\",\"embeddableConfig\":{\"enhancements\":{}},\"panelRefName\":\"panel_d7e33257-de57-40cb-9171-3dd739dd1875\"}]","timeRestore":false,"title":"Managed dashboard with by-ref panels","version":1},"coreMigrationVersion":"8.8.0","created_at":"2024-02-01T22:06:58.824Z","id":"c44c86f9-b105-4a9c-9a24-449a58a827f3","managed":true,"references":[{"id":"managed-feb9-4ba6-9538-1b8f67fb4f57","name":"536c52e4-ecf1-4cde-9323-cc1c3de1fdd2:panel_536c52e4-ecf1-4cde-9323-cc1c3de1fdd2","type":"visualization"},{"id":"managed-36db-4a3b-a4ba-7a64ab8f130b","name":"f19bd0df-03e7-4181-9adf-e3b3b4c97e19:panel_f19bd0df-03e7-4181-9adf-e3b3b4c97e19","type":"lens"},{"id":"managed-d7ab-46eb-a807-8fed28ed8566","name":"26f25c71-2b7c-4540-8c1c-c003b5657978:panel_26f25c71-2b7c-4540-8c1c-c003b5657978","type":"map"},{"id":"managed-3d62-4113-ac7c-de2e20a68fbc","name":"d7e33257-de57-40cb-9171-3dd739dd1875:panel_d7e33257-de57-40cb-9171-3dd739dd1875","type":"search"}],"type":"dashboard","typeMigrationVersion":"8.9.0","updated_at":"2024-02-01T22:06:58.824Z","version":"WzQyMywxXQ=="}
  {"excludedObjects":[],"excludedObjectsCount":0,"exportedCount":6,"missingRefCount":0,"missingReferences":[]}
  ```

   When duplicating the above managed dashboard, all by-reference panels should be cloned **by value**. This dashboard also includes references to managed Maps and Saved Search saved objects, so you should double check that adding these panels to a dashboard via the "Add from library" panel **also** adds them by-value.

- **Sample Managed Links** (does not include related dashboard saved objects - links may be broken)

  ```
  {"attributes":{"description":"","layout":"vertical","links":[{"destinationRefName":"link_f199a328-3727-4305-845e-b1d6173c226e_dashboard","id":"f199a328-3727-4305-845e-b1d6173c226e","order":0,"type":"dashboardLink"},{"destinationRefName":"link_07768a9c-84de-4e19-8beb-1b33f6402fe1_dashboard","id":"07768a9c-84de-4e19-8beb-1b33f6402fe1","order":1,"type":"dashboardLink"}],"title":"Managed links"},"coreMigrationVersion":"8.8.0","created_at":"2024-08-12T20:32:29.893Z","created_by":"u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0","id":"2234c78d-04c1-4506-91bd-9b832413ee0f","managed":true,"references":[{"id":"0f7c088d-6844-4605-a132-fe2553044b09","name":"link_f199a328-3727-4305-845e-b1d6173c226e_dashboard","type":"dashboard"},{"id":"722b74f0-b882-11e8-a6d9-e546fe2bba5f","name":"link_07768a9c-84de-4e19-8beb-1b33f6402fe1_dashboard","type":"dashboard"}],"type":"links","updated_at":"2024-08-12T20:32:29.893Z","updated_by":"u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0","version":"Wzg0NiwxXQ=="}
  {"excludedObjects":[],"excludedObjectsCount":0,"exportedCount":1,"missingRefCount":0,"missingReferences":[]}
  ```

   When adding the above links panel via the "Add from library" flyout, it should add that panel **by-value** with no reference to the original SO.

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
