### PR TITLE
[ES|QL] Hides the METRICS command

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -116,7 +116,8 @@ describe('autocomplete', () => {
     },
   });
 
-  const sourceCommands = ['row', 'from', 'show', 'metrics'];
+  // const sourceCommands = ['row', 'from', 'show', 'metrics']; Uncomment when metrics is being released
+  const sourceCommands = ['row', 'from', 'show'];
 
   describe('New command', () => {
     testSuggestions(
@@ -1278,7 +1279,7 @@ describe('autocomplete', () => {
     // Source command
     testSuggestions(
       'F',
-      ['FROM $0', 'ROW $0', 'SHOW $0', 'METRICS $0'].map(attachTriggerCommand).map(attachAsSnippet),
+      ['FROM $0', 'ROW $0', 'SHOW $0'].map(attachTriggerCommand).map(attachAsSnippet),
       undefined,
       1
     );

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -192,6 +192,7 @@ export const commandDefinitions: CommandDefinition[] = [
   },
   {
     name: 'metrics',
+    hidden: true,
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.metricsDoc', {
       defaultMessage:
         'A metrics-specific source command, use this command to load data from TSDB indices. ' +


### PR DESCRIPTION
## Summary

Thanks to the hidden property added [here](https://github.com/elastic/kibana/pull/189827) we can now hide the METRICS command.
