### PR TITLE
[Lens] Fine grained telemetry for Kibana server

### DIFF
--- a/packages/kbn-search-types/src/kibana_search_types.ts
+++ b/packages/kbn-search-types/src/kibana_search_types.ts
@@ -68,4 +68,14 @@ export interface IKibanaSearchResponse<RawResponse = any> {
    * HTTP request parameters from elasticsearch transport client t
    */
   requestParams?: SanitizedConnectionRequestParams;
+
+  /**
+   * The time in milliseconds it took to execute the request
+   */
+  esTiming?: number;
+
+  /**
+   * The time in milliseconds it took to parse the request
+   */
+  serializeTiming?: number;
 }

--- a/src/plugins/data/server/search/strategies/ese_search/response_utils.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/response_utils.ts
@@ -35,13 +35,16 @@ export function toAsyncKibanaSearchStatusResponse(
 export function toAsyncKibanaSearchResponse(
   response: AsyncSearchResponse,
   warning?: string,
-  requestParams?: ConnectionRequestParams
+  requestParams?: ConnectionRequestParams,
+  responseTimings?: { networkTime?: number; serializeTime?: number }
 ): IKibanaSearchResponse {
   return {
     id: response.id,
     rawResponse: response.response,
     isPartial: response.is_partial,
     isRunning: response.is_running,
+    esTiming: responseTimings?.networkTime,
+    serializeTiming: responseTimings?.serializeTime,
     ...(warning ? { warning } : {}),
     ...(requestParams ? { requestParams: sanitizeRequestParams(requestParams) } : {}),
     ...getTotalLoaded(response.response),

--- a/src/plugins/data/server/search/types.ts
+++ b/src/plugins/data/server/search/types.ts
@@ -36,6 +36,13 @@ export interface SearchStrategyDependencies {
   searchSessionsClient: IScopedSearchSessionsClient;
   request: KibanaRequest;
   rollupsEnabled?: boolean;
+  diagnostics: {
+    registerRequestId: (esId: string, rawId: string) => void;
+    getTimings: (esId: string) => {
+      networkTime: number | undefined;
+      serializeTime: number | undefined;
+    };
+  };
 }
 
 export interface ISearchSetup {

--- a/src/plugins/inspector/common/adapters/request/request_responder.ts
+++ b/src/plugins/inspector/common/adapters/request/request_responder.ts
@@ -53,6 +53,12 @@ export class RequestResponder {
 
   public finish(status: RequestStatus, response: Response): void {
     this.request.time = response.time ?? Date.now() - this.request.startTime;
+    if (response.json?.esTiming != null) {
+      this.request.esTime = response.json?.esTiming;
+    }
+    if (response.json?.serializeTiming != null) {
+      this.request.serializeTime = response.json?.serializeTiming;
+    }
     this.request.status = status;
     this.request.response = moveRequestParamsToTopLevel(response);
     this.onChange();

--- a/src/plugins/inspector/common/adapters/request/types.ts
+++ b/src/plugins/inspector/common/adapters/request/types.ts
@@ -35,6 +35,8 @@ export interface Request extends RequestParams {
   stats?: RequestStatistics;
   status: RequestStatus;
   time?: number;
+  esTime?: number;
+  serializeTime?: number;
 }
 
 export interface RequestParams {


### PR DESCRIPTION
## Summary

This is a PoC for #189396

The implementation is still rough and leverages all the esClient events described in https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/observability.html

The new telemetry would be able to breakdown the `time2data` into new fine grained categories:
* Total time 2 data (includes all ES time, network and all kibana overhead)
* ES time: timings as reported by `response.took`
* ES network time: time spent on network between Kibana server and ES server
* Kibana serialization time: time spend on the kibana server to deserialize the response

The example Telemetry JSON is here:
```json
{
    "eventName": "lensVisualizationRenderTime",
    "duration": 840.5999999046326,
    "key1": "time_to_data",
    "value1": 514.0999999046326,
    "key2": "time_to_render",
    "value2": 313.5,
    "key3": "es_time",
    "value3": 13,
    "key4": "es_network_time",
    "value4": 163,
    "key5": "kibana_serialize_time",
    "value5": 1
}
```