### PR TITLE
[managed content] unskip for maps managed content

### DIFF
--- a/x-pack/test/functional/apps/managed_content/managed_content.ts
+++ b/x-pack/test/functional/apps/managed_content/managed_content.ts
@@ -110,7 +110,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('maps', async () => {
         await PageObjects.common.navigateToActualUrl(
           'maps',
-          '/map/managed-d7ab-46eb-a807-8fed28ed8566'
+          'map/managed-d7ab-46eb-a807-8fed28ed8566'
         );
         await PageObjects.maps.waitForLayerAddPanelClosed();
 
@@ -118,7 +118,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await PageObjects.common.navigateToActualUrl(
           'maps',
-          '/map/unmanaged-d7ab-46eb-a807-8fed28ed8566'
+          'map/unmanaged-d7ab-46eb-a807-8fed28ed8566'
         );
         await PageObjects.maps.waitForLayerAddPanelClosed();
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/190227
One more test that broke when unskipping other ones



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->