### PR TITLE
[Discover] Fix styles in grid toolbar

### DIFF
--- a/packages/kbn-unified-data-table/src/components/custom_toolbar/render_custom_toolbar.scss
+++ b/packages/kbn-unified-data-table/src/components/custom_toolbar/render_custom_toolbar.scss
@@ -55,11 +55,11 @@
       animation: none !important;
       transform: none !important;
     }
+  }
 
-    .unifiedDataTableToolbarControlIconButton + & {
-      border-inline-start: $euiBorderThin;
-      border-radius: 0;
-    }
+  .unifiedDataTableToolbarControlIconButton + .unifiedDataTableToolbarControlIconButton {
+    border-inline-start: $euiBorderThin;
+    border-radius: 0;
   }
 
   .unifiedDataTableToolbarBottom {


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/190247

## Summary

This PR restores vertical borders between the toolbar icon buttons.

<img width="538" alt="Screenshot 2024-08-09 at 18 00 26" src="https://github.com/user-attachments/assets/3c383209-6557-4e58-b03a-ed76f5ab1015">
