### PR TITLE
Feat/renovate custom chainguard matcher pt2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -440,7 +440,7 @@
       "description": "Update Wolfi base image",
       "customType": "regex",
       "fileMatch": [
-        "^src/dev/build/tasks/os_packages/docker_generator/run\\.ts$"
+        "\\.ts$"
       ],
       "matchStrings": [
         "docker\\.elastic\\.co/wolfi/chainguard-base:(?<currentValue>[-a-zA-Z0-9.]+)?(?:@(?<currentDigest>sha256:[a-fA-F0-9]+))?"

--- a/renovate.json
+++ b/renovate.json
@@ -446,7 +446,7 @@
       "description": "Update Wolfi base image",
       "customType": "regex",
       "fileMatch": [
-        "\\.ts$"
+        "^src/dev/build/tasks/os_packages/docker_generator/run\\.ts$"
       ],
       "matchStrings": [
         "docker\\.elastic\\.co/wolfi/chainguard-base:(?<currentValue>[-a-zA-Z0-9.]+)?(?:@(?<currentDigest>sha256:[a-fA-F0-9]+))?"

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,12 @@
       "enabled": false
     },
     {
+      "matchPackageNames": [
+        "docker.elastic.co/wolfi/chainguard-base"
+      ],
+      "enabled": true
+    },
+    {
       "groupName": "GitHub actions",
       "matchManagers": ["github-actions"],
       "reviewers": ["team:kibana-operations"],

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -43,10 +43,9 @@ export async function runDockerGenerator(
   if (flags.baseImage === 'ubuntu') baseImageName = 'ubuntu:20.04';
   if (flags.baseImage === 'ubi') baseImageName = 'docker.elastic.co/ubi9/ubi-minimal:latest';
   /**
-   * Renovate config contains a regex manager to automatically update any references to the Chainguard images within
-   * any .ts files.
+   * Renovate config contains a regex manager to automatically updates this Chainguard reference
    *
-   * If this logic moves to file with an ending for anything other than .ts, then the Renovate regex manager
+   * If this logic moves to another file or under another name, then the Renovate regex manager
    * for automatic Chainguard updates will break.
    */
   if (flags.baseImage === 'wolfi')

--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -42,6 +42,13 @@ export async function runDockerGenerator(
   let baseImageName = '';
   if (flags.baseImage === 'ubuntu') baseImageName = 'ubuntu:20.04';
   if (flags.baseImage === 'ubi') baseImageName = 'docker.elastic.co/ubi9/ubi-minimal:latest';
+  /**
+   * Renovate config contains a regex manager to automatically update any references to the Chainguard images within
+   * any .ts files.
+   *
+   * If this logic moves to file with an ending for anything other than .ts, then the Renovate regex manager
+   * for automatic Chainguard updates will break.
+   */
   if (flags.baseImage === 'wolfi')
     baseImageName =
       'docker.elastic.co/wolfi/chainguard-base:latest@sha256:082266206be6e559baea1c8b2eeb4fb86ea1318a0cf99cbf0e612dd2c611e80b';


### PR DESCRIPTION
## Summary

Drops a comment for the current chaingaurd reference incase it is implemented in a tech that requires endings other than `.ts`, and then creates a PR grouping for the chainguard images.
