### PR TITLE
[optimizer] Mute SASS mixed-decls warnings

### DIFF
--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -217,9 +217,12 @@ export function getWebpackConfig(
                           // Muted - see https://github.com/elastic/kibana/issues/190345 for tracking remediation
                           if (warning?.deprecationType?.id === 'mixed-decls') return;
 
-                          if (warning.deprecation) return process.stderr.write(`DEPRECATION WARNING: ${message}\n${warning.stack}`);
+                          if (warning.deprecation)
+                            return process.stderr.write(
+                              `DEPRECATION WARNING: ${message}\n${warning.stack}`
+                            );
                           process.stderr.write('WARNING: ' + message);
-                        }
+                        },
                       },
                     },
                   },

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -212,6 +212,15 @@ export function getWebpackConfig(
                       includePaths: [Path.resolve(worker.repoRoot, 'node_modules')],
                       sourceMap: true,
                       quietDeps: true,
+                      logger: {
+                        warn: (message: string, warning: any) => {
+                          // Muted - see https://github.com/elastic/kibana/issues/190345 for tracking remediation
+                          if (warning?.deprecationType?.id === 'mixed-decls') return;
+
+                          if (warning.deprecation) return process.stderr.write(`DEPRECATION WARNING: ${message}\n${warning.stack}`);
+                          process.stderr.write('WARNING: ' + message);
+                        }
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
These are impacting DX.  Remediation will be tracked at https://github.com/elastic/kibana/issues/190345.

## Testing

`node scripts/build_kibana_platform_plugins` and `yarn start` should not log warnings about the `mixed-decls` sass rule
