### PR TITLE
[sonar scan] Scan public directories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -38,7 +38,7 @@ sonar.exclusions=\
   **/mock_responses/**/*, \
   **/mocks/**/*, \
   **/node_modules/**/*, \
-  **/public/**/*, \
+  **/target/**/*, \
   **/scripts/**/*, \
   **/storybook/**/*, \
   **/stubs.ts, \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -39,7 +39,6 @@ sonar.exclusions=\
   **/mocks/**/*, \
   **/node_modules/**/*, \
   **/target/**/*, \
-  **/scripts/**/*, \
   **/storybook/**/*, \
   **/stubs.ts, \
   **/test/**/*, \
@@ -47,6 +46,9 @@ sonar.exclusions=\
   **/test_mocks.ts, \
   **/test_resources/**/*, \
   **/tests/**/*, \
-  src/dev/**/*
+  src/dev/**/*, \
+  x-pack/plugins/*/scripts, \
+  src/plugins/*/scripts, \
+  packages/*/scripts,
 
 sonar.javascript.node.maxspace=8192

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -47,8 +47,8 @@ sonar.exclusions=\
   **/test_resources/**/*, \
   **/tests/**/*, \
   src/dev/**/*, \
-  x-pack/plugins/*/scripts, \
-  src/plugins/*/scripts, \
-  packages/*/scripts,
+  x-pack/plugins/*/scripts/**/*, \
+  src/plugins/*/scripts/**/*, \
+  packages/*/scripts/**/*,
 
 sonar.javascript.node.maxspace=8192


### PR DESCRIPTION
legrego helpfully pointed out that these files should be scanned - they include client side code.  The replaces the exclusion of `public` with `target`, the compiled version of this source.