### PR TITLE
[Search] [Playground] Fix Stream Buffer issue 

### DIFF
--- a/x-pack/plugins/search_playground/server/utils/stream_factory.ts
+++ b/x-pack/plugins/search_playground/server/utils/stream_factory.ts
@@ -10,10 +10,9 @@
 // - removed support for ndjson
 // - improved the cloud proxy buffer to work for our use case (works for newline string chunks vs ndjson only)
 
-import type { Logger } from '@kbn/core/server';
-
 import { PassThrough } from 'stream';
 
+import type { Logger } from '@kbn/logging';
 import type { ResponseHeaders } from '@kbn/core-http-server';
 import { repeat } from 'lodash';
 
@@ -28,21 +27,28 @@ export interface StreamResponseWithHeaders {
 export interface StreamFactoryReturnType {
   DELIMITER: string;
   end: () => void;
-  push: (d: string) => void;
+  push: (d: string, drain?: boolean) => void;
   responseWithHeaders: StreamResponseWithHeaders;
 }
 
-export function streamFactory(logger: Logger, flushFix: boolean = true): StreamFactoryReturnType {
+/**
+ * Sets up a response stream with support for gzip compression depending on provided
+ * request headers. Any non-string data pushed to the stream will be streamed as NDJSON.
+ *
+ * @param logger - Kibana logger.
+ * @param isCloud - Adds an attribute with a random string payload to overcome buffer flushing with certain proxy configurations.
+ *
+ * @returns An object with stream attributes and methods.
+ */
+export function streamFactory(logger: Logger, isCloud: boolean = false): StreamFactoryReturnType {
+  const stream = new PassThrough();
+
   const cloudProxyBufferSize = 4096;
 
-  const flushPayload = flushFix
+  const flushPayload = isCloud
     ? DELIMITER + '10: "' + repeat('0', cloudProxyBufferSize * 2) + '"' + DELIMITER
     : undefined;
   let currentBufferSize = 0;
-
-  const stream = new PassThrough();
-  const backPressureBuffer: string[] = [];
-  let tryToEnd = false;
 
   const flushBufferIfNeeded = () => {
     if (currentBufferSize && currentBufferSize <= cloudProxyBufferSize) {
@@ -53,50 +59,110 @@ export function streamFactory(logger: Logger, flushFix: boolean = true): StreamF
 
   const flushIntervalId = setInterval(flushBufferIfNeeded, 250);
 
+  // If waiting for draining of the stream, items will be added to this buffer.
+  const backPressureBuffer: string[] = [];
+
+  // Flag will be set when the "drain" listener is active so we can avoid setting multiple listeners.
+  let waitForDrain = false;
+
+  // Instead of a flag this is an array where we check if we are waiting on any callback from writing to the stream.
+  // It needs to be an array to avoid running into race conditions.
+  const waitForCallbacks: number[] = [];
+
+  // Flag to set if the stream should be ended. Because there could be items in the backpressure buffer, we might
+  // not want to end the stream right away. Once the backpressure buffer is cleared, we'll end the stream eventually.
+  let tryToEnd = false;
+
+  function logDebugMessage(msg: string) {
+    logger.debug(`HTTP Response Stream: ${msg}`);
+  }
+
   function end() {
     tryToEnd = true;
-    clearInterval(flushIntervalId);
 
+    logDebugMessage(`backPressureBuffer size on end(): ${backPressureBuffer.length}`);
+    logDebugMessage(`waitForCallbacks size on end(): ${waitForCallbacks.length}`);
+
+    clearInterval(flushIntervalId);
+    logDebugMessage(`cleared flush interval`);
+
+    // Before ending the stream, we need to empty the backPressureBuffer
     if (backPressureBuffer.length > 0) {
       const el = backPressureBuffer.shift();
       if (el !== undefined) {
-        push(el);
+        push(el, true);
       }
       return;
     }
 
-    stream.end();
+    if (waitForCallbacks.length === 0) {
+      logDebugMessage('All backPressureBuffer and waitForCallbacks cleared, ending the stream.');
+      stream.end();
+    }
   }
 
-  function push(d: string) {
-    if (d === undefined) {
+  function push(line: string, drain = false) {
+    logDebugMessage(
+      `Push to stream. Current backPressure buffer size: ${backPressureBuffer.length}, drain flag: ${drain}`
+    );
+
+    if (line === undefined) {
       logger.error('Stream chunk must not be undefined.');
       return;
     }
 
-    if (backPressureBuffer.length > 0) {
-      backPressureBuffer.push(d);
-      return;
-    }
-
-    if (tryToEnd) {
+    if ((!drain && waitForDrain) || (!drain && backPressureBuffer.length > 0)) {
+      logDebugMessage('Adding item to backpressure buffer.');
+      backPressureBuffer.push(line);
       return;
     }
 
     try {
-      const line = d as unknown as string;
-      const writeOk = stream.write(line);
+      waitForCallbacks.push(1);
+      const writeOk = stream.write(line, () => {
+        waitForCallbacks.pop();
 
+        if (tryToEnd && waitForCallbacks.length === 0) {
+          end();
+        }
+      });
+
+      logDebugMessage(`Ok to write to the stream again? ${writeOk}`);
+
+      // if the buffer size is less than the cloud proxy buffer size, we can add the size of the current line to the buffer size
       currentBufferSize =
         currentBufferSize <= cloudProxyBufferSize
           ? JSON.stringify(line).length + currentBufferSize
           : cloudProxyBufferSize;
 
       if (!writeOk) {
-        backPressureBuffer.push(d);
+        logDebugMessage(`Should we add the "drain" listener?: ${!waitForDrain}`);
+        if (!waitForDrain) {
+          waitForDrain = true;
+          stream.once('drain', () => {
+            logDebugMessage(
+              'The "drain" listener triggered, we can continue pushing to the stream.'
+            );
+
+            waitForDrain = false;
+            if (backPressureBuffer.length > 0) {
+              const el = backPressureBuffer.shift();
+              if (el !== undefined) {
+                push(el, true);
+              }
+            }
+          });
+        }
+      } else if (writeOk && drain && backPressureBuffer.length > 0) {
+        logDebugMessage('Continue clearing the backpressure buffer.');
+        const el = backPressureBuffer.shift();
+        if (el !== undefined) {
+          push(el, true);
+        }
       }
     } catch (e) {
       logger.error(`Could not serialize or stream data chunk: ${e.toString()}`);
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary

This occurs when the context is very large and has difficulty flushing to the stream. When writing a large blob to stream, the stream may not be ready to process any further chunks. When it isn't ready, the stream will return false. The fix is we honour this scenario, creating a back pressure buffer to keep it in memory and checking on each new chunk whether the write is ready.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->