### PR TITLE
[8.15] Update dependency @launchdarkly/node-server-sdk to ^9.5.0 (main) (#190101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -943,7 +943,7 @@
     "@langchain/langgraph": "^0.0.31",
     "@langchain/openai": "^0.1.3",
     "@langtrase/trace-attributes": "^3.0.8",
-    "@launchdarkly/node-server-sdk": "^9.4.6",
+    "@launchdarkly/node-server-sdk": "^9.5.0",
     "@loaders.gl/core": "^3.4.7",
     "@loaders.gl/json": "^3.4.7",
     "@loaders.gl/shapefile": "^3.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7075,10 +7075,10 @@
     "@launchdarkly/js-sdk-common" "2.5.0"
     semver "7.5.4"
 
-"@launchdarkly/node-server-sdk@^9.4.6":
-  version "9.4.6"
-  resolved "https://registry.yarnpkg.com/@launchdarkly/node-server-sdk/-/node-server-sdk-9.4.6.tgz#e1a1614e05eab2515090c7862764498a2f9b2b1e"
-  integrity sha512-IcQqiaYrAgmCvh1LsfjEVRa4Wk97PWirHnbVu6fRc97kt8WCKDlVo2O+IbOcC6scJVGDJU4aXVehTkfbhUq1Lg==
+"@launchdarkly/node-server-sdk@^9.5.0":
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/@launchdarkly/node-server-sdk/-/node-server-sdk-9.5.0.tgz#171c235a16836611e3c6d8d95945afa24832fc10"
+  integrity sha512-nNH011mToDKEUz5Nrux3bdatgmHj+SQGUCCD1+R5wgzpdvwZxhi7w1W+9Wl6QrqB+LcpBfKp2+vMQH/4KLsDXg==
   dependencies:
     "@launchdarkly/js-server-sdk-common" "2.4.4"
     https-proxy-agent "^5.0.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Update dependency @launchdarkly/node-server-sdk to ^9.5.0 (main) (#190101)](https://github.com/elastic/kibana/pull/190101)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"elastic-renovate-prod[bot]","email":"174716857+elastic-renovate-prod[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-08-08T10:16:02Z","message":"Update dependency @launchdarkly/node-server-sdk to ^9.5.0 (main) (#190101)","sha":"671a34323753eb043a663dfbb818f0a2b92214e9","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","Team:Security","release_note:skip","backport missing","💝community","backport:prev-minor","v8.16.0"],"number":190101,"url":"https://github.com/elastic/kibana/pull/190101","mergeCommit":{"message":"Update dependency @launchdarkly/node-server-sdk to ^9.5.0 (main) (#190101)","sha":"671a34323753eb043a663dfbb818f0a2b92214e9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/190101","number":190101,"mergeCommit":{"message":"Update dependency @launchdarkly/node-server-sdk to ^9.5.0 (main) (#190101)","sha":"671a34323753eb043a663dfbb818f0a2b92214e9"}}]}] BACKPORT-->