### PR TITLE
Stabilize Discover sidebar tests

### DIFF
--- a/test/functional/page_objects/unified_field_list.ts
+++ b/test/functional/page_objects/unified_field_list.ts
@@ -36,6 +36,7 @@ export class UnifiedFieldListPageObject extends FtrService {
   }
 
   public async getSidebarAriaDescription(): Promise<string> {
+    await this.header.waitUntilLoadingHasFinished();
     return (
       (await (
         await this.testSubjects.find('fieldListGrouped__ariaDescription')


### PR DESCRIPTION
## Summary

This PR tries to stabilize the Discover sidebar tests which started to be flaky when running against MKI.

### Details

The serverless Discover sidebar tests (`Common Group 5.x-pack/test_serverless/functional/test_suites/common/discover/group6/_sidebar·ts`) started to become flaky when running against MKI. 5 out of the last 10 runs failed for the same reason:
```
discover/group6 discover sidebar renders field groups should render even when retrieving documents failed with an error

Error: expected '48 available fields. 6 empty fields. 4 meta fields.' to equal '49 available fields. 5 empty fields. 4 meta fields.'
    at Assertion.assert (expect.js:100:11)
    at Assertion.apply (expect.js:227:8)
    at Assertion.be (expect.js:69:22)
    at Context. (_sidebar.ts:644:83)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.apply (wrap_function.js:73:16)
```

So it seems the newly added field is sometimes listed as `empty` instead of `available`.

Failure screenshot:

![image](https://github.com/user-attachments/assets/e3615604-90ad-445c-9026-fd7c7865991e)

The screenshot shows an active global loading indicator, so that might be the reason for the flakiness (loading not quite done sometimes, so field listed as `empty`).

This PR tries to fix this flakiness by adding a wait for the global loading right before fetching the sidebar details.