### PR TITLE
[Stateful sidenav] Don't fetch active space on unauthenticated routes

### DIFF
--- a/src/plugins/navigation/public/plugin.test.ts
+++ b/src/plugins/navigation/public/plugin.test.ts
@@ -69,6 +69,31 @@ describe('Navigation Plugin', () => {
     expect(coreStart.chrome.project.changeActiveSolutionNavigation).toHaveBeenCalledWith('es');
   });
 
+  it('should not load the active space on non authenticated pages', async () => {
+    const { plugin, coreStart, unifiedSearch, cloud, spaces } = setup();
+
+    coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(true);
+
+    const activeSpace$ = of({ solution: 'es' } as Pick<Space, 'solution'>);
+    activeSpace$.pipe = jest.fn().mockReturnValue(activeSpace$);
+    activeSpace$.subscribe = jest.fn().mockReturnValue(activeSpace$);
+    spaces.getActiveSpace$ = jest.fn().mockReturnValue(activeSpace$);
+
+    plugin.start(coreStart, { unifiedSearch, cloud, spaces });
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(activeSpace$.pipe).not.toHaveBeenCalled();
+    expect(activeSpace$.subscribe).not.toHaveBeenCalled();
+
+    // Test that the activeSpace$ observable is accessed when not an anonymous path
+    coreStart.http.anonymousPaths.isAnonymous.mockReturnValue(false);
+    plugin.start(coreStart, { unifiedSearch, cloud, spaces });
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(activeSpace$.pipe).toHaveBeenCalled();
+    expect(activeSpace$.subscribe).toHaveBeenCalled();
+  });
+
   describe('addSolutionNavigation()', () => {
     it('should update the solution navigation definitions', async () => {
       const { plugin, coreStart, unifiedSearch, cloud } = setup();

--- a/src/plugins/navigation/public/plugin.tsx
+++ b/src/plugins/navigation/public/plugin.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import React from 'react';
-import { of, ReplaySubject, take, map, Observable } from 'rxjs';
+import { of, ReplaySubject, take, map, Observable, switchMap } from 'rxjs';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -123,9 +123,14 @@ export class NavigationPublicPlugin
         if (!this.isSolutionNavEnabled) return;
         this.addSolutionNavigation(solutionNavigation);
       },
-      isSolutionNavEnabled$: activeSpace$.pipe(
-        map((activeSpace) => {
-          return this.isSolutionNavEnabled && getIsProjectNav(activeSpace?.solution);
+      isSolutionNavEnabled$: of(this.getIsUnauthenticated(core.http)).pipe(
+        switchMap((isUnauthenticated) => {
+          if (isUnauthenticated) return of(false);
+          return activeSpace$.pipe(
+            map((activeSpace) => {
+              return this.isSolutionNavEnabled && getIsProjectNav(activeSpace?.solution);
+            })
+          );
         })
       ),
     };

--- a/src/plugins/navigation/server/ui_settings.test.ts
+++ b/src/plugins/navigation/server/ui_settings.test.ts
@@ -41,6 +41,21 @@ describe('ui settings', () => {
         await expect(defaultRoute.getValue!()).resolves.toBe(DEFAULT_ROUTES.classic);
       });
 
+      it('should return classic when accessing a non authenticated route', async () => {
+        const spaces = spacesMock.createStart();
+        const mockSpace: Pick<Space, 'solution'> = { solution: 'es' };
+        spaces.spacesService.getActiveSpace.mockResolvedValue(mockSpace as Space);
+        core.getStartServices.mockResolvedValue([{} as any, { spaces }, {} as any]);
+
+        const { defaultRoute } = getUiSettings(core, logger);
+        const requestMock = {
+          auth: { isAuthenticated: false },
+        };
+        await expect(defaultRoute.getValue!({ request: requestMock as any })).resolves.toBe(
+          DEFAULT_ROUTES.classic
+        );
+      });
+
       it('should return the route based on the active space', async () => {
         const spaces = spacesMock.createStart();
 
@@ -50,7 +65,10 @@ describe('ui settings', () => {
           core.getStartServices.mockResolvedValue([{} as any, { spaces }, {} as any]);
           const { defaultRoute } = getUiSettings(core, logger);
 
-          await expect(defaultRoute.getValue!({ request: {} as any })).resolves.toBe(
+          const requestMock = {
+            auth: { isAuthenticated: true },
+          };
+          await expect(defaultRoute.getValue!({ request: requestMock as any })).resolves.toBe(
             DEFAULT_ROUTES[solution]
           );
         }

--- a/src/plugins/navigation/server/ui_settings.ts
+++ b/src/plugins/navigation/server/ui_settings.ts
@@ -34,6 +34,8 @@ export const getUiSettings = (
         }
 
         try {
+          if (!request.auth.isAuthenticated) return DEFAULT_ROUTES.classic;
+
           const activeSpace = await spaces.spacesService.getActiveSpace(request);
 
           const solution = activeSpace?.solution ?? 'classic';


### PR DESCRIPTION
This PR fixes a bug where the `navigation` plugin tries to fetch the active space on unauthenticated routes (e.g. the login page). This created noise in the log and could mis lead users that something was wrong.

For context, the navigation plugin fetches the active space on the client to decide which side navigation to render and on the server to decide which default route to redirect for the space home page.

Fixes https://github.com/elastic/kibana/issues/190135

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->