### PR TITLE
[Fleet] Fix duplicates in agent version list

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.test.ts
@@ -221,6 +221,42 @@ describe('getAvailableVersions', () => {
     expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
   });
 
+  it('should not include duplicate', async () => {
+    mockKibanaVersion = '300.0.0';
+    mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
+    mockedFetch.mockResolvedValueOnce({
+      status: 200,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify([
+          [
+            {
+              title: 'Elastic Agent 8.1.0',
+              version_number: '8.1.0',
+            },
+            {
+              title: 'Elastic Agent 8.10.0',
+              version_number: '8.10.0',
+            },
+            {
+              title: 'Elastic Agent 8.10.0',
+              version_number: '8.10.0+build202407291657',
+            },
+            {
+              title: 'Elastic Agent 8.9.2',
+              version_number: '8.9.2',
+            },
+            ,
+          ],
+        ])
+      ),
+    } as any);
+
+    const res = await getAvailableVersions({ ignoreCache: true });
+
+    // Should sort, uniquify and filter out versions < 7.17
+    expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
+  });
+
   it('should cache results', async () => {
     mockKibanaVersion = '9.0.0';
     mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);

--- a/x-pack/plugins/fleet/server/services/agents/versions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.ts
@@ -111,10 +111,12 @@ export const getAvailableVersions = async ({
 
   // Coerce each version to a semver object and compare to our `MINIMUM_SUPPORTED_VERSION` - we
   // only want support versions in the final result. We'll also sort by newest version first.
-  availableVersions = uniq([...availableVersions, ...apiVersions])
-    .map((item: any) => semverCoerce(item)?.version || '')
-    .filter((v: any) => semverGte(v, MINIMUM_SUPPORTED_VERSION))
-    .sort((a: any, b: any) => (semverGt(a, b) ? -1 : 1));
+  availableVersions = uniq(
+    [...availableVersions, ...apiVersions]
+      .map((item: any) => semverCoerce(item)?.version || '')
+      .filter((v: any) => semverGte(v, MINIMUM_SUPPORTED_VERSION))
+      .sort((a: any, b: any) => (semverGt(a, b) ? -1 : 1))
+  );
 
   // if api versions are empty (air gapped or API not available), we add current kibana version, as the build file might not contain the latest released version
   if (


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/189964

Version 8.14.3 was a duplicate in the available version list when trying to upgrade an agent 

That PR fix that, and add a unit test to cover that scenario.

## UI Changes


<img width="450" alt="Screenshot 2024-08-13 at 9 50 04 AM" src="https://github.com/user-attachments/assets/ce89f6c6-e1a6-461a-b9ad-5049bf587e05">
