### PR TITLE
[Search] update copy for try in console button, to Run in Console

### DIFF
--- a/packages/kbn-try-in-console/components/try_in_console_button.test.tsx
+++ b/packages/kbn-try-in-console/components/try_in_console_button.test.tsx
@@ -73,7 +73,7 @@ describe('TryInConsoleButton', () => {
     const wrapper = render(<TryInConsoleButton {...defaultProps(props)} />);
 
     expect(wrapper.getByTestId('tryInConsoleButton')).toBeTruthy();
-    expect(wrapper.getByRole('button')).toHaveTextContent('Try in Console');
+    expect(wrapper.getByRole('button')).toHaveTextContent('Run in Console');
     expect(mockLocatorUseUrl).toHaveBeenCalledWith(
       {
         loadFrom: 'data:text/plain,OIUQKgBA9A+gzgFwIYLkA',
@@ -87,7 +87,7 @@ describe('TryInConsoleButton', () => {
     const wrapper = render(<TryInConsoleButton {...defaultProps(props)} />);
 
     expect(wrapper.getByTestId('tryInConsoleLink')).toBeTruthy();
-    expect(wrapper.getByRole('button')).toHaveTextContent('Try in Console');
+    expect(wrapper.getByRole('button')).toHaveTextContent('Run in Console');
   });
   it('renders null if dev tools are unavailable', async () => {
     const props: Partial<TryInConsoleButtonProps> = {
@@ -153,7 +153,7 @@ describe('TryInConsoleButton', () => {
     const props: Partial<TryInConsoleButtonProps> = { request: 'GET /_stats' };
     render(<TryInConsoleButton {...defaultProps(props)} />);
 
-    fireEvent.click(screen.getByText('Try in Console'));
+    fireEvent.click(screen.getByText('Run in Console'));
 
     expect(windowOpenSpy).toHaveBeenCalledTimes(1);
     expect(windowOpenSpy).toHaveBeenCalledWith('/app/test/dev_tools', '_blank', 'noreferrer');
@@ -161,7 +161,7 @@ describe('TryInConsoleButton', () => {
   it('can open in new tab without data', async () => {
     render(<TryInConsoleButton {...defaultProps({})} />);
 
-    fireEvent.click(screen.getByText('Try in Console'));
+    fireEvent.click(screen.getByText('Run in Console'));
 
     expect(mockLocatorUseUrl).toHaveBeenCalledWith({}, undefined, [undefined]);
     expect(windowOpenSpy).toHaveBeenCalledTimes(1);
@@ -175,7 +175,7 @@ describe('TryInConsoleButton', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('Try in Console'));
+    fireEvent.click(screen.getByText('Run in Console'));
 
     expect(windowOpenSpy).toHaveBeenCalledTimes(0);
     expect(mockConsole.openEmbeddedConsole).toHaveBeenCalledTimes(1);
@@ -185,7 +185,7 @@ describe('TryInConsoleButton', () => {
     mockConsole.isEmbeddedConsoleAvailable.mockReturnValue(false);
     render(<TryInConsoleButton {...defaultProps({ consolePlugin: mockConsole })} />);
 
-    fireEvent.click(screen.getByText('Try in Console'));
+    fireEvent.click(screen.getByText('Run in Console'));
 
     expect(windowOpenSpy).toHaveBeenCalledTimes(1);
     expect(mockConsole.openEmbeddedConsole).toHaveBeenCalledTimes(0);

--- a/packages/kbn-try-in-console/components/try_in_console_button.tsx
+++ b/packages/kbn-try-in-console/components/try_in_console_button.tsx
@@ -16,7 +16,9 @@ import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { compressToEncodedURIComponent } from 'lz-string';
 
-const TRY_IN_CONSOLE = i18n.translate('tryInConsole.button', { defaultMessage: 'Try in Console' });
+const RUN_IN_CONSOLE = i18n.translate('tryInConsole.button.text', {
+  defaultMessage: 'Run in Console',
+});
 
 export interface TryInConsoleButtonProps {
   request?: string;
@@ -32,7 +34,7 @@ export const TryInConsoleButton = ({
   application,
   consolePlugin,
   sharePlugin,
-  content = TRY_IN_CONSOLE,
+  content = RUN_IN_CONSOLE,
   showIcon = true,
   type = 'emptyButton',
 }: TryInConsoleButtonProps) => {
@@ -70,11 +72,11 @@ export const TryInConsoleButton = ({
       consolePlugin?.isEmbeddedConsoleAvailable?.()
     ) {
       return i18n.translate('tryInConsole.embeddedConsoleButton.ariaLabel', {
-        defaultMessage: 'Try in Console  - opens in embedded console',
+        defaultMessage: 'Run in Console  - opens in embedded console',
       });
     }
     return i18n.translate('tryInConsole.inNewTab.button.ariaLabel', {
-      defaultMessage: 'Try in Console  - opens in a new tab',
+      defaultMessage: 'Run in Console  - opens in a new tab',
     });
   };
 

--- a/packages/kbn-try-in-console/components/try_in_console_button.tsx
+++ b/packages/kbn-try-in-console/components/try_in_console_button.tsx
@@ -85,7 +85,7 @@ export const TryInConsoleButton = ({
     'aria-label': getAriaLabel(),
     onClick,
   };
-  const iconType = showIcon ? 'popout' : undefined;
+  const iconType = showIcon ? 'play' : undefined;
 
   switch (type) {
     case 'link':


### PR DESCRIPTION
## Summary

Updated the default copy for "Try in Console" to be "Run in Console" instead.

### Screenshots
<img width="716" alt="image" src="https://github.com/user-attachments/assets/ccd102ec-4732-429f-bb7b-76c157481c09">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
