### PR TITLE
[renovate] Test github action package match

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "helpers:pinGitHubActionDigestsToSemver"],
   "ignorePaths": ["**/__fixtures__/**", "**/fixtures/**"],
   "enabledManagers": ["npm", "github-actions", "custom.regex"],
   "baseBranches": ["main", "7.17"],
@@ -29,6 +29,7 @@
     {
       "groupName": "GitHub actions",
       "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/checkout"],
       "reviewers": ["team:kibana-operations"],
       "matchBaseBranches": ["main"],
       "labels": ["Team:Operations", "backport:all-open", "release_note:skip"],


### PR DESCRIPTION
Another attempt at fixing github action pinning.  This scopes us to the actions/checkout package only for now, and we can expand it later.

Previously: https://github.com/elastic/kibana/pull/190377, which was successful for the auto-approve-backport acttion.