### PR TITLE
[Security Solution] Updates the `test:generate:serverless-dev` script to align with the latest serverless defaults

### DIFF
--- a/x-pack/plugins/security_solution/package.json
+++ b/x-pack/plugins/security_solution/package.json
@@ -24,7 +24,7 @@
     "cypress:dw:endpoint:open": "echo '\n** WARNING **: Run script `cypress:dw:endpoint:open` no longer valid! Use `cypress:dw:open` instead\n'",
     "junit:merge": "../../../node_modules/.bin/mochawesome-merge ../../../target/kibana-security-solution/cypress/results/mochawesome*.json > ../../../target/kibana-security-solution/cypress/results/output.json && ../../../node_modules/.bin/marge ../../../target/kibana-security-solution/cypress/results/output.json --reportDir ../../../target/kibana-security-solution/cypress/results && yarn junit:transform && mkdir -p ../../../target/junit && cp ../../../target/kibana-security-solution/cypress/results/*.xml ../../../target/junit/",
     "test:generate": "node scripts/endpoint/resolver_generator",
-    "test:generate:serverless-dev": "node scripts/endpoint/resolver_generator --node http://elastic_serverless:changeme@127.0.0.1:9200 --kibana http://elastic_serverless:changeme@127.0.0.1:5601",
+    "test:generate:serverless-dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 node --no-warnings scripts/endpoint/resolver_generator --node https://elastic_serverless:changeme@127.0.0.1:9200 --kibana http://elastic_serverless:changeme@127.0.0.1:5601",
     "mappings:generate": "node scripts/mappings/mappings_generator",
     "mappings:load": "node scripts/mappings/mappings_loader",
     "junit:transform": "node scripts/junit_transformer --pathPattern '../../../target/kibana-security-solution/cypress/results/*.xml' --rootDirectory ../../../ --reportName 'Security Solution Cypress' --writeInPlace",


### PR DESCRIPTION
## [Security Solution] Updates the `test:generate:serverless-dev` script to align with the latest serverless defaults

This PR updates the `test:generate:serverless-dev` script, (which runs `scripts/endpoint/resolver_generator`), to align with the latest serverless defaults.

After this change, running the following command:

```sh
yarn test:generate:serverless-dev
```

populates a local serverless project with generated alerts and events (for testing).

### Desk testing

1) Start a new (development) instance of Elasticsearch:

```sh
yarn es serverless --clean --projectType security
```

2) Start a local (development) instance of Kibana:

```sh
yarn start --serverless=security --no-base-path
```

3) Login to the project as the `admin` user

4) Install the default detection rules

5) Change to the `$KIBANA_HOME/x-pack/plugins/security_solution` directory:

```sh
cd $KIBANA_HOME/x-pack/plugins/security_solution
```

6) Run the following command:

```sh
yarn test:generate:serverless-dev
```

**Expected result**

- The `resolver_generator` script populates the serverless project with alerts and events, as illustrated by the output below:

```
 info Build flavor: serverless
 info Indexing host and alerts...
 info Creating and indexing documents took: 15098ms
✨  Done in 17.37s.
```

**Actual result**

- The `resolver_generator` script does NOT populate the serverless project with alerts and events, as illustrated by the output below:

```
info Build flavor: serverless
info Indexing host and alerts...
Unhandled Promise rejection detected:

EndpointDataLoadingError: other side closed - Local: 127.0.0.1:63688, Remote: 127.0.0.1:9200
    at wrapErrorIfNeeded (utils.ts:29:7)
    at wrapErrorAndRejectPromise (utils.ts:32:75)
    at index_endpoint_hosts.ts:259:26 {
  meta: ConnectionError: other side closed - Local: 127.0.0.1:63688, Remote: 127.0.0.1:9200
      at SniffingTransport.request (/Users/$USER/Projects/forks/$USER/kibana/node_modules/@elastic/transport/src/Transport.ts:630:17)
      at Client.BulkApi [as bulk] (/Users/$USER/Projects/forks/$USER/kibana/node_modules/@elastic/elasticsearch/src/api/api/bulk.ts:75:10)
      at index_endpoint_hosts.ts:259:26 {
    options: { redaction: [Object] },
    meta: {
      body: undefined,
      statusCode: 0,
      headers: {},
      meta: [Object],
      warnings: null
    }
  }
}

Terminating process...
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
