### PR TITLE
[Fleet] Exclude events log from EA diagnostic collection in modal

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3352,7 +3352,7 @@
                       ]
                     }
                   },
-                  "exclude_event_logs": {
+                  "exclude_events_log": {
                     "type": "boolean"
                   }
                 },

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3246,6 +3246,9 @@
                         }
                       ]
                     }
+                  },
+                  "exclude_event_logs": {
+                    "type": "boolean"
                   }
                 }
               }
@@ -3348,6 +3351,9 @@
                         }
                       ]
                     }
+                  },
+                  "exclude_event_logs": {
+                    "type": "boolean"
                   }
                 },
                 "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -3247,7 +3247,7 @@
                       ]
                     }
                   },
-                  "exclude_event_logs": {
+                  "exclude_events_log": {
                     "type": "boolean"
                   }
                 }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2025,7 +2025,7 @@ paths:
                       - type: string
                         enum:
                           - CPU
-                exclude_event_logs:
+                exclude_events_log:
                   type: boolean
                   description: Excludes the event data logs from the diagnostic
       responses:

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2086,7 +2086,7 @@ paths:
                       - type: string
                         enum:
                           - CPU
-                exclude_event_logs:
+                exclude_events_log:
                   type: boolean
                   description: Excludes the event data logs from the diagnostic
               required:

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2025,6 +2025,9 @@ paths:
                       - type: string
                         enum:
                           - CPU
+                exclude_event_logs:
+                  type: boolean
+                  description: Excludes the event data logs from the diagnostic
       responses:
         '200':
           description: OK
@@ -2083,6 +2086,9 @@ paths:
                       - type: string
                         enum:
                           - CPU
+                exclude_event_logs:
+                  type: boolean
+                  description: Excludes the event data logs from the diagnostic
               required:
                 - agents
             example:

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_request_diagnostics.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_request_diagnostics.yaml
@@ -40,7 +40,7 @@ post:
                   - type: string
                     enum:
                       - "CPU"
-            exclude_event_logs:
+            exclude_events_log:
               type: boolean
           required:
             - agents

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_request_diagnostics.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@bulk_request_diagnostics.yaml
@@ -40,6 +40,8 @@ post:
                   - type: string
                     enum:
                       - "CPU"
+            exclude_event_logs:
+              type: boolean
           required:
             - agents
         example:

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}@request_diagnostics.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}@request_diagnostics.yaml
@@ -21,7 +21,7 @@ post:
                   - type: string
                     enum:
                       - "CPU"
-            exclude_event_logs:
+            exclude_events_log:
               type: boolean
   responses:
     '200':

--- a/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}@request_diagnostics.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/agents@{agent_id}@request_diagnostics.yaml
@@ -21,6 +21,8 @@ post:
                   - type: string
                     enum:
                       - "CPU"
+            exclude_event_logs:
+              type: boolean
   responses:
     '200':
       description: OK

--- a/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/agent.ts
@@ -164,6 +164,7 @@ export enum RequestDiagnosticsAdditionalMetrics {
 export interface PostRequestDiagnosticsRequest {
   body: {
     additional_metrics: RequestDiagnosticsAdditionalMetrics[];
+    exclude_events_log?: boolean;
   };
 }
 
@@ -175,6 +176,7 @@ export interface PostRequestBulkDiagnosticsRequest {
     agents: string[] | string;
     batchSize?: number;
     additional_metrics: RequestDiagnosticsAdditionalMetrics[];
+    exclude_events_log?: boolean;
   };
 }
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.test.tsx
@@ -101,4 +101,6 @@ describe('AgentRequestDiagnosticsModal', () => {
       agents: ['agent1', 'agent2'],
     });
   });
+
+  // TODO Create test
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.test.tsx
@@ -58,6 +58,7 @@ describe('AgentRequestDiagnosticsModal', () => {
 
     expect(mockSendPostRequestDiagnostics).toHaveBeenCalledWith('agent1', {
       additional_metrics: ['CPU'],
+      exclude_events_log: true,
     });
   });
 
@@ -70,6 +71,23 @@ describe('AgentRequestDiagnosticsModal', () => {
 
     expect(mockSendPostRequestDiagnostics).toHaveBeenCalledWith('agent1', {
       additional_metrics: [],
+      exclude_events_log: true,
+    });
+  });
+
+  it('should have Exclude Events Log set to false when checkbox is checked', async () => {
+    const { utils } = render();
+
+    act(() => {
+      fireEvent.click(utils.getByTestId('includeEventsLogCheckbox'));
+    });
+    act(() => {
+      fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
+    });
+
+    expect(mockSendPostRequestDiagnostics).toHaveBeenCalledWith('agent1', {
+      additional_metrics: [],
+      exclude_events_log: false,
     });
   });
 
@@ -86,6 +104,7 @@ describe('AgentRequestDiagnosticsModal', () => {
     expect(mockSendPostBulkRequestDiagnostics).toHaveBeenCalledWith({
       additional_metrics: ['CPU'],
       agents: ['agent1', 'agent2'],
+      exclude_events_log: true,
     });
   });
 
@@ -98,9 +117,25 @@ describe('AgentRequestDiagnosticsModal', () => {
 
     expect(mockSendPostBulkRequestDiagnostics).toHaveBeenCalledWith({
       additional_metrics: [],
+      exclude_events_log: true,
       agents: ['agent1', 'agent2'],
     });
   });
 
-  // TODO Create test
+  it('should have Exclude Events Log set to false when checkbox is checked within bulk action', async () => {
+    const { utils } = render({ agents: [{ id: 'agent1' }, { id: 'agent2' }], agentCount: 2 });
+
+    act(() => {
+      fireEvent.click(utils.getByTestId('includeEventsLogCheckbox'));
+    });
+    act(() => {
+      fireEvent.click(utils.getByTestId('confirmModalConfirmButton'));
+    });
+
+    expect(mockSendPostBulkRequestDiagnostics).toHaveBeenCalledWith({
+      additional_metrics: [],
+      exclude_events_log: false,
+      agents: ['agent1', 'agent2'],
+    });
+  });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
@@ -19,7 +19,6 @@ import {
   useStartServices,
   useLink,
 } from '../../../../hooks';
-import { RequestDiagnosticExclude } from '../../../../../../../common/types/rest_spec/agent';
 
 interface Props {
   onClose: () => void;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
@@ -133,24 +133,20 @@ export const AgentRequestDiagnosticsModal: React.FunctionComponent<Props> = ({
           defaultMessage="Diagnostics files are stored in Elasticsearch, and as such can incur storage costs. By default, files are periodically deleted via an ILM policy."
         />
       </p>
-      <p>
-        <EuiCheckbox
-          id="cpuMetricsCheckbox"
-          data-test-subj="cpuMetricsCheckbox"
-          label="Collect additional CPU metrics"
-          checked={cpuMetricsEnabled}
-          onChange={() => setCPUMetricsEnabled(!cpuMetricsEnabled)}
-        />
-      </p>
-      <p>
-        <EuiCheckbox
-          id="includeEventsLogCheckbox"
-          data-test-subj="includeEventsLogCheckbox"
-          label="Include Events Logs (might contain sensible information)"
-          checked={includeEventsLogEnabled}
-          onChange={() => setIncludeEventsLog(!includeEventsLogEnabled)}
-        />
-      </p>
+      <EuiCheckbox
+        id="cpuMetricsCheckbox"
+        data-test-subj="cpuMetricsCheckbox"
+        label="Collect additional CPU metrics"
+        checked={cpuMetricsEnabled}
+        onChange={() => setCPUMetricsEnabled(!cpuMetricsEnabled)}
+      />
+      <EuiCheckbox
+        id="includeEventsLogCheckbox"
+        data-test-subj="includeEventsLogCheckbox"
+        label="Include Events Logs (might contain sensible information)"
+        checked={includeEventsLogEnabled}
+        onChange={() => setIncludeEventsLog(!includeEventsLogEnabled)}
+      />
     </EuiConfirmModal>
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
@@ -135,14 +135,24 @@ export const AgentRequestDiagnosticsModal: React.FunctionComponent<Props> = ({
       <EuiCheckbox
         id="cpuMetricsCheckbox"
         data-test-subj="cpuMetricsCheckbox"
-        label="Collect additional CPU metrics"
+        label={
+          <FormattedMessage
+            id="xpack.fleet.requestDiagnostics.cpuMetricsCheckboxLabel"
+            defaultMessage="Collect additional CPU metrics"
+          />
+        }
         checked={cpuMetricsEnabled}
         onChange={() => setCPUMetricsEnabled(!cpuMetricsEnabled)}
       />
       <EuiCheckbox
         id="includeEventsLogCheckbox"
         data-test-subj="includeEventsLogCheckbox"
-        label="Include Events Logs (might contain sensible information)"
+        label={
+          <FormattedMessage
+            id="xpack.fleet.requestDiagnostics.includeEventsLogCheckboxLabel"
+            defaultMessage="Include Events Logs (might contain sensible information)"
+          />
+        }
         checked={includeEventsLogEnabled}
         onChange={() => setIncludeEventsLog(!includeEventsLogEnabled)}
       />

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
@@ -19,6 +19,7 @@ import {
   useStartServices,
   useLink,
 } from '../../../../hooks';
+import { RequestDiagnosticExclude } from '../../../../../../../common/types/rest_spec/agent';
 
 interface Props {
   onClose: () => void;
@@ -37,19 +38,23 @@ export const AgentRequestDiagnosticsModal: React.FunctionComponent<Props> = ({
   const { getPath } = useLink();
   const history = useHistory();
   const [cpuMetricsEnabled, setCPUMetricsEnabled] = useState(false);
+  const [includeEventsLogEnabled, setIncludeEventsLog] = useState(false);
 
   async function onSubmit() {
     try {
       setIsSubmitting(true);
       const additionalMetrics = cpuMetricsEnabled ? [RequestDiagnosticsAdditionalMetrics.CPU] : [];
+      const excludeEventsLog = includeEventsLogEnabled ? false : true;
 
       const { error } = isSingleAgent
         ? await sendPostRequestDiagnostics((agents[0] as Agent).id, {
             additional_metrics: additionalMetrics,
+            exclude_events_log: excludeEventsLog,
           })
         : await sendPostBulkRequestDiagnostics({
             agents: typeof agents === 'string' ? agents : agents.map((agent) => agent.id),
             additional_metrics: additionalMetrics,
+            exclude_events_log: excludeEventsLog,
           });
       if (error) {
         throw error;
@@ -135,6 +140,15 @@ export const AgentRequestDiagnosticsModal: React.FunctionComponent<Props> = ({
           label="Collect additional CPU metrics"
           checked={cpuMetricsEnabled}
           onChange={() => setCPUMetricsEnabled(!cpuMetricsEnabled)}
+        />
+      </p>
+      <p>
+        <EuiCheckbox
+          id="includeEventsLogCheckbox"
+          data-test-subj="includeEventsLogCheckbox"
+          label="Include Events Logs (might contain sensible information)"
+          checked={includeEventsLogEnabled}
+          onChange={() => setIncludeEventsLog(!includeEventsLogEnabled)}
         />
       </p>
     </EuiConfirmModal>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_request_diagnostics_modal/index.tsx
@@ -44,7 +44,7 @@ export const AgentRequestDiagnosticsModal: React.FunctionComponent<Props> = ({
     try {
       setIsSubmitting(true);
       const additionalMetrics = cpuMetricsEnabled ? [RequestDiagnosticsAdditionalMetrics.CPU] : [];
-      const excludeEventsLog = includeEventsLogEnabled ? false : true;
+      const excludeEventsLog = !includeEventsLogEnabled;
 
       const { error } = isSingleAgent
         ? await sendPostRequestDiagnostics((agents[0] as Agent).id, {

--- a/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.test.ts
@@ -36,7 +36,7 @@ describe('request diagnostics handler', () => {
   let mockRequest: KibanaRequest<
     { agentId: string },
     undefined,
-    { additional_metrics: RequestDiagnosticsAdditionalMetrics[] },
+    { additional_metrics: RequestDiagnosticsAdditionalMetrics[]; exclude_events_log?: boolean },
     any
   >;
 
@@ -59,7 +59,7 @@ describe('request diagnostics handler', () => {
     } as unknown as RequestHandlerContext;
     mockRequest = httpServerMock.createKibanaRequest({
       params: { agentId: 'agent1' },
-      body: { additional_metrics: ['CPU'] },
+      body: { additional_metrics: ['CPU'], exclude_events_log: false },
     });
   });
 

--- a/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.test.ts
@@ -88,5 +88,3 @@ describe('request diagnostics handler', () => {
     });
   });
 });
-
-// TODO Add test

--- a/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.test.ts
@@ -88,3 +88,5 @@ describe('request diagnostics handler', () => {
     });
   });
 });
+
+// TODO Add test

--- a/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.ts
@@ -41,7 +41,8 @@ export const requestDiagnosticsHandler: RequestHandler<
     const result = await AgentService.requestDiagnostics(
       esClient,
       request.params.agentId,
-      request.body?.additional_metrics
+      request.body?.additional_metrics,
+      request.body?.exclude_events_log,
     );
 
     return response.ok({ body: { actionId: result.actionId } });
@@ -66,6 +67,7 @@ export const bulkRequestDiagnosticsHandler: RequestHandler<
       ...agentOptions,
       batchSize: request.body.batchSize,
       additionalMetrics: request.body.additional_metrics,
+      excludeEventsLog: request.body.exclude_events_log,
     });
 
     return response.ok({ body: { actionId: result.actionId } });

--- a/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/request_diagnostics_handler.ts
@@ -42,7 +42,7 @@ export const requestDiagnosticsHandler: RequestHandler<
       esClient,
       request.params.agentId,
       request.body?.additional_metrics,
-      request.body?.exclude_events_log,
+      request.body?.exclude_events_log
     );
 
     return response.ok({ body: { actionId: result.actionId } });

--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics.ts
@@ -23,7 +23,8 @@ import {
 export async function requestDiagnostics(
   esClient: ElasticsearchClient,
   agentId: string,
-  additionalMetrics?: RequestDiagnosticsAdditionalMetrics[]
+  additionalMetrics?: RequestDiagnosticsAdditionalMetrics[],
+  excludeEventsLog?: boolean,
 ): Promise<{ actionId: string }> {
   const response = await createAgentAction(esClient, {
     agents: [agentId],
@@ -32,6 +33,7 @@ export async function requestDiagnostics(
     expiration: new Date(Date.now() + REQUEST_DIAGNOSTICS_TIMEOUT_MS).toISOString(),
     data: {
       additional_metrics: additionalMetrics,
+      exclude_events_log: excludeEventsLog,
     },
   });
   return { actionId: response.id };
@@ -43,12 +45,14 @@ export async function bulkRequestDiagnostics(
   options: GetAgentsOptions & {
     batchSize?: number;
     additionalMetrics?: RequestDiagnosticsAdditionalMetrics[];
+    excludeEventsLog?: boolean;
   }
 ): Promise<{ actionId: string }> {
   if ('agentIds' in options) {
     const givenAgents = await getAgents(esClient, soClient, options);
     return await requestDiagnosticsBatch(esClient, givenAgents, {
       additionalMetrics: options.additionalMetrics,
+      excludeEventsLog: options.excludeEventsLog,
     });
   }
 
@@ -63,6 +67,7 @@ export async function bulkRequestDiagnostics(
     const givenAgents = await getAgents(esClient, soClient, options);
     return await requestDiagnosticsBatch(esClient, givenAgents, {
       additionalMetrics: options.additionalMetrics,
+      excludeEventsLog: options.excludeEventsLog,
     });
   } else {
     return await new RequestDiagnosticsActionRunner(

--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics.ts
@@ -24,7 +24,7 @@ export async function requestDiagnostics(
   esClient: ElasticsearchClient,
   agentId: string,
   additionalMetrics?: RequestDiagnosticsAdditionalMetrics[],
-  excludeEventsLog?: boolean,
+  excludeEventsLog?: boolean
 ): Promise<{ actionId: string }> {
   const response = await createAgentAction(esClient, {
     agents: [agentId],

--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics_action_runner.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics_action_runner.ts
@@ -39,6 +39,7 @@ export async function requestDiagnosticsBatch(
     actionId?: string;
     total?: number;
     additionalMetrics?: RequestDiagnosticsAdditionalMetrics[];
+    excludeEventsLog?: boolean;
   }
 ): Promise<{ actionId: string }> {
   const errors: Record<Agent['id'], Error> = {};
@@ -66,6 +67,7 @@ export async function requestDiagnosticsBatch(
     total,
     data: {
       additional_metrics: options.additionalMetrics,
+      exclude_events_log: options.excludeEventsLog,
     },
   });
 

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -9,7 +9,10 @@ import { schema } from '@kbn/config-schema';
 import moment from 'moment';
 import semverIsValid from 'semver/functions/valid';
 
-import { RequestDiagnosticsAdditionalMetrics } from '../../../common/types';
+import {
+  RequestDiagnosticsAdditionalMetrics,
+  RequestDiagnosticExclude,
+ } from '../../../common/types';
 
 import { SO_SEARCH_LIMIT, AGENTS_PREFIX, AGENT_MAPPINGS } from '../../constants';
 
@@ -170,6 +173,7 @@ export const PostRequestDiagnosticsActionRequestSchema = {
       additional_metrics: schema.maybe(
         schema.arrayOf(schema.oneOf([schema.literal(RequestDiagnosticsAdditionalMetrics.CPU)]))
       ),
+      exclude_events_log: schema.maybe(schema.boolean()),
     })
   ),
 };
@@ -181,6 +185,7 @@ export const PostBulkRequestDiagnosticsActionRequestSchema = {
     additional_metrics: schema.maybe(
       schema.arrayOf(schema.oneOf([schema.literal(RequestDiagnosticsAdditionalMetrics.CPU)]))
     ),
+    exclude_events_log: schema.maybe(schema.boolean()),
   }),
 };
 

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -9,10 +9,7 @@ import { schema } from '@kbn/config-schema';
 import moment from 'moment';
 import semverIsValid from 'semver/functions/valid';
 
-import {
-  RequestDiagnosticsAdditionalMetrics,
-  RequestDiagnosticExclude,
- } from '../../../common/types';
+import { RequestDiagnosticsAdditionalMetrics } from '../../../common/types';
 
 import { SO_SEARCH_LIMIT, AGENTS_PREFIX, AGENT_MAPPINGS } from '../../constants';
 

--- a/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
@@ -162,7 +162,85 @@ export default function (providerContext: FtrProviderContext) {
       const action: any = actionsRes.hits.hits[0]._source;
       expect(action.data.additional_metrics).contain('CPU');
     });
+
+    it('should create action with exclude_events_log when api contains exclude_events_log option', async () => {
+      await supertest
+        .post(`/api/fleet/agents/agent1/request_diagnostics`)
+        .set('kbn-xsrf', 'xxx')
+        .send({
+          exclude_events_log: false,
+        })
+        .expect(200);
+      const actionsRes = await es.search({
+        index: '.fleet-actions',
+        body: {
+          sort: [{ '@timestamp': { order: 'desc' } }],
+        },
+      });
+      const action: any = actionsRes.hits.hits[0]._source;
+      expect(action.data.exclude_events_log).equal(false);
+    });
+
+    it('/agents/bulk_request_diagnostics should add exclude_events_log option to action doc', async () => {
+      await supertestWithoutAuth
+        .post(`/api/fleet/agents/bulk_request_diagnostics`)
+        .set('kbn-xsrf', 'xxx')
+        .auth(testUsers.fleet_agents_read_only.username, testUsers.fleet_agents_read_only.password)
+        .send({
+          agents: ['agent2', 'agent3'],
+          exclude_events_log: true,
+        });
+
+      const actionsRes = await es.search({
+        index: '.fleet-actions',
+        body: {
+          sort: [{ '@timestamp': { order: 'desc' } }],
+        },
+      });
+      const action: any = actionsRes.hits.hits[0]._source;
+      expect(action.data.exclude_events_log).equal(true);
+    });
+
+    it('should create action with exclude_events_log when api contains exclude_events_log and collect CPU option', async () => {
+      await supertest
+        .post(`/api/fleet/agents/agent1/request_diagnostics`)
+        .set('kbn-xsrf', 'xxx')
+        .send({
+          additional_metrics: ['CPU'],
+          exclude_events_log: false,
+        })
+        .expect(200);
+      const actionsRes = await es.search({
+        index: '.fleet-actions',
+        body: {
+          sort: [{ '@timestamp': { order: 'desc' } }],
+        },
+      });
+      const action: any = actionsRes.hits.hits[0]._source;
+      expect(action.data.exclude_events_log).equal(false);
+      expect(action.data.additional_metrics).contain('CPU');
+    });
+
+    it('/agents/bulk_request_diagnostics should add exclude_events_log and collect CPU option to action doc', async () => {
+      await supertestWithoutAuth
+        .post(`/api/fleet/agents/bulk_request_diagnostics`)
+        .set('kbn-xsrf', 'xxx')
+        .auth(testUsers.fleet_agents_read_only.username, testUsers.fleet_agents_read_only.password)
+        .send({
+          agents: ['agent2', 'agent3'],
+          additional_metrics: ['CPU'],
+          exclude_events_log: true,
+        });
+
+      const actionsRes = await es.search({
+        index: '.fleet-actions',
+        body: {
+          sort: [{ '@timestamp': { order: 'desc' } }],
+        },
+      });
+      const action: any = actionsRes.hits.hits[0]._source;
+      expect(action.data.exclude_events_log).equal(true);
+      expect(action.data.additional_metrics).contain('CPU');
+    });
   });
 }
-
-// TODO Add test

--- a/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
@@ -164,3 +164,5 @@ export default function (providerContext: FtrProviderContext) {
     });
   });
 }
+
+// TODO Add test


### PR DESCRIPTION
## Summary

In 8.15 we've reintroduced the logging of raw events when in debug log via https://github.com/elastic/beats/pull/38767.

Given the Elastic Agent is able to read the flag from the action (https://github.com/elastic/elastic-agent/blob/44528c49507c18e71a4cfd2a6ba4f0904bd32009/internal/pkg/fleetapi/action.go#L483), I'm attempting to draft a PR.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### Risk Matrix

- Is it safe to send the new parameter to Elastic Agents which do not support the `exclude_event_logs`?
- Do we need to handle the saved objects types of the Diagnostic Request?

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
