### PR TITLE
skip flaky test: https://github.com/elastic/kibana/issues/186996

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/components/update_status.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/update_status.test.tsx
@@ -11,7 +11,8 @@ import { TestProvidersComponent } from '../mocks/test_providers';
 import { UpdateStatus } from './update_status';
 
 describe('<UpdateStatus />', () => {
-  it('should render Updated now', () => {
+  // Flaky: https://github.com/elastic/kibana/issues/186996
+  it.skip('should render Updated now', () => {
     const result = render(<UpdateStatus updatedAt={Date.now()} isUpdating={false} />, {
       wrapper: TestProvidersComponent,
     });


### PR DESCRIPTION
## Summary
Manually skipping test from https://github.com/elastic/kibana/issues/186996 - it's going to stay flaky, as it's depending on the `new Date()`s hitting the same second.