### PR TITLE
[ES|QL] Cleanup the filters when transitioning from dataviews to ES|QL

### DIFF
--- a/src/plugins/discover/public/application/main/state_management/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_state.test.ts
@@ -756,12 +756,15 @@ describe('Test discover state actions', () => {
   test('transitionFromDataViewToESQL', async () => {
     const savedSearchWithQuery = copySavedSearch(savedSearchMock);
     const query = { query: "foo: 'bar'", language: 'kuery' };
+    const filters = [{ meta: { index: 'the-data-view-id' }, query: { match_all: {} } }];
     savedSearchWithQuery.searchSource.setField('query', query);
+    savedSearchWithQuery.searchSource.setField('filter', filters);
     const { state } = await getState('/', { savedSearch: savedSearchWithQuery });
     await state.actions.transitionFromDataViewToESQL(dataViewMock);
     expect(state.appState.getState().query).toStrictEqual({
       esql: 'FROM the-data-view-title | LIMIT 10',
     });
+    expect(state.appState.getState().filters).toStrictEqual([]);
   });
 
   test('transitionFromESQLToDataView', async () => {

--- a/src/plugins/discover/public/application/main/state_management/discover_state.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_state.ts
@@ -383,6 +383,7 @@ export function getDiscoverStateContainer({
     const queryString = getInitialESQLQuery(dataView);
     appStateContainer.update({
       query: { esql: queryString },
+      filters: [],
       dataSource: {
         type: DataSourceType.Esql,
       },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/190459

Clean ups the filters when moving from DataViews to ES|QL mode.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
