### PR TITLE
[ES|QL] Fixes console error when creating ES|QL charts

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -153,9 +153,6 @@ export function LensEditConfigurationFlyout({
       }
     };
     getESQLGridAttrs();
-    return () => {
-      abortController.abort();
-    };
   }, [adHocDataViews, dataGridAttrs, query, startDependencies]);
 
   const attributesChanged: boolean = useMemo(() => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/190442

This is causing the error, as it is not needed. The abortController when passed to the search strategy is handled by it
