### PR TITLE
[build] Update node cleanup paths

### DIFF
--- a/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
@@ -15,12 +15,12 @@ export const CleanNodeBuilds: Task = {
     for (const platform of config.getTargetPlatforms()) {
       await deleteAll(
         [
-          build.resolvePathForPlatform(platform, '*/node/*/lib/node_modules'),
-          build.resolvePathForPlatform(platform, '*/node/*/bin/npm'),
-          build.resolvePathForPlatform(platform, '*/node/*/bin/npx'),
-          build.resolvePathForPlatform(platform, '*/node/*/bin/corepack'),
-          build.resolvePathForPlatform(platform, '*/node/*/CHANGELOG.md'),
-          build.resolvePathForPlatform(platform, '*/node/*/README.md'),
+          build.resolvePathForPlatform(platform, 'node/*/lib/node_modules'),
+          build.resolvePathForPlatform(platform, 'node/*/bin/npm'),
+          build.resolvePathForPlatform(platform, 'node/*/bin/npx'),
+          build.resolvePathForPlatform(platform, 'node/*/bin/corepack'),
+          build.resolvePathForPlatform(platform, 'node/*/CHANGELOG.md'),
+          build.resolvePathForPlatform(platform, 'node/*/README.md'),
         ],
         log
       );

--- a/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
+++ b/src/dev/build/tasks/nodejs/clean_node_builds_task.ts
@@ -15,12 +15,12 @@ export const CleanNodeBuilds: Task = {
     for (const platform of config.getTargetPlatforms()) {
       await deleteAll(
         [
-          build.resolvePathForPlatform(platform, '*/node/lib/node_modules'),
-          build.resolvePathForPlatform(platform, '*/node/bin/npm'),
-          build.resolvePathForPlatform(platform, '*/node/bin/npx'),
-          build.resolvePathForPlatform(platform, '*/node/bin/corepack'),
-          build.resolvePathForPlatform(platform, '*/node/CHANGELOG.md'),
-          build.resolvePathForPlatform(platform, '*/node/README.md'),
+          build.resolvePathForPlatform(platform, '*/node/*/lib/node_modules'),
+          build.resolvePathForPlatform(platform, '*/node/*/bin/npm'),
+          build.resolvePathForPlatform(platform, '*/node/*/bin/npx'),
+          build.resolvePathForPlatform(platform, '*/node/*/bin/corepack'),
+          build.resolvePathForPlatform(platform, '*/node/*/CHANGELOG.md'),
+          build.resolvePathForPlatform(platform, '*/node/*/README.md'),
         ],
         log
       );


### PR DESCRIPTION
Prior to introducing node variants, we were cleaning up unused files included with Node.js.  The node paths changed, and the cleanup paths were not.  This fixes the issue.

## Testing

`$KIBANA_HOME/node/*` should be cleaned of unused files, see the patterns in the diff for exact files.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->