### PR TITLE
[8.15] [OAS/HTTP] Empty response bodies (status only) and descriptions for responses (#188632)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -499,7 +499,8 @@
                   "description": "Kibana's operational status. A minimal response is sent for unauthorized users."
                 }
               }
-            }
+            },
+            "description": "Overall status is OK and Kibana should be functioning normally."
           },
           "503": {
             "content": {
@@ -516,7 +517,8 @@
                   "description": "Kibana's operational status. A minimal response is sent for unauthorized users."
                 }
               }
-            }
+            },
+            "description": "Kibana or some of it's essential services are unavailable. Kibana may be degraded or unavailable."
           }
         },
         "summary": "Get Kibana's current status",

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -499,7 +499,8 @@
                   "description": "Kibana's operational status. A minimal response is sent for unauthorized users."
                 }
               }
-            }
+            },
+            "description": "Overall status is OK and Kibana should be functioning normally."
           },
           "503": {
             "content": {
@@ -516,7 +517,8 @@
                   "description": "Kibana's operational status. A minimal response is sent for unauthorized users."
                 }
               }
-            }
+            },
+            "description": "Kibana or some of it's essential services are unavailable. Kibana may be degraded or unavailable."
           }
         },
         "summary": "Get Kibana's current status",

--- a/packages/core/http/core-http-router-server-internal/src/router.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.test.ts
@@ -164,14 +164,14 @@ describe('Router', () => {
         isConfigSchema(
           (
             validationSchemas as () => RouteValidatorRequestAndResponses<unknown, unknown, unknown>
-          )().response![200].body()
+          )().response![200].body!()
         )
       ).toBe(true);
       expect(
         isConfigSchema(
           (
             validationSchemas as () => RouteValidatorRequestAndResponses<unknown, unknown, unknown>
-          )().response![404].body()
+          )().response![404].body!()
         )
       ).toBe(true);
     }

--- a/packages/core/http/core-http-router-server-internal/src/util.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/util.test.ts
@@ -21,6 +21,10 @@ describe('prepareResponseValidation', () => {
         404: {
           body: jest.fn(() => schema.string()),
         },
+        500: {
+          description: 'just a description',
+          body: undefined,
+        },
         unsafe: {
           body: true,
         },
@@ -32,13 +36,15 @@ describe('prepareResponseValidation', () => {
     expect(prepared).toEqual({
       200: { body: expect.any(Function) },
       404: { body: expect.any(Function) },
+      500: { description: 'just a description', body: undefined },
       unsafe: { body: true },
     });
 
-    [1, 2, 3].forEach(() => prepared[200].body());
-    [1, 2, 3].forEach(() => prepared[404].body());
+    [1, 2, 3].forEach(() => prepared[200].body!());
+    [1, 2, 3].forEach(() => prepared[404].body!());
 
     expect(validation.response![200].body).toHaveBeenCalledTimes(1);
     expect(validation.response![404].body).toHaveBeenCalledTimes(1);
+    expect(validation.response![500].body).toBeUndefined();
   });
 });

--- a/packages/core/http/core-http-router-server-internal/src/util.ts
+++ b/packages/core/http/core-http-router-server-internal/src/util.ts
@@ -9,24 +9,22 @@
 import { once } from 'lodash';
 import {
   isFullValidatorContainer,
+  type RouteValidatorFullConfigResponse,
   type RouteConfig,
   type RouteMethod,
   type RouteValidator,
 } from '@kbn/core-http-server';
-import type { ObjectType, Type } from '@kbn/config-schema';
 
 function isStatusCode(key: string) {
   return !isNaN(parseInt(key, 10));
 }
 
-interface ResponseValidation {
-  [statusCode: number]: { body: () => ObjectType | Type<unknown> };
-}
-
-export function prepareResponseValidation(validation: ResponseValidation): ResponseValidation {
+export function prepareResponseValidation(
+  validation: RouteValidatorFullConfigResponse
+): RouteValidatorFullConfigResponse {
   const responses = Object.entries(validation).map(([key, value]) => {
     if (isStatusCode(key)) {
-      return [key, { body: once(value.body) }];
+      return [key, { ...value, ...(value.body ? { body: once(value.body) } : {}) }];
     }
     return [key, value];
   });

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -191,13 +191,13 @@ export class CoreVersionedRoute implements VersionedRoute {
 
     const response = await handler.fn(ctx, req, res);
 
-    if (this.router.isDev && validation?.response?.[response.status]) {
+    if (this.router.isDev && validation?.response?.[response.status]?.body) {
       const { [response.status]: responseValidation, unsafe } = validation.response;
       try {
         validate(
           { body: response.payload },
           {
-            body: unwrapVersionedResponseBodyValidation(responseValidation.body),
+            body: unwrapVersionedResponseBodyValidation(responseValidation.body!),
             unsafe: { body: unsafe?.body },
           }
         );

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/util.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/util.test.ts
@@ -7,14 +7,55 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { VersionedRouteResponseValidation } from '@kbn/core-http-server';
-import { isCustomValidation, unwrapVersionedResponseBodyValidation } from './util';
+import type { VersionedRouteResponseValidation } from '@kbn/core-http-server';
+import {
+  isCustomValidation,
+  unwrapVersionedResponseBodyValidation,
+  prepareVersionedRouteValidation,
+} from './util';
 
 test.each([
   [() => schema.object({}), false],
   [{ custom: () => ({ value: 1 }) }, true],
 ])('isCustomValidation correctly detects custom validation %#', (input, result) => {
   expect(isCustomValidation(input)).toBe(result);
+});
+
+describe('prepareVersionedRouteValidation', () => {
+  it('wraps only expected values', () => {
+    const validate = {
+      request: {},
+      response: {
+        200: {
+          body: jest.fn(() => schema.string()),
+        },
+        404: {
+          body: jest.fn(() => schema.string()),
+        },
+        500: {
+          description: 'just a description',
+          body: undefined,
+        },
+      },
+    };
+
+    const prepared = prepareVersionedRouteValidation({
+      version: '1',
+      validate,
+    });
+
+    expect(prepared).toEqual({
+      version: '1',
+      validate: {
+        request: {},
+        response: {
+          200: { body: expect.any(Function) },
+          404: { body: expect.any(Function) },
+          500: { description: 'just a description', body: undefined },
+        },
+      },
+    });
+  });
 });
 
 test('unwrapVersionedResponseBodyValidation', () => {
@@ -29,6 +70,6 @@ test('unwrapVersionedResponseBodyValidation', () => {
     },
   };
 
-  expect(unwrapVersionedResponseBodyValidation(validation[200].body)).toBe(mySchema);
-  expect(unwrapVersionedResponseBodyValidation(validation[404].body)).toBe(custom);
+  expect(unwrapVersionedResponseBodyValidation(validation[200].body!)).toBe(mySchema);
+  expect(unwrapVersionedResponseBodyValidation(validation[404].body!)).toBe(custom);
 });

--- a/packages/core/http/core-http-router-server-internal/src/versioned_router/util.ts
+++ b/packages/core/http/core-http-router-server-internal/src/versioned_router/util.ts
@@ -30,7 +30,7 @@ export function isCustomValidation(
  * @internal
  */
 export function unwrapVersionedResponseBodyValidation(
-  validation: VersionedRouteResponseValidation[number]['body']
+  validation: VersionedResponseBodyValidation
 ): RouteValidationSpec<unknown> {
   if (isCustomValidation(validation)) {
     return validation.custom;
@@ -43,8 +43,15 @@ function prepareValidation(validation: VersionedRouteValidation<unknown, unknown
     const { unsafe, ...responseValidations } = validation.response;
     const result: VersionedRouteResponseValidation = {};
 
-    for (const [key, { body }] of Object.entries(responseValidations)) {
-      result[key as unknown as number] = { body: isCustomValidation(body) ? body : once(body) };
+    for (const [key, value] of Object.entries(responseValidations)) {
+      result[key as unknown as number] = {
+        ...value,
+      };
+      if (value.body) {
+        result[key as unknown as number].body = isCustomValidation(value.body)
+          ? value.body
+          : once(value.body);
+      }
     }
 
     return {

--- a/packages/core/http/core-http-server/src/router/route_validator.ts
+++ b/packages/core/http/core-http-server/src/router/route_validator.ts
@@ -169,10 +169,14 @@ export type RouteValidatorFullConfigRequest<P, Q, B> = RouteValidatorConfig<P, Q
 export interface RouteValidatorFullConfigResponse {
   [statusCode: number]: {
     /**
+     * A description of the response. This is required input for complete OAS documentation.
+     */
+    description?: string;
+    /**
      * A string representing the mime type of the response body.
      */
     bodyContentType?: string;
-    body: LazyValidator;
+    body?: LazyValidator;
   };
   unsafe?: {
     body?: boolean;

--- a/packages/core/http/core-http-server/src/versioning/types.ts
+++ b/packages/core/http/core-http-server/src/versioning/types.ts
@@ -274,10 +274,14 @@ export type VersionedResponseBodyValidation =
 export interface VersionedRouteResponseValidation {
   [statusCode: number]: {
     /**
+     * A description of the response. This is required input for complete OAS documentation.
+     */
+    description?: string;
+    /**
      * A string representing the mime type of the response body.
      */
     bodyContentType?: string;
-    body: VersionedResponseBodyValidation;
+    body?: VersionedResponseBodyValidation;
   };
   unsafe?: { body?: boolean };
 }

--- a/packages/core/status/core-status-server-internal/src/routes/status.ts
+++ b/packages/core/status/core-status-server-internal/src/routes/status.ts
@@ -119,9 +119,11 @@ export const registerStatusRoute = ({
         },
         response: {
           200: {
+            description: 'Overall status is OK and Kibana should be functioning normally.',
             body: statusResponse,
           },
           503: {
+            description: `Kibana or some of it's essential services are unavailable. Kibana may be degraded or unavailable.`,
             body: statusResponse,
           },
         },

--- a/packages/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/packages/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -85,6 +85,7 @@ Object {
                 },
               },
             },
+            "description": undefined,
           },
         },
         "summary": "",
@@ -211,6 +212,8 @@ Object {
                 },
               },
             },
+            "description": "OK response oas-test-version-1
+OK response oas-test-version-2",
           },
         },
         "summary": "versioned route",
@@ -220,6 +223,34 @@ Object {
       },
     },
     "/foo/{id}/{path*}": Object {
+      "delete": Object {
+        "description": "route description",
+        "operationId": "/foo/{id}/{path*}#2",
+        "parameters": Array [
+          Object {
+            "description": "The version of the API to use",
+            "in": "header",
+            "name": "elastic-api-version",
+            "schema": Object {
+              "default": "2023-10-31",
+              "enum": Array [
+                "2023-10-31",
+              ],
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": undefined,
+        "responses": Object {
+          "200": Object {
+            "description": "good response",
+          },
+        },
+        "summary": "route summary",
+        "tags": Array [
+          "bar",
+        ],
+      },
       "get": Object {
         "description": "route description",
         "operationId": "/foo/{id}/{path*}#0",
@@ -358,6 +389,7 @@ Object {
                 },
               },
             },
+            "description": undefined,
           },
         },
         "summary": "route summary",
@@ -503,6 +535,7 @@ Object {
                 },
               },
             },
+            "description": undefined,
           },
         },
         "summary": "route summary",
@@ -611,6 +644,7 @@ Object {
                 },
               },
             },
+            "description": undefined,
           },
         },
         "summary": "",
@@ -687,6 +721,7 @@ Object {
                 "schema": Object {},
               },
             },
+            "description": undefined,
           },
         },
         "summary": "",
@@ -724,6 +759,7 @@ Object {
                 "schema": Object {},
               },
             },
+            "description": undefined,
           },
         },
         "summary": "",

--- a/packages/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
+++ b/packages/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
@@ -1,0 +1,461 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { z } from 'zod';
+import { schema } from '@kbn/config-schema';
+
+export const sharedOas = {
+  components: {
+    schemas: {},
+    securitySchemes: {
+      apiKeyAuth: {
+        in: 'header',
+        name: 'Authorization',
+        type: 'apiKey',
+      },
+      basicAuth: {
+        scheme: 'basic',
+        type: 'http',
+      },
+    },
+  },
+  info: {
+    title: 'test',
+    version: '99.99.99',
+  },
+  openapi: '3.0.0',
+  paths: {
+    '/bar': {
+      get: {
+        deprecated: true,
+        operationId: '/bar#0',
+        parameters: [
+          {
+            description: 'The version of the API to use',
+            in: 'header',
+            name: 'elastic-api-version',
+            schema: {
+              default: 'oas-test-version-2',
+              enum: ['oas-test-version-1', 'oas-test-version-2'],
+              type: 'string',
+            },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json; Elastic-Api-Version=oas-test-version-1': {
+              schema: {
+                additionalProperties: false,
+                properties: {
+                  booleanDefault: {
+                    default: true,
+                    description: 'defaults to to true',
+                    type: 'boolean',
+                  },
+                  ipType: {
+                    format: 'ipv4',
+                    type: 'string',
+                  },
+                  literalType: {
+                    enum: ['literallythis'],
+                    type: 'string',
+                  },
+                  maybeNumber: {
+                    maximum: 1000,
+                    minimum: 1,
+                    type: 'number',
+                  },
+                  record: {
+                    additionalProperties: {
+                      type: 'string',
+                    },
+                    type: 'object',
+                  },
+                  string: {
+                    maxLength: 10,
+                    minLength: 1,
+                    type: 'string',
+                  },
+                  union: {
+                    anyOf: [
+                      {
+                        description: 'Union string',
+                        maxLength: 1,
+                        type: 'string',
+                      },
+                      {
+                        description: 'Union number',
+                        minimum: 0,
+                        type: 'number',
+                      },
+                    ],
+                  },
+                  uri: {
+                    default: 'prototest://something',
+                    format: 'uri',
+                    type: 'string',
+                  },
+                },
+                required: ['string', 'ipType', 'literalType', 'record', 'union'],
+                type: 'object',
+              },
+            },
+            'application/json; Elastic-Api-Version=oas-test-version-2': {
+              schema: {
+                additionalProperties: false,
+                properties: {
+                  foo: {
+                    type: 'string',
+                  },
+                },
+                required: ['foo'],
+                type: 'object',
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'OK response oas-test-version-1\nOK response oas-test-version-2',
+            content: {
+              'application/json; Elastic-Api-Version=oas-test-version-1': {
+                schema: {
+                  additionalProperties: false,
+                  description: 'fooResponse',
+                  properties: {
+                    fooResponseWithDescription: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['fooResponseWithDescription'],
+                  type: 'object',
+                },
+              },
+              'application/octet-stream; Elastic-Api-Version=oas-test-version-2': {
+                schema: {
+                  description: 'stream response',
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+        summary: 'versioned route',
+        tags: ['versioned'],
+      },
+    },
+    '/foo/{id}/{path*}': {
+      get: {
+        description: 'route description',
+        operationId: '/foo/{id}/{path*}#0',
+        parameters: [
+          {
+            description: 'The version of the API to use',
+            in: 'header',
+            name: 'elastic-api-version',
+            schema: {
+              default: '2023-10-31',
+              enum: ['2023-10-31'],
+              type: 'string',
+            },
+          },
+          {
+            description: 'id',
+            in: 'path',
+            name: 'id',
+            required: true,
+            schema: {
+              maxLength: 36,
+              type: 'string',
+            },
+          },
+          {
+            description: 'path',
+            in: 'path',
+            name: 'path',
+            required: true,
+            schema: {
+              maxLength: 36,
+              type: 'string',
+            },
+          },
+          {
+            description: 'page',
+            in: 'query',
+            name: 'page',
+            required: false,
+            schema: {
+              default: 1,
+              maximum: 999,
+              minimum: 1,
+              type: 'number',
+            },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json; Elastic-Api-Version=2023-10-31': {
+              schema: {
+                additionalProperties: false,
+                properties: {
+                  booleanDefault: {
+                    default: true,
+                    description: 'defaults to to true',
+                    type: 'boolean',
+                  },
+                  ipType: {
+                    format: 'ipv4',
+                    type: 'string',
+                  },
+                  literalType: {
+                    enum: ['literallythis'],
+                    type: 'string',
+                  },
+                  maybeNumber: {
+                    maximum: 1000,
+                    minimum: 1,
+                    type: 'number',
+                  },
+                  record: {
+                    additionalProperties: {
+                      type: 'string',
+                    },
+                    type: 'object',
+                  },
+                  string: {
+                    maxLength: 10,
+                    minLength: 1,
+                    type: 'string',
+                  },
+                  union: {
+                    anyOf: [
+                      {
+                        description: 'Union string',
+                        maxLength: 1,
+                        type: 'string',
+                      },
+                      {
+                        description: 'Union number',
+                        minimum: 0,
+                        type: 'number',
+                      },
+                    ],
+                  },
+                  uri: {
+                    default: 'prototest://something',
+                    format: 'uri',
+                    type: 'string',
+                  },
+                },
+                required: ['string', 'ipType', 'literalType', 'record', 'union'],
+                type: 'object',
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            content: {
+              'application/json; Elastic-Api-Version=2023-10-31': {
+                schema: {
+                  maxLength: 10,
+                  minLength: 1,
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+        summary: 'route summary',
+        tags: ['bar'],
+      },
+      post: {
+        description: 'route description',
+        operationId: '/foo/{id}/{path*}#1',
+        parameters: [
+          {
+            description: 'The version of the API to use',
+            in: 'header',
+            name: 'elastic-api-version',
+            schema: {
+              default: '2023-10-31',
+              enum: ['2023-10-31'],
+              type: 'string',
+            },
+          },
+          {
+            description: 'id',
+            in: 'path',
+            name: 'id',
+            required: true,
+            schema: {
+              maxLength: 36,
+              type: 'string',
+            },
+          },
+          {
+            description: 'path',
+            in: 'path',
+            name: 'path',
+            required: true,
+            schema: {
+              maxLength: 36,
+              type: 'string',
+            },
+          },
+          {
+            description: 'page',
+            in: 'query',
+            name: 'page',
+            required: false,
+            schema: {
+              default: 1,
+              maximum: 999,
+              minimum: 1,
+              type: 'number',
+            },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json; Elastic-Api-Version=2023-10-31': {
+              schema: {
+                additionalProperties: false,
+                properties: {
+                  booleanDefault: {
+                    default: true,
+                    description: 'defaults to to true',
+                    type: 'boolean',
+                  },
+                  ipType: {
+                    format: 'ipv4',
+                    type: 'string',
+                  },
+                  literalType: {
+                    enum: ['literallythis'],
+                    type: 'string',
+                  },
+                  maybeNumber: {
+                    maximum: 1000,
+                    minimum: 1,
+                    type: 'number',
+                  },
+                  record: {
+                    additionalProperties: {
+                      type: 'string',
+                    },
+                    type: 'object',
+                  },
+                  string: {
+                    maxLength: 10,
+                    minLength: 1,
+                    type: 'string',
+                  },
+                  union: {
+                    anyOf: [
+                      {
+                        description: 'Union string',
+                        maxLength: 1,
+                        type: 'string',
+                      },
+                      {
+                        description: 'Union number',
+                        minimum: 0,
+                        type: 'number',
+                      },
+                    ],
+                  },
+                  uri: {
+                    default: 'prototest://something',
+                    format: 'uri',
+                    type: 'string',
+                  },
+                },
+                required: ['string', 'ipType', 'literalType', 'record', 'union'],
+                type: 'object',
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            content: {
+              'application/json; Elastic-Api-Version=2023-10-31': {
+                schema: {
+                  maxLength: 10,
+                  minLength: 1,
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+        summary: 'route summary',
+        tags: ['bar'],
+      },
+    },
+  },
+  security: [
+    {
+      basicAuth: [],
+    },
+  ],
+  servers: [
+    {
+      url: 'https://test.oas',
+    },
+  ],
+  tags: [
+    {
+      name: 'bar',
+    },
+    {
+      name: 'versioned',
+    },
+  ],
+};
+
+export function createSharedConfigSchema() {
+  return schema.object({
+    string: schema.string({ maxLength: 10, minLength: 1 }),
+    maybeNumber: schema.maybe(schema.number({ max: 1000, min: 1 })),
+    booleanDefault: schema.boolean({
+      defaultValue: true,
+      meta: {
+        description: 'defaults to to true',
+      },
+    }),
+    ipType: schema.ip({ versions: ['ipv4'] }),
+    literalType: schema.literal('literallythis'),
+    record: schema.recordOf(schema.string(), schema.string()),
+    union: schema.oneOf([
+      schema.string({ maxLength: 1, meta: { description: 'Union string' } }),
+      schema.number({ min: 0, meta: { description: 'Union number' } }),
+    ]),
+    uri: schema.uri({
+      scheme: ['prototest'],
+      defaultValue: () => 'prototest://something',
+    }),
+  });
+}
+
+export function createSharedZodSchema() {
+  return z.object({
+    string: z.string().max(10).min(1),
+    maybeNumber: z.number().max(1000).min(1).optional(),
+    booleanDefault: z.boolean({ description: 'defaults to to true' }).default(true),
+    ipType: z.string().ip({ version: 'v4' }),
+    literalType: z.literal('literallythis'),
+    record: z.record(z.string(), z.string()),
+    union: z.union([
+      z.string({ description: 'Union string' }).max(1),
+      z.number({ description: 'Union number' }).min(0),
+    ]),
+    uri: z.string().url().default('prototest://something'),
+  });
+}

--- a/packages/kbn-router-to-openapispec/src/generate_oas.test.ts
+++ b/packages/kbn-router-to-openapispec/src/generate_oas.test.ts
@@ -19,7 +19,21 @@ describe('generateOpenApiDocument', () => {
   describe('@kbn/config-schema', () => {
     it('generates the expected OpenAPI document', () => {
       const [routers, versionedRouters] = createTestRouters({
-        routers: { testRouter: { routes: [{ method: 'get' }, { method: 'post' }] } },
+        routers: {
+          testRouter: {
+            routes: [
+              { method: 'get' },
+              { method: 'post' },
+              {
+                method: 'delete',
+                validationSchemas: {
+                  request: {},
+                  response: { [200]: { description: 'good response' } },
+                },
+              },
+            ],
+          },
+        },
         versionedRouters: { testVersionedRouter: { routes: [{}] } },
       });
       expect(

--- a/packages/kbn-router-to-openapispec/src/generate_oas.test.util.ts
+++ b/packages/kbn-router-to-openapispec/src/generate_oas.test.util.ts
@@ -80,6 +80,7 @@ export const getVersionedRouterDefaults = () => ({
           },
           response: {
             [200]: {
+              description: 'OK response oas-test-version-1',
               body: () =>
                 schema.object(
                   { fooResponseWithDescription: schema.string() },
@@ -98,6 +99,7 @@ export const getVersionedRouterDefaults = () => ({
           request: { body: schema.object({ foo: schema.string() }) },
           response: {
             [200]: {
+              description: 'OK response oas-test-version-2',
               body: () => schema.stream({ meta: { description: 'stream response' } }),
               bodyContentType: 'application/octet-stream',
             },

--- a/packages/kbn-router-to-openapispec/src/process_router.test.ts
+++ b/packages/kbn-router-to-openapispec/src/process_router.test.ts
@@ -33,10 +33,12 @@ describe('extractResponses', () => {
         response: {
           200: {
             bodyContentType: 'application/test+json',
+            description: 'OK response',
             body: () => schema.object({ bar: schema.number({ min: 1, max: 99 }) }),
           },
           404: {
             bodyContentType: 'application/test2+json',
+            description: 'Not Found response',
             body: () => schema.object({ ok: schema.literal(false) }),
           },
           unsafe: { body: false },
@@ -45,6 +47,7 @@ describe('extractResponses', () => {
     };
     expect(extractResponses(route, oasConverter)).toEqual({
       200: {
+        description: 'OK response',
         content: {
           'application/test+json; Elastic-Api-Version=2023-10-31': {
             schema: {
@@ -59,6 +62,7 @@ describe('extractResponses', () => {
         },
       },
       404: {
+        description: 'Not Found response',
         content: {
           'application/test2+json; Elastic-Api-Version=2023-10-31': {
             schema: {

--- a/packages/kbn-router-to-openapispec/src/process_versioned_router.test.ts
+++ b/packages/kbn-router-to-openapispec/src/process_versioned_router.test.ts
@@ -20,60 +20,6 @@ import {
   extractVersionedRequestBodies,
 } from './process_versioned_router';
 
-const route: VersionedRouterRoute = {
-  path: '/foo',
-  method: 'get',
-  options: {
-    access: 'public',
-    options: { body: { access: ['application/test+json'] } as any },
-  },
-  handlers: [
-    {
-      fn: jest.fn(),
-      options: {
-        version: '2023-10-31',
-        validate: () => ({
-          request: {
-            body: schema.object({ foo: schema.string() }),
-          },
-          response: {
-            200: {
-              bodyContentType: 'application/test+json',
-              body: () => schema.object({ bar: schema.number({ min: 1, max: 99 }) }),
-            },
-            404: {
-              bodyContentType: 'application/test2+json',
-              body: () => schema.object({ ok: schema.literal(false) }),
-            },
-            unsafe: { body: false },
-          },
-        }),
-      },
-    },
-    {
-      fn: jest.fn(),
-      options: {
-        version: '2024-12-31',
-        validate: () => ({
-          request: {
-            body: schema.object({ foo2: schema.string() }),
-          },
-          response: {
-            200: {
-              bodyContentType: 'application/test+json',
-              body: () => schema.object({ bar2: schema.number({ min: 1, max: 99 }) }),
-            },
-            500: {
-              bodyContentType: 'application/test2+json',
-              body: () => schema.object({ ok: schema.literal(false) }),
-            },
-            unsafe: { body: false },
-          },
-        }),
-      },
-    },
-  ],
-};
 let oasConverter: OasConverter;
 beforeEach(() => {
   oasConverter = new OasConverter();
@@ -81,7 +27,9 @@ beforeEach(() => {
 
 describe('extractVersionedRequestBodies', () => {
   test('handles full request config as expected', () => {
-    expect(extractVersionedRequestBodies(route, oasConverter, ['application/json'])).toEqual({
+    expect(
+      extractVersionedRequestBodies(createTestRoute(), oasConverter, ['application/json'])
+    ).toEqual({
       'application/json; Elastic-Api-Version=2023-10-31': {
         schema: {
           additionalProperties: false,
@@ -112,8 +60,11 @@ describe('extractVersionedRequestBodies', () => {
 
 describe('extractVersionedResponses', () => {
   test('handles full response config as expected', () => {
-    expect(extractVersionedResponses(route, oasConverter, ['application/test+json'])).toEqual({
+    expect(
+      extractVersionedResponses(createTestRoute(), oasConverter, ['application/test+json'])
+    ).toEqual({
       200: {
+        description: 'OK response 2023-10-31\nOK response 2024-12-31', // merge multiple version descriptions
         content: {
           'application/test+json; Elastic-Api-Version=2023-10-31': {
             schema: {
@@ -138,6 +89,7 @@ describe('extractVersionedResponses', () => {
         },
       },
       404: {
+        description: 'Not Found response 2023-10-31',
         content: {
           'application/test2+json; Elastic-Api-Version=2023-10-31': {
             schema: {
@@ -172,7 +124,7 @@ describe('extractVersionedResponses', () => {
 describe('processVersionedRouter', () => {
   it('correctly extracts the version based on the version filter', () => {
     const baseCase = processVersionedRouter(
-      { getRoutes: () => [route] } as unknown as CoreVersionedRouter,
+      { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
       new OasConverter(),
       createOperationIdCounter(),
       {}
@@ -184,7 +136,7 @@ describe('processVersionedRouter', () => {
     ]);
 
     const filteredCase = processVersionedRouter(
-      { getRoutes: () => [route] } as unknown as CoreVersionedRouter,
+      { getRoutes: () => [createTestRoute()] } as unknown as CoreVersionedRouter,
       new OasConverter(),
       createOperationIdCounter(),
       { version: '2023-10-31' }
@@ -193,4 +145,62 @@ describe('processVersionedRouter', () => {
       'application/test+json; Elastic-Api-Version=2023-10-31',
     ]);
   });
+});
+
+const createTestRoute: () => VersionedRouterRoute = () => ({
+  path: '/foo',
+  method: 'get',
+  options: {
+    access: 'public',
+    options: { body: { access: ['application/test+json'] } as any },
+  },
+  handlers: [
+    {
+      fn: jest.fn(),
+      options: {
+        version: '2023-10-31',
+        validate: () => ({
+          request: {
+            body: schema.object({ foo: schema.string() }),
+          },
+          response: {
+            200: {
+              description: 'OK response 2023-10-31',
+              bodyContentType: 'application/test+json',
+              body: () => schema.object({ bar: schema.number({ min: 1, max: 99 }) }),
+            },
+            404: {
+              description: 'Not Found response 2023-10-31',
+              bodyContentType: 'application/test2+json',
+              body: () => schema.object({ ok: schema.literal(false) }),
+            },
+            unsafe: { body: false },
+          },
+        }),
+      },
+    },
+    {
+      fn: jest.fn(),
+      options: {
+        version: '2024-12-31',
+        validate: () => ({
+          request: {
+            body: schema.object({ foo2: schema.string() }),
+          },
+          response: {
+            200: {
+              description: 'OK response 2024-12-31',
+              bodyContentType: 'application/test+json',
+              body: () => schema.object({ bar2: schema.number({ min: 1, max: 99 }) }),
+            },
+            500: {
+              bodyContentType: 'application/test2+json',
+              body: () => schema.object({ ok: schema.literal(false) }),
+            },
+            unsafe: { body: false },
+          },
+        }),
+      },
+    },
+  ],
 });

--- a/packages/kbn-router-to-openapispec/src/util.test.ts
+++ b/packages/kbn-router-to-openapispec/src/util.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { OpenAPIV3 } from 'openapi-types';
-import { buildGlobalTags, prepareRoutes } from './util';
+import { buildGlobalTags, mergeResponseContent, prepareRoutes } from './util';
 import { assignToPaths, extractTags } from './util';
 
 describe('extractTags', () => {
@@ -157,5 +157,31 @@ describe('prepareRoutes', () => {
     },
   ])('returns the expected routes #%#', ({ input, output, filters }) => {
     expect(prepareRoutes(input, filters)).toEqual(output);
+  });
+});
+
+describe('mergeResponseContent', () => {
+  it('returns an empty object if no content is provided', () => {
+    expect(mergeResponseContent(undefined, undefined)).toEqual({});
+    expect(mergeResponseContent({}, {})).toEqual({});
+  });
+
+  it('merges content objects', () => {
+    expect(
+      mergeResponseContent(
+        {
+          ['application/json+v1']: { encoding: {} },
+        },
+        {
+          ['application/json+v1']: { example: 'overridden' },
+          ['application/json+v2']: {},
+        }
+      )
+    ).toEqual({
+      content: {
+        ['application/json+v1']: { example: 'overridden' },
+        ['application/json+v2']: {},
+      },
+    });
   });
 });

--- a/packages/kbn-router-to-openapispec/src/util.ts
+++ b/packages/kbn-router-to-openapispec/src/util.ts
@@ -131,3 +131,14 @@ export const assignToPaths = (
   const pathName = path.replace('?', '');
   paths[pathName] = { ...paths[pathName], ...pathObject };
 };
+
+export const mergeResponseContent = (
+  a: OpenAPIV3.ResponseObject['content'],
+  b: OpenAPIV3.ResponseObject['content']
+) => {
+  const mergedContent = {
+    ...(a ?? {}),
+    ...(b ?? {}),
+  };
+  return { ...(Object.keys(mergedContent).length ? { content: mergedContent } : {}) };
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[OAS/HTTP] Empty response bodies (status only) and descriptions for responses (#188632)](https://github.com/elastic/kibana/pull/188632)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2024-07-22T13:29:15Z","message":"[OAS/HTTP] Empty response bodies (status only) and descriptions for responses (#188632)\n\n## Summary\r\n\r\n* Adds the ability to exclude a response schema when declaring route\r\nschemas\r\n* Adds the ability to provide a description of a the response\r\n\r\nSee code comments for more info.\r\n\r\n## Example\r\n\r\nYou can declare a response with no validation to imply an empty object\r\nin OAS\r\n\r\n```\r\nrouter.versioned.post({ version: '2023-10-31', access: 'public', path: '...' })\r\n  .addVersion({\r\n    validation: {\r\n      responses: {\r\n        201: { description: 'Resource created!' }\r\n      }\r\n    }\r\n  }, () => {})\r\n```\r\n\r\nWill result in\r\n\r\n```jsonc\r\n{\r\n //...\r\n  201: { description: 'Resource created!' }\r\n //...\r\n}\r\n```\r\n\r\n## Risks\r\n\r\nNo notable risks","sha":"a8091ab0acff6f8fae2cbe19c273048fb2734632","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:http","Team:Core","release_note:skip","backport:skip","v8.15.0","Feature:OAS","v8.16.0"],"number":188632,"url":"https://github.com/elastic/kibana/pull/188632","mergeCommit":{"message":"[OAS/HTTP] Empty response bodies (status only) and descriptions for responses (#188632)\n\n## Summary\r\n\r\n* Adds the ability to exclude a response schema when declaring route\r\nschemas\r\n* Adds the ability to provide a description of a the response\r\n\r\nSee code comments for more info.\r\n\r\n## Example\r\n\r\nYou can declare a response with no validation to imply an empty object\r\nin OAS\r\n\r\n```\r\nrouter.versioned.post({ version: '2023-10-31', access: 'public', path: '...' })\r\n  .addVersion({\r\n    validation: {\r\n      responses: {\r\n        201: { description: 'Resource created!' }\r\n      }\r\n    }\r\n  }, () => {})\r\n```\r\n\r\nWill result in\r\n\r\n```jsonc\r\n{\r\n //...\r\n  201: { description: 'Resource created!' }\r\n //...\r\n}\r\n```\r\n\r\n## Risks\r\n\r\nNo notable risks","sha":"a8091ab0acff6f8fae2cbe19c273048fb2734632"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188632","number":188632,"mergeCommit":{"message":"[OAS/HTTP] Empty response bodies (status only) and descriptions for responses (#188632)\n\n## Summary\r\n\r\n* Adds the ability to exclude a response schema when declaring route\r\nschemas\r\n* Adds the ability to provide a description of a the response\r\n\r\nSee code comments for more info.\r\n\r\n## Example\r\n\r\nYou can declare a response with no validation to imply an empty object\r\nin OAS\r\n\r\n```\r\nrouter.versioned.post({ version: '2023-10-31', access: 'public', path: '...' })\r\n  .addVersion({\r\n    validation: {\r\n      responses: {\r\n        201: { description: 'Resource created!' }\r\n      }\r\n    }\r\n  }, () => {})\r\n```\r\n\r\nWill result in\r\n\r\n```jsonc\r\n{\r\n //...\r\n  201: { description: 'Resource created!' }\r\n //...\r\n}\r\n```\r\n\r\n## Risks\r\n\r\nNo notable risks","sha":"a8091ab0acff6f8fae2cbe19c273048fb2734632"}}]}] BACKPORT-->