### PR TITLE
[PoC] Entities data source profile

### DIFF
--- a/src/plugins/discover/public/context_awareness/profile_providers/entities_data_source_profile/index.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/entities_data_source_profile/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { createEntitiesDataSourceProfileProvider } from './profile';

--- a/src/plugins/discover/public/context_awareness/profile_providers/entities_data_source_profile/profile.tsx
+++ b/src/plugins/discover/public/context_awareness/profile_providers/entities_data_source_profile/profile.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { DataSourceCategory, DataSourceProfileProvider } from '../../profiles';
+import { extractIndexPatternFrom } from '../extract_index_pattern_from';
+
+export const createEntitiesDataSourceProfileProvider = (): DataSourceProfileProvider => ({
+  profileId: 'entities-data-source-profile',
+  profile: {
+    // Custom rendering in grid cells
+    getCellRenderers: (prev) => () => ({
+      ...prev(),
+
+      // This is your summary column
+      _source: (props) => {
+        return <pre>{JSON.stringify(props.row.flattened, null, 2)}</pre>;
+      },
+
+      // Another cell renderer by field name
+      other_field: (props) => {
+        const val = props.row.flattened.other_field;
+
+        return <marquee>{val}</marquee>;
+      },
+    }),
+
+    // You can define default columns with this
+    getDefaultAppState: () => () => ({
+      columns: [{ name: '@timestamp', width: 212 }, { name: 'other_field' }],
+    }),
+
+    // Add a new doc viewer tab
+    getDocViewer: (prev) => (params) => {
+      const prevDocViewer = prev(params);
+
+      return {
+        ...prevDocViewer,
+        docViewsRegistry: (registry) => {
+          registry.add({
+            id: 'doc_view_entity_overview',
+            title: 'Entity overview',
+            order: 0,
+            component: (props) => {
+              return (
+                <>
+                  <br />
+                  <h1 css={{ fontWeight: 'bold' }}>Entity overview</h1>
+                  <br />
+                  <pre>{JSON.stringify(props.hit.flattened, null, 2)}</pre>
+                </>
+              );
+            },
+          });
+
+          return prevDocViewer.docViewsRegistry(registry);
+        },
+      };
+    },
+
+    // Custom row actions can be added like this
+    getRowAdditionalLeadingControls: (prev) => (params) =>
+      [
+        ...(prev(params) || []),
+        {
+          id: 'entity_control',
+          headerAriaLabel: 'Entity control',
+          renderControl: (Control, rowProps) => {
+            return (
+              <Control
+                label="Entity control"
+                iconType="gear"
+                onClick={() => {
+                  alert(`Entity control clicked. Row index: ${rowProps.rowIndex}`);
+                }}
+              />
+            );
+          },
+        },
+      ],
+  },
+  resolve: (params) => {
+    const indexPattern = extractIndexPatternFrom(params);
+
+    if (!indexPattern?.startsWith('entities-')) {
+      return { isMatch: false };
+    }
+
+    return {
+      isMatch: true,
+      context: { category: DataSourceCategory.Entities },
+    };
+  },
+});

--- a/src/plugins/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -23,6 +23,7 @@ import {
   createProfileProviderServices,
   ProfileProviderServices,
 } from './profile_provider_services';
+import { createEntitiesDataSourceProfileProvider } from './entities_data_source_profile';
 
 export const registerProfileProviders = ({
   rootProfileService,
@@ -91,6 +92,7 @@ const createRootProfileProviders = (_providerServices: ProfileProviderServices) 
   [] as RootProfileProvider[];
 
 const createDataSourceProfileProviders = (providerServices: ProfileProviderServices) => [
+  createEntitiesDataSourceProfileProvider(),
   ...createLogsDataSourceProfileProviders(providerServices),
 ];
 

--- a/src/plugins/discover/public/context_awareness/profiles/data_source_profile.ts
+++ b/src/plugins/discover/public/context_awareness/profiles/data_source_profile.ts
@@ -14,6 +14,7 @@ import type { Profile } from '../types';
 import type { RootContext } from './root_profile';
 
 export enum DataSourceCategory {
+  Entities = 'entities',
   Logs = 'logs',
   Default = 'default',
 }


### PR DESCRIPTION
## Summary

A PoC for an entities data source profile in Discover:

https://github.com/user-attachments/assets/7390c623-3249-4d61-b9eb-ae8e86996a2b

Dummy doc:
```
POST entities-test/_doc
{
  "@timestamp": "2024-08-06T06:31:10.093Z",
  "container.id": "docker://5948521",
  "container.name": "nginx",
  "data_stream.dataset": "synth",
  "data_stream.namespace": "default",
  "ecs.version": "1.10.0",
  "event.dataset": "kubernetes.container",
  "event.module": "kubernetes",
  "host.ip": "192.168.1.235",
  "kubernetes.namespace": "staging",
  "kubernetes.node.name": "node-7",
  "kubernetes.pod.name": "redis-pod-24",
  "process.pid": "n008",
  "other_field": "MY COOL FIELD"
}
```