### PR TITLE
[QA]Fix monaco console request in stack functional integration.

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/ccs/ccs_console.js
+++ b/x-pack/test/stack_functional_integration/apps/ccs/ccs_console.js
@@ -30,7 +30,7 @@ export default function ({ getService, getPageObjects }) {
         await PageObjects.console.monaco.clearEditorText();
       });
       it('it should be able to access remote data', async () => {
-        await PageObjects.console.enterRequest(
+        await PageObjects.console.monaco.enterText(
           '\nGET ftr-remote:makelogs工程-*/_search\n {\n "query": {\n "bool": {\n "must": [\n {"match": {"extension" : "jpg"} \n}\n}\n}\n}\n}'
         );
         await PageObjects.console.clickPlay();


### PR DESCRIPTION
## Summary
Switches to the correct method for sending a request to the dev console. Previous one was using the old Ace eaditor dev console. 


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->