### PR TITLE
Fix Risk Entity Calculation MKI test  

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
@@ -141,7 +141,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await waitForRiskScoresToBePresent({ es, log, scoreCount: 2 });
         const persistedScores = await readRiskScores(es);
 
-        expect(persistedScores.length).to.greaterThan(1); // the risk score will is calculated once by the risk engine and a second time by the API
+        expect(persistedScores.length).to.greaterThan(1); // the risk score is calculated once by the risk engine and a second time by the API
         const [persistedScoreByApi, persistedScoreByEngine] = normalizeScores(persistedScores);
 
         expect(persistedScoreByApi).to.eql(expectedScore);
@@ -192,7 +192,7 @@ export default ({ getService }: FtrProviderContext): void => {
           await waitForRiskScoresToBePresent({ es, log, scoreCount: 2 });
           const persistedScores = await readRiskScores(es);
 
-          expect(persistedScores.length).to.greaterThan(1); // the risk score will is calculated once by the risk engine and a second time by the API
+          expect(persistedScores.length).to.greaterThan(1); // the risk score is calculated once by the risk engine and a second time by the API
           const [persistedScoreByApi, persistedScoreByEngine] = normalizeScores(persistedScores);
           expect(persistedScoreByApi).to.eql(expectedScore);
           expect(persistedScoreByApi).to.eql(persistedScoreByEngine);

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_score_entity_calculation.ts
@@ -57,9 +57,8 @@ export default ({ getService }: FtrProviderContext): void => {
     return result;
   };
 
-  const calculateEntityRiskScoreAfterRuleCreationAndExecution = async (
+  const createRuleAndWaitExecution = async (
     documentId: string,
-    identifier: string,
     {
       alerts = 1,
       riskScore = 21,
@@ -67,7 +66,9 @@ export default ({ getService }: FtrProviderContext): void => {
     }: { alerts?: number; riskScore?: number; maxSignals?: number } = {}
   ) => {
     await createAndSyncRuleAndAlerts({ query: `id: ${documentId}`, alerts, riskScore, maxSignals });
+  };
 
+  const calculateEntityRiskScore = async (identifier: string) => {
     return await calculateEntityRiskScores({
       body: {
         identifier_type: 'host',
@@ -102,9 +103,7 @@ export default ({ getService }: FtrProviderContext): void => {
       beforeEach(async () => {
         await deleteAllAlerts(supertest, log, es);
         await deleteAllRules(supertest, log);
-
         await cleanRiskEngine({ kibanaServer, es, log });
-        await riskEngineRoutes.init();
       });
 
       afterEach(async () => {
@@ -118,11 +117,11 @@ export default ({ getService }: FtrProviderContext): void => {
       it('calculates and persists risk score for entity', async () => {
         const documentId = uuidv4();
         await indexListOfDocuments([buildDocument({ host: { name: 'host-1' } }, documentId)]);
+        await createRuleAndWaitExecution(documentId);
+        await riskEngineRoutes.init();
+        await waitForRiskScoresToBePresent({ es, log, scoreCount: 1 });
 
-        const results = await calculateEntityRiskScoreAfterRuleCreationAndExecution(
-          documentId,
-          'host-1'
-        );
+        const results = await calculateEntityRiskScore('host-1');
 
         const expectedScore = {
           calculated_level: 'Unknown',
@@ -139,13 +138,14 @@ export default ({ getService }: FtrProviderContext): void => {
         expect(score).to.eql(expectedScore);
         expect(results.success).to.be(true);
 
-        await waitForRiskScoresToBePresent({ es, log });
+        await waitForRiskScoresToBePresent({ es, log, scoreCount: 2 });
         const persistedScores = await readRiskScores(es);
 
-        expect(persistedScores.length).to.eql(1);
-        const [persistedScore] = normalizeScores(persistedScores);
+        expect(persistedScores.length).to.greaterThan(1); // the risk score will is calculated once by the risk engine and a second time by the API
+        const [persistedScoreByApi, persistedScoreByEngine] = normalizeScores(persistedScores);
 
-        expect(persistedScore).to.eql(expectedScore);
+        expect(persistedScoreByApi).to.eql(expectedScore);
+        expect(persistedScoreByApi).to.eql(persistedScoreByEngine);
       });
 
       describe('with asset criticality data', () => {
@@ -167,11 +167,12 @@ export default ({ getService }: FtrProviderContext): void => {
           const documentId = uuidv4();
           await indexListOfDocuments([buildDocument({ host: { name: 'host-1' } }, documentId)]);
           await waitForAssetCriticalityToBePresent({ es, log });
+          await createRuleAndWaitExecution(documentId);
+          await riskEngineRoutes.init();
+          await waitForRiskScoresToBePresent({ es, log, scoreCount: 1 });
 
-          const results = await calculateEntityRiskScoreAfterRuleCreationAndExecution(
-            documentId,
-            'host-1'
-          );
+          const results = await calculateEntityRiskScore('host-1');
+
           const expectedScore = {
             criticality_level: 'high_impact',
             criticality_modifier: 1.5,
@@ -188,20 +189,21 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(results.success).to.be(true);
           expect(score).to.eql(expectedScore);
 
-          await waitForRiskScoresToBePresent({ es, log });
+          await waitForRiskScoresToBePresent({ es, log, scoreCount: 2 });
           const persistedScores = await readRiskScores(es);
-          expect(persistedScores.length).to.eql(1);
 
-          const [persistedScore] = normalizeScores(persistedScores);
+          expect(persistedScores.length).to.greaterThan(1); // the risk score will is calculated once by the risk engine and a second time by the API
+          const [persistedScoreByApi, persistedScoreByEngine] = normalizeScores(persistedScores);
+          expect(persistedScoreByApi).to.eql(expectedScore);
+          expect(persistedScoreByApi).to.eql(persistedScoreByEngine);
 
-          expect(persistedScore).to.eql(expectedScore);
           const [rawScore] = persistedScores;
 
           expect(
             rawScore.host?.risk.category_1_score! + rawScore.host?.risk.category_2_score!
           ).to.be.within(
-            persistedScore.calculated_score_norm! - 0.000000000000001,
-            persistedScore.calculated_score_norm! + 0.000000000000001
+            persistedScoreByApi.calculated_score_norm! - 0.000000000000001,
+            persistedScoreByApi.calculated_score_norm! + 0.000000000000001
           );
         });
       });


### PR DESCRIPTION
## Summary

When the Entity Calculation API is called, the risk engine is also running and inserting documents into the risk score index. That is why we can't assert that only the API will insert documents into the index.

To make the test more reliable, I updated the code to wait for the risk engine to run before calling the API. This way, we can assert that the document produced by the API is created after it is called.

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
