### PR TITLE
[Config] Fix handling of splittable subkeys when processing values

### DIFF
--- a/packages/kbn-config/src/__fixtures__/unsplittable_3.yml
+++ b/packages/kbn-config/src/__fixtures__/unsplittable_3.yml
@@ -1,0 +1,7 @@
+
+'[foo.bar]': "foobar"
+list:
+  - id: "id1"
+    '[a.b]': ['foo', 'bar']
+    test.this.out: ['foo', 'bar']
+

--- a/packages/kbn-config/src/raw/read_config.test.ts
+++ b/packages/kbn-config/src/raw/read_config.test.ts
@@ -131,6 +131,33 @@ test('supports unsplittable key syntax on nested list', () => {
   `);
 });
 
+test('supports unsplittable key syntax on nested list with splittable subkeys', () => {
+  const config = getConfigFromFiles([fixtureFile('/unsplittable_3.yml')]);
+
+  expect(config).toMatchInlineSnapshot(`
+    Object {
+      "foo.bar": "foobar",
+      "list": Array [
+        Object {
+          "a.b": Array [
+            "foo",
+            "bar",
+          ],
+          "id": "id1",
+          "test": Object {
+            "this": Object {
+              "out": Array [
+                "foo",
+                "bar",
+              ],
+            },
+          },
+        },
+      ],
+    }
+  `);
+});
+
 test('supports var:default syntax', () => {
   process.env.KBN_ENV_VAR1 = 'val1';
 

--- a/packages/kbn-config/src/raw/read_config.ts
+++ b/packages/kbn-config/src/raw/read_config.ts
@@ -59,7 +59,9 @@ function processEntryValue(value: any) {
         delete value[subKey];
         set(value, [unsplitKey], processEntryValue(subVal));
       } else {
-        set(value, subKey, processEntryValue(subVal));
+        const subKeySplits = splitKey(subKey);
+        if (subKeySplits.length > 1) delete value[subKey];
+        set(value, subKeySplits, processEntryValue(subVal));
       }
     }
   } else if (typeof value === 'string') {


### PR DESCRIPTION
## Summary

Follow up from https://github.com/elastic/kibana/pull/178841

## Release note

We fixed a bug when processing YAML configuration keys that contain dotted notation in objects in arrays. This can manifest as a validation error causing Kibana to not start.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->