### PR TITLE
[Observability Onboarding] Link to right APM onboarding from the panel

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.ts
@@ -23,7 +23,11 @@ export function useCustomCardsForCategory(
   const history = useHistory();
   const location = useLocation();
   const {
-    services: { application, http },
+    services: {
+      application,
+      http,
+      context: { isServerless },
+    },
   } = useKibana<ObservabilityOnboardingAppServices>();
   const getUrlForApp = application?.getUrlForApp;
 
@@ -31,6 +35,9 @@ export function useCustomCardsForCategory(
   const { href: customLogsUrl } = reactRouterNavigate(history, `/customLogs/${location.search}`);
   const { href: otelLogsUrl } = reactRouterNavigate(history, `/otel-logs/${location.search}`);
   const { href: kubernetesUrl } = reactRouterNavigate(history, `/kubernetes/${location.search}`);
+
+  const apmUrl = `${getUrlForApp?.('apm')}/${isServerless ? 'onboarding' : 'tutorial'}`;
+  const otelApmUrl = isServerless ? `${apmUrl}?agent=openTelemetry` : apmUrl;
 
   const otelCard: VirtualCard = {
     id: 'otel-logs',
@@ -68,7 +75,7 @@ export function useCustomCardsForCategory(
               src: 'apmApp',
             },
           ],
-          url: `${getUrlForApp?.('apm')}/onboarding` ?? '',
+          url: apmUrl,
           version: '',
           integration: '',
         },
@@ -85,7 +92,7 @@ export function useCustomCardsForCategory(
               src: http?.staticAssets.getPluginAssetHref('opentelemetry.svg') ?? '',
             },
           ],
-          url: `${getUrlForApp?.('apm')}/onboarding?agent=openTelemetry` ?? '',
+          url: otelApmUrl,
           version: '',
           integration: '',
         },


### PR DESCRIPTION
The APM and OpenTelemetry tiles on the "Add data" page always link to the`/onboarding` page. However, on stateful, it should be `/tutorial` instead (this is also what the "Add data" button in the top right of the APM page links to).

This PR fixes the links, so the tiles link to the new streamlined onboarding flow for serverless and to the old one for stateful.

On the new flow the "OpenTelemetry" tab is automatically selected. In this fix, this isn't done for the old onboarding flow, as this would require further changes. These can be done as a follow-up separate to this PR to get the fix in place for 8.15.1

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->