### PR TITLE
[Search] [Playground] Adding playground locators

### DIFF
--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -230,6 +230,7 @@ export const APP_SEARCH_URL = '/app/enterprise_search/app_search';
 export const ENTERPRISE_SEARCH_ELASTICSEARCH_URL = '/app/enterprise_search/elasticsearch';
 export const WORKPLACE_SEARCH_URL = '/app/enterprise_search/workplace_search';
 export const CREATE_NEW_INDEX_URL = '/search_indices/new_index';
+export const PLAYGROUND_URL = '/playground';
 
 export const MANAGE_API_KEYS_URL = '/app/management/security/api_keys';
 

--- a/x-pack/plugins/enterprise_search/common/locators/create_index_locator.tsx
+++ b/x-pack/plugins/enterprise_search/common/locators/create_index_locator.tsx
@@ -5,16 +5,14 @@
  * 2.0.
  */
 
-import { LocatorDefinition } from '@kbn/share-plugin/common';
-import { SerializableRecord } from '@kbn/utility-types';
+import type { LocatorDefinition } from '@kbn/share-plugin/common';
+import type { SerializableRecord } from '@kbn/utility-types';
 
 import { CREATE_NEW_INDEX_URL, ENTERPRISE_SEARCH_CONTENT_PLUGIN } from '../constants';
 
-export type CreatIndexLocatorParams = SerializableRecord;
+export type CreateIndexLocatorParams = SerializableRecord;
 
-export class CreatIndexLocatorDefinition implements LocatorDefinition<CreatIndexLocatorParams> {
-  public readonly id = 'CREATE_INDEX_LOCATOR_ID';
-
+export class CreateIndexLocatorDefinition implements LocatorDefinition<CreateIndexLocatorParams> {
   public readonly getLocation = async () => {
     return {
       app: ENTERPRISE_SEARCH_CONTENT_PLUGIN.ID,
@@ -22,4 +20,6 @@ export class CreatIndexLocatorDefinition implements LocatorDefinition<CreatIndex
       state: {},
     };
   };
+
+  public readonly id = 'CREATE_INDEX_LOCATOR_ID';
 }

--- a/x-pack/plugins/enterprise_search/common/locators/index.ts
+++ b/x-pack/plugins/enterprise_search/common/locators/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SharePluginSetup } from '@kbn/share-plugin/public';
+
+import {
+  CreateIndexLocatorDefinition,
+  type CreateIndexLocatorParams,
+} from './create_index_locator';
+import { PlaygroundLocatorDefinition, type PlaygroundLocatorParams } from './playground_locator';
+
+export function registerLocators(share: SharePluginSetup) {
+  share.url.locators.create<CreateIndexLocatorParams>(new CreateIndexLocatorDefinition());
+  share.url.locators.create<PlaygroundLocatorParams>(new PlaygroundLocatorDefinition());
+}

--- a/x-pack/plugins/enterprise_search/common/locators/playground_locator.tsx
+++ b/x-pack/plugins/enterprise_search/common/locators/playground_locator.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LocatorDefinition } from '@kbn/share-plugin/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+
+import { APPLICATIONS_PLUGIN, PLAYGROUND_URL } from '../constants';
+
+export type PlaygroundLocatorParams = { 'default-index': string } & SerializableRecord;
+
+export class PlaygroundLocatorDefinition implements LocatorDefinition<PlaygroundLocatorParams> {
+  public readonly getLocation = async (params: PlaygroundLocatorParams) => {
+    const defaultIndex = params['default-index'];
+    const path = `${PLAYGROUND_URL}${defaultIndex ? `?default-index=${defaultIndex}` : ''}`;
+
+    return {
+      app: APPLICATIONS_PLUGIN.ID,
+      path,
+      state: {},
+    };
+  };
+
+  public readonly id = 'PLAYGROUND_LOCATOR_ID';
+}

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -57,10 +57,8 @@ import {
   INFERENCE_ENDPOINTS_PLUGIN,
   SEMANTIC_SEARCH_PLUGIN,
 } from '../common/constants';
-import {
-  CreatIndexLocatorDefinition,
-  CreatIndexLocatorParams,
-} from '../common/locators/create_index_locator';
+import { registerLocators } from '../common/locators';
+
 import { ClientConfigType, InitialAppData } from '../common/types';
 
 import { ENGINES_PATH } from './applications/app_search/routes';
@@ -523,7 +521,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       visibleIn: [],
     });
 
-    share?.url.locators.create<CreatIndexLocatorParams>(new CreatIndexLocatorDefinition());
+    registerLocators(share!);
 
     if (config.canDeployEntSearch) {
       core.application.register({

--- a/x-pack/plugins/search_playground/public/locators/index.ts
+++ b/x-pack/plugins/search_playground/public/locators/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { type SharePluginSetup } from '@kbn/share-plugin/public';
+import { PlaygroundLocatorDefinition, type PlaygroundLocatorParams } from './playground_locator';
+
+export function registerLocators(share: SharePluginSetup) {
+  share.url.locators.create<PlaygroundLocatorParams>(new PlaygroundLocatorDefinition());
+}

--- a/x-pack/plugins/search_playground/public/locators/playground_locator.tsx
+++ b/x-pack/plugins/search_playground/public/locators/playground_locator.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LocatorDefinition } from '@kbn/share-plugin/common';
+import type { SerializableRecord } from '@kbn/utility-types';
+
+import { PLUGIN_ID } from '../../common';
+
+export type PlaygroundLocatorParams = { 'default-index': string } & SerializableRecord;
+
+const PLAYGROUND_URL = '/chat';
+
+export class PlaygroundLocatorDefinition implements LocatorDefinition<PlaygroundLocatorParams> {
+  public readonly getLocation = async (params: PlaygroundLocatorParams) => {
+    const defaultIndex = params['default-index'];
+    const path = `${PLAYGROUND_URL}${defaultIndex ? `?default-index=${defaultIndex}` : ''}`;
+
+    return {
+      app: PLUGIN_ID,
+      path,
+      state: {},
+    };
+  };
+
+  public readonly id = 'PLAYGROUND_LOCATOR_ID';
+}

--- a/x-pack/plugins/search_playground/public/plugin.ts
+++ b/x-pack/plugins/search_playground/public/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   CoreSetup,
   Plugin,
   CoreStart,
@@ -16,12 +16,14 @@ import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 import { docLinks } from '../common/doc_links';
 import { PlaygroundHeaderDocs } from './components/playground_header_docs';
 import { Playground, getPlaygroundProvider } from './embeddable';
-import {
+import type {
+  AppPluginSetupDependencies,
   AppPluginStartDependencies,
   SearchPlaygroundConfigType,
   SearchPlaygroundPluginSetup,
   SearchPlaygroundPluginStart,
 } from './types';
+import { registerLocators } from './locators';
 
 export class SearchPlaygroundPlugin
   implements Plugin<SearchPlaygroundPluginSetup, SearchPlaygroundPluginStart>
@@ -33,7 +35,8 @@ export class SearchPlaygroundPlugin
   }
 
   public setup(
-    core: CoreSetup<AppPluginStartDependencies, SearchPlaygroundPluginStart>
+    core: CoreSetup<AppPluginStartDependencies, SearchPlaygroundPluginStart>,
+    deps: AppPluginSetupDependencies
   ): SearchPlaygroundPluginSetup {
     if (!this.config.ui?.enabled) return {};
 
@@ -52,6 +55,8 @@ export class SearchPlaygroundPlugin
         return renderApp(coreStart, startDeps, element);
       },
     });
+
+    registerLocators(deps.share);
 
     return {};
   }

--- a/x-pack/plugins/search_playground/public/types.ts
+++ b/x-pack/plugins/search_playground/public/types.ts
@@ -15,7 +15,7 @@ import { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
 import { SecurityPluginStart } from '@kbn/security-plugin/public';
 import { HttpStart } from '@kbn/core-http-browser';
 import React, { ComponentType } from 'react';
-import { SharePluginStart } from '@kbn/share-plugin/public';
+import { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import { CloudSetup } from '@kbn/cloud-plugin/public';
 import { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
 import { AppMountParameters } from '@kbn/core/public';
@@ -34,6 +34,10 @@ export interface SearchPlaygroundPluginStart {
   PlaygroundProvider: React.FC<React.ComponentProps<typeof PlaygroundProviderComponent>>;
   Playground: React.FC<React.ComponentProps<typeof App>>;
   PlaygroundHeaderDocs: React.FC<React.ComponentProps<typeof PlaygroundHeaderDocs>>;
+}
+
+export interface AppPluginSetupDependencies {
+  share: SharePluginSetup;
 }
 
 export interface AppPluginStartDependencies {

--- a/x-pack/plugins/search_playground/tsconfig.json
+++ b/x-pack/plugins/search_playground/tsconfig.json
@@ -38,7 +38,8 @@
     "@kbn/core-logging-server-mocks",
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
-    "@kbn/console-plugin"
+    "@kbn/console-plugin",
+    "@kbn/utility-types"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Adds locators for the playground app in the enterprise search and search playground plugins.
These will be used by the file upload tool to link to Playground after a successful upload.  https://github.com/elastic/kibana/pull/186956
These locators are not registered in the observability or security serverless projects, and so the file upload plugin will not render the link to Playground.

Note to reviewers, I originally attempted to have one common locator class which would be used by both plugins, this turned out to be more trouble due to cross plugin import restrictions, plus I was concerned the increase to the enterprise search bundle would be larger than the size of the duplicated function.
