### PR TITLE
[Fleet] Fix root level yaml variables dollar escape

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -327,6 +327,25 @@ input: logs
     });
   });
 
+  it('should support $$$$ yaml values at root level', () => {
+    const streamTemplate = `
+input: logs
+{{custom}}
+    `;
+    const vars = {
+      custom: {
+        type: 'yaml',
+        value: 'test: $$$$',
+      },
+    };
+
+    const output = compileTemplate(vars, streamTemplate);
+    expect(output).toEqual({
+      input: 'logs',
+      test: '$$$$',
+    });
+  });
+
   it('should suport !!str for string values', () => {
     const stringTemplate = `
 my-package:

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -164,8 +164,7 @@ function replaceRootLevelYamlVariables(yamlVariables: { [k: string]: any }, yaml
 
   let patchedTemplate = yamlTemplate;
   Object.entries(yamlVariables).forEach(([key, val]) => {
-    patchedTemplate = patchedTemplate.replace(
-      new RegExp(`^"${key}"`, 'gm'),
+    patchedTemplate = patchedTemplate.replace(new RegExp(`^"${key}"`, 'gm'), () =>
       val ? safeDump(val) : ''
     );
   });


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/188377

The way we handle root level yaml variable is done via a regex.replace, that function do not handle `$` sign correctly as it's a placehold for matches, (see [doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement))

That PR fix the usage we do of that function.

## How to test 

Try to add a custom log integration with the advanced yaml configuration `test: $$$$` and verify the policy contains that value.

<img width="649" alt="Screenshot 2024-08-15 at 10 47 05 AM" src="https://github.com/user-attachments/assets/35442174-db4c-452d-94ed-67e01c4c3737">
<img width="700" alt="Screenshot 2024-08-15 at 10 47 37 AM" src="https://github.com/user-attachments/assets/610dff8d-95df-4699-8197-259dd8466780">


