### PR TITLE
[ci] Update backport labels

### DIFF
--- a/.github/workflows/fix-version-gaps.yml
+++ b/.github/workflows/fix-version-gaps.yml
@@ -16,8 +16,9 @@ jobs:
       && !(
         contains(github.event.pull_request.labels.*.name, 'backport:prev-minor')
         || contains(github.event.pull_request.labels.*.name, 'backport:prev-major')
+        || contains(github.event.pull_request.labels.*.name, 'backport:current-major')
         || contains(github.event.pull_request.labels.*.name, 'backport:all-open')
-        || contains(github.event.pull_request.labels.*.name, 'backport:auto-version')
+        || contains(github.event.pull_request.labels.*.name, 'backport:version')
       )
       && !(
         (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -16,8 +16,9 @@ jobs:
           github.event.action == 'labeled' && (
             github.event.label.name == 'backport:prev-minor'
             || github.event.label.name == 'backport:prev-major'
+            || github.event.label.name == 'backport:current-major'
             || github.event.label.name == 'backport:all-open'
-            || github.event.label.name == 'backport:auto-version'
+            || github.event.label.name == 'backport:version'
           )
         )
         || (github.event.action == 'closed')


### PR DESCRIPTION
Removes backport:auto-version - never implemented
Adds backport:current-major - backport to all supported minor versions of the current major version
Adds backport:version - backport to adjacent semver labels, intended to replace auto-backport
