### PR TITLE
[FIPS] Use compliant algorithms in Optimizer

### DIFF
--- a/packages/kbn-optimizer/src/common/bundle.test.ts
+++ b/packages/kbn-optimizer/src/common/bundle.test.ts
@@ -59,7 +59,7 @@ it('creates cache keys', () => {
       },
       "dllName": "manifest-name",
       "dllRefs": Object {
-        "./some-foo.ts": "1:ku/53aRMuAA+4TmQeCWA/w:GtuPW9agF2yecW0xAIHtUQ",
+        "./some-foo.ts": "1:8ZZnQFMG7xLG5lQakybjWCNbihQ:6Yk7GIWDT9j4uCAeHPI2xJcHgrE",
       },
       "spec": Object {
         "banner": undefined,

--- a/packages/kbn-optimizer/src/common/dll_manifest.ts
+++ b/packages/kbn-optimizer/src/common/dll_manifest.ts
@@ -19,7 +19,7 @@ export interface ParsedDllManifest {
 }
 
 const hash = (s: string) => {
-  return Crypto.createHash('md5').update(s).digest('base64').replace(/=+$/, '');
+  return Crypto.createHash('sha1').update(s).digest('base64').replace(/=+$/, '');
 };
 
 export function parseDllManifest(manifest: DllManifest): ParsedDllManifest {

--- a/packages/kbn-optimizer/src/worker/webpack.config.ts
+++ b/packages/kbn-optimizer/src/worker/webpack.config.ts
@@ -50,6 +50,7 @@ export function getWebpackConfig(
     profile: worker.profileWebpack,
 
     output: {
+      hashFunction: 'sha1',
       path: bundle.outputDir,
       filename: `${bundle.id}.${bundle.type}.js`,
       chunkFilename: `${bundle.id}.chunk.[id].js`,


### PR DESCRIPTION
## Summary

Updates the Optimizer to user FIPS compliant algorithms, otherwise Kibana will crash during startup in development mode. This was originally part of #188887.