### PR TITLE
[PoC] Temporarily pin selected fields in Unified Doc Viewer

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/get_pin_control.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/get_pin_control.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
+import classNames from 'classnames';
 import type { TableRow } from './table_cell_actions';
 
 interface PinControlCellProps {
@@ -26,10 +27,15 @@ const PinControlCell: React.FC<PinControlCellProps> = React.memo(({ row }) => {
   const { euiTheme } = useEuiTheme();
 
   const fieldName = row.field.field;
+  const isSelected = row.field.selected;
   const isPinned = row.field.pinned;
   const label = isPinned
     ? i18n.translate('unifiedDocViewer.docViews.table.unpinFieldLabel', {
         defaultMessage: 'Unpin field',
+      })
+    : isSelected
+    ? i18n.translate('unifiedDocViewer.docViews.table.pinSelectedFieldLabel', {
+        defaultMessage: 'Pin selected field',
       })
     : i18n.translate('unifiedDocViewer.docViews.table.pinFieldLabel', {
         defaultMessage: 'Pin field',
@@ -38,7 +44,10 @@ const PinControlCell: React.FC<PinControlCellProps> = React.memo(({ row }) => {
   return (
     <div
       data-test-subj={`unifiedDocViewer_pinControl_${fieldName}`}
-      className={!isPinned ? 'kbnDocViewer__fieldsGrid__pinAction' : undefined}
+      className={classNames({
+        ['kbnDocViewer__fieldsGrid__pinAction']: !isPinned && !isSelected,
+        ['kbnDocViewer__fieldsGrid__pinSelectedAction']: !isPinned && isSelected,
+      })}
       css={css`
         margin-left: ${isPinned ? '-1px' : 0}; // to align filled/unfilled pin icons better
         width: ${euiTheme.size.l};

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.scss
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.scss
@@ -76,9 +76,18 @@
     border-bottom: $euiBorderThin;
   }
 
+  // .kbnDocViewer__fieldsGrid__selectedRow {
+  //   background-color: tintOrShade($euiColorPrimary, 95%, 70%);
+  // }
+
+  // &.euiDataGrid--rowHoverHighlight .euiDataGridRow:not(.kbnDocViewer__fieldsGrid__selectedRow):hover {
   &.euiDataGrid--rowHoverHighlight .euiDataGridRow:hover {
     background-color: tintOrShade($euiColorLightShade, 50%, 0);
   }
+
+  // .kbnDocViewer__fieldsGrid__selectedRow:hover {
+  //   background-color: tintOrShade($euiColorPrimary, 90%, 70%);
+  // }
 
   & [data-gridcell-column-id='name'] .euiDataGridRowCell__content {
     padding-top: 0;
@@ -89,17 +98,23 @@
     padding: $euiSizeXS / 2 0 0 $euiSizeXS;
   }
 
+  .kbnDocViewer__fieldsGrid__pinSelectedAction {
+    opacity: .35;
+  }
+
   .kbnDocViewer__fieldsGrid__pinAction {
     opacity: 0;
   }
 
   & [data-gridcell-column-id='pin_field']:focus-within {
-    .kbnDocViewer__fieldsGrid__pinAction {
+    .kbnDocViewer__fieldsGrid__pinAction, .kbnDocViewer__fieldsGrid__pinSelectedAction {
       opacity: 1;
     }
   }
 
-  .euiDataGridRow:hover .kbnDocViewer__fieldsGrid__pinAction {
-    opacity: 1;
+  .euiDataGridRow:hover {
+    .kbnDocViewer__fieldsGrid__pinAction, .kbnDocViewer__fieldsGrid__pinSelectedAction {
+      opacity: 1;
+    }
   }
 }

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
@@ -14,6 +14,7 @@ import { DocViewFilterFn, FieldRecordLegacy } from '@kbn/unified-doc-viewer/type
 export interface TableRow {
   action: Omit<FieldRecordLegacy['action'], 'isActive'>;
   field: {
+    selected: boolean;
     pinned: boolean;
     onTogglePinned: (field: string) => void;
   } & FieldRecordLegacy['field'];


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)