### PR TITLE
[CI] Fix flaky anomaly detection functional test

### DIFF
--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/index.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/index.ts
@@ -34,8 +34,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./anomaly_charts_dashboard_embeddables'));
     loadTestFile(require.resolve('./single_metric_viewer_dashboard_embeddables'));
     loadTestFile(require.resolve('./anomaly_embeddables_migration'));
-    loadTestFile(require.resolve('./lens_to_ml'));
-    loadTestFile(require.resolve('./map_to_ml'));
-    loadTestFile(require.resolve('./lens_to_ml_with_wizard'));
+    // loadTestFile(require.resolve('./lens_to_ml'));
+    // loadTestFile(require.resolve('./map_to_ml'));
+    // loadTestFile(require.resolve('./lens_to_ml_with_wizard'));
   });
 }

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/index.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/index.ts
@@ -31,11 +31,11 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await ml.testResources.resetKibanaTimeZone();
     });
 
-    loadTestFile(require.resolve('./anomaly_charts_dashboard_embeddables'));
-    loadTestFile(require.resolve('./single_metric_viewer_dashboard_embeddables'));
-    loadTestFile(require.resolve('./anomaly_embeddables_migration'));
+    // loadTestFile(require.resolve('./anomaly_charts_dashboard_embeddables'));
+    // loadTestFile(require.resolve('./single_metric_viewer_dashboard_embeddables'));
+    // loadTestFile(require.resolve('./anomaly_embeddables_migration'));
     // loadTestFile(require.resolve('./lens_to_ml'));
     // loadTestFile(require.resolve('./map_to_ml'));
-    // loadTestFile(require.resolve('./lens_to_ml_with_wizard'));
+    loadTestFile(require.resolve('./lens_to_ml_with_wizard'));
   });
 }

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/index.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/index.ts
@@ -31,11 +31,11 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
       await ml.testResources.resetKibanaTimeZone();
     });
 
-    // loadTestFile(require.resolve('./anomaly_charts_dashboard_embeddables'));
-    // loadTestFile(require.resolve('./single_metric_viewer_dashboard_embeddables'));
-    // loadTestFile(require.resolve('./anomaly_embeddables_migration'));
-    // loadTestFile(require.resolve('./lens_to_ml'));
-    // loadTestFile(require.resolve('./map_to_ml'));
+    loadTestFile(require.resolve('./anomaly_charts_dashboard_embeddables'));
+    loadTestFile(require.resolve('./single_metric_viewer_dashboard_embeddables'));
+    loadTestFile(require.resolve('./anomaly_embeddables_migration'));
+    loadTestFile(require.resolve('./lens_to_ml'));
+    loadTestFile(require.resolve('./map_to_ml'));
     loadTestFile(require.resolve('./lens_to_ml_with_wizard'));
   });
 }

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/lens_to_ml_with_wizard.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/lens_to_ml_with_wizard.ts
@@ -136,7 +136,7 @@ export default function ({ getService, getPageObject, getPageObjects }: FtrProvi
 
       await ml.lensVisualizations.assertNumberOfIncompatibleLensLayers(numberOfIncompatibleLayers);
 
-      ml.lensVisualizations.clickCreateJobFromLayerWithWizard(0);
+      await ml.lensVisualizations.clickCreateJobFromLayerWithWizard(0);
 
       await retrySwitchTab(1, 10);
       tabsCount++;
@@ -161,7 +161,7 @@ export default function ({ getService, getPageObject, getPageObjects }: FtrProvi
 
       await ml.lensVisualizations.assertNumberOfIncompatibleLensLayers(numberOfIncompatibleLayers);
 
-      ml.lensVisualizations.clickCreateJobFromLayerWithWizard(0);
+      await ml.lensVisualizations.clickCreateJobFromLayerWithWizard(0);
 
       await retrySwitchTab(1, 10);
       tabsCount++;
@@ -186,7 +186,7 @@ export default function ({ getService, getPageObject, getPageObjects }: FtrProvi
 
       await ml.lensVisualizations.assertNumberOfIncompatibleLensLayers(numberOfIncompatibleLayers);
 
-      ml.lensVisualizations.clickCreateJobFromLayerWithWizard(1);
+      await ml.lensVisualizations.clickCreateJobFromLayerWithWizard(1);
 
       await retrySwitchTab(1, 10);
       tabsCount++;
@@ -215,7 +215,7 @@ export default function ({ getService, getPageObject, getPageObjects }: FtrProvi
 
       await dashboardPreparation(selectedPanelTitle);
 
-      ml.lensVisualizations.assertMLJobMenuActionDoesNotExist(selectedPanelTitle);
+      await ml.lensVisualizations.assertMLJobMenuActionDoesNotExist(selectedPanelTitle);
     });
   });
 }


### PR DESCRIPTION
## Summary
There are several cases where anomaly detection tests fail (find below). The error claims an unhandled promise rejection through a stale element. It could be simply a check or an operation that happens after the browser driver moves on to another test.

I originally wanted to find the tests that seem to fail, but the nature of the failures (unhandled rejections) line up nicely with missed `await`s - I've also added a supposed fix, verified with 50x flaky runs.

Errors:
  - https://buildkite.com/elastic/kibana-on-merge/builds/49005#01916999-a25b-4c59-8d91-99cf4b83981b
  - https://buildkite.com/elastic/kibana-on-merge/builds/49004
  - https://buildkite.com/elastic/kibana-elasticsearch-snapshot-verify/builds/4373
  - https://buildkite.com/elastic/kibana-on-merge/builds/49002
  - ...


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->