### PR TITLE
[docs] Resolve migration failures: allow copying as curl and remove outdated 7.12 known issue

### DIFF
--- a/docs/setup/upgrade/resolving-migration-failures.asciidoc
+++ b/docs/setup/upgrade/resolving-migration-failures.asciidoc
@@ -18,24 +18,6 @@ When you address the root cause for the migration failure,
 {kib} automatically retries the migration.
 If you're unable to resolve a failed migration, contact Support.
 
-
-[float]
-==== Known issues with {fleet} beta
-If you see a`timeout_exception` or `receive_timeout_transport_exception` error,
-it might be from a known known issue in 7.12.0 if you tried the {fleet} beta.
-Upgrade migrations fail because of a large number of documents in the `.kibana` index,
-which causes {kib} to log errors such as:
-
-[source,sh]
---------------------------------------------
-Error: Unable to complete saved object migrations for the [.kibana] index. Please check the health of your Elasticsearch cluster and try again. Error: [receive_timeout_transport_exception]: [instance-0000000002][10.32.1.112:19541][cluster:monitor/task/get] request_id [2648] timed out after [59940ms]
-
-Error: Unable to complete saved object migrations for the [.kibana] index. Please check the health of your Elasticsearch cluster and try again. Error: [timeout_exception]: Timed out waiting for completion of [org.elasticsearch.index.reindex.BulkByScrollTask@6a74c54]
---------------------------------------------
-
-For instructions on how to mitigate the known issue, refer to https://github.com/elastic/kibana/issues/95321[the GitHub issue].
-
-
 [float]
 ==== Corrupt saved objects
 To find and remedy problems caused by corrupt documents, we highly recommend testing your {kib} upgrade in a development cluster,

--- a/docs/setup/upgrade/resolving-migration-failures.asciidoc
+++ b/docs/setup/upgrade/resolving-migration-failures.asciidoc
@@ -38,7 +38,7 @@ To delete the documents that cause migrations to fail, take the following steps:
 
 . Create a role as follows:
 +
-[source,sh]
+[source,console]
 --------------------------------------------
 PUT _security/role/grant_kibana_system_indices
 {
@@ -58,7 +58,7 @@ PUT _security/role/grant_kibana_system_indices
 
 . Create a user with the role above and `superuser` built-in role:
 +
-[source,sh]
+[source,console]
 --------------------------------------------
 POST /_security/user/temporarykibanasuperuser
 {
@@ -69,7 +69,7 @@ POST /_security/user/temporarykibanasuperuser
 
 . Remove the write block which the migration system has placed on the previous index:
 +
-[source,sh]
+[source,console]
 --------------------------------------------
 PUT .kibana_7.12.1_001/_settings
 {
@@ -81,7 +81,7 @@ PUT .kibana_7.12.1_001/_settings
 
 . Delete the corrupt document:
 +
-[source,sh]
+[source,console]
 --------------------------------------------
 DELETE .kibana_7.12.0_001/_doc/marketing_space:dashboard:e3c5fc71-ac71-4805-bcab-2bcc9cc93275
 --------------------------------------------
@@ -167,7 +167,7 @@ The process is waiting for a yellow index status. There are two known causes:
 
 Before retrying the migration, inspect the output of the `_cluster/allocation/explain?index=${targetIndex}` API to identify why the index isn't yellow:
 
-[source,sh]
+[source,console]
 --------------------------------------------
 GET _cluster/allocation/explain
 {
@@ -202,7 +202,7 @@ Unable to complete saved object migrations for the [.kibana] index: [incompatibl
 --------------------------------------------
 
 To get around the issue, remove the transient and persisted routing allocation settings:
-[source,sh]
+[source,console]
 --------------------------------------------
 PUT /_cluster/settings
 {


### PR DESCRIPTION
## Summary

This allows users to copy the documented console commands as curl commands. Useful since users don't have access to console when there's a migration failure. I also removed a known 7.12 issue that's no longer relevant for 8.x users.

Example:
<img width="815" alt="Screenshot 2024-08-19 at 12 48 36" src="https://github.com/user-attachments/assets/973fe626-7593-4d65-91d3-3c7aab5e9c63">

clicking "copy as curl" produces:
```
curl -X PUT "localhost:9200/_security/role/grant_kibana_system_indices?pretty" -H 'Content-Type: application/json' -d'
{
  "indices": [
    {
      "names": [
        ".kibana*"
      ],
      "privileges": [
        "all"
      ],
      "allow_restricted_indices": true
    }
  ]
}
'
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.10","8.11","8.12","8.13","8.14","8.15","8.7","8.8","8.9"]} ONMERGE-->