### PR TITLE
Wait between instances, but not after the last one

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
@@ -182,7 +182,8 @@ describe('migration v2', () => {
           errors.push(err.message);
         })
       );
-      if (i < instances.length - 1) {
+      if (i < instances.length - 2) {
+        // We wait between instances, but not after the last one
         await delay(delayInSec * 1000);
       }
     }


### PR DESCRIPTION
## Summary

Resolves #156117

This should save us from unnecessarily waiting 5s in the tests.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->