### PR TITLE
[Observability Onboarding] Add ARIA labels to ambiguous links in footer

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/footer/footer.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/footer/footer.tsx
@@ -60,6 +60,10 @@ export const Footer: FunctionComponent = () => {
         'xpack.observability_onboarding.experimentalOnboardingFlow.exploreForumFlexItemLinkLabel',
         { defaultMessage: 'Discuss forum' }
       ),
+      linkARIALabel: i18n.translate(
+        'xpack.observability_onboarding.experimentalOnboardingFlow.exploreForumFlexItemLinkARIALabel',
+        { defaultMessage: 'Open Elastic Discuss forum' }
+      ),
       link: URL_FORUM,
     },
     {
@@ -77,6 +81,10 @@ export const Footer: FunctionComponent = () => {
       linkLabel: i18n.translate(
         'xpack.observability_onboarding.experimentalOnboardingFlow.browseDocumentationFlexItemLinkLabel',
         { defaultMessage: 'Learn more' }
+      ),
+      linkARIALabel: i18n.translate(
+        'xpack.observability_onboarding.experimentalOnboardingFlow.browseDocumentationFlexItemLinkARIALabel',
+        { defaultMessage: 'Learn more about all Elastic features' }
       ),
       link: docLinks.links.observability.guide,
     },
@@ -118,6 +126,7 @@ export const Footer: FunctionComponent = () => {
             <p>
               <EuiLink
                 data-test-subj="observabilityOnboardingFooterLearnMoreLink"
+                aria-label={section.linkARIALabel}
                 href={section.link}
                 target="_blank"
                 external


### PR DESCRIPTION
Closes https://github.com/elastic/observability-accessibility/issues/126 **(internal 🔒)**

Fixes accessibility issue with ambiguous link labels.