### PR TITLE
Revert "Revert "Replace 'model_id' with 'inference_id' for inference endpoints""

### DIFF
--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -278,7 +278,7 @@ export type InferenceServiceSettings =
 
 export type InferenceAPIConfigResponse = {
   // Refers to a deployment id
-  model_id: string;
+  inference_id: string;
   task_type: 'sparse_embedding' | 'text_embedding';
   task_settings: {
     model?: string;

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
@@ -731,7 +731,7 @@ describe('<IndexDetailsPage />', () => {
           httpRequestsMockHelpers.setInferenceModels({
             data: [
               {
-                model_id: customInferenceModel,
+                inference_id: customInferenceModel,
                 task_type: 'sparse_embedding',
                 service: 'elser',
                 service_settings: {

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -71,9 +71,9 @@ jest.mock('../../../public/application/components/mappings_editor/mappings_state
 jest.mock('../../../public/application/services/api', () => ({
   useLoadInferenceEndpoints: jest.fn().mockReturnValue({
     data: [
-      { model_id: 'endpoint-1', task_type: 'text_embedding' },
-      { model_id: 'endpoint-2', task_type: 'sparse_embedding' },
-      { model_id: 'endpoint-3', task_type: 'completion' },
+      { inference_id: 'endpoint-1', task_type: 'text_embedding' },
+      { inference_id: 'endpoint-2', task_type: 'sparse_embedding' },
+      { inference_id: 'endpoint-3', task_type: 'completion' },
     ] as InferenceAPIConfigResponse[],
     isLoading: false,
     error: null,

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -54,10 +54,10 @@ type SelectInferenceIdContentProps = SelectInferenceIdProps & {
 
 const defaultEndpoints = [
   {
-    model_id: 'elser_model_2',
+    inference_id: 'elser_model_2',
   },
   {
-    model_id: 'e5',
+    inference_id: 'e5',
   },
 ];
 
@@ -135,15 +135,15 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
     );
 
     const missingDefaultEndpoints = defaultEndpoints.filter(
-      (endpoint) => !(filteredEndpoints || []).find((e) => e.model_id === endpoint.model_id)
+      (endpoint) => !(filteredEndpoints || []).find((e) => e.inference_id === endpoint.inference_id)
     );
     const newOptions: EuiSelectableOption[] = [
       ...(filteredEndpoints || []),
       ...missingDefaultEndpoints,
     ].map((endpoint) => ({
-      label: endpoint.model_id,
-      'data-test-subj': `custom-inference_${endpoint.model_id}`,
-      checked: value === endpoint.model_id ? 'on' : undefined,
+      label: endpoint.inference_id,
+      'data-test-subj': `custom-inference_${endpoint.inference_id}`,
+      checked: value === endpoint.inference_id ? 'on' : undefined,
     }));
     if (value && !newOptions.find((option) => option.label === value)) {
       // Sometimes we create a new endpoint but the backend is slow in updating so we need to optimistically update

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.test.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.test.ts
@@ -142,7 +142,7 @@ jest.mock('../../../../../../../services/api', () => ({
   getInferenceEndpoints: jest.fn().mockResolvedValue({
     data: [
       {
-        model_id: 'e5',
+        inference_id: 'e5',
         task_type: 'text_embedding',
         service: 'elasticsearch',
         service_settings: {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.ts
@@ -119,7 +119,7 @@ export function useSemanticText(props: UseSemanticTextProps) {
     dispatch({ type: 'field.add', value: data });
     const inferenceEndpoints = await getInferenceEndpoints();
     const hasInferenceEndpoint = inferenceEndpoints.data?.some(
-      (inference) => inference.model_id === inferenceId
+      (inference) => inference.inference_id === inferenceId
     );
     // if inference endpoint exists already, do not create new inference endpoint
     if (hasInferenceEndpoint) {

--- a/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts
+++ b/x-pack/plugins/index_management/public/application/hooks/use_index_errors.ts
@@ -40,7 +40,7 @@ export const useIndexErrors = (
       const semanticTextFieldsWithErrors = semanticTextFields
         .map((field) => {
           const model = endpoints.find(
-            (endpoint) => endpoint.model_id === field.source.inference_id
+            (endpoint) => endpoint.inference_id === field.source.inference_id
           );
           if (!model) {
             return {

--- a/x-pack/plugins/index_management/public/hooks/use_details_page_mappings_model_management.test.ts
+++ b/x-pack/plugins/index_management/public/hooks/use_details_page_mappings_model_management.test.ts
@@ -49,7 +49,7 @@ jest.mock('../application/services/api', () => ({
   getInferenceEndpoints: jest.fn().mockResolvedValue({
     data: [
       {
-        model_id: 'e5',
+        inference_id: 'e5',
         task_type: 'text_embedding',
         service: 'elasticsearch',
         service_settings: {

--- a/x-pack/plugins/index_management/public/hooks/use_details_page_mappings_model_management.ts
+++ b/x-pack/plugins/index_management/public/hooks/use_details_page_mappings_model_management.ts
@@ -45,7 +45,7 @@ const getCustomInferenceIdMap = (
           isDownloading: false,
           modelStats: undefined,
         };
-    inferenceMap[model.model_id] = inferenceEntry;
+    inferenceMap[model.inference_id] = inferenceEntry;
     return inferenceMap;
   }, {});
   const defaultInferenceIds = {

--- a/x-pack/plugins/ml/public/application/model_management/delete_models_modal.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/delete_models_modal.tsx
@@ -49,7 +49,7 @@ export const DeleteModelsModal: FC<DeleteModelsModalProps> = ({ models, onClose 
   const modelsWithInferenceAPIs = models.filter((m) => m.hasInferenceServices);
 
   const inferenceAPIsIDs: string[] = modelsWithInferenceAPIs.flatMap((model) => {
-    return (model.inference_apis ?? []).map((inference) => inference.model_id);
+    return (model.inference_apis ?? []).map((inference) => inference.inference_id);
   });
 
   const pipelinesCount = modelsWithPipelines.reduce((acc, curr) => {

--- a/x-pack/plugins/ml/public/application/model_management/force_stop_dialog.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/force_stop_dialog.tsx
@@ -41,7 +41,7 @@ export const StopModelDeploymentsConfirmDialog: FC<ForceStopModelConfirmDialogPr
         // Filter out deployments that are used by inference services
         .filter((deploymentId) => {
           if (!model.inference_apis) return true;
-          return !model.inference_apis.some((inference) => inference.model_id === deploymentId);
+          return !model.inference_apis.some((inference) => inference.inference_id === deploymentId);
         })
     );
   }, [model]);
@@ -110,7 +110,7 @@ export const StopModelDeploymentsConfirmDialog: FC<ForceStopModelConfirmDialogPr
   ]);
 
   const inferenceServiceIDs = useMemo<string[]>(() => {
-    return (model.inference_apis ?? []).map((inference) => inference.model_id);
+    return (model.inference_apis ?? []).map((inference) => inference.inference_id);
   }, [model]);
 
   return (

--- a/x-pack/plugins/ml/public/application/model_management/inference_api_tab.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/inference_api_tab.tsx
@@ -28,7 +28,7 @@ export const InferenceApi: FC<InferenceAPITabProps> = ({ inferenceApis }) => {
       {inferenceApis.map((inferenceApi, i) => {
         const initialIsOpen = i <= 2;
 
-        const modelId = inferenceApi.model_id;
+        const modelId = inferenceApi.inference_id;
 
         return (
           <React.Fragment key={modelId}>

--- a/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/model_actions.tsx
@@ -329,7 +329,7 @@ export function useModelActions({
             item.deployment_ids.some(
               (dId) =>
                 Array.isArray(item.inference_apis) &&
-                !item.inference_apis.some((inference) => inference.model_id === dId)
+                !item.inference_apis.some((inference) => inference.inference_id === dId)
             )),
         enabled: (item) => !isLoading,
         onClick: async (item) => {

--- a/x-pack/plugins/ml/server/routes/trained_models.test.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.test.ts
@@ -33,7 +33,7 @@ describe('populateInferenceServicesProvider', () => {
       { model_id: 'model2' },
     ] as TrainedModelConfigResponse[];
 
-    client.asInternalUser.transport.request.mockResolvedValue({ models: inferenceServices });
+    client.asInternalUser.transport.request.mockResolvedValue({ endpoints: inferenceServices });
 
     jest.clearAllMocks();
   });
@@ -44,7 +44,7 @@ describe('populateInferenceServicesProvider', () => {
 
   describe('when the user has required privileges', () => {
     beforeEach(() => {
-      client.asCurrentUser.transport.request.mockResolvedValue({ models: inferenceServices });
+      client.asCurrentUser.transport.request.mockResolvedValue({ endpoints: inferenceServices });
     });
 
     test('should populate inference services for trained models', async () => {

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -69,16 +69,16 @@ export const populateInferenceServicesProvider = (client: IScopedClusterClient) 
 
     try {
       // Check if model is used by an inference service
-      const { models } = await esClient.transport.request<{
-        models: InferenceAPIConfigResponse[];
+      const { endpoints } = await esClient.transport.request<{
+        endpoints: InferenceAPIConfigResponse[];
       }>({
         method: 'GET',
         path: `/_inference/_all`,
       });
 
       const inferenceAPIMap = groupBy(
-        models,
-        (model) => model.service === 'elser' && model.service_settings.model_id
+        endpoints,
+        (endpoint) => endpoint.service === 'elser' && endpoint.service_settings.model_id
       );
 
       for (const model of trainedModels) {

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.test.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.test.tsx
@@ -13,7 +13,7 @@ import { CopyIDAction } from './copy_id_action';
 const mockInferenceEndpoint = {
   deployment: 'not_applicable',
   endpoint: {
-    model_id: 'hugging-face-embeddings',
+    inference_id: 'hugging-face-embeddings',
     task_type: 'text_embedding',
     service: 'hugging_face',
     service_settings: {
@@ -58,7 +58,7 @@ describe('CopyIDAction', () => {
 
   it('renders the label with correct text', () => {
     const TestComponent = () => {
-      return <CopyIDAction modelId={mockInferenceEndpoint.endpoint.model_id} />;
+      return <CopyIDAction inferenceId={mockInferenceEndpoint.endpoint.inference_id} />;
     };
 
     const { getByTestId } = render(<TestComponent />);

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.tsx
@@ -11,22 +11,22 @@ import React from 'react';
 import { useKibana } from '../../../../../../hooks/use_kibana';
 
 interface CopyIDActionProps {
-  modelId: string;
+  inferenceId: string;
 }
 
-export const CopyIDAction = ({ modelId }: CopyIDActionProps) => {
+export const CopyIDAction = ({ inferenceId }: CopyIDActionProps) => {
   const {
     services: { notifications },
   } = useKibana();
   const toasts = notifications?.toasts;
 
   return (
-    <EuiCopy textToCopy={modelId}>
+    <EuiCopy textToCopy={inferenceId}>
       {(copy) => (
         <EuiButtonIcon
           aria-label={i18n.translate('xpack.searchInferenceEndpoints.actions.copyID', {
-            defaultMessage: 'Copy inference endpoint ID {modelId}',
-            values: { modelId },
+            defaultMessage: 'Copy inference endpoint ID {inferenceId}',
+            values: { inferenceId },
           })}
           data-test-subj="inference-endpoints-action-copy-id-label"
           iconType="copyClipboard"
@@ -34,8 +34,8 @@ export const CopyIDAction = ({ modelId }: CopyIDActionProps) => {
             copy();
             toasts?.addSuccess({
               title: i18n.translate('xpack.searchInferenceEndpoints.actions.copyIDSuccess', {
-                defaultMessage: 'Inference endpoint ID {modelId} copied',
-                values: { modelId },
+                defaultMessage: 'Inference endpoint ID {inferenceId} copied',
+                values: { inferenceId },
               }),
             });
           }}

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/delete_action.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/delete_action.tsx
@@ -28,7 +28,7 @@ export const DeleteAction: React.FC<DeleteActionProps> = ({ selectedEndpoint }) 
 
     deleteEndpoint({
       type: selectedEndpoint.type,
-      id: selectedEndpoint.endpoint.model_id,
+      id: selectedEndpoint.endpoint.inference_id,
     });
   };
 
@@ -37,7 +37,7 @@ export const DeleteAction: React.FC<DeleteActionProps> = ({ selectedEndpoint }) 
       <EuiButtonIcon
         aria-label={i18n.translate('xpack.searchInferenceEndpoints.actions.deleteEndpoint', {
           defaultMessage: 'Delete inference endpoint {selectedEndpointName}',
-          values: { selectedEndpointName: selectedEndpoint?.endpoint.model_id },
+          values: { selectedEndpointName: selectedEndpoint?.endpoint.inference_id },
         })}
         key="delete"
         iconType="trash"

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.test.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@kbn/ml-trained-models-utils', () => ({
 describe('RenderEndpoint component tests', () => {
   describe('with cohere service', () => {
     const mockEndpoint = {
-      model_id: 'cohere-2',
+      inference_id: 'cohere-2',
       service: 'cohere',
       service_settings: {
         similarity: 'cosine',
@@ -68,7 +68,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('with elasticsearch service', () => {
     const mockEndpoint = {
-      model_id: 'model-123',
+      inference_id: 'model-123',
       service: 'elasticsearch',
       service_settings: {
         num_allocations: 5,
@@ -102,7 +102,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('with azureaistudio service', () => {
     const mockEndpoint = {
-      model_id: 'azure-ai-1',
+      inference_id: 'azure-ai-1',
       service: 'azureaistudio',
       service_settings: {
         target: 'westus',
@@ -155,7 +155,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('with azureopenai service', () => {
     const mockEndpoint = {
-      model_id: 'azure-openai-1',
+      inference_id: 'azure-openai-1',
       service: 'azureopenai',
       service_settings: {
         resource_name: 'resource-xyz',
@@ -174,7 +174,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('with mistral service', () => {
     const mockEndpoint = {
-      model_id: 'mistral-ai-1',
+      inference_id: 'mistral-ai-1',
       service: 'mistral',
       service_settings: {
         model: 'model-xyz',
@@ -233,7 +233,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('with googleaistudio service', () => {
     const mockEndpoint = {
-      model_id: 'google-ai-1',
+      inference_id: 'google-ai-1',
       service: 'googleaistudio',
       service_settings: {
         model_id: 'model-abc',
@@ -267,7 +267,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('with amazonbedrock service', () => {
     const mockEndpoint = {
-      model_id: 'amazon-bedrock-1',
+      inference_id: 'amazon-bedrock-1',
       service: 'amazonbedrock',
       service_settings: {
         region: 'us-west-1',
@@ -287,7 +287,7 @@ describe('RenderEndpoint component tests', () => {
 
   describe('for MIT licensed models', () => {
     const mockEndpointWithMitLicensedModel = {
-      model_id: 'model-123',
+      inference_id: 'model-123',
       service: 'elasticsearch',
       service_settings: {
         num_allocations: 5,
@@ -306,7 +306,7 @@ describe('RenderEndpoint component tests', () => {
 
     it('does not render the MIT license badge if the model is not eligible', () => {
       const mockEndpointWithNonMitLicensedModel = {
-        model_id: 'model-123',
+        inference_id: 'model-123',
         service: 'elasticsearch',
         service_settings: {
           num_allocations: 5,

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.tsx
@@ -23,7 +23,7 @@ export const EndpointInfo: React.FC<EndpointInfoProps> = ({ endpoint }) => {
   return (
     <EuiFlexGroup gutterSize="xs" direction="column">
       <EuiFlexItem>
-        <strong>{endpoint.model_id}</strong>
+        <strong>{endpoint.inference_id}</strong>
       </EuiFlexItem>
       <EuiFlexItem css={{ textWrap: 'wrap' }}>
         <EndpointModelInfo endpoint={endpoint} />

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -15,7 +15,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const inferenceEndpoints = [
   {
-    model_id: 'my-elser-model-05',
+    inference_id: 'my-elser-model-05',
     task_type: 'sparse_embedding',
     service: 'elser',
     service_settings: {
@@ -26,7 +26,7 @@ const inferenceEndpoints = [
     task_settings: {},
   },
   {
-    model_id: 'my-elser-model-04',
+    inference_id: 'my-elser-model-04',
     task_type: 'sparse_embedding',
     service: 'elser',
     service_settings: {

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -108,7 +108,7 @@ export const TabularPage: React.FC<TabularPageProps> = ({ inferenceEndpoints }) 
       actions: [
         {
           render: (inferenceEndpoint: InferenceEndpointUI) => (
-            <CopyIDAction modelId={inferenceEndpoint.endpoint.model_id} />
+            <CopyIDAction inferenceId={inferenceEndpoint.endpoint.inference_id} />
           ),
         },
         {

--- a/x-pack/plugins/search_inference_endpoints/public/hooks/use_table_data.test.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/hooks/use_table_data.test.tsx
@@ -16,7 +16,7 @@ import { TRAINED_MODEL_STATS_QUERY_KEY } from '../../common/constants';
 
 const inferenceEndpoints = [
   {
-    model_id: 'my-elser-model-04',
+    inference_id: 'my-elser-model-04',
     task_type: 'sparse_embedding',
     service: 'elser',
     service_settings: {
@@ -27,7 +27,7 @@ const inferenceEndpoints = [
     task_settings: {},
   },
   {
-    model_id: 'my-elser-model-01',
+    inference_id: 'my-elser-model-01',
     task_type: 'sparse_embedding',
     service: 'elser',
     service_settings: {
@@ -38,7 +38,7 @@ const inferenceEndpoints = [
     task_settings: {},
   },
   {
-    model_id: 'my-elser-model-05',
+    inference_id: 'my-elser-model-05',
     task_type: 'text_embedding',
     service: 'elasticsearch',
     service_settings: {
@@ -110,11 +110,13 @@ describe('useTableData', () => {
     );
 
     const expectedSortedData = [...inferenceEndpoints].sort((a, b) =>
-      b.model_id.localeCompare(a.model_id)
+      b.inference_id.localeCompare(a.inference_id)
     );
 
-    const sortedEndpoints = result.current.sortedTableData.map((item) => item.endpoint.model_id);
-    const expectedModelIds = expectedSortedData.map((item) => item.model_id);
+    const sortedEndpoints = result.current.sortedTableData.map(
+      (item) => item.endpoint.inference_id
+    );
+    const expectedModelIds = expectedSortedData.map((item) => item.inference_id);
 
     expect(sortedEndpoints).toEqual(expectedModelIds);
   });
@@ -146,7 +148,9 @@ describe('useTableData', () => {
       { wrapper }
     );
     const filteredData = result.current.sortedTableData;
-    expect(filteredData.every((item) => item.endpoint.model_id.includes(searchKey))).toBeTruthy();
+    expect(
+      filteredData.every((item) => item.endpoint.inference_id.includes(searchKey))
+    ).toBeTruthy();
   });
 
   it('should update deployment status based on deploymentStatus object', () => {

--- a/x-pack/plugins/search_inference_endpoints/public/hooks/use_table_data.tsx
+++ b/x-pack/plugins/search_inference_endpoints/public/hooks/use_table_data.tsx
@@ -64,7 +64,7 @@ export const useTableData = (
     }
 
     return filteredEndpoints
-      .filter((endpoint) => endpoint.model_id.includes(searchKey))
+      .filter((endpoint) => endpoint.inference_id.includes(searchKey))
       .map((endpoint) => {
         const isElasticService =
           endpoint.service === ServiceProviderKeys.elasticsearch ||
@@ -94,9 +94,9 @@ export const useTableData = (
       const bValue = b[queryParams.sortField];
 
       if (queryParams.sortOrder === SortOrder.asc) {
-        return aValue.model_id.localeCompare(bValue.model_id);
+        return aValue.inference_id.localeCompare(bValue.inference_id);
       } else {
-        return bValue.model_id.localeCompare(aValue.model_id);
+        return bValue.inference_id.localeCompare(aValue.inference_id);
       }
     });
   }, [tableData, queryParams]);

--- a/x-pack/plugins/search_inference_endpoints/server/lib/fetch_inference_endpoints.test.ts
+++ b/x-pack/plugins/search_inference_endpoints/server/lib/fetch_inference_endpoints.test.ts
@@ -12,28 +12,28 @@ import { fetchInferenceEndpoints } from './fetch_inference_endpoints';
 describe('fetch indices', () => {
   const mockInferenceEndpointsResponse = [
     {
-      model_id: 'my-elser-model-03',
+      inference_id: 'my-elser-model-03',
       task_type: 'sparse_embedding',
       service: 'elser',
       service_settings: { num_allocations: 1, num_threads: 1, model_id: '.elser_model_2' },
       task_settings: {},
     },
     {
-      model_id: 'my-elser-model-04',
+      inference_id: 'my-elser-model-04',
       task_type: 'sparse_embedding',
       service: 'elser',
       service_settings: { num_allocations: 1, num_threads: 1, model_id: '.elser_model_2' },
       task_settings: {},
     },
     {
-      model_id: 'my-elser-model-05',
+      inference_id: 'my-elser-model-05',
       task_type: 'sparse_embedding',
       service: 'elser',
       service_settings: { num_allocations: 1, num_threads: 1, model_id: '.elser_model_2' },
       task_settings: {},
     },
     {
-      model_id: 'my-elser-model-06',
+      inference_id: 'my-elser-model-06',
       task_type: 'sparse_embedding',
       service: 'elser',
       service_settings: { num_allocations: 1, num_threads: 1, model_id: '.elser_model_2' },

--- a/x-pack/test/api_integration/apis/management/index_management/inference_endpoints.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/inference_endpoints.ts
@@ -54,7 +54,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(inferenceEndpoints).to.be.ok();
       expect(
         inferenceEndpoints.some(
-          (endpoint: InferenceAPIConfigResponse) => endpoint.model_id === inferenceId
+          (endpoint: InferenceAPIConfigResponse) => endpoint.inference_id === inferenceId
         )
       ).to.eql(true, `${inferenceId} not found in the GET _inference/_all response`);
     });

--- a/x-pack/test_serverless/api_integration/test_suites/common/index_management/inference_endpoints.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/index_management/inference_endpoints.ts
@@ -65,7 +65,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(inferenceEndpoints).to.be.ok();
       expect(
         inferenceEndpoints.some(
-          (endpoint: InferenceAPIConfigResponse) => endpoint.model_id === inferenceId
+          (endpoint: InferenceAPIConfigResponse) => endpoint.inference_id === inferenceId
         )
       ).to.eql(true, `${inferenceId} not found in the GET _inference/_all response`);
     });


### PR DESCRIPTION
Reverts elastic/kibana#189732


This PR changes the reference to inference_id instead of model_id for Inference APIs.

### Test in local dev


https://github.com/user-attachments/assets/49c0a2ed-b4d9-45cb-9653-cfe2120ad636

