### PR TITLE
[Fleet] Add GitHub action to auto-approve bundled package PR's

### DIFF
--- a/.github/workflows/auto-approve-bundled-package-updates.yml
+++ b/.github/workflows/auto-approve-bundled-package-updates.yml
@@ -3,7 +3,7 @@ on:
     types:
       - opened
     paths:
-      - 'fleet-packages.json'
+      - 'fleet_packages.json'
 
 jobs:
   approve:

--- a/.github/workflows/auto-approve-bundled-package-updates.yml
+++ b/.github/workflows/auto-approve-bundled-package-updates.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
     paths:

--- a/.github/workflows/auto-approve-bundled-package-updates.yml
+++ b/.github/workflows/auto-approve-bundled-package-updates.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request_target:
+    types:
+      - opened
+    paths:
+      - 'fleet-packages.json'
+
+jobs:
+  approve:
+    name: Auto-approve bundled package updates
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'update-bundled-packages') &&
+      github.event.pull_request.user.login == 'elasticmachine'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0


### PR DESCRIPTION
## Summary

Adds a GitHub action similar to others where Fleet's bundled package PR's will be auto approved by the GitHub actions user. Today, these PR's require human intervention which causes headaches. 

Example PR: https://github.com/elastic/kibana/pull/189514

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->