### PR TITLE
Update learn more link address

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/content/callouts/legacy_metric_callout.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/content/callouts/legacy_metric_callout.tsx
@@ -9,12 +9,12 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import { InventoryItemType, SnapshotMetricType } from '@kbn/metrics-data-access-plugin/common';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-import { HOST_METRICS_DOC_HREF } from '../../../../common/visualizations';
 import { toMetricOpt } from '../../../../../common/snapshot_metric_i18n';
 import { useAssetDetailsRenderPropsContext } from '../../hooks/use_asset_details_render_props';
 import { ContentTabIds } from '../../types';
 import { useTabSwitcherContext } from '../../hooks/use_tab_switcher';
 
+export const HOST_LEGACY_METRICS_DOC_HREF = 'https://ela.st/host-metrics-legacy';
 const DISMISSAL_LEGACY_ALERT_METRIC_STORAGE_KEY = 'infraAssetDetails:legacy_alert_metric_dismissed';
 
 export const LegacyAlertMetricCallout = ({
@@ -66,7 +66,7 @@ export const LegacyAlertMetricCallout = ({
           learnMoreLink: (
             <EuiLink
               data-test-subj="infraAssetDetailsLegacyMetricAlertCalloutLink"
-              href={HOST_METRICS_DOC_HREF}
+              href={HOST_LEGACY_METRICS_DOC_HREF}
               target="_blank"
             >
               <FormattedMessage


### PR DESCRIPTION
closes [#190764](https://github.com/elastic/kibana/issues/190764)
 
## Summary

Update the Learn More link on the legacy metric callout to point to https://ela.st/host-metrics-legacy

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/67caf5d4-fcb7-4ddc-b650-b65b7bd87b49">

NODE: https://ela.st/host-metrics-legacy shortened URL redirect still needs to be updated.

### How to test

- Start a local Kibana instance (pointing to an oblt cluster is easier)
- Navigate to Inventory > Hosts, click on a host name to navigate to the Asset Details page
- Change the URL, adding the following queryparam: `alertMetric:rx`
- Inspect the Learn More link href
