### PR TITLE
[8.15] Hide manual rule run behind feature flag for bulk actions (#188506)

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/use_bulk_actions.tsx
@@ -16,6 +16,7 @@ import { MAX_MANUAL_RULE_RUN_BULK_SIZE } from '../../../../../../common/constant
 import type { TimeRange } from '../../../../rule_gaps/types';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { convertRulesFilterToKQL } from '../../../../../../common/detection_engine/rule_management/rule_filtering';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { DuplicateOptions } from '../../../../../../common/detection_engine/rule_management/constants';
 import type {
   BulkActionEditPayload,
@@ -88,6 +89,7 @@ export const useBulkActions = ({
     actions: { clearRulesSelection, setIsPreflightInProgress },
   } = rulesTableContext;
 
+  const isManualRuleRunEnabled = useIsExperimentalFeatureEnabled('manualRuleRunEnabled');
   const getBulkItemsPopoverContent = useCallback(
     (closePopover: () => void): EuiContextMenuPanelDescriptor[] => {
       const selectedRules = rules.filter(({ id }) => selectedRuleIds.includes(id));
@@ -446,14 +448,18 @@ export const useBulkActions = ({
               onClick: handleExportAction,
               icon: undefined,
             },
-            {
-              key: i18n.BULK_ACTION_MANUAL_RULE_RUN,
-              name: i18n.BULK_ACTION_MANUAL_RULE_RUN,
-              'data-test-subj': 'scheduleRuleRunBulk',
-              disabled: containsLoading || (!containsEnabled && !isAllSelected),
-              onClick: handleScheduleRuleRunAction,
-              icon: undefined,
-            },
+            ...(isManualRuleRunEnabled
+              ? [
+                  {
+                    key: i18n.BULK_ACTION_MANUAL_RULE_RUN,
+                    name: i18n.BULK_ACTION_MANUAL_RULE_RUN,
+                    'data-test-subj': 'scheduleRuleRunBulk',
+                    disabled: containsLoading || (!containsEnabled && !isAllSelected),
+                    onClick: handleScheduleRuleRunAction,
+                    icon: undefined,
+                  },
+                ]
+              : []),
             {
               key: i18n.BULK_ACTION_DISABLE,
               name: i18n.BULK_ACTION_DISABLE,
@@ -594,6 +600,7 @@ export const useBulkActions = ({
       filterOptions,
       completeBulkEditForm,
       startServices,
+      isManualRuleRunEnabled,
     ]
   );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Hide manual rule run behind feature flag for bulk actions (#188506)](https://github.com/elastic/kibana/pull/188506)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Khristinin Nikita","email":"nikita.khristinin@elastic.co"},"sourceCommit":{"committedDate":"2024-07-29T07:54:49Z","message":"Hide manual rule run behind feature flag for bulk actions (#188506)\n\n## Hide manual rule run behind feature flag for bulk actions\r\n\r\nCurrently it exposes on serverless, but user can't run it still. We are\r\nwaiting for docs, to remove FF\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5a09ec9a308a69acdab8c9470bfc447b9f11a645","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v8.16.0"],"number":188506,"url":"https://github.com/elastic/kibana/pull/188506","mergeCommit":{"message":"Hide manual rule run behind feature flag for bulk actions (#188506)\n\n## Hide manual rule run behind feature flag for bulk actions\r\n\r\nCurrently it exposes on serverless, but user can't run it still. We are\r\nwaiting for docs, to remove FF\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5a09ec9a308a69acdab8c9470bfc447b9f11a645"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188506","number":188506,"mergeCommit":{"message":"Hide manual rule run behind feature flag for bulk actions (#188506)\n\n## Hide manual rule run behind feature flag for bulk actions\r\n\r\nCurrently it exposes on serverless, but user can't run it still. We are\r\nwaiting for docs, to remove FF\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5a09ec9a308a69acdab8c9470bfc447b9f11a645"}}]}] BACKPORT-->