### PR TITLE
fix: Home > Synthetics > Overview > Data Retention tab - When reading content in table colums 2-4, the content in column 1 should be reiterated.

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/settings/data_retention/dsl_retention_tab.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/settings/data_retention/dsl_retention_tab.tsx
@@ -25,6 +25,7 @@ export const DslRetentionTab = () => {
 
   return (
     <EuiBasicTable
+      rowHeader="name"
       items={dataStreamStatuses}
       loading={loading === true}
       columns={DSL_RETENTION_COLUMNS}


### PR DESCRIPTION
Closes: https://github.com/elastic/observability-accessibility/issues/130

## Description

`Home` > `Synthetics` > `Overview` > `Data Retention tab` - When reading content in table colums 2-4, the content in column 1 should be reiterated.

### Steps to recreate

1. Navigate to the `Serverless Observability Solution `instance.
2. Open the `Synthetics -> Settings -> Data-Retention` page (`app/synthetics/settings/data-retention`)

### What was changed
 
1. `rowHeader="name"` attribute was added 

### Screen

<img width="1293" alt="image" src="https://github.com/user-attachments/assets/81dc8f21-ab13-43c8-9a4e-b4c6a2c76cf4">



