### PR TITLE
[Search] Log and return instead of swallow errors in Playground

### DIFF
--- a/x-pack/plugins/search_playground/server/routes.ts
+++ b/x-pack/plugins/search_playground/server/routes.ts
@@ -57,7 +57,7 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
 
       const { indices } = request.body;
@@ -89,14 +89,14 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const [{ analytics }, { actions, cloud }] = await getStartServices();
 
       const { client } = (await context.core).elasticsearch;
       const aiClient = Assist({
         es_client: client.asCurrentUser,
       } as AssistClientOptionsWithClient);
-      const { messages, data } = await request.body;
+      const { messages, data } = request.body;
       const { chatModel, chatPrompt, questionRewritePrompt, connector } = await getChatParams(
         {
           connectorId: data.connector_id,
@@ -184,7 +184,7 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const { name, expiresInDays, indices } = request.body;
       const { client } = (await context.core).elasticsearch;
 
@@ -223,7 +223,7 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const { search_query: searchQuery, size } = request.query;
       const {
         client: { asCurrentUser },

--- a/x-pack/plugins/search_playground/tsconfig.json
+++ b/x-pack/plugins/search_playground/tsconfig.json
@@ -39,7 +39,8 @@
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
     "@kbn/console-plugin",
-    "@kbn/utility-types"
+    "@kbn/utility-types",
+    "@kbn/kibana-utils-plugin"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This stops the Kibana server from swallowing all playground errors, instead logging them and then returning a meaningful error to the frontend.


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->