### PR TITLE
read selected options from 'selections' key instead of 'selectedOptions' key

### DIFF
--- a/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/get_options_list_control_factory.test.tsx
+++ b/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/get_options_list_control_factory.test.tsx
@@ -84,7 +84,7 @@ describe('Options List Control Api', () => {
         {
           dataViewId: 'myDataViewId',
           fieldName: 'myFieldName',
-          selectedOptions: ['cool', 'test'],
+          selections: ['cool', 'test'],
         },
         getMockedBuildApi(uuid, factory, controlGroupApi),
         uuid,
@@ -216,7 +216,7 @@ describe('Options List Control Api', () => {
         {
           dataViewId: 'myDataViewId',
           fieldName: 'myFieldName',
-          selectedOptions: ['woof', 'bark'],
+          selections: ['woof', 'bark'],
         },
         getMockedBuildApi(uuid, factory, controlGroupApi),
         uuid,
@@ -248,7 +248,7 @@ describe('Options List Control Api', () => {
         {
           dataViewId: 'myDataViewId',
           fieldName: 'myFieldName',
-          selectedOptions: ['woof', 'bark'],
+          selections: ['woof', 'bark'],
         },
         getMockedBuildApi(uuid, factory, controlGroupApi),
         uuid,
@@ -293,7 +293,7 @@ describe('Options List Control Api', () => {
           dataViewId: 'myDataViewId',
           fieldName: 'myFieldName',
           singleSelect: true,
-          selectedOptions: ['woof'],
+          selections: ['woof'],
         },
         getMockedBuildApi(uuid, factory, controlGroupApi),
         uuid,

--- a/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/options_list_context_provider.tsx
+++ b/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/options_list_context_provider.tsx
@@ -18,7 +18,7 @@ import {
 import { OptionsListSelection } from '../../../../../common/options_list/options_list_selections';
 
 export type ContextStateManager = ControlStateManager<
-  Omit<OptionsListComponentState, 'exclude' | 'existsSelected' | 'selectedOptions'>
+  Omit<OptionsListComponentState, 'exclude' | 'existsSelected' | 'selections'>
 > & {
   selectedOptions: PublishingSubject<OptionsListSelection[] | undefined>;
   existsSelected: PublishingSubject<boolean | undefined>;

--- a/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/options_list_control_selections.ts
+++ b/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/options_list_control_selections.ts
@@ -17,7 +17,7 @@ export function initializeOptionsListSelections(
   onSelectionChange: () => void
 ) {
   const selectedOptions$ = new BehaviorSubject<OptionsListSelection[] | undefined>(
-    initialState.selectedOptions ?? []
+    initialState.selections ?? []
   );
   const selectedOptionsComparatorFunction = (
     a: OptionsListSelection[] | undefined,
@@ -50,11 +50,11 @@ export function initializeOptionsListSelections(
     comparators: {
       exclude: [exclude$, setExclude],
       existsSelected: [existsSelected$, setExistsSelected],
-      selectedOptions: [selectedOptions$, setSelectedOptions, selectedOptionsComparatorFunction],
+      selections: [selectedOptions$, setSelectedOptions, selectedOptionsComparatorFunction],
     } as StateComparators<
-      Pick<OptionsListControlState, 'exclude' | 'existsSelected' | 'selectedOptions'>
+      Pick<OptionsListControlState, 'exclude' | 'existsSelected' | 'selections'>
     >,
-    hasInitialSelections: initialState.selectedOptions?.length || initialState.existsSelected,
+    hasInitialSelections: initialState.selections?.length || initialState.existsSelected,
     selectedOptions$: selectedOptions$ as PublishingSubject<OptionsListSelection[] | undefined>,
     setSelectedOptions,
     existsSelected$: existsSelected$ as PublishingSubject<boolean | undefined>,

--- a/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/types.ts
+++ b/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/types.ts
@@ -29,7 +29,7 @@ export interface OptionsListControlState
     OptionsListDisplaySettings {
   searchTechnique?: OptionsListSearchTechnique;
   sort?: OptionsListSortingType;
-  selectedOptions?: OptionsListSelection[];
+  selections?: OptionsListSelection[];
   existsSelected?: boolean;
   runPastTimeout?: boolean;
   singleSelect?: boolean;


### PR DESCRIPTION
Existing option list controls store state in `selections` key. Need to continue to use this key to apply selections on load.

### test
1. run kibana with `yarn start --run-examples`
2. navigate to controls developer example
3. make selections to `Agent` options list
4. Click "Save" button
5. refresh page, verify `Agent` retains selections