### PR TITLE
[Backport] Add debug logging for flaky session cleanup test

### DIFF
--- a/x-pack/test/security_api_integration/tests/session_lifespan/cleanup.ts
+++ b/x-pack/test/security_api_integration/tests/session_lifespan/cleanup.ts
@@ -19,6 +19,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertestWithoutAuth');
   const es = getService('es');
+  const esSupertest = getService('esSupertest');
   const esDeleteAllIndices = getService('esDeleteAllIndices');
   const config = getService('config');
   const randomness = getService('randomness');
@@ -72,9 +73,19 @@ export default function ({ getService }: FtrProviderContext) {
     return cookie;
   }
 
+  async function addESDebugLoggingSettings() {
+    const addLogging = {
+      persistent: {
+        'logger.org.elasticsearch.xpack.security.authc': 'debug',
+      },
+    };
+    await esSupertest.put('/_cluster/settings').send(addLogging).expect(200);
+  }
+
   describe('Session Lifespan cleanup', () => {
     beforeEach(async () => {
       await es.cluster.health({ index: '.kibana_security_session*', wait_for_status: 'green' });
+      await addESDebugLoggingSettings();
       await esDeleteAllIndices('.kibana_security_session*');
     });
 


### PR DESCRIPTION
## Summary

Add settings to the ES Test cluster to enable debug logs so that if this test fails in the future, we will have more logs to investigate the issue. 


__Related:__ https://github.com/elastic/kibana/issues/186254