### PR TITLE
[ResponseOps][Connectors] Add deprecation warning to the Teams Connector

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/teams/teams_connectors.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/teams/teams_connectors.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiLink } from '@elastic/eui';
+import { EuiCallOut, EuiLink, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { FieldConfig, UseField } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { fieldValidators } from '@kbn/es-ui-shared-plugin/static/forms/helpers';
@@ -42,18 +42,28 @@ const TeamsActionFields: React.FunctionComponent<ActionConnectorFieldsProps> = (
   const { docLinks } = useKibana().services;
 
   return (
-    <UseField
-      path="secrets.webhookUrl"
-      config={getWebhookUrlConfig(docLinks)}
-      component={Field}
-      componentProps={{
-        euiFieldProps: {
-          readOnly,
-          'data-test-subj': 'teamsWebhookUrlInput',
-          fullWidth: true,
-        },
-      }}
-    />
+    <>
+      <UseField
+        path="secrets.webhookUrl"
+        config={getWebhookUrlConfig(docLinks)}
+        component={Field}
+        componentProps={{
+          euiFieldProps: {
+            readOnly,
+            'data-test-subj': 'teamsWebhookUrlInput',
+            fullWidth: true,
+          },
+        }}
+      />
+      <EuiSpacer size="m" />
+      <EuiCallOut
+        size="s"
+        color="warning"
+        iconType="warning"
+        data-test-subj={'microsoftTeamsWebhookDeprecationWarning'}
+        title={i18n.WEBHOOK_DEPRECATION_WARNING}
+      />
+    </>
   );
 };
 

--- a/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
@@ -32,6 +32,6 @@ export const WEBHOOK_DEPRECATION_WARNING = i18n.translate(
   'xpack.stackConnectors.components.teams.warning.webhookDeprecation',
   {
     defaultMessage:
-      'Microsoft has deprecated the old way of configuring Webhooks. If you have not updated it yet the Webhook URL will stop working in December 2024. Please follow the documentation link to configure it again.',
+      'Microsoft Teams deprecated some methods for configuring webhooks. Follow the documentation link to create a supported webhook URL. If the URL is not updated by December 31, 2024, notifications will stop. ',
   }
 );

--- a/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
@@ -32,6 +32,6 @@ export const WEBHOOK_DEPRECATION_WARNING = i18n.translate(
   'xpack.stackConnectors.components.teams.warning.webhookDeprecation',
   {
     defaultMessage:
-      'Microsoft Teams deprecated some methods for configuring webhooks. Follow the documentation link to create a supported webhook URL. If the URL is not updated by December 31, 2024, notifications will stop. ',
+      'Microsoft Teams deprecated some methods for configuring webhooks. Follow the documentation link to create a supported webhook URL. If the URL is not updated by December 31, 2024, notifications will stop.',
   }
 );

--- a/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
@@ -27,3 +27,11 @@ export const MESSAGE_REQUIRED = i18n.translate(
     defaultMessage: 'Message is required.',
   }
 );
+
+export const WEBHOOK_DEPRECATION_WARNING = i18n.translate(
+  'xpack.stackConnectors.components.teams.warning.webhookDeprecation',
+  {
+    defaultMessage:
+      'Microsoft has deprecated the old way of configuring Webhooks. If you have not updated it yet the Webhook URL will stop working in December 2024. Please follow the documentation link to configure it again.',
+  }
+);


### PR DESCRIPTION
Fixes #190944

## Summary

**The exact text is still a work in progress.**

<img width="895" alt="Screenshot 2024-08-21 at 11 02 37" src="https://github.com/user-attachments/assets/8aca356d-cd3d-425d-b849-7769b18324d9">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->