### PR TITLE
[8.15] [Search] Log and return instead of swallow errors in Playground (#190796)

### DIFF
--- a/x-pack/plugins/search_playground/server/routes.ts
+++ b/x-pack/plugins/search_playground/server/routes.ts
@@ -57,7 +57,7 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
 
       const { indices } = request.body;
@@ -89,14 +89,14 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const [{ analytics }, { actions, cloud }] = await getStartServices();
 
       const { client } = (await context.core).elasticsearch;
       const aiClient = Assist({
         es_client: client.asCurrentUser,
       } as AssistClientOptionsWithClient);
-      const { messages, data } = await request.body;
+      const { messages, data } = request.body;
       const { chatModel, chatPrompt, questionRewritePrompt, connector } = await getChatParams(
         {
           connectorId: data.connector_id,
@@ -184,7 +184,7 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const { name, expiresInDays, indices } = request.body;
       const { client } = (await context.core).elasticsearch;
 
@@ -223,7 +223,7 @@ export function defineRoutes({
         }),
       },
     },
-    errorHandler(async (context, request, response) => {
+    errorHandler(logger)(async (context, request, response) => {
       const { search_query: searchQuery, size } = request.query;
       const {
         client: { asCurrentUser },

--- a/x-pack/plugins/search_playground/tsconfig.json
+++ b/x-pack/plugins/search_playground/tsconfig.json
@@ -38,7 +38,9 @@
     "@kbn/core-logging-server-mocks",
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
-    "@kbn/console-plugin"
+    "@kbn/console-plugin",
+    "@kbn/utility-types",
+    "@kbn/kibana-utils-plugin"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/plugins/search_playground/tsconfig.json
+++ b/x-pack/plugins/search_playground/tsconfig.json
@@ -39,7 +39,6 @@
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
     "@kbn/console-plugin",
-    "@kbn/utility-types",
     "@kbn/kibana-utils-plugin"
   ],
   "exclude": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Search] Log and return instead of swallow errors in Playground (#190796)](https://github.com/elastic/kibana/pull/190796)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-08-21T09:51:35Z","message":"[Search] Log and return instead of swallow errors in Playground (#190796)\n\n## Summary\r\n\r\nThis stops the Kibana server from swallowing all playground errors,\r\ninstead logging them and then returning a meaningful error to the\r\nfrontend.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8d4704f1fe77c98a682a8a0de507ca5186129925","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","v8.16.0","v8.15.1"],"number":190796,"url":"https://github.com/elastic/kibana/pull/190796","mergeCommit":{"message":"[Search] Log and return instead of swallow errors in Playground (#190796)\n\n## Summary\r\n\r\nThis stops the Kibana server from swallowing all playground errors,\r\ninstead logging them and then returning a meaningful error to the\r\nfrontend.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8d4704f1fe77c98a682a8a0de507ca5186129925"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/190796","number":190796,"mergeCommit":{"message":"[Search] Log and return instead of swallow errors in Playground (#190796)\n\n## Summary\r\n\r\nThis stops the Kibana server from swallowing all playground errors,\r\ninstead logging them and then returning a meaningful error to the\r\nfrontend.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"8d4704f1fe77c98a682a8a0de507ca5186129925"}},{"branch":"8.15","label":"v8.15.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->