### PR TITLE
[Infra] Add a link to host metrics docs

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/alerting/inventory/components/expression.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/inventory/components/expression.tsx
@@ -444,7 +444,8 @@ const StyledHealthCss = css`
 export const ExpressionRow: FC<PropsWithChildren<ExpressionRowProps>> = (props) => {
   const [isExpanded, toggle] = useToggle(true);
 
-  const { children, setRuleParams, expression, errors, expressionId, remove, canDelete } = props;
+  const { children, setRuleParams, expression, errors, expressionId, remove, canDelete, nodeType } =
+    props;
   const {
     metric,
     comparator = COMPARATORS.GREATER_THAN,
@@ -554,7 +555,7 @@ export const ExpressionRow: FC<PropsWithChildren<ExpressionRowProps>> = (props) 
   const ofFields = useMemo(() => {
     let myMetrics: SnapshotMetricType[] = hostSnapshotMetricTypes;
 
-    switch (props.nodeType) {
+    switch (nodeType) {
       case 'awsEC2':
         myMetrics = awsEC2SnapshotMetricTypes;
         break;
@@ -577,8 +578,8 @@ export const ExpressionRow: FC<PropsWithChildren<ExpressionRowProps>> = (props) 
         myMetrics = containerSnapshotMetricTypes;
         break;
     }
-    return myMetrics.map((myMetric) => toMetricOpt(myMetric, props.nodeType));
-  }, [props.nodeType]);
+    return myMetrics.map((myMetric) => toMetricOpt(myMetric, nodeType));
+  }, [nodeType]);
 
   return (
     <>
@@ -608,6 +609,7 @@ export const ExpressionRow: FC<PropsWithChildren<ExpressionRowProps>> = (props) 
                     text: string;
                   }>
                 }
+                nodeType={nodeType}
                 onChange={updateMetric}
                 onChangeCustom={updateCustomMetric}
                 errors={errors}

--- a/x-pack/plugins/observability_solution/infra/public/alerting/inventory/components/metric.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/inventory/components/metric.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiLink,
   EuiPopover,
   EuiPopoverTitle,
   EuiSelect,
@@ -24,6 +25,8 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { debounce } from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
 import { IErrorObject } from '@kbn/triggers-actions-ui-plugin/public';
+import type { InventoryItemType } from '@kbn/metrics-data-access-plugin/common';
+import { HOST_METRICS_DOC_HREF } from '../../../common/visualizations';
 import { useMetricsDataViewContext } from '../../../containers/metrics_source';
 import { getCustomMetricLabel } from '../../../../common/formatters/get_custom_metric_label';
 import {
@@ -37,6 +40,7 @@ import {
 interface Props {
   metric?: { value: string; text: string };
   metrics: Array<{ value: string; text: string }>;
+  nodeType: InventoryItemType;
   errors: IErrorObject;
   onChange: (metric?: string) => void;
   onChangeCustom: (customMetric?: SnapshotCustomMetricInput) => void;
@@ -91,6 +95,7 @@ export const MetricExpression = ({
   onChange,
   onChangeCustom,
   popupPosition,
+  nodeType,
 }: Props) => {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [customMetricTabOpen, setCustomMetricTabOpen] = useState(metric?.value === 'custom');
@@ -312,7 +317,23 @@ export const MetricExpression = ({
           </>
         ) : (
           <EuiFormRow fullWidth>
-            <EuiFlexGroup>
+            <EuiFlexGroup direction="column" gutterSize="s">
+              {nodeType === 'host' && (
+                <EuiFlexItem>
+                  <EuiLink
+                    data-test-subj="containerViewMetricsDocumentationLink"
+                    href={HOST_METRICS_DOC_HREF}
+                    target="_blank"
+                  >
+                    {i18n.translate(
+                      'xpack.infra.containerViewPage.tooltip.whatAreTheseMetricsLink',
+                      {
+                        defaultMessage: 'What are these metrics?',
+                      }
+                    )}
+                  </EuiLink>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem className="actOf__metricContainer">
                 <EuiComboBox
                   fullWidth

--- a/x-pack/plugins/observability_solution/infra/public/alerting/inventory/components/metric.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/alerting/inventory/components/metric.tsx
@@ -321,12 +321,12 @@ export const MetricExpression = ({
               {nodeType === 'host' && (
                 <EuiFlexItem>
                   <EuiLink
-                    data-test-subj="containerViewMetricsDocumentationLink"
+                    data-test-subj="alertFlyoutHostMetricsDocumentationLink"
                     href={HOST_METRICS_DOC_HREF}
                     target="_blank"
                   >
                     {i18n.translate(
-                      'xpack.infra.containerViewPage.tooltip.whatAreTheseMetricsLink',
+                      'xpack.infra.metrics.alertFlyout.expression.metric.whatAreTheseMetricsLink',
                       {
                         defaultMessage: 'What are these metrics?',
                       }


### PR DESCRIPTION
closes [#190953](https://github.com/elastic/kibana/issues/190953)

## Summary

The link is not shown for K8s pods

<img width="500px" alt="image" src="https://github.com/user-attachments/assets/5c86d44e-4088-4bd6-a151-3fcf518dc752">

The link is shown for hosts

<img width="500px" alt="image" src="https://github.com/user-attachments/assets/7b195990-1b28-4e73-818e-3024a0725007">



### How to test

- Navigate to `Inventory` 
- Click on Alerts and Rules > Infrastructure > Create Inventory rule
- Click on the metric to open the metric selection popover
  - Validate if the link appears and redirects to the docs page
- Do the same with other asset types (Containers, Docker, etc) 
