### PR TITLE
[canvas] fix by-value map embeddables have broken layers

### DIFF
--- a/x-pack/plugins/canvas/public/components/hooks/use_canvas_api.tsx
+++ b/x-pack/plugins/canvas/public/components/hooks/use_canvas_api.tsx
@@ -49,6 +49,7 @@ export const useCanvasApi: () => CanvasContainerApi = () => {
         createNewEmbeddable(panelType, initialState);
       },
       disableTriggers: true,
+      type: 'canvas',
       /**
        * getSerializedStateForChild is left out here because we cannot access the state here. That method
        * is injected in `x-pack/plugins/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx`

--- a/x-pack/plugins/canvas/types/embeddables.ts
+++ b/x-pack/plugins/canvas/types/embeddables.ts
@@ -11,6 +11,7 @@ import { EmbeddableInput as Input } from '@kbn/embeddable-plugin/common';
 import type {
   HasAppContext,
   HasDisableTriggers,
+  HasType,
   PublishesViewMode,
   PublishesUnifiedSearch,
 } from '@kbn/presentation-publishing';
@@ -25,5 +26,6 @@ export type EmbeddableInput = Input & {
 export type CanvasContainerApi = PublishesViewMode &
   CanAddNewPanel &
   HasDisableTriggers &
+  HasType &
   HasSerializedChildState &
   Partial<HasAppContext & PublishesUnifiedSearch>;

--- a/x-pack/plugins/maps/public/react_embeddable/map_react_embeddable.tsx
+++ b/x-pack/plugins/maps/public/react_embeddable/map_react_embeddable.tsx
@@ -12,6 +12,7 @@ import { APPLY_FILTER_TRIGGER } from '@kbn/data-plugin/public';
 import { ReactEmbeddableFactory, VALUE_CLICK_TRIGGER } from '@kbn/embeddable-plugin/public';
 import { EmbeddableStateWithType } from '@kbn/embeddable-plugin/common';
 import {
+  apiIsOfType,
   areTriggersDisabled,
   getUnchangingComparator,
   initializeTimeRange,
@@ -121,6 +122,16 @@ export const mapEmbeddableFactory: ReactEmbeddableFactory<
         // No references to extract for by-reference embeddable since all references are stored with by-reference saved object
         return {
           rawState: getByReferenceState(rawState, rawState.savedObjectId),
+          references: [],
+        };
+      }
+
+      /**
+       * Canvas does not support references
+       */
+      if (apiIsOfType(parentApi, 'canvas')) {
+        return {
+          rawState: getByValueState(rawState, savedMap.getAttributes()),
           references: [],
         };
       }

--- a/x-pack/plugins/maps/public/react_embeddable/map_react_embeddable.tsx
+++ b/x-pack/plugins/maps/public/react_embeddable/map_react_embeddable.tsx
@@ -127,7 +127,7 @@ export const mapEmbeddableFactory: ReactEmbeddableFactory<
       }
 
       /**
-       * Canvas does not support references
+       * Canvas by-value embeddables do not support references
        */
       if (apiIsOfType(parentApi, 'canvas')) {
         return {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/190994

### Test instructions
1. create new canvas workpad
2. Click "Select type" and select "Maps"
3. Add a documents layer to your map and click "Save and return"
4. Click "canvas" bread crumb to go back to canvas listing page
5. Open you work pad again. Map should still display data

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->