### PR TITLE
[workflows] Upgrade codeql-action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
         ref: ${{ matrix.branch }}
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -42,7 +42,7 @@ jobs:
     #     yarn kbn bootstrap --no-validate --no-vscode
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3
       # env:
       #   NODE_OPTIONS: "--max-old-space-size=6144"
       with:


### PR DESCRIPTION
Fixes deprecation warnings e.g.
https://github.com/elastic/kibana/actions/runs/10479478609.

The only breaking change is the Node.js version, which is already being overriden.  See https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

https://github.com/github/codeql-action/blob/main/CHANGELOG.md