### PR TITLE
Flaky #190724

### DIFF
--- a/packages/core/apps/core-apps-server-internal/src/core_app.ts
+++ b/packages/core/apps/core-apps-server-internal/src/core_app.ts
@@ -29,13 +29,13 @@ import type {
 import type { InternalStaticAssets } from '@kbn/core-http-server-internal';
 import {
   combineLatest,
-  concatMap,
   firstValueFrom,
   map,
   type Observable,
   ReplaySubject,
   shareReplay,
   Subject,
+  switchMap,
   takeUntil,
   timer,
 } from 'rxjs';
@@ -238,7 +238,7 @@ export class CoreAppsService {
       // Poll for updates
       combineLatest([savedObjectsClient$, timer(0, 10_000)])
         .pipe(
-          concatMap(async ([soClient]) => {
+          switchMap(async ([soClient]) => {
             try {
               const persistedOverrides = await soClient.get<Record<string, unknown>>(
                 DYNAMIC_CONFIG_OVERRIDES_SO_TYPE,
@@ -300,7 +300,10 @@ export class CoreAppsService {
             await soClient.create(DYNAMIC_CONFIG_OVERRIDES_SO_TYPE, newGlobalOverrides, {
               id: DYNAMIC_CONFIG_OVERRIDES_SO_ID,
               overwrite: true,
+              refresh: false,
             });
+            // set it again in memory in case the timer polling the SO for updates has overridden it during this update.
+            this.configService.setDynamicConfigOverrides(req.body);
           } catch (err) {
             if (err instanceof ValidationError) {
               return res.badRequest({ body: err });


### PR DESCRIPTION
## Summary

Resolves #190724

The flakiness might be caused by a race condition when, after setting the dynamic override in memory, the timer-based poller to reload the config from the SO might kick in while the SO is being updated, effectively loading in memory the old config. 

After 10s (next tick), the final expected config should win because it's stored in the SO, but that time is too much for the FTR to wait.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
