### PR TITLE
[CI] Log error on fast-async-transform failure

### DIFF
--- a/packages/kbn-babel-transform/fast_async_transformer.js
+++ b/packages/kbn-babel-transform/fast_async_transformer.js
@@ -39,6 +39,8 @@ async function withFastAsyncTransform(config, block) {
   try {
     await block(transform);
     success = true;
+  } catch (e) {
+    console.error('Error during transformation', e);
   } finally {
     try {
       await pool.destroy();


### PR DESCRIPTION
## Summary
A missed catch+log during the fast transformation of typescript files to js files caused the task pooling library, `piscina` to terminate without a warning. The terminated workers would crash with unexpected messages, and that resulted in original errors to be lost, and misleading error messages. This PR adds some logging. 

See: https://buildkite.com/elastic/kibana-pull-request/builds/228663#019170d4-4f00-4ccc-915e-7d8b0a6ca020 - the original causes were incorrect `await` usages, but that was never revealed, because we only got the messages that arrived to a terminated worker.

See also, for more background: https://elastic.slack.com/archives/C5UDAFZQU/p1724236149083029

<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->