### PR TITLE
[SharedUX] Resolve Sass Mixed Declaration issues

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/collapsible_nav.scss
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/collapsible_nav.scss
@@ -7,9 +7,9 @@ $screenHeightBreakpoint: $euiSize * 15;
 }
 
 .kbnCollapsibleNav__recentsListGroup {
-  @include euiYScroll;
   max-height: $euiSize * 10;
   margin-right: -$euiSizeS;
+  @include euiYScroll;
 }
 
 .kbnCollapsibleNav__solutions {

--- a/packages/shared-ux/page/solution_nav/src/solution_nav.scss
+++ b/packages/shared-ux/page/solution_nav/src/solution_nav.scss
@@ -10,10 +10,10 @@
 }
 
 .kbnSolutionNav {
-  @include euiYScroll;
-
   display: flex;
   flex-direction: column;
+
+  @include euiYScroll;
 
   @include euiBreakpoint('m', 'l', 'xl') {
     width: $solutionNavWidth;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/190886
Closes https://github.com/elastic/kibana/issues/190887

This resolves Sass mixed declaration issues by moving declarations to the top of the rule, above all nesting.

The following screenshots show that no style regressions were created by this PR:

----
**`.kbnCollapsibleNav__recentsListGroup`:**
![image](https://github.com/user-attachments/assets/74218960-3c9f-48c3-a0de-e1924b9f89a8)

----
**`.kbnSolutionNav`:**
![image](https://github.com/user-attachments/assets/b59088f3-d845-4b8a-b0eb-44642de90a60)


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
