### PR TITLE
[ci] Add retry to saved object migration step

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -589,6 +589,11 @@ steps:
       preemptible: true
     artifact_paths:
       "target/plugin_so_types_snapshot.json"
+    timeout_in_minutes: 30
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
This is running on a spot instance and should retry if the agent is lost.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->