### PR TITLE
Size down log overview content

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_header.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_header.tsx
@@ -43,7 +43,7 @@ export function LogsOverviewHeader({ doc }: { doc: LogDocumentOverview }) {
   });
 
   const accordionTitle = (
-    <EuiTitle size="xs">
+    <EuiTitle size="xxs">
       <p>{contentLabel}</p>
     </EuiTitle>
   );
@@ -80,7 +80,7 @@ export function LogsOverviewHeader({ doc }: { doc: LogDocumentOverview }) {
         <EuiFlexItem grow={false}>{logLevelAndTimestamp}</EuiFlexItem>
       </EuiFlexGroup>
       <HoverActionPopover value={value} field={field} anchorPosition="downCenter" display="block">
-        <EuiCodeBlock overflowHeight={100} paddingSize="m" isCopyable language="txt" fontSize="m">
+        <EuiCodeBlock overflowHeight={100} paddingSize="s" isCopyable language="txt" fontSize="s">
           {value}
         </EuiCodeBlock>
       </HoverActionPopover>


### PR DESCRIPTION
## Summary

Decrease the accordion title and code block content within the log overview tab.

------

The content in the log overview tab of the doc viewer flyout was large relative to surrounding UI elements (see below). The changes in this PR make it more consistent with other sections of the page.

**Before**
<img src="https://github.com/user-attachments/assets/521356d6-1170-47fb-9931-34072296fc7e" width="420" />


**After**
<img src="https://github.com/user-attachments/assets/51922e37-94a2-4f00-80fa-8202069717fc" width="420" />

_Font sizes now comparable to those used in and around the data grid, for example._

![CleanShot 2024-08-21 at 21 55 23@2x](https://github.com/user-attachments/assets/32f06022-b9aa-4211-8cb6-01bc44abfbad)

### Checklist


Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

