### PR TITLE
[Cloud Security] align vertically controls on bechmark pages

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -23,7 +23,6 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { useKibana } from '../../common/hooks/use_kibana';
 import { getFindingsDetectionRuleSearchTagsFromArrayOfRules } from '../../../common/utils/detection_rules';
 import {
@@ -294,9 +293,6 @@ const CurrentPageOfTotal = ({
       size="xs"
       iconType="arrowDown"
       iconSide="right"
-      css={css`
-        padding-bottom: ${euiThemeVars.euiSizeS};
-      `}
       data-test-subj={RULES_BULK_ACTION_BUTTON}
     >
       Bulk actions
@@ -326,7 +322,7 @@ const CurrentPageOfTotal = ({
   return (
     <EuiFlexItem grow={false}>
       <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="s">
+      <EuiFlexGroup gutterSize="s" alignItems={'center'}>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
             <FormattedMessage
@@ -347,9 +343,6 @@ const CurrentPageOfTotal = ({
               onClick={setSelectAllRules}
               size="xs"
               iconType="pagesSelect"
-              css={css`
-                padding-bottom: ${euiThemeVars.euiSizeS};
-              `}
               data-test-subj={RULES_SELECT_ALL_RULES}
             >
               <FormattedMessage
@@ -363,9 +356,6 @@ const CurrentPageOfTotal = ({
               onClick={() => setSelectedRules([])}
               size="xs"
               iconType="cross"
-              css={css`
-                padding-bottom: ${euiThemeVars.euiSizeS};
-              `}
               data-test-subj={RULES_CLEAR_ALL_RULES_SELECTION}
             >
               <FormattedMessage


### PR DESCRIPTION
## Summary

- part of https://github.com/elastic/security-team/issues/10316
- fixes https://github.com/elastic/security-team/issues/9428#issuecomment-2107656242

## Screenshots


<img width="1725" alt="Screenshot 2024-08-22 at 12 34 47" src="https://github.com/user-attachments/assets/1ff67185-e67d-4aad-9fa2-004508149230">
<img width="1728" alt="Screenshot 2024-08-22 at 12 34 54" src="https://github.com/user-attachments/assets/7c2f359c-f8c9-4b1d-8a44-b7be76e16610">
