### PR TITLE
[ResponseOps][Connectors] Update deprecation warning in the Teams Connector

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/teams/teams_connectors.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/teams/teams_connectors.tsx
@@ -55,14 +55,18 @@ const TeamsActionFields: React.FunctionComponent<ActionConnectorFieldsProps> = (
           },
         }}
       />
-      <EuiSpacer size="m" />
-      <EuiCallOut
-        size="s"
-        color="warning"
-        iconType="warning"
-        data-test-subj={'microsoftTeamsWebhookDeprecationWarning'}
-        title={i18n.WEBHOOK_DEPRECATION_WARNING}
-      />
+      {isEdit && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="warning"
+            data-test-subj={'microsoftTeamsWebhookDeprecationWarning'}
+            title={i18n.WEBHOOK_DEPRECATION_WARNING}
+          />
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Summary

It's the same as https://github.com/elastic/kibana/pull/190958. I just decided not to show the warning when creating the connector, only when editing an existing one.