### PR TITLE
[Reporting] Test cleanup fixes 2

### DIFF
--- a/x-pack/plugins/reporting/server/routes/common/jobs/get_job_routes.ts
+++ b/x-pack/plugins/reporting/server/routes/common/jobs/get_job_routes.ts
@@ -108,6 +108,8 @@ export const commonJobsRouteHandlerFactory = (
       counters,
       { isInternal },
       async (doc) => {
+        // FIXME look for potential report job task in task manager and remove that too
+
         const docIndex = doc.index;
         const stream = await getContentStream(reporting, { id: docId, index: docIndex });
         const reportingSetup = reporting.getPluginSetupDeps();

--- a/x-pack/test/accessibility/apps/group3/reporting.ts
+++ b/x-pack/test/accessibility/apps/group3/reporting.ts
@@ -36,6 +36,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     after(async () => {
+      // FIXME: wait for queued report to finish before clean up
       await reporting.teardownLogs();
       await deleteReportingUser();
     });

--- a/x-pack/test/functional/apps/discover/reporting.ts
+++ b/x-pack/test/functional/apps/discover/reporting.ts
@@ -103,7 +103,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.selectIndexPattern('ecommerce');
       });
 
-      it('generates a report with single timefilter', async () => {
+      it('exposes a POST URL for a report with single timefilter', async () => {
         await PageObjects.discover.clickNewSearchButton();
         await PageObjects.timePicker.setCommonlyUsedTime('Last_24 hours');
         await PageObjects.discover.saveSearch('single-timefilter-search');

--- a/x-pack/test/reporting_api_integration/reporting_and_security/datastream.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/datastream.ts
@@ -16,14 +16,13 @@ export default function ({ getService }: FtrProviderContext) {
   describe('Data Stream', () => {
     before(async () => {
       await reportingAPI.initEcommerce();
-
-      // for this test, we don't need to wait for the job to finish or verify the result
       await reportingAPI.postJob(
         `/api/reporting/generate/csv_searchsource?jobParams=%28browserTimezone%3AUTC%2Ccolumns%3A%21%28%29%2CobjectType%3Asearch%2CsearchSource%3A%28fields%3A%21%28%28field%3A%27%2A%27%2Cinclude_unmapped%3Atrue%29%29%2Cfilter%3A%21%28%28meta%3A%28field%3A%27%40timestamp%27%2Cindex%3A%27logstash-%2A%27%2Cparams%3A%28%29%29%2Cquery%3A%28range%3A%28%27%40timestamp%27%3A%28format%3Astrict_date_optional_time%2Cgte%3A%272015-09-22T09%3A17%3A53.728Z%27%2Clte%3A%272015-09-22T09%3A30%3A50.786Z%27%29%29%29%29%2C%28%27%24state%27%3A%28store%3AappState%29%2Cmeta%3A%28alias%3A%21n%2Cdisabled%3A%21f%2Cindex%3A%27logstash-%2A%27%2Ckey%3Aquery%2Cnegate%3A%21f%2Ctype%3Acustom%2Cvalue%3A%27%7B%22bool%22%3A%7B%22minimum_should_match%22%3A1%2C%22should%22%3A%5B%7B%22match_phrase%22%3A%7B%22%40tags%22%3A%22info%22%7D%7D%5D%7D%7D%27%29%2Cquery%3A%28bool%3A%28minimum_should_match%3A1%2Cshould%3A%21%28%28match_phrase%3A%28%27%40tags%27%3Ainfo%29%29%29%29%29%29%29%2Cindex%3A%27logstash-%2A%27%2Cquery%3A%28language%3Akuery%2Cquery%3A%27%27%29%2Csort%3A%21%28%28%27%40timestamp%27%3A%28format%3Astrict_date_optional_time%2Corder%3Adesc%29%29%29%29%2Ctitle%3A%27A%20saved%20search%20with%20match_phrase%20filter%20and%20no%20columns%20selected%27%2Cversion%3A%278.15.0%27%29`
       );
     });
 
     after(async () => {
+      // FIXME wait for report to complete before cleanup
       await reportingAPI.deleteAllReports();
       await reportingAPI.teardownEcommerce();
     });

--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -72,6 +72,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // FIXME wait for reports to complete before teardown
       await reportingAPI.teardownLogs();
       await reportingAPI.makeAllReportingIndicesUnmanaged(); // ensure that a delete phase does not remove the index while future tests are running
     });

--- a/x-pack/test/reporting_api_integration/reporting_without_security/csv/job_apis_csv.ts
+++ b/x-pack/test/reporting_api_integration/reporting_without_security/csv/job_apis_csv.ts
@@ -55,6 +55,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // FIXME wait for reports to complete before teardown
       await reportingAPI.teardownLogs();
       await esArchiver.unload('x-pack/test/functional/es_archives/logstash_functional');
     });

--- a/x-pack/test/reporting_api_integration/services/scenarios.ts
+++ b/x-pack/test/reporting_api_integration/services/scenarios.ts
@@ -208,6 +208,7 @@ export function createScenarios({ getService }: Pick<FtrProviderContext, 'getSer
     return job?.output?.error_code;
   };
 
+  // FIXME: remove this and use the delete API for each report created during testing
   const deleteAllReports = async () => {
     log.debug('ReportingAPI.deleteAllReports');
 

--- a/x-pack/test/reporting_functional/reporting_and_security/management.ts
+++ b/x-pack/test/reporting_functional/reporting_and_security/management.ts
@@ -21,6 +21,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       await reportingFunctional.initEcommerce();
     });
     after(async () => {
+      // FIXME: wait for the report job to finish before clean up
       await reportingFunctional.teardownEcommerce();
     });
 
@@ -47,7 +48,6 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       await PageObjects.common.navigateToApp('reporting');
       await PageObjects.common.sleep(3000); // Wait an amount of time for auto-polling to refresh the jobs
 
-      // We do not need to wait for the report to finish generating
       await (await testSubjects.find('euiCollapsedItemActionsButton')).click();
       await (await testSubjects.find('reportOpenInKibanaApp')).click();
 

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/datastream.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/datastream.ts
@@ -34,7 +34,6 @@ export default function ({ getService }: FtrProviderContext) {
       await esArchiver.load(archives.ecommerce.data);
       await kibanaServer.importExport.load(archives.ecommerce.savedObjects);
 
-      // for this test, we don't need to wait for the job to finish or verify the result
       await reportingAPI.createReportJobInternal(
         'csv_searchsource',
         {
@@ -54,6 +53,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
+      // FIXME wait for job to finish before clean up
       await reportingAPI.deleteAllReports(roleAuthc, internalReqHeader);
       await esArchiver.unload(archives.ecommerce.data);
       await kibanaServer.importExport.unload(archives.ecommerce.savedObjects);

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
@@ -30,6 +30,7 @@ export default ({ getService }: FtrProviderContext) => {
       internalReqHeader = svlCommonApi.getInternalRequestHeader();
     });
     after(async () => {
+      // FIXME wait for job to finish before invalidating user
       await svlUserManager.invalidateM2mApiKeyWithRoleScope(adminUser);
     });
 
@@ -63,7 +64,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it(`user can delete a report they've created`, async () => {
-        // for this test, we don't need to wait for the job to finish or verify the result
         const response = await supertestWithoutAuth
           .delete(`${INTERNAL_ROUTES.JOBS.DELETE_PREFIX}/${reportJob.id}`)
           .set(...API_HEADER)


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/191676
Follows https://github.com/elastic/kibana/pull/190099

Reporting Functional tests and API integration tests potentially create degraded Task Manager metrics. These scenarios will unsuccessful task manager task:

* If the data view is removed before the report job task is flushed
* If the test user is removed before the report job is flushed

This PR seeks to improve Task Manager metrics for reporting jobs by being more careful in cleanup after tests. A good way to do this is to call `await reportingAPI.expectAllJobsToFinishSuccessfully(reportPaths)` in the `after()` hook before remove the user and test archive data.