### PR TITLE
[DOCS] Microsoft Teams connector known issue

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -100,7 +100,7 @@ For more information, refer to {kibana-pull}190590[#190590].
 [%collapsible]
 ====
 *Details* +
-One of the methods for configuring incoming webhooks in Microsoft Teams is being retired.
+The original method for configuring incoming webhooks in Microsoft Teams is being retired.
 Refer to https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/[Retirement of Office 365 connectors within Microsoft Teams] and {kibana-issue}187823[#187823].
 
 *Impact* +

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -108,7 +108,7 @@ If you used the *Incoming Webhook* app in Microsoft Teams to generate a webhook 
 
 *Workaround* +
 Use the *Workflows* app in Microsoft Teams to create a new webhook URL, as described in <<configuring-teams>>.
-Update your Microsoft Teams connectors to use the new URL before the end of December 2024.
+Update your Microsoft Teams connector to use the new URL before the end of December 2024.
 ====
 
 [float]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -94,6 +94,22 @@ This can manifest as a validation error causing Kibana to not start.
 For more information, refer to {kibana-pull}190590[#190590].
 ====
 
+[discrete]
+[[known-187823]]
+.Connectors require update due to Microsoft Teams product retirement
+[%collapsible]
+====
+*Details* +
+One of the methods for configuring incoming webhooks in Microsoft Teams is being retired.
+Refer to https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/[Retirement of Office 365 connectors within Microsoft Teams] and {kibana-issue}187823[#187823].
+
+*Impact* +
+If you used the *Incoming Webhook* app in Microsoft Teams to generate a webhook URL for a <<teams-action-type,Microsoft Teams connector>>, it will stop working in December 2024.
+
+*Workaround* +
+Use the *Workflows* app in Microsoft Teams to create a new webhook URL, as described in <<configuring-teams>>.
+Update your Microsoft Teams connectors to use the new URL before the end of December 2024.
+====
 
 [float]
 [[deprecations-8.15.0]]

--- a/docs/management/connectors/action-types/teams.asciidoc
+++ b/docs/management/connectors/action-types/teams.asciidoc
@@ -8,7 +8,7 @@
 :frontmatter-tags-content-type: [how-to] 
 :frontmatter-tags-user-goals: [configure]
 
-The Microsoft Teams connector uses https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook[Incoming Webhooks].
+The Microsoft Teams connector uses a webhook to send notifications.
 
 [float]
 [[define-teams-ui]]


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/187823

This PR creates a known issue in the release notes and removes an outdated URL from the Microsoft Teams connector documentation.

### Preview

https://kibana_bk_191143.docs-preview.app.elstc.co/guide/en/kibana/master/release-notes-8.15.0.html#known-issues-8.15.0

<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->