### PR TITLE
[OAS][DOCS] Add feedback links for Kibana APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,11 @@ x-pack/test/security_api_integration/plugins/audit_log/audit.log
 # ignore FTR temp directory
 .ftr
 role_users.json
+
+# Ignore temporary files in oas_docs
+output/kibana.serverless.tmp1.yaml
+output/kibana.serverless.tmp2.yaml
+output/kibana.tmp1.yaml
+output/kibana.tmp2.yaml
+output/kibana.new.yaml
+output/kibana.serverless.new.yaml

--- a/oas_docs/kibana.info.serverless.yaml
+++ b/oas_docs/kibana.info.serverless.yaml
@@ -32,6 +32,9 @@ info:
     url: https://www.elastic.co/licensing/elastic-license
   contact: 
     name: Kibana Team
+  x-feedbackLink:
+    label: Feedback
+    url: https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
 security:
   - apiKeyAuth: []
 components:

--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -30,6 +30,9 @@ info:
     url: https://www.elastic.co/licensing/elastic-license
   contact:
     name: Kibana Team
+  x-feedbackLink:
+    label: Feedback
+    url: https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
 servers:
   - url: https://{kibana_url}
     variables:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -52,6 +52,10 @@ info:
     url: 'https://www.elastic.co/licensing/elastic-license'
   title: Kibana Serverless APIs
   version: 1.0.2
+  x-feedbackLink:
+    label: Feedback
+    url: >-
+      https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
 servers:
   - url: 'http://{kibana_host}:{port}'
     variables:
@@ -879,37 +883,6 @@ paths:
       summary: Create agent action
       tags:
         - Elastic Agent actions
-  '/agents/{agentId}/actions/{actionId}/cancel':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: actionId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: agent-action-cancel
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_action'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Cancel agent action
-      tags:
-        - Elastic Agent actions
   '/agents/{agentId}/reassign':
     parameters:
       - in: path
@@ -1228,6 +1201,32 @@ paths:
         '400':
           $ref: '#/components/responses/Fleet_error'
       summary: Get agent action status
+      tags:
+        - Elastic Agent actions
+  '/agents/actions/{actionId}/cancel':
+    parameters:
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: agent-action-cancel
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_action'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Cancel agent action
       tags:
         - Elastic Agent actions
   /agents/bulk_reassign:
@@ -2190,6 +2189,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -2261,6 +2261,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -2367,6 +2368,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:
@@ -3322,6 +3324,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -3393,6 +3396,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -3499,6 +3503,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:
@@ -4425,6 +4430,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -4496,6 +4502,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -4602,6 +4609,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:
@@ -5592,6 +5600,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -5663,6 +5672,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -5769,6 +5779,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -51,6 +51,10 @@ info:
     url: 'https://www.elastic.co/licensing/elastic-license'
   title: Kibana APIs
   version: 1.0.2
+  x-feedbackLink:
+    label: Feedback
+    url: >-
+      https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
 servers:
   - url: 'https://{kibana_url}'
     variables:
@@ -862,37 +866,6 @@ paths:
       summary: Create agent action
       tags:
         - Elastic Agent actions
-  '/agents/{agentId}/actions/{actionId}/cancel':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: actionId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: agent-action-cancel
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_action'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Cancel agent action
-      tags:
-        - Elastic Agent actions
   '/agents/{agentId}/reassign':
     parameters:
       - in: path
@@ -1211,6 +1184,32 @@ paths:
         '400':
           $ref: '#/components/responses/Fleet_error'
       summary: Get agent action status
+      tags:
+        - Elastic Agent actions
+  '/agents/actions/{actionId}/cancel':
+    parameters:
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: agent-action-cancel
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_action'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Cancel agent action
       tags:
         - Elastic Agent actions
   /agents/bulk_reassign:
@@ -2892,6 +2891,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -2963,6 +2963,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -3069,6 +3070,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:
@@ -4024,6 +4026,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -4095,6 +4098,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -4201,6 +4205,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:
@@ -5127,6 +5132,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -5198,6 +5204,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -5304,6 +5311,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:
@@ -6294,6 +6302,7 @@ paths:
                               - maxExecutableActions
                               - maxAlerts
                               - maxQueuedActions
+                              - ruleExecution
                             type: string
                         required:
                           - reason
@@ -6365,6 +6374,7 @@ paths:
                           - maxExecutableActions
                           - maxAlerts
                           - maxQueuedActions
+                          - ruleExecution
                         nullable: true
                         type: string
                     required:
@@ -6471,6 +6481,7 @@ paths:
                                         - maxExecutableActions
                                         - maxAlerts
                                         - maxQueuedActions
+                                        - ruleExecution
                                       nullable: true
                                       type: string
                                   required:


### PR DESCRIPTION
## Summary

This PR:

- adds feedback links to the Kibana openAPI documents, as described in https://docs.bump.sh/help/publish-documentation/feedback/. The feedback link creates an issue in the docs_content repo for now.
- adds some files in the oas_docs repo to the .gitignore file
- regenerates the API output files, which also reflect changes from https://github.com/elastic/kibana/pull/190069


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->