### PR TITLE
[ES|QL] unskip missing index tests

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.from.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.from.ts
@@ -89,7 +89,7 @@ export const validationFromCommandTestSuite = (setup: helpers.Setup) => {
             ]);
           });
 
-          test.skip('errors on unknown index', async () => {
+          test('errors on unknown index', async () => {
             const { expectErrors } = await setup();
 
             await expectErrors(`FROM index, missingIndex`, ['Unknown index [missingIndex]']);

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -37369,6 +37369,307 @@
       "warning": []
     },
     {
+      "query": "row var = mv_percentile(5.5, 5.5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row mv_percentile(5.5, 5.5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(to_double(true), to_double(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(5.5, 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row mv_percentile(5.5, 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(to_double(true), to_integer(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(to_double(true), 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(5, 5.5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row mv_percentile(5, 5.5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(to_integer(true), to_double(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(5, 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row mv_percentile(5, 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(to_integer(true), to_integer(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(to_integer(true), 5)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(5, to_double(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(5, to_integer(true))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row var = mv_percentile(true, true)",
+      "error": [
+        "Argument of [mv_percentile] must be [double], found value [true] type [boolean]",
+        "Argument of [mv_percentile] must be [double], found value [true] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(doubleField, doubleField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(booleanField, booleanField) > 0",
+      "error": [
+        "Argument of [mv_percentile] must be [double], found value [booleanField] type [boolean]",
+        "Argument of [mv_percentile] must be [double], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(doubleField, integerField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(doubleField, longField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(integerField, doubleField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(integerField, integerField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(integerField, longField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(longField, doubleField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(longField, integerField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where mv_percentile(longField, longField) > 0",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(doubleField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(doubleField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(to_double(booleanField), to_double(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(booleanField, booleanField)",
+      "error": [
+        "Argument of [mv_percentile] must be [double], found value [booleanField] type [boolean]",
+        "Argument of [mv_percentile] must be [double], found value [booleanField] type [boolean]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(doubleField, integerField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(doubleField, integerField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(to_double(booleanField), to_integer(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(doubleField, longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(doubleField, longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(to_double(booleanField), longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(integerField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(integerField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(to_integer(booleanField), to_double(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(integerField, integerField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(integerField, integerField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(to_integer(booleanField), to_integer(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(integerField, longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(integerField, longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(to_integer(booleanField), longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(longField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(longField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(longField, to_double(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(longField, integerField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(longField, integerField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(longField, to_integer(booleanField))",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval var = mv_percentile(longField, longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(longField, longField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(doubleField, doubleField, extraArg)",
+      "error": [
+        "Error: [mv_percentile] function expects exactly 2 arguments, got 3."
+      ],
+      "warning": []
+    },
+    {
+      "query": "from a_index | sort mv_percentile(doubleField, doubleField)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | eval mv_percentile(null, null)",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "row nullVar = null | eval mv_percentile(nullVar, nullVar)",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "f",
       "error": [
         "SyntaxError: mismatched input 'f' expecting {'explain', 'from', 'meta', 'metrics', 'row', 'show'}"
@@ -37581,6 +37882,48 @@
       "error": [
         "SyntaxError: mismatched input '=' expecting <EOF>",
         "Unknown index [assignment]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "FROM index, missingIndex",
+      "error": [
+        "Unknown index [missingIndex]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from average()",
+      "error": [
+        "Unknown index [average()]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "fRom custom_function()",
+      "error": [
+        "Unknown index [custom_function()]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "FROM indexes*",
+      "error": [
+        "Unknown index [indexes*]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "from numberField",
+      "error": [
+        "Unknown index [numberField]"
+      ],
+      "warning": []
+    },
+    {
+      "query": "FROM policy",
+      "error": [
+        "Unknown index [policy]"
       ],
       "warning": []
     },


### PR DESCRIPTION
## Summary

With https://github.com/elastic/elasticsearch/issues/111712, Elasticsearch is again erroring when an index is missing. So, we can unskip the test.
