### PR TITLE
[Security Solution][On-Week POC] ai assistant in flyout

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -476,15 +476,22 @@ const AssistantComponent: React.FC<Props> = ({
 
   useEffect(() => {
     // Adding `conversationTitle !== selectedConversationTitle` to prevent auto-run still executing after changing selected conversation
-    if (currentConversation?.messages.length || conversationTitle !== currentConversation?.title) {
-      return;
-    }
-
-    if (autoPopulatedOnce) {
+    // if (currentConversation?.messages.length || conversationTitle !== currentConversation?.title) {
+    //   return;
+    // }
+    // console.log(conversationTitle === currentConversation?.title);
+    if (conversationTitle !== currentConversation?.title) {
       return;
     }
 
     const promptContext: PromptContext | undefined = promptContexts[promptContextId];
+    if (promptContext.suggestedUserPrompt != null) {
+      setUserPrompt(promptContext.suggestedUserPrompt);
+    }
+    if (autoPopulatedOnce) {
+      return;
+    }
+
     if (
       promptContext != null &&
       !isLoadingAnonymizationFields &&
@@ -508,10 +515,6 @@ const AssistantComponent: React.FC<Props> = ({
         };
 
         addNewSelectedPromptContext();
-      }
-
-      if (promptContext.suggestedUserPrompt != null) {
-        setUserPrompt(promptContext.suggestedUserPrompt);
       }
     }
   }, [

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/use_assistant_overlay/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/use_assistant_overlay/index.tsx
@@ -80,7 +80,11 @@ export const useAssistantOverlay = (
   /**
    * Optionally provide a map of replacements associated with the context, i.e. replacements for an attack discovery that's provided as context
    */
-  replacements?: Replacements | null
+  replacements?: Replacements | null,
+  /**
+   * Optionally provide a conversation ID to associate the context with an existing conversation
+   */
+  conversationId?: string
 ): UseAssistantOverlay => {
   const { http } = useAssistantContext();
   const { data: connectors } = useLoadConnectors({
@@ -148,6 +152,7 @@ export const useAssistantOverlay = (
             },
             category: 'assistant',
             title: conversationTitle ?? '',
+            id: conversationId,
           });
         } catch (e) {
           /* empty */
@@ -172,6 +177,7 @@ export const useAssistantOverlay = (
       isAssistantEnabled,
       isLoading,
       promptContextId,
+      conversationId,
     ]
   );
 

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -207,6 +207,15 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
             prevPromptContexts,
             promptContext,
           });
+        } else if (
+          promptContext != null &&
+          prevPromptContexts[promptContext.id].suggestedUserPrompt !==
+            promptContext.suggestedUserPrompt
+        ) {
+          return updatePromptContexts({
+            prevPromptContexts,
+            promptContext,
+          });
         } else {
           return prevPromptContexts;
         }

--- a/x-pack/plugins/security_solution/public/assistant/content/quick_prompts/translations.ts
+++ b/x-pack/plugins/security_solution/public/assistant/content/quick_prompts/translations.ts
@@ -22,6 +22,14 @@ export const ALERT_SUMMARIZATION_PROMPT = i18n.translate(
   }
 );
 
+export const EVENT_SUMMARIZATION_PROMPT = i18n.translate(
+  'xpack.securitySolution.assistant.quickPrompts.alertSummarizationPrompt',
+  {
+    defaultMessage:
+      'As an expert in security operations and incident response, provide a breakdown of the attached event and summarize what it might mean for my organization.',
+  }
+);
+
 export const ESQL_QUERY_GENERATION_TITLE = i18n.translate(
   'xpack.securitySolution.assistant.quickPrompts.esqlQueryGenerationTitle',
   {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_actions.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_actions.tsx
@@ -6,17 +6,13 @@
  */
 
 import type { VFC } from 'react';
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { EuiButtonIcon, EuiCopy, EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { NewChatByTitle } from '@kbn/elastic-assistant';
+import { useAssistantContext } from '@kbn/elastic-assistant';
 import { useGetFlyoutLink } from '../hooks/use_get_flyout_link';
 import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
 import { useAssistant } from '../hooks/use_assistant';
-import {
-  ALERT_SUMMARY_CONVERSATION_ID,
-  EVENT_SUMMARY_CONVERSATION_ID,
-} from '../../../../common/components/event_details/translations';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { SHARE_BUTTON_TEST_ID } from './test_ids';
 
@@ -35,10 +31,13 @@ export const HeaderActions: VFC = memo(() => {
 
   const showShareAlertButton = isAlert && alertDetailsLink;
 
-  const { showAssistant, promptContextId } = useAssistant({
-    dataFormattedForFieldBrowser,
-    isAlert,
-  });
+  const { showAssistant, showAssistantOverlay, promptContext } = useAssistant();
+  const { registerPromptContext } = useAssistantContext();
+
+  const showOverlay = useCallback(() => {
+    registerPromptContext(promptContext);
+    showAssistantOverlay(true);
+  }, [showAssistantOverlay, registerPromptContext, promptContext]);
 
   return (
     <EuiFlexGroup
@@ -50,12 +49,11 @@ export const HeaderActions: VFC = memo(() => {
     >
       {showAssistant && (
         <EuiFlexItem grow={false}>
-          <NewChatByTitle
-            conversationTitle={
-              isAlert ? ALERT_SUMMARY_CONVERSATION_ID : EVENT_SUMMARY_CONVERSATION_ID
-            }
-            promptContextId={promptContextId}
-            iconOnly
+          <EuiButtonIcon
+            data-test-subj="newChatByTitle"
+            iconType={'discuss'}
+            onClick={showOverlay}
+            color={'text'}
           />
         </EuiFlexItem>
       )}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
@@ -23,6 +23,7 @@ import {
   AlertsCasesTourSteps,
   SecurityStepId,
 } from '../../../../common/components/guided_onboarding_tour/tour_config';
+import { PropmptHistory } from './prompt_history';
 
 const KEY = 'insights';
 
@@ -63,6 +64,8 @@ export const InsightsSection = memo(() => {
       <CorrelationsOverview />
       <EuiSpacer size="s" />
       <PrevalenceOverview />
+      <EuiSpacer size="s" />
+      <PropmptHistory />
     </ExpandableSection>
   );
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/prompt_history.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/prompt_history.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { VFC } from 'react';
+import React, { memo, useState, useEffect } from 'react';
+import { useConversation } from '@kbn/elastic-assistant/impl/assistant/use_conversation';
+import { FormattedMessage } from '@kbn/i18n-react';
+import type { Conversation } from '@kbn/elastic-assistant';
+import { once } from 'lodash/fp';
+import { ExpandablePanel } from '../../../shared/components/expandable_panel';
+import { useGetAssistantContext } from '../hooks/use_get_assistant_context';
+
+/**
+ * Displays the prompt history of the conversation
+ */
+export const PropmptHistory: VFC = memo(() => {
+  const [conversation, setConversation] = useState<Conversation | null>(null);
+  const { getConversation } = useConversation();
+
+  const { conversationId, isAssistantEnabled } = useGetAssistantContext();
+
+  useEffect(() => {
+    if (isAssistantEnabled) {
+      const onLoad = once(async () => {
+        const res = await getConversation(conversationId, true);
+        if (res) {
+          setConversation(res);
+        }
+      });
+      onLoad();
+    }
+  }, [isAssistantEnabled, getConversation, conversationId]);
+
+  if (!conversation) {
+    return null;
+  }
+  const promptHistory = conversation.messages.filter((msg) => msg.role === 'user');
+
+  return (
+    <ExpandablePanel
+      header={{
+        title: (
+          <FormattedMessage
+            id="xpack.securitySolution.flyout.right.insights.correlations.overviewTitle"
+            defaultMessage="Prompt history"
+          />
+        ),
+        iconType: 'discuss',
+      }}
+    >
+      {promptHistory.map((prompt, index) => (
+        <div key={index}>{prompt.content}</div>
+      ))}
+    </ExpandablePanel>
+  );
+});
+
+PropmptHistory.displayName = 'PropmptHistory';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_assistant_context.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_assistant_context.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PromptContext } from '@kbn/elastic-assistant';
+import { useCallback, useMemo } from 'react';
+import { useAssistantAvailability } from '../../../../assistant/use_assistant_availability';
+import { getRawData } from '../../../../assistant/helpers';
+import {
+  ALERT_SUMMARY_CONTEXT_DESCRIPTION,
+  ALERT_SUMMARY_VIEW_CONTEXT_TOOLTIP,
+  EVENT_SUMMARY_CONTEXT_DESCRIPTION,
+  EVENT_SUMMARY_VIEW_CONTEXT_TOOLTIP,
+  SUMMARY_VIEW,
+} from '../../../../common/components/event_details/translations';
+import {
+  ALERT_SUMMARIZATION_PROMPT,
+  EVENT_SUMMARIZATION_PROMPT,
+} from '../../../../assistant/content/quick_prompts/translations';
+import { useBasicDataFromDetailsData } from '../../shared/hooks/use_basic_data_from_details_data';
+import { useDocumentDetailsContext } from '../../shared/context';
+
+const ALERT_CONTEXTS = {
+  category: 'alert',
+  titlePrefix: 'Alert',
+  description: ALERT_SUMMARY_CONTEXT_DESCRIPTION(SUMMARY_VIEW),
+  tooltip: ALERT_SUMMARY_VIEW_CONTEXT_TOOLTIP,
+};
+
+const EVENT_CONTEXTS = {
+  category: 'event',
+  titlePrefix: 'Event',
+  description: EVENT_SUMMARY_CONTEXT_DESCRIPTION(SUMMARY_VIEW),
+  tooltip: EVENT_SUMMARY_VIEW_CONTEXT_TOOLTIP,
+};
+
+const getPromptContextByType = (isAlert: boolean, type?: string) => {
+  if (type === 'investigation') {
+    return {
+      ...ALERT_CONTEXTS,
+      suggestedUserPrompt: 'Create an investigation guide for this alert',
+    };
+  }
+  if (type === 'summary') {
+    if (isAlert) {
+      return {
+        ...ALERT_CONTEXTS,
+        suggestedUserPrompt: ALERT_SUMMARIZATION_PROMPT,
+      };
+    } else {
+      return {
+        ...EVENT_CONTEXTS,
+        suggestedUserPrompt: EVENT_SUMMARIZATION_PROMPT,
+      };
+    }
+  }
+  return isAlert ? ALERT_CONTEXTS : EVENT_CONTEXTS;
+};
+
+export type PromptType = 'summary' | 'investigation';
+
+export interface UseGetAssistantContextResult {
+  /**
+   * Returns true if the assistant button is visible
+   */
+  showAssistant: boolean;
+  /**
+   * Returns true if the assistant is enabled
+   */
+  isAssistantEnabled: boolean;
+  /**
+   * The conversation title for the assistant context
+   */
+  conversationTitle: string;
+  /**
+   * The conversation ID for the assistant context
+   */
+  conversationId: string;
+  /**
+   * The assistant prompt context
+   */
+  promptContext: PromptContext;
+}
+
+/*
+ * This hook is used to get the assistant context for the document details flyout.
+ */
+export const useGetAssistantContext = (type?: PromptType): UseGetAssistantContextResult => {
+  const { dataFormattedForFieldBrowser, eventId } = useDocumentDetailsContext();
+  const { isAlert } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
+
+  const { hasAssistantPrivilege, isAssistantEnabled } = useAssistantAvailability();
+  const getPromptContext = useCallback(
+    async () => getRawData(dataFormattedForFieldBrowser ?? []),
+    [dataFormattedForFieldBrowser]
+  );
+
+  const promptContext = getPromptContextByType(isAlert, type);
+
+  return useMemo(
+    () => ({
+      isAssistantEnabled,
+      showAssistant: hasAssistantPrivilege && isAssistantEnabled,
+      conversationTitle: `${promptContext.titlePrefix}-${eventId}`,
+      conversationId: eventId,
+      promptContext: {
+        ...promptContext,
+        id: eventId,
+        getPromptContext,
+      },
+    }),
+    [promptContext, eventId, getPromptContext, hasAssistantPrivilege, isAssistantEnabled]
+  );
+};


### PR DESCRIPTION
## Summary

Integrate ai assistant in flyout experience:
- `Summary this alert` opens ai assistant with the alert summary quick prompt
- When no investigation guide is set for the rule, `Create an investigation guide` button opens ai assistant with prefilled prompt to generate a guide for the current alert
- Use alert id as conversation id (different from conversation title!):
   - each alert has its own conversation
   - past prompts can now by fetched, and shown in prompt history under insights

https://github.com/user-attachments/assets/123f8632-a334-40f3-a63b-26df349624ff


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
