### PR TITLE
[React@18 prep] run `useCallback-implicit-any` on  `/packages`

### DIFF
--- a/packages/kbn-alerts-grouping/src/components/alerts_grouping.tsx
+++ b/packages/kbn-alerts-grouping/src/components/alerts_grouping.tsx
@@ -17,7 +17,7 @@ import React, {
   useState,
 } from 'react';
 import type { Filter } from '@kbn/es-query';
-import { isNoneGroup, useGrouping } from '@kbn/grouping';
+import { GroupOption, isNoneGroup, useGrouping } from '@kbn/grouping';
 import { isEqual } from 'lodash/fp';
 import { i18n } from '@kbn/i18n';
 import { useAlertsDataView } from '@kbn/alerts-ui-shared/src/common/hooks/use_alerts_data_view';
@@ -89,7 +89,7 @@ const AlertsGroupingInternal = <T extends BaseAlertsGroupAggregations>(
   ) as [number[], Dispatch<SetStateAction<number[]>>, () => void];
 
   const onOptionsChange = useCallback(
-    (options) => {
+    (options: GroupOption[]) => {
       // useGrouping > useAlertsGroupingState options sync
       // the available grouping options change when the user selects
       // a new field not in the default ones

--- a/packages/kbn-alerts-ui-shared/src/rule_form/rule_actions/rule_actions_alerts_filter_timeframe.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/rule_actions/rule_actions_alerts_filter_timeframe.tsx
@@ -142,7 +142,7 @@ export const RuleActionsAlertsFilterTimeframe: React.FC<RuleActionsAlertsFilterT
   );
 
   const onChangeTimezone = useCallback(
-    (value) => {
+    (value: Array<{ label: string }>) => {
       setSelectedTimezone(value);
       if (value[0].label) updateTimeframe({ timezone: value[0].label });
     },

--- a/packages/kbn-alerts-ui-shared/src/rule_form/rule_definition/rule_definition.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/rule_definition/rule_definition.tsx
@@ -96,7 +96,7 @@ export const RuleDefinition = () => {
   }, [selectedRuleTypeModel, docLinks]);
 
   const onChangeMetaData = useCallback(
-    (newMetadata) => {
+    (newMetadata: Record<string, unknown>) => {
       dispatch({
         type: 'setMetadata',
         payload: newMetadata,

--- a/packages/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_inputs.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_inputs.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiRangeProps } from '@elastic/eui';
 import {
   MIN_LOOK_BACK_WINDOW,
   MAX_LOOK_BACK_WINDOW,
@@ -63,14 +63,16 @@ export const RuleSettingsFlappingInputs = (props: RuleSettingsFlappingInputsProp
     onStatusChangeThresholdChange,
   } = props;
 
-  const internalOnLookBackWindowChange = useCallback(
+  const internalOnLookBackWindowChange = useCallback<Exclude<EuiRangeProps['onChange'], undefined>>(
     (e) => {
       onLookBackWindowChange(parseInt(e.currentTarget.value, 10));
     },
     [onLookBackWindowChange]
   );
 
-  const internalOnStatusChangeThresholdChange = useCallback(
+  const internalOnStatusChangeThresholdChange = useCallback<
+    Exclude<EuiRangeProps['onChange'], undefined>
+  >(
     (e) => {
       onStatusChangeThresholdChange(parseInt(e.currentTarget.value, 10));
     },

--- a/packages/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_inputs.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_settings/rule_settings_flapping_inputs.tsx
@@ -63,16 +63,14 @@ export const RuleSettingsFlappingInputs = (props: RuleSettingsFlappingInputsProp
     onStatusChangeThresholdChange,
   } = props;
 
-  const internalOnLookBackWindowChange = useCallback<Exclude<EuiRangeProps['onChange'], undefined>>(
+  const internalOnLookBackWindowChange = useCallback<NonNullable<EuiRangeProps['onChange']>>(
     (e) => {
       onLookBackWindowChange(parseInt(e.currentTarget.value, 10));
     },
     [onLookBackWindowChange]
   );
 
-  const internalOnStatusChangeThresholdChange = useCallback<
-    Exclude<EuiRangeProps['onChange'], undefined>
-  >(
+  const internalOnStatusChangeThresholdChange = useCallback<NonNullable<EuiRangeProps['onChange']>>(
     (e) => {
       onStatusChangeThresholdChange(parseInt(e.currentTarget.value, 10));
     },

--- a/packages/kbn-coloring/src/shared_components/coloring/color_ranges/color_ranges_item.tsx
+++ b/packages/kbn-coloring/src/shared_components/coloring/color_ranges/color_ranges_item.tsx
@@ -127,7 +127,8 @@ export function ColorRangeItem({
   );
 
   const onValueChange = useCallback(
-    ({ target: { value: targetValue } }) => {
+    ({ target: { value: targetValue } }: any) => {
+      // TODO targetValue is a string or a number?
       setLocalValue(targetValue);
       dispatch({
         type: 'updateValue',
@@ -138,7 +139,7 @@ export function ColorRangeItem({
   );
 
   const onUpdateColor = useCallback(
-    (color) => {
+    (color: string) => {
       dispatch({ type: 'updateColor', payload: { index, color, dataBounds, palettes } });
     },
     [dispatch, index, dataBounds, palettes]

--- a/packages/kbn-coloring/src/shared_components/coloring/color_ranges/color_ranges_item.tsx
+++ b/packages/kbn-coloring/src/shared_components/coloring/color_ranges/color_ranges_item.tsx
@@ -127,9 +127,8 @@ export function ColorRangeItem({
   );
 
   const onValueChange = useCallback(
-    ({ target: { value: targetValue } }: any) => {
-      // TODO targetValue is a string or a number?
-      setLocalValue(targetValue);
+    ({ target: { value: targetValue } }: React.ChangeEvent<HTMLInputElement>) => {
+      setLocalValue(+targetValue);
       dispatch({
         type: 'updateValue',
         payload: { index, value: targetValue, accessor, dataBounds, palettes },

--- a/packages/kbn-field-utils/src/components/field_description/field_description.tsx
+++ b/packages/kbn-field-utils/src/components/field_description/field_description.tsx
@@ -98,7 +98,7 @@ export const FieldDescriptionContent: React.FC<
   );
 
   const truncateFieldDescription = useCallback(
-    (nextValue) => {
+    (nextValue: boolean) => {
       setIsTruncated(nextValue);
       setShouldTruncateByDefault(nextValue);
     },

--- a/packages/kbn-grouping/src/components/accordion_panel/index.tsx
+++ b/packages/kbn-grouping/src/components/accordion_panel/index.tsx
@@ -102,7 +102,7 @@ const GroupPanelComponent = <T,>({
   );
 
   const onToggle = useCallback(
-    (isOpen) => {
+    (isOpen: boolean) => {
       if (onToggleGroup) {
         onToggleGroup(isOpen, groupBucket);
       }

--- a/packages/kbn-management/settings/components/field_input/code_editor.tsx
+++ b/packages/kbn-management/settings/components/field_input/code_editor.tsx
@@ -71,7 +71,7 @@ export const CodeEditor = ({ onChange, type, isReadOnly, name, ...props }: CodeE
   }, []);
 
   const editorDidMount = useCallback(
-    (editor) => {
+    (editor: monaco.editor.IStandaloneCodeEditor) => {
       setEditorCalculatedHeight(editor);
 
       editor.onDidChangeModelContent(() => {

--- a/packages/kbn-management/settings/components/field_input/input/array_input.tsx
+++ b/packages/kbn-management/settings/components/field_input/input/array_input.tsx
@@ -39,7 +39,7 @@ export const ArrayInput = ({
   const onUpdate = useUpdate({ onInputChange, field });
 
   const updateValue = useCallback(
-    async (newValue: string, onUpdateFn) => {
+    async (newValue: string, onUpdateFn: typeof onUpdate) => {
       const parsedValue = newValue
         .replace(REGEX, ',')
         .split(',')

--- a/packages/kbn-management/settings/components/field_input/input/code_editor_input.tsx
+++ b/packages/kbn-management/settings/components/field_input/input/code_editor_input.tsx
@@ -53,7 +53,7 @@ export const CodeEditorInput = ({
   const onUpdate = useUpdate({ onInputChange, field });
 
   const updateValue = useCallback(
-    async (newValue: string, onUpdateFn) => {
+    async (newValue: string, onUpdateFn: typeof onUpdate) => {
       let parsedValue;
 
       // Validate JSON syntax

--- a/packages/kbn-management/settings/components/field_input/input/number_input.tsx
+++ b/packages/kbn-management/settings/components/field_input/input/number_input.tsx
@@ -36,7 +36,7 @@ export const NumberInput = ({
   const onUpdate = useUpdate({ onInputChange, field });
 
   const updateValue = useCallback(
-    async (newValue: number, onUpdateFn) => {
+    async (newValue: number, onUpdateFn: typeof onUpdate) => {
       const validationResponse = await validateChange(field.id, newValue);
       if (validationResponse.successfulValidation && !validationResponse.valid) {
         onUpdateFn({

--- a/packages/kbn-securitysolution-autocomplete/src/field_value_lists/index.tsx
+++ b/packages/kbn-securitysolution-autocomplete/src/field_value_lists/index.tsx
@@ -64,7 +64,7 @@ export const AutocompleteFieldListsComponent: React.FC<AutocompleteFieldListsPro
     largeLists: [],
   });
   const { loading, result, start } = useFindListsBySize();
-  const getLabel = useCallback(({ name }) => name, []);
+  const getLabel = useCallback(({ name }: { name: string }) => name, []);
 
   const optionsMemo = useMemo(
     () => filterFieldToList(listData, selectedField),

--- a/packages/kbn-securitysolution-autocomplete/src/operator/index.tsx
+++ b/packages/kbn-securitysolution-autocomplete/src/operator/index.tsx
@@ -44,7 +44,7 @@ export const OperatorComponent: React.FC<OperatorState> = ({
   selectedField,
   'aria-label': ariaLabel,
 }): JSX.Element => {
-  const getLabel = useCallback(({ message }): string => message, []);
+  const getLabel = useCallback(({ message }: { message: string }): string => message, []);
   const optionsMemo = useMemo(
     (): OperatorOption[] =>
       operatorOptions != null && operatorOptions.length > 0

--- a/packages/kbn-securitysolution-exception-list-components/src/search_bar/index.tsx
+++ b/packages/kbn-securitysolution-exception-list-components/src/search_bar/index.tsx
@@ -74,7 +74,7 @@ const SearchBarComponent: FC<SearchBarProps> = ({
   onAddExceptionClick,
 }) => {
   const handleOnSearch = useCallback(
-    ({ queryText }): void => {
+    ({ queryText }: { queryText: string }): void => {
       onSearch({ search: queryText });
     },
     [onSearch]

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -237,8 +237,10 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
   const containerRef = useRef<HTMLElement>(null);
 
   // When the editor is on full size mode, the user can resize the height of the editor.
-  const onMouseDownResizeHandler = useCallback(
-    (mouseDownEvent) => {
+  const onMouseDownResizeHandler = useCallback<
+    React.ComponentProps<typeof ResizableButton>['onMouseDownResizeHandler']
+  >(
+    (mouseDownEvent: /* TODO: pageY could be missing */ any) => {
       const startSize = editorHeight;
       const startPosition = mouseDownEvent.pageY;
 
@@ -257,7 +259,9 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     [editorHeight]
   );
 
-  const onKeyDownResizeHandler = useCallback(
+  const onKeyDownResizeHandler = useCallback<
+    React.ComponentProps<typeof ResizableButton>['onKeyDownResizeHandler']
+  >(
     (keyDownEvent) => {
       let height = editorHeight;
       if (

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -240,9 +240,15 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
   const onMouseDownResizeHandler = useCallback<
     React.ComponentProps<typeof ResizableButton>['onMouseDownResizeHandler']
   >(
-    (mouseDownEvent: /* TODO: pageY could be missing */ any) => {
+    (mouseDownEvent) => {
+      function isMouseEvent(e: React.TouchEvent | React.MouseEvent): e is React.MouseEvent {
+        return e && 'pageY' in e;
+      }
+
       const startSize = editorHeight;
-      const startPosition = mouseDownEvent.pageY;
+      const startPosition = isMouseEvent(mouseDownEvent)
+        ? mouseDownEvent?.pageY
+        : mouseDownEvent?.touches[0].pageY;
 
       function onMouseMove(mouseMoveEvent: MouseEvent) {
         const height = startSize - startPosition + mouseMoveEvent.pageY;

--- a/packages/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -34,7 +34,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CELL_CLASS } from '../utils/get_render_cell_value';
 import { defaultTimeColumnWidth } from '../constants';
-import { useColumns } from '../hooks/use_data_grid_columns';
+import { useColumns, UseColumnsProps } from '../hooks/use_data_grid_columns';
 import { capabilitiesServiceMock } from '@kbn/core-capabilities-browser-mocks';
 import { dataViewsMock } from '../../__mocks__/data_views';
 
@@ -105,7 +105,7 @@ const renderDataTable = (props: Partial<UnifiedDataTableProps>) => {
       capabilities,
       dataView: dataViewMock,
       dataViews: dataViewsMock,
-      setAppState: useCallback((state) => {
+      setAppState: useCallback<UseColumnsProps['setAppState']>((state) => {
         if (state.columns) {
           setColumns(state.columns);
         }

--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -860,7 +860,7 @@ export const UnifiedDataTable = ({
   );
 
   const onTableSort = useCallback(
-    (sortingColumnsData) => {
+    (sortingColumnsData: EuiDataGridSorting['columns']) => {
       if (isSortEnabled) {
         if (onSort) {
           onSort(sortingColumnsData.map(({ id, direction }: SortObj) => [id, direction]));

--- a/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
@@ -63,9 +63,9 @@ export const UnifiedDataTableAdditionalDisplaySettings: React.FC<
     [onChangeSampleSize]
   );
 
-  const onChangeActiveSampleSize = useCallback<Exclude<EuiRangeProps['onChange'], undefined>>(
-    (event: any /* TODO event.target.value may be empty */) => {
-      if (!event.target.value) {
+  const onChangeActiveSampleSize = useCallback<NonNullable<EuiRangeProps['onChange']>>(
+    (event) => {
+      if (!('value' in event.target) || !event.target.value) {
         setActiveSampleSize('');
         return;
       }

--- a/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { EuiFormRow, EuiHorizontalRule, EuiRange } from '@elastic/eui';
+import { EuiFormRow, EuiHorizontalRule, EuiRange, EuiRangeProps } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { debounce } from 'lodash';
 import { RowHeightSettings, RowHeightSettingsProps } from './row_height_settings';
@@ -63,8 +63,8 @@ export const UnifiedDataTableAdditionalDisplaySettings: React.FC<
     [onChangeSampleSize]
   );
 
-  const onChangeActiveSampleSize = useCallback(
-    (event) => {
+  const onChangeActiveSampleSize = useCallback<Exclude<EuiRangeProps['onChange'], undefined>>(
+    (event: any /* TODO event.target.value may be empty */) => {
       if (!event.target.value) {
         setActiveSampleSize('');
         return;

--- a/packages/kbn-unified-data-table/src/hooks/use_selected_docs.ts
+++ b/packages/kbn-unified-data-table/src/hooks/use_selected_docs.ts
@@ -82,7 +82,7 @@ export const useSelectedDocs = (docMap: Map<string, DataTableRecord>): UseSelect
   const selectedDocsCount = selectedDocIds.length;
 
   const getCountOfFilteredSelectedDocs = useCallback(
-    (docIds) => {
+    (docIds: string[]) => {
       if (!selectedDocsCount) {
         return 0;
       }

--- a/packages/react/kibana_mount/utils.ts
+++ b/packages/react/kibana_mount/utils.ts
@@ -17,7 +17,7 @@ export const useIfMounted = () => {
     []
   );
 
-  const ifMounted = useCallback((func) => {
+  const ifMounted = useCallback((func: Function) => {
     if (isMounted.current && func) {
       func();
     }


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/138222

run `useCallback-implicit-any` codemod on  `/packages`, manually fix `any` where possible

To upgrade the repo to React@18 we need to fix [types](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) breaking changes.


This is another attempt of https://github.com/elastic/kibana/pull/182344 but trying in smaller steps 
