### PR TITLE
Fix connector docker version

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/constants.ts
@@ -43,7 +43,7 @@ docker run \\
 
     --rm \\
 
-    docker.elastic.co/enterprise-search/elastic-connectors:${version} \\
+    docker.elastic.co/enterprise-search/elastic-connectors:${version}.0 \\
 
     /app/bin/elastic-ingest \\
 


### PR DESCRIPTION
## Summary

Fix connector docker version it needs to have trailing `.0`. This UI panel was only added in `8.15` so no need to backprot to pre 8.15. 

In 8.16 we remove the trailing `.0` so not merging to main. 