### PR TITLE
[ObsUX][Infra] Fix redirect to other apps from node details

### DIFF
--- a/x-pack/plugins/observability_solution/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
+++ b/x-pack/plugins/observability_solution/metrics_data_access/public/components/infrastructure_node_metrics_tables/shared/components/metrics_node_details_link.tsx
@@ -8,7 +8,6 @@
 import { parse } from '@kbn/datemath';
 import { EuiLink } from '@elastic/eui';
 import React from 'react';
-import { useLinkProps } from '@kbn/observability-shared-plugin/public';
 import type { InventoryItemType } from '../../../../../common/inventory_models/types';
 import { useNodeDetailsRedirect } from '../../../../pages/link_to/use_node_details_redirect';
 
@@ -28,16 +27,14 @@ export const MetricsNodeDetailsLink = ({
   timerange,
 }: MetricsNodeDetailsLinkProps) => {
   const { getNodeDetailUrl } = useNodeDetailsRedirect();
-  const linkProps = useLinkProps(
-    getNodeDetailUrl({
-      nodeType,
-      nodeId: id,
-      search: {
-        from: parse(timerange.from)?.valueOf(),
-        to: parse(timerange.to)?.valueOf(),
-      },
-    })
-  );
+  const linkProps = getNodeDetailUrl({
+    nodeType,
+    nodeId: id,
+    search: {
+      from: parse(timerange.from)?.valueOf(),
+      to: parse(timerange.to)?.valueOf(),
+    },
+  });
 
   return (
     <EuiLink data-test-subj="infraMetricsNodeDetailsLinkLink" href={linkProps.href}>

--- a/x-pack/plugins/observability_solution/metrics_data_access/public/hooks/use_kibana.tsx
+++ b/x-pack/plugins/observability_solution/metrics_data_access/public/hooks/use_kibana.tsx
@@ -12,12 +12,14 @@ import {
   KibanaReactContextValue,
   useKibana,
 } from '@kbn/kibana-react-plugin/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 
-export type PluginKibanaContextValue = CoreStart;
+export type PluginKibanaContextValue = CoreStart & { share: SharePluginStart };
 
 export const createKibanaContextForPlugin = (core: CoreStart) =>
   createKibanaReactContext<PluginKibanaContextValue>({
     ...core,
+    share: {} as SharePluginStart,
   });
 
 export const useKibanaContextForPlugin =

--- a/x-pack/plugins/observability_solution/metrics_data_access/public/hooks/use_kibana.tsx
+++ b/x-pack/plugins/observability_solution/metrics_data_access/public/hooks/use_kibana.tsx
@@ -14,7 +14,7 @@ import {
 } from '@kbn/kibana-react-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 
-export type PluginKibanaContextValue = CoreStart & { share: SharePluginStart };
+export type PluginKibanaContextValue = CoreStart & { share?: SharePluginStart };
 
 export const createKibanaContextForPlugin = (core: CoreStart) =>
   createKibanaReactContext<PluginKibanaContextValue>({

--- a/x-pack/plugins/observability_solution/metrics_data_access/public/pages/link_to/use_node_details_redirect.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/public/pages/link_to/use_node_details_redirect.ts
@@ -39,7 +39,7 @@ export const useNodeDetailsRedirect = () => {
   } = useKibanaContextForPlugin();
 
   const appId = useObservable(currentAppId$);
-  const locator = share.url.locators.get<AssetDetailsLocatorParams>(ASSET_DETAILS_LOCATOR_ID);
+  const locator = share?.url.locators.get<AssetDetailsLocatorParams>(ASSET_DETAILS_LOCATOR_ID);
 
   const getNodeDetailUrl = useCallback(
     ({

--- a/x-pack/plugins/observability_solution/metrics_data_access/public/pages/link_to/use_node_details_redirect.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/public/pages/link_to/use_node_details_redirect.ts
@@ -7,8 +7,13 @@
 
 import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
-import type { LinkDescriptor } from '@kbn/observability-shared-plugin/public';
 import useObservable from 'react-use/lib/useObservable';
+import { RouterLinkProps, getRouterLinkProps } from '@kbn/router-utils/src/get_router_link_props';
+import { Search } from 'history';
+import {
+  type AssetDetailsLocatorParams,
+  ASSET_DETAILS_LOCATOR_ID,
+} from '@kbn/observability-shared-plugin/common';
 import type { InventoryItemType } from '../../../common/inventory_models/types';
 import { useKibanaContextForPlugin } from '../../hooks/use_kibana';
 
@@ -18,15 +23,24 @@ interface QueryParams {
   assetName?: string;
 }
 
+export interface RouteState {
+  originAppId: string;
+  originPathname: string;
+  originSearch?: Search;
+}
+
 export const useNodeDetailsRedirect = () => {
   const location = useLocation();
   const {
     services: {
       application: { currentAppId$ },
+      share,
     },
   } = useKibanaContextForPlugin();
 
   const appId = useObservable(currentAppId$);
+  const locator = share.url.locators.get<AssetDetailsLocatorParams>(ASSET_DETAILS_LOCATOR_ID);
+
   const getNodeDetailUrl = useCallback(
     ({
       nodeType,
@@ -36,34 +50,54 @@ export const useNodeDetailsRedirect = () => {
       nodeType: InventoryItemType;
       nodeId: string;
       search: QueryParams;
-    }): LinkDescriptor => {
+    }): RouterLinkProps => {
       const { to, from, ...rest } = search;
-
-      return {
-        app: 'metrics',
-        pathname: `link-to/${nodeType}-detail/${nodeId}`,
-        search: {
-          ...rest,
-          ...(to && from
+      const queryParams = {
+        nodeDetails:
+          Object.keys(rest).length > 0
             ? {
-                to: `${to}`,
-                from: `${from}`,
+                ...rest,
+                dateRange: {
+                  from: from ? new Date(from).toISOString() : undefined,
+                  to: to ? new Date(to).toISOString() : undefined,
+                },
               }
-            : undefined),
-          // While we don't have a shared state between all page in infra, this makes it possible to restore a page state when returning to the previous route
-          ...(location.search || location.pathname
-            ? {
-                state: JSON.stringify({
-                  originAppId: appId,
-                  originSearch: location.search,
-                  originPathname: location.pathname,
-                }),
-              }
-            : undefined),
+            : {},
+        _a: {
+          time: {
+            ...(from ? { from: new Date(from).toISOString() } : undefined),
+            ...(to ? { to: new Date(to).toISOString() } : undefined),
+            interval: '>=1m',
+          },
         },
       };
+
+      const nodeDetailsLocatorParams = {
+        ...queryParams,
+        assetType: nodeType,
+        assetId: nodeId,
+        state: {
+          ...(location.state ?? {}),
+          ...(location.key
+            ? ({
+                originAppId: appId,
+                originSearch: location.search,
+                originPathname: location.pathname,
+              } as RouteState)
+            : {}),
+        },
+      };
+
+      const nodeDetailsLinkProps = getRouterLinkProps({
+        href: locator?.getRedirectUrl(nodeDetailsLocatorParams),
+        onClick: () => {
+          locator?.navigate(nodeDetailsLocatorParams, { replace: false });
+        },
+      });
+
+      return nodeDetailsLinkProps;
     },
-    [location.pathname, appId, location.search]
+    [appId, location.key, location.pathname, location.search, location.state, locator]
   );
 
   return { getNodeDetailUrl };

--- a/x-pack/plugins/observability_solution/metrics_data_access/tsconfig.json
+++ b/x-pack/plugins/observability_solution/metrics_data_access/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/core-http-request-handler-context-server",
     "@kbn/lens-embeddable-utils",
     "@kbn/react-kibana-context-render",
-    "@kbn/react-kibana-context-theme"
+    "@kbn/react-kibana-context-theme",
+    "@kbn/router-utils"
   ]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/190510

The return button in the asset details failed to return to another app

##### How to test

From apm service details, navigate to Infrastructure tab, click in one of the nodes that would navigate to the node details page, when clicking the Return button it should redirect back to APM/Services/{serviceName}/Infrastructure


https://github.com/user-attachments/assets/07555fa6-246b-43c3-81bf-592b550713a0

