### PR TITLE
fix: [AXE-CORE][Serverless - Observability] Observability -> AIOps->Anomaly Detection page fails scope attribute should be used correctly a11y check

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/analytics_list.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/analytics_list.tsx
@@ -278,6 +278,7 @@ export const DataFrameAnalyticsList: FC<Props> = ({
       <EuiSpacer size="m" />
       <div data-test-subj="mlAnalyticsTableContainer">
         <EuiInMemoryTable<DataFrameAnalyticsListRow>
+          rowHeader={DataFrameAnalyticsListColumn.id}
           allowNeutralSort={false}
           columns={columns}
           itemIdToExpandedRowMap={itemIdToExpandedRowMap}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/use_columns.tsx
@@ -216,7 +216,6 @@ export const useColumns = (
       sortable: (item: DataFrameAnalyticsListRow) => item.id,
       truncateText: { lines: TRUNCATE_TEXT_LINES },
       'data-test-subj': 'mlAnalyticsTableColumnId',
-      scope: 'row',
       render: (id: string) => {
         return <span title={id}>{id}</span>;
       },

--- a/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list/jobs_list.js
+++ b/x-pack/plugins/ml/public/application/jobs/jobs_list/components/jobs_list/jobs_list.js
@@ -170,7 +170,6 @@ export class JobsList extends Component {
         sortable: true,
         truncateText: false,
         width: '15%',
-        scope: 'row',
         render: (id, item) => {
           if (!isManagedJob(item)) return id;
 
@@ -395,6 +394,7 @@ export class JobsList extends Component {
           'data-test-subj': `mlJobListRow row-${item.id}`,
         })}
         css={{ '.euiTableRow-isExpandedRow .euiTableCellContent': { animation: 'none' } }}
+        rowHeader="id"
       />
     );
   }


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/188859

## Describe the Bug:

On the Observability -> AIOps -> Anomaly Detection page, the `scope` attribute is incorrectly used, failing the a11y check.

**Element location:**

``` 
.euiTableRow.euiTableRow-isSelectable.euiTableRow-hasActions:nth-child(1) > .css-dmrba8-euiTableRowCell-middle-desktop[scope="row"][data-test-subj="mlJobListColumnId"]
```

## What Was Changed:
1. The incorrect `scope: 'row'` attribute was removed.
2. Added `rowHeader="id"`.

## Screen: 

<img width="1384" alt="image" src="https://github.com/user-attachments/assets/f2a44e87-43b3-4e5a-b0d2-7fe9378380c8">

> No issues in AXE report

<img width="1384" alt="image" src="https://github.com/user-attachments/assets/342a6f8f-a6f2-473a-897c-f9f5133368b0">






