### PR TITLE
[UII] Add retries to starting Kibana for jest preconfiguration integration tests

### DIFF
--- a/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
@@ -49,56 +49,74 @@ describe('Fleet cloud preconfiguration', () => {
 
     esServer = await startES();
     const startOrRestartKibana = async (kbnConfig: any = defaultKbnConfig) => {
-      if (kbnServer) {
-        await kbnServer.stop();
-      }
+      const maxTries = 3;
+      let currentTry = 0;
 
-      const root = createRootWithCorePlugins(
-        {
-          xpack: {
-            ...kbnConfig.xpack,
-            fleet: {
-              ...kbnConfig.xpack.fleet,
-              registryUrl,
+      const startOrRestart = async () => {
+        if (kbnServer) {
+          await kbnServer.stop();
+        }
+
+        const root = createRootWithCorePlugins(
+          {
+            xpack: {
+              ...kbnConfig.xpack,
+              fleet: {
+                ...kbnConfig.xpack.fleet,
+                registryUrl,
+              },
             },
-          },
-          logging: {
-            appenders: {
-              file: {
-                type: 'file',
-                fileName: logFilePath,
-                layout: {
-                  type: 'json',
+            logging: {
+              appenders: {
+                file: {
+                  type: 'file',
+                  fileName: logFilePath,
+                  layout: {
+                    type: 'json',
+                  },
                 },
               },
+              loggers: [
+                {
+                  name: 'root',
+                  appenders: ['file'],
+                },
+                {
+                  name: 'plugins.fleet',
+                  level: 'all',
+                },
+              ],
             },
-            loggers: [
-              {
-                name: 'root',
-                appenders: ['file'],
-              },
-              {
-                name: 'plugins.fleet',
-                level: 'all',
-              },
-            ],
           },
-        },
-        { oss: false }
-      );
+          { oss: false }
+        );
 
-      await root.preboot();
-      const coreSetup = await root.setup();
-      const coreStart = await root.start();
+        await root.preboot();
+        const coreSetup = await root.setup();
+        const coreStart = await root.start();
 
-      kbnServer = {
-        root,
-        coreSetup,
-        coreStart,
-        stop: async () => await root.shutdown(),
+        kbnServer = {
+          root,
+          coreSetup,
+          coreStart,
+          stop: async () => await root.shutdown(),
+        };
+
+        await waitForFleetSetup(kbnServer.root);
       };
-      await waitForFleetSetup(kbnServer.root);
+
+      try {
+        currentTry++;
+        await startOrRestart();
+      } catch (e) {
+        if (currentTry < maxTries) {
+          await startOrRestart();
+        } else {
+          throw e;
+        }
+      }
     };
+
     await startOrRestartKibana();
 
     return {


### PR DESCRIPTION
## Summary

Resolves #172759
Resolves #172760
Resolves #172761

Add retries to starting Kibana for this test suite to hopefully mitigate future flakiness.


### Checklist

- ~~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~ Doesn't seem like I can run Jest integration tests here.