### PR TITLE
Clarify macOS support

### DIFF
--- a/docs/setup/install/targz.asciidoc
+++ b/docs/setup/install/targz.asciidoc
@@ -17,7 +17,8 @@ link:/downloads/past-releases[Past Releases page].
 
 [NOTE]
 ====
-macOS is supported for development purposes only and is not covered under the support SLA for [production-supported operating systems](https://www.elastic.co/support/matrix#kibana). 
+macOS is supported for development purposes only and is not covered under the support SLA for link:https://www.elastic.co/support/matrix#kibana[production-supported operating systems]. 
+====
 
 [[install-linux64]]
 ==== Download and install the Linux 64-bit package

--- a/docs/setup/install/targz.asciidoc
+++ b/docs/setup/install/targz.asciidoc
@@ -15,6 +15,9 @@ link:/downloads/kibana[Download Kibana] page.
 Other versions can be found on the
 link:/downloads/past-releases[Past Releases page].
 
+[NOTE]
+====
+macOS is supported for development purposes only and is not covered under the support SLA for [production-supported operating systems](https://www.elastic.co/support/matrix#kibana). 
 
 [[install-linux64]]
 ==== Download and install the Linux 64-bit package


### PR DESCRIPTION
Clarifying macOS support is limited to development environments only.

Please back-port accordingly.  Thx!

<!--ONMERGE {"backportTargets":["7.17","8.0","8.1","8.10","8.11","8.12","8.13","8.14","8.15","8.2","8.3","8.4","8.5","8.6","8.7","8.8","8.9"]} ONMERGE-->