### PR TITLE
[Automatic Import] resolve a bug in ECS missing fields detection

### DIFF
--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/validate.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/validate.ts
@@ -6,8 +6,8 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ECS_FULL } from '../../../common/ecs';
-import type { EcsBaseNodeParams } from './types';
 import { ECS_RESERVED } from './constants';
+import type { EcsBaseNodeParams } from './types';
 
 const valueFieldKeys = new Set(['target', 'confidence', 'date_formats', 'type']);
 type AnyObject = Record<string, any>;
@@ -27,6 +27,8 @@ function extractKeys(data: AnyObject, prefix: string = ''): Set<string> {
       if ([...valueFieldKeys].every((k) => valueKeys.has(k))) {
         keys.add(fullKey);
       } else {
+        // Needs to be added, so that fields mapped directly under the data_stream key is detected
+        keys.add(fullKey);
         // Recursively extract keys if the current value is a nested object
         for (const nestedKey of extractKeys(value, fullKey)) {
           keys.add(nestedKey);

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/validate.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/validate.ts
@@ -22,17 +22,10 @@ function extractKeys(data: AnyObject, prefix: string = ''): Set<string> {
       // Directly add the key for arrays without iterating over elements
       keys.add(fullKey);
     } else if (typeof value === 'object' && value !== null) {
-      const valueKeys = new Set(Object.keys(value));
-
-      if ([...valueFieldKeys].every((k) => valueKeys.has(k))) {
-        keys.add(fullKey);
-      } else {
-        // Needs to be added, so that fields mapped directly under the data_stream key is detected
-        keys.add(fullKey);
-        // Recursively extract keys if the current value is a nested object
-        for (const nestedKey of extractKeys(value, fullKey)) {
-          keys.add(nestedKey);
-        }
+      keys.add(fullKey);
+      // Recursively extract keys if the current value is a nested object
+      for (const nestedKey of extractKeys(value, fullKey)) {
+        keys.add(nestedKey);
       }
     } else {
       // Add the key if the value is not an object or is null


### PR DESCRIPTION
## Summary

Resolves a bug when comparing LLM ECS mapping output with combined samples, and the mapping is right under the data_stream object, providing false positive results.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->