### PR TITLE
[Uptime] Use rounded values for es query

### DIFF
--- a/x-pack/plugins/observability_solution/uptime/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/uptime/public/plugin.ts
@@ -311,7 +311,7 @@ function setUptimeAppStatus(
     } else {
       const hasUptimePrivileges = coreStart.application.capabilities.uptime?.show;
       if (hasUptimePrivileges) {
-        const indexStatusPromise = UptimeDataHelper(coreStart).indexStatus('now-7d', 'now');
+        const indexStatusPromise = UptimeDataHelper(coreStart).indexStatus('now-7d/d', 'now/d');
         indexStatusPromise.then((indexStatus) => {
           if (indexStatus.indexExists) {
             registerUptimeRoutesWithNavigation(coreStart, pluginsStart);


### PR DESCRIPTION
## Summary

Use rounded values for es query !!

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->