### PR TITLE
[7.17] [UII] Use signed version of old endpoint package for setup test (#191311)

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/setup.ts
@@ -21,9 +21,8 @@ export default function (providerContext: FtrProviderContext) {
   describe('setup api', async () => {
     skipIfNoDockerRegistry(providerContext);
     setupFleetAndAgents(providerContext);
-    // FAILING ES FORWARD COMPATIBILITY: https://github.com/elastic/kibana/issues/164754
-    describe.skip('setup performs upgrades', async () => {
-      const oldEndpointVersion = '0.13.0';
+    describe('setup performs upgrades', async () => {
+      const oldEndpointVersion = '1.0.0';
       beforeEach(async () => {
         await supertest
           .post(`/api/fleet/epm/packages/endpoint-${oldEndpointVersion}`)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[UII] Use signed version of old endpoint package for setup test (#191311)](https://github.com/elastic/kibana/pull/191311)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2024-08-26T23:25:14Z","message":"[UII] Use signed version of old endpoint package for setup test (#191311)\n\n## Summary\r\n\r\nAs the title says :)","sha":"c361abd78c863c2e21a0cfd12adceaf4804cd3c9","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:all-open","v8.16.0","v8.15.1"],"number":191311,"url":"https://github.com/elastic/kibana/pull/191311","mergeCommit":{"message":"[UII] Use signed version of old endpoint package for setup test (#191311)\n\n## Summary\r\n\r\nAs the title says :)","sha":"c361abd78c863c2e21a0cfd12adceaf4804cd3c9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/191311","number":191311,"mergeCommit":{"message":"[UII] Use signed version of old endpoint package for setup test (#191311)\n\n## Summary\r\n\r\nAs the title says :)","sha":"c361abd78c863c2e21a0cfd12adceaf4804cd3c9"}},{"branch":"8.15","label":"v8.15.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/191327","number":191327,"state":"MERGED","mergeCommit":{"sha":"c3524ddeb070c8dbb67425d57ef49e6b6643e643","message":"[8.15] [UII] Use signed version of old endpoint package for setup test (#191311) (#191327)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.15`:\n- [[UII] Use signed version of old endpoint package for setup test\n(#191311)](https://github.com/elastic/kibana/pull/191311)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jen\nHuang\",\"email\":\"its.jenetic@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2024-08-26T23:25:14Z\",\"message\":\"[UII]\nUse signed version of old endpoint package for setup test\n(#191311)\\n\\n## Summary\\r\\n\\r\\nAs the title says\n:)\",\"sha\":\"c361abd78c863c2e21a0cfd12adceaf4804cd3c9\",\"branchLabelMapping\":{\"^v8.16.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:Fleet\",\"backport:all-open\",\"v8.16.0\"],\"title\":\"[UII]\nUse signed version of old endpoint package for setup\ntest\",\"number\":191311,\"url\":\"https://github.com/elastic/kibana/pull/191311\",\"mergeCommit\":{\"message\":\"[UII]\nUse signed version of old endpoint package for setup test\n(#191311)\\n\\n## Summary\\r\\n\\r\\nAs the title says\n:)\",\"sha\":\"c361abd78c863c2e21a0cfd12adceaf4804cd3c9\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v8.16.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/191311\",\"number\":191311,\"mergeCommit\":{\"message\":\"[UII]\nUse signed version of old endpoint package for setup test\n(#191311)\\n\\n## Summary\\r\\n\\r\\nAs the title says\n:)\",\"sha\":\"c361abd78c863c2e21a0cfd12adceaf4804cd3c9\"}}]}] BACKPORT-->\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}}]}] BACKPORT-->