### PR TITLE
[Search] Remove Dashboard and Search App Buttons When Gated Form is Showing

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.test.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { setMockValues } from '../../../__mocks__/kea_logic';
+
 import React from 'react';
 
 import { shallow } from 'enzyme';
@@ -16,7 +18,13 @@ import { WorkplaceSearchHeaderActions } from '.';
 describe('WorkplaceSearchHeaderActions', () => {
   const ENT_SEARCH_URL = 'http://localhost:3002';
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMockValues({ dataLoading: false, organization: { kibanaUIsEnabled: true } });
+  });
+
   it('does not render without an Enterprise Search URL set', () => {
+    setMockValues({ dataLoading: false, organization: {} });
     const wrapper = shallow(<WorkplaceSearchHeaderActions />);
 
     expect(wrapper.isEmptyRender()).toBe(true);
@@ -38,5 +46,22 @@ describe('WorkplaceSearchHeaderActions', () => {
     expect(wrapper.find('[data-test-subj="HeaderSearchButton"]').prop('href')).toEqual(
       'http://localhost:3002/ws/search'
     );
+  });
+
+  it('renders the dashboard and search button when not gated', () => {
+    externalUrl.enterpriseSearchUrl = ENT_SEARCH_URL;
+    const wrapper = shallow(<WorkplaceSearchHeaderActions />);
+
+    expect(wrapper.find('[data-test-subj="PersonalDashboardButton"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test-subj="HeaderSearchButton"]').exists()).toBe(true);
+  });
+
+  it('does not render the dashboard and search button on the gated form', () => {
+    externalUrl.enterpriseSearchUrl = ENT_SEARCH_URL;
+    setMockValues({ dataLoading: false, organization: { kibanaUIsEnabled: false } });
+    const wrapper = shallow(<WorkplaceSearchHeaderActions />);
+
+    expect(wrapper.find('[data-test-subj="PersonalDashboardButton"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test-subj="HeaderSearchButton"]').exists()).toBe(false);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/components/layout/kibana_header_actions.tsx
@@ -7,16 +7,33 @@
 
 import React from 'react';
 
+import { useValues } from 'kea';
+
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { externalUrl, getWorkplaceSearchUrl } from '../../../shared/enterprise_search_url';
 import { EndpointsHeaderAction } from '../../../shared/layout/endpoints_header_action';
 import { EuiButtonEmptyTo } from '../../../shared/react_router_helpers';
+import { AppLogic } from '../../app_logic';
 import { NAV } from '../../constants';
 import { PRIVATE_SOURCES_PATH } from '../../routes';
 
 export const WorkplaceSearchHeaderActions: React.FC = () => {
+  const {
+    organization: { kibanaUIsEnabled },
+  } = useValues(AppLogic);
+
   if (!externalUrl.enterpriseSearchUrl) return null;
+
+  if (!kibanaUIsEnabled) {
+    // we can't just return a null here as it will not render
+    // the Endpoints and Keys flyout button
+    return (
+      <EndpointsHeaderAction>
+        <></>
+      </EndpointsHeaderAction>
+    );
+  }
 
   return (
     <EndpointsHeaderAction>


### PR DESCRIPTION
## Summary

When the Workplace Search interstitial form is showing, we have buttons to the user's personal dashboard and search applications - but, since Workplace Search is not set up yet, these buttons go to a 404. This PR hides these buttons only for the gate form.

![image](https://github.com/user-attachments/assets/7f9b0b89-f30a-4802-b03f-c9c88871b06a)

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->