### PR TITLE
[ES|QL] Add mechanism to simulate long queries

### DIFF
--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -9,21 +9,31 @@
 import type { KibanaRequest } from '@kbn/core/server';
 import { esFieldTypeToKibanaFieldType } from '@kbn/field-types';
 import { i18n } from '@kbn/i18n';
-import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
+import type {
+  IKibanaSearchRequest,
+  IKibanaSearchResponse,
+  ISearchGeneric,
+} from '@kbn/search-types';
 import type { Datatable, ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
 import { RequestAdapter } from '@kbn/inspector-plugin/common';
 import { getStartEndParams } from '@kbn/esql-utils';
-
 import { zipObject } from 'lodash';
-import { Observable, defer, throwError } from 'rxjs';
-import { catchError, map, switchMap, tap } from 'rxjs';
-import { buildEsQuery } from '@kbn/es-query';
-import type { ISearchGeneric } from '@kbn/search-types';
-import type { ESQLSearchResponse, ESQLSearchParams } from '@kbn/es-types';
+import { catchError, defer, map, Observable, switchMap, tap, throwError } from 'rxjs';
+import { buildEsQuery, type Filter } from '@kbn/es-query';
+import type { ESQLSearchParams, ESQLSearchResponse } from '@kbn/es-types';
 import { getEsQueryConfig } from '../../es_query';
 import { getTime } from '../../query';
-import { ESQL_ASYNC_SEARCH_STRATEGY, KibanaContext, ESQL_TABLE_TYPE } from '..';
+import { ESQL_ASYNC_SEARCH_STRATEGY, ESQL_TABLE_TYPE, KibanaContext } from '..';
 import { UiSettingsCommon } from '../..';
+
+declare global {
+  interface Window {
+    /**
+     * Debug setting to make requests complete slower than normal. Only available on snapshots where `error_query` is enabled in ES.
+     */
+    ELASTIC_ESQL_DELAY_SECONDS?: number;
+  }
+}
 
 type Input = KibanaContext | null;
 type Output = Observable<Datatable>;
@@ -166,12 +176,31 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
                 fieldName: timeField,
               });
 
-            params.filter = buildEsQuery(
-              undefined,
-              input.query || [],
-              [...(input.filters ?? []), ...(timeFilter ? [timeFilter] : [])],
-              esQueryConfigs
-            );
+            // Used for debugging & inside automated tests to simulate a slow query
+            const delayFilter: Filter | undefined = window.ELASTIC_ESQL_DELAY_SECONDS
+              ? {
+                  meta: {},
+                  query: {
+                    error_query: {
+                      indices: [
+                        {
+                          name: '*',
+                          error_type: 'warning',
+                          stall_time_seconds: window.ELASTIC_ESQL_DELAY_SECONDS,
+                        },
+                      ],
+                    },
+                  },
+                }
+              : undefined;
+
+            const filters = [
+              ...(input.filters ?? []),
+              ...(timeFilter ? [timeFilter] : []),
+              ...(delayFilter ? [delayFilter] : []),
+            ];
+
+            params.filter = buildEsQuery(undefined, input.query || [], filters, esQueryConfigs);
           }
 
           let startTime = Date.now();


### PR DESCRIPTION
## Summary

Adds a mechanism to simulate a long-running query in ES|QL.

Elasticsearch provides a query type, `error_query`, in snapshot builds that allows passing a delay to simulate long-running queries. This PR adds a way to utilize this for testing & debugging purposes.

To use: In your browser console, simply execute the following:

```js
window.ELASTIC_ESQL_DELAY_SECONDS = 5;
```

This will cause search requests to pause for 5 seconds (on each shard). This can then be used in testing & debugging.

It should be noted that this is similar in pattern to the existing `window.ELASTIC_LENS_DELAY_SECONDS` pattern that Lens uses.