### PR TITLE
[8.15] [Automatic Import] Prepare to support more connectors (#191278)

### DIFF
--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/categorization.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/categorization.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(categorizationMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: CategorizationState = categorizationTestState;
+const state: CategorizationState = categorizationTestState;
 
 describe('Testing categorization handler', () => {
   it('handleCategorization()', async () => {
-    const response = await handleCategorization(testState, mockLlm);
+    const response = await handleCategorization({ state, model });
     expect(response.currentPipeline).toStrictEqual(
       categorizationExpectedHandlerResponse.currentPipeline
     );

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/categorization.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/categorization.ts
@@ -4,21 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { Pipeline } from '../../../common';
-import type { CategorizationState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { SimplifiedProcessors, SimplifiedProcessor, CategorizationState } from '../../types';
+import type { CategorizationNodeParams } from './types';
 import { combineProcessors } from '../../util/processors';
 import { CATEGORIZATION_MAIN_PROMPT } from './prompts';
 import { CATEGORIZATION_EXAMPLE_PROCESSORS } from './constants';
 
-export async function handleCategorization(
-  state: CategorizationState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleCategorization({
+  state,
+  model,
+}: CategorizationNodeParams): Promise<Partial<CategorizationState>> {
   const categorizationMainPrompt = CATEGORIZATION_MAIN_PROMPT;
   const outputParser = new JsonOutputParser();
   const categorizationMainGraph = categorizationMainPrompt.pipe(model).pipe(outputParser);

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/errors.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/errors.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(categorizationMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: CategorizationState = categorizationTestState;
+const state: CategorizationState = categorizationTestState;
 
 describe('Testing categorization handler', () => {
   it('handleErrors()', async () => {
-    const response = await handleErrors(testState, mockLlm);
+    const response = await handleErrors({ state, model });
     expect(response.currentPipeline).toStrictEqual(
       categorizationExpectedHandlerResponse.currentPipeline
     );

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/errors.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/errors.ts
@@ -4,20 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { Pipeline } from '../../../common';
-import type { CategorizationState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { CategorizationNodeParams } from './types';
+import type { SimplifiedProcessors, SimplifiedProcessor, CategorizationState } from '../../types';
 import { combineProcessors } from '../../util/processors';
 import { CATEGORIZATION_ERROR_PROMPT } from './prompts';
 
-export async function handleErrors(
-  state: CategorizationState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleErrors({
+  state,
+  model,
+}: CategorizationNodeParams): Promise<Partial<CategorizationState>> {
   const categorizationErrorPrompt = CATEGORIZATION_ERROR_PROMPT;
 
   const outputParser = new JsonOutputParser();

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.test.ts
@@ -31,7 +31,7 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: "I'll callback later.",
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
@@ -45,7 +45,7 @@ jest.mock('../../util/pipeline', () => ({
 }));
 
 describe('runCategorizationGraph', () => {
-  const mockClient = {
+  const client = {
     asCurrentUser: {
       ingest: {
         simulate: jest.fn(),
@@ -131,14 +131,14 @@ describe('runCategorizationGraph', () => {
 
   it('Ensures that the graph compiles', async () => {
     try {
-      await getCategorizationGraph(mockClient, mockLlm);
+      await getCategorizationGraph({ client, model });
     } catch (error) {
-      // noop
+      throw Error(`getCategorizationGraph threw an error: ${error}`);
     }
   });
 
   it('Runs the whole graph, with mocked outputs from the LLM.', async () => {
-    const categorizationGraph = await getCategorizationGraph(mockClient, mockLlm);
+    const categorizationGraph = await getCategorizationGraph({ client, model });
 
     (testPipeline as jest.Mock)
       .mockResolvedValueOnce(testPipelineValidResult)
@@ -151,8 +151,8 @@ describe('runCategorizationGraph', () => {
     let response;
     try {
       response = await categorizationGraph.invoke(mockedRequestWithPipeline);
-    } catch (e) {
-      // noop
+    } catch (error) {
+      throw Error(`getCategorizationGraph threw an error: ${error}`);
     }
 
     expect(response.results).toStrictEqual(categorizationExpectedResults);

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.ts
@@ -5,14 +5,10 @@
  * 2.0.
  */
 
-import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { StateGraphArgs } from '@langchain/langgraph';
 import { StateGraph, END, START } from '@langchain/langgraph';
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
 import type { CategorizationState } from '../../types';
+import type { CategorizationGraphParams, CategorizationBaseNodeParams } from './types';
 import { prefixSamples, formatSamples } from '../../util/samples';
 import { handleCategorization } from './categorization';
 import { handleValidatePipeline } from '../../util/graph';
@@ -105,7 +101,7 @@ const graphState: StateGraphArgs<CategorizationState>['channels'] = {
   },
 };
 
-function modelInput(state: CategorizationState): Partial<CategorizationState> {
+function modelInput({ state }: CategorizationBaseNodeParams): Partial<CategorizationState> {
   const samples = prefixSamples(state);
   const formattedSamples = formatSamples(samples);
   const initialPipeline = JSON.parse(JSON.stringify(state.currentPipeline));
@@ -122,7 +118,7 @@ function modelInput(state: CategorizationState): Partial<CategorizationState> {
   };
 }
 
-function modelOutput(state: CategorizationState): Partial<CategorizationState> {
+function modelOutput({ state }: CategorizationBaseNodeParams): Partial<CategorizationState> {
   return {
     finalized: true,
     lastExecutedChain: 'modelOutput',
@@ -133,14 +129,14 @@ function modelOutput(state: CategorizationState): Partial<CategorizationState> {
   };
 }
 
-function validationRouter(state: CategorizationState): string {
+function validationRouter({ state }: CategorizationBaseNodeParams): string {
   if (Object.keys(state.currentProcessors).length === 0) {
     return 'categorization';
   }
   return 'validateCategorization';
 }
 
-function chainRouter(state: CategorizationState): string {
+function chainRouter({ state }: CategorizationBaseNodeParams): string {
   if (Object.keys(state.errors).length > 0) {
     return 'errors';
   }
@@ -157,27 +153,26 @@ function chainRouter(state: CategorizationState): string {
   return END;
 }
 
-export async function getCategorizationGraph(
-  client: IScopedClusterClient,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function getCategorizationGraph({ client, model }: CategorizationGraphParams) {
   const workflow = new StateGraph({
     channels: graphState,
   })
-    .addNode('modelInput', modelInput)
-    .addNode('modelOutput', modelOutput)
+    .addNode('modelInput', (state: CategorizationState) => modelInput({ state }))
+    .addNode('modelOutput', (state: CategorizationState) => modelOutput({ state }))
     .addNode('handleCategorization', (state: CategorizationState) =>
-      handleCategorization(state, model)
+      handleCategorization({ state, model })
     )
     .addNode('handleValidatePipeline', (state: CategorizationState) =>
-      handleValidatePipeline(state, client)
+      handleValidatePipeline({ state, client })
     )
-    .addNode('handleCategorizationValidation', handleCategorizationValidation)
+    .addNode('handleCategorizationValidation', (state: CategorizationState) =>
+      handleCategorizationValidation({ state })
+    )
     .addNode('handleInvalidCategorization', (state: CategorizationState) =>
-      handleInvalidCategorization(state, model)
+      handleInvalidCategorization({ state, model })
     )
-    .addNode('handleErrors', (state: CategorizationState) => handleErrors(state, model))
-    .addNode('handleReview', (state: CategorizationState) => handleReview(state, model))
+    .addNode('handleErrors', (state: CategorizationState) => handleErrors({ state, model }))
+    .addNode('handleReview', (state: CategorizationState) => handleReview({ state, model }))
     .addEdge(START, 'modelInput')
     .addEdge('modelOutput', END)
     .addEdge('modelInput', 'handleValidatePipeline')
@@ -185,16 +180,24 @@ export async function getCategorizationGraph(
     .addEdge('handleInvalidCategorization', 'handleValidatePipeline')
     .addEdge('handleErrors', 'handleValidatePipeline')
     .addEdge('handleReview', 'handleValidatePipeline')
-    .addConditionalEdges('handleValidatePipeline', validationRouter, {
-      categorization: 'handleCategorization',
-      validateCategorization: 'handleCategorizationValidation',
-    })
-    .addConditionalEdges('handleCategorizationValidation', chainRouter, {
-      modelOutput: 'modelOutput',
-      errors: 'handleErrors',
-      invalidCategorization: 'handleInvalidCategorization',
-      review: 'handleReview',
-    });
+    .addConditionalEdges(
+      'handleValidatePipeline',
+      (state: CategorizationState) => validationRouter({ state }),
+      {
+        categorization: 'handleCategorization',
+        validateCategorization: 'handleCategorizationValidation',
+      }
+    )
+    .addConditionalEdges(
+      'handleCategorizationValidation',
+      (state: CategorizationState) => chainRouter({ state }),
+      {
+        modelOutput: 'modelOutput',
+        errors: 'handleErrors',
+        invalidCategorization: 'handleInvalidCategorization',
+        review: 'handleReview',
+      }
+    );
 
   const compiledCategorizationGraph = workflow.compile();
   return compiledCategorizationGraph;

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/invalid.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/invalid.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(categorizationMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: CategorizationState = categorizationTestState;
+const state: CategorizationState = categorizationTestState;
 
 describe('Testing categorization handler', () => {
   it('handleInvalidCategorization()', async () => {
-    const response = await handleInvalidCategorization(testState, mockLlm);
+    const response = await handleInvalidCategorization({ state, model });
     expect(response.currentPipeline).toStrictEqual(
       categorizationExpectedHandlerResponse.currentPipeline
     );

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/invalid.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/invalid.ts
@@ -4,21 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { Pipeline } from '../../../common';
-import type { CategorizationState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { CategorizationNodeParams } from './types';
+import type { SimplifiedProcessors, SimplifiedProcessor, CategorizationState } from '../../types';
 import { combineProcessors } from '../../util/processors';
 import { ECS_EVENT_TYPES_PER_CATEGORY } from './constants';
 import { CATEGORIZATION_VALIDATION_PROMPT } from './prompts';
 
-export async function handleInvalidCategorization(
-  state: CategorizationState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleInvalidCategorization({
+  state,
+  model,
+}: CategorizationNodeParams): Promise<Partial<CategorizationState>> {
   const categorizationInvalidPrompt = CATEGORIZATION_VALIDATION_PROMPT;
 
   const outputParser = new JsonOutputParser();

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/review.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/review.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(categorizationMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: CategorizationState = categorizationTestState;
+const state: CategorizationState = categorizationTestState;
 
 describe('Testing categorization handler', () => {
   it('handleReview()', async () => {
-    const response = await handleReview(testState, mockLlm);
+    const response = await handleReview({ state, model });
     expect(response.currentPipeline).toStrictEqual(
       categorizationExpectedHandlerResponse.currentPipeline
     );

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/review.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/review.ts
@@ -4,21 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import { CATEGORIZATION_REVIEW_PROMPT } from './prompts';
 import type { Pipeline } from '../../../common';
-import type { CategorizationState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { CategorizationNodeParams } from './types';
+import type { SimplifiedProcessors, SimplifiedProcessor, CategorizationState } from '../../types';
 import { combineProcessors } from '../../util/processors';
 import { ECS_EVENT_TYPES_PER_CATEGORY } from './constants';
 
-export async function handleReview(
-  state: CategorizationState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleReview({
+  state,
+  model,
+}: CategorizationNodeParams): Promise<Partial<CategorizationState>> {
   const categorizationReviewPrompt = CATEGORIZATION_REVIEW_PROMPT;
   const outputParser = new JsonOutputParser();
   const categorizationReview = categorizationReviewPrompt.pipe(model).pipe(outputParser);

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/types.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+import type { CategorizationState, ChatModels } from '../../types';
+
+export interface CategorizationBaseNodeParams {
+  state: CategorizationState;
+}
+
+export interface CategorizationNodeParams extends CategorizationBaseNodeParams {
+  model: ChatModels;
+}
+
+export interface CategorizationGraphParams {
+  model: ChatModels;
+  client: IScopedClusterClient;
+}

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/validate.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/validate.test.ts
@@ -9,12 +9,12 @@ import { handleCategorizationValidation } from './validate';
 import type { CategorizationState } from '../../types';
 import { categorizationTestState } from '../../../__jest__/fixtures/categorization';
 
-const testState: CategorizationState = categorizationTestState;
+const state: CategorizationState = categorizationTestState;
 
 describe('Testing categorization invalid category', () => {
   it('handleCategorizationValidation()', async () => {
-    testState.pipelineResults = [{ test: 'testresult', event: { category: ['foo'] } }];
-    const response = handleCategorizationValidation(testState);
+    state.pipelineResults = [{ test: 'testresult', event: { category: ['foo'] } }];
+    const response = handleCategorizationValidation({ state });
     expect(response.invalidCategorization).toEqual([
       {
         error:
@@ -27,8 +27,8 @@ describe('Testing categorization invalid category', () => {
 
 describe('Testing categorization invalid type', () => {
   it('handleCategorizationValidation()', async () => {
-    testState.pipelineResults = [{ test: 'testresult', event: { type: ['foo'] } }];
-    const response = handleCategorizationValidation(testState);
+    state.pipelineResults = [{ test: 'testresult', event: { type: ['foo'] } }];
+    const response = handleCategorizationValidation({ state });
     expect(response.invalidCategorization).toEqual([
       {
         error:
@@ -41,10 +41,10 @@ describe('Testing categorization invalid type', () => {
 
 describe('Testing categorization invalid compatibility', () => {
   it('handleCategorizationValidation()', async () => {
-    testState.pipelineResults = [
+    state.pipelineResults = [
       { test: 'testresult', event: { category: ['authentication'], type: ['access'] } },
     ];
-    const response = handleCategorizationValidation(testState);
+    const response = handleCategorizationValidation({ state });
     expect(response.invalidCategorization).toEqual([
       {
         error: 'event.type (access) not compatible with any of the event.category (authentication)',

--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/validate.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/validate.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import type { CategorizationState } from '../../types';
+import type { CategorizationBaseNodeParams } from './types';
 import { ECS_EVENT_TYPES_PER_CATEGORY, EVENT_CATEGORIES, EVENT_TYPES } from './constants';
 
 import type { EventCategories } from './constants';
@@ -22,11 +23,9 @@ interface CategorizationError {
   error: string;
 }
 
-export function handleCategorizationValidation(state: CategorizationState): {
-  previousInvalidCategorization: string;
-  invalidCategorization: CategorizationError[];
-  lastExecutedChain: string;
-} {
+export function handleCategorizationValidation({
+  state,
+}: CategorizationBaseNodeParams): Partial<CategorizationState> {
   let previousInvalidCategorization = '';
   const errors: CategorizationError[] = [];
   const pipelineResults = state.pipelineResults as PipelineResult[];

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/duplicates.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/duplicates.test.ts
@@ -14,15 +14,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: EcsMappingState = ecsTestState;
+const state: EcsMappingState = ecsTestState;
 
 describe('Testing ecs handler', () => {
   it('handleDuplicates()', async () => {
-    const response = await handleDuplicates(testState, mockLlm);
+    const response = await handleDuplicates({ state, model });
     expect(response.currentMapping).toStrictEqual({ message: 'll callback later.' });
     expect(response.lastExecutedChain).toBe('duplicateFields');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/duplicates.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/duplicates.ts
@@ -4,18 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
+import type { EcsNodeParams } from './types';
 import type { EcsMappingState } from '../../types';
 import { ECS_DUPLICATES_PROMPT } from './prompts';
 
-export async function handleDuplicates(
-  state: EcsMappingState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleDuplicates({
+  state,
+  model,
+}: EcsNodeParams): Promise<Partial<EcsMappingState>> {
   const outputParser = new JsonOutputParser();
   const ecsDuplicatesGraph = ECS_DUPLICATES_PROMPT.pipe(model).pipe(outputParser);
 

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.test.ts
@@ -24,7 +24,7 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: "I'll callback later.",
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
@@ -69,16 +69,22 @@ describe('EcsGraph', () => {
       // When getEcsGraph runs, langgraph compiles the graph it will error if the graph has any issues.
       // Common issues for example detecting a node has no next step, or there is a infinite loop between them.
       try {
-        await getEcsGraph(mockLlm);
+        await getEcsGraph({ model });
       } catch (error) {
-        fail(`getEcsGraph threw an error: ${error}`);
+        throw Error(`getEcsGraph threw an error: ${error}`);
       }
     });
     it('Runs the whole graph, with mocked outputs from the LLM.', async () => {
       // The mocked outputs are specifically crafted to trigger ALL different conditions, allowing us to test the whole graph.
       // This is why we have all the expects ensuring each function was called.
-      const ecsGraph = await getEcsGraph(mockLlm);
-      const response = await ecsGraph.invoke(mockedRequest);
+      const ecsGraph = await getEcsGraph({ model });
+      let response;
+      try {
+        response = await ecsGraph.invoke(mockedRequest);
+      } catch (error) {
+        throw Error(`getEcsGraph threw an error: ${error}`);
+      }
+
       expect(response.results).toStrictEqual(ecsMappingExpectedResults);
 
       // Check if the functions were called

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/index.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/index.ts
@@ -4,4 +4,5 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 export { getEcsGraph } from './graph';

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/invalid.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/invalid.test.ts
@@ -14,15 +14,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: EcsMappingState = ecsTestState;
+const state: EcsMappingState = ecsTestState;
 
 describe('Testing ecs handlers', () => {
   it('handleInvalidEcs()', async () => {
-    const response = await handleInvalidEcs(testState, mockLlm);
+    const response = await handleInvalidEcs({ state, model });
     expect(response.currentMapping).toStrictEqual({ message: 'll callback later.' });
     expect(response.lastExecutedChain).toBe('invalidEcs');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/invalid.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/invalid.ts
@@ -4,18 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
 import { JsonOutputParser } from '@langchain/core/output_parsers';
+import type { EcsNodeParams } from './types';
 import type { EcsMappingState } from '../../types';
 import { ECS_INVALID_PROMPT } from './prompts';
 
-export async function handleInvalidEcs(
-  state: EcsMappingState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleInvalidEcs({
+  state,
+  model,
+}: EcsNodeParams): Promise<Partial<EcsMappingState>> {
   const outputParser = new JsonOutputParser();
   const ecsInvalidEcsGraph = ECS_INVALID_PROMPT.pipe(model).pipe(outputParser);
 

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/mapping.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/mapping.test.ts
@@ -14,15 +14,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: EcsMappingState = ecsTestState;
+const state: EcsMappingState = ecsTestState;
 
 describe('Testing ecs handler', () => {
   it('handleEcsMapping()', async () => {
-    const response = await handleEcsMapping(testState, mockLlm);
+    const response = await handleEcsMapping({ state, model });
     expect(response.currentMapping).toStrictEqual({ message: 'll callback later.' });
     expect(response.lastExecutedChain).toBe('ecsMapping');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/mapping.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/mapping.ts
@@ -4,18 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
+import type { EcsNodeParams } from './types';
 import type { EcsMappingState } from '../../types';
 import { ECS_MAIN_PROMPT } from './prompts';
 
-export async function handleEcsMapping(
-  state: EcsMappingState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleEcsMapping({
+  state,
+  model,
+}: EcsNodeParams): Promise<Partial<EcsMappingState>> {
   const outputParser = new JsonOutputParser();
   const ecsMainGraph = ECS_MAIN_PROMPT.pipe(model).pipe(outputParser);
 

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.test.ts
@@ -14,15 +14,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: EcsMappingState = ecsTestState;
+const state: EcsMappingState = ecsTestState;
 
 describe('Testing ecs handler', () => {
   it('handleMissingKeys()', async () => {
-    const response = await handleMissingKeys(testState, mockLlm);
+    const response = await handleMissingKeys({ state, model });
     expect(response.currentMapping).toStrictEqual({ message: 'll callback later.' });
     expect(response.lastExecutedChain).toBe('missingKeys');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.ts
@@ -4,18 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
-import type { EcsMappingState } from '../../types';
+import { EcsNodeParams } from './types';
+import { EcsMappingState } from '../../types';
 import { ECS_MISSING_KEYS_PROMPT } from './prompts';
 
-export async function handleMissingKeys(
-  state: EcsMappingState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleMissingKeys({
+  state,
+  model,
+}: EcsNodeParams): Promise<Partial<EcsMappingState>> {
   const outputParser = new JsonOutputParser();
   const ecsMissingGraph = ECS_MISSING_KEYS_PROMPT.pipe(model).pipe(outputParser);
 

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/model.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/model.ts
@@ -9,15 +9,16 @@ import { ECS_EXAMPLE_ANSWER, ECS_FIELDS } from './constants';
 import { createPipeline } from './pipeline';
 import { mergeAndChunkSamples } from './chunk';
 import type { EcsMappingState } from '../../types';
+import type { EcsBaseNodeParams } from './types';
 
-export function modelSubOutput(state: EcsMappingState): Partial<EcsMappingState> {
+export function modelSubOutput({ state }: EcsBaseNodeParams): Partial<EcsMappingState> {
   return {
     lastExecutedChain: 'ModelSubOutput',
     finalMapping: state.currentMapping,
   };
 }
 
-export function modelInput(state: EcsMappingState): Partial<EcsMappingState> {
+export function modelInput({ state }: EcsBaseNodeParams): Partial<EcsMappingState> {
   const prefixedSamples = prefixSamples(state);
   const sampleChunks = mergeAndChunkSamples(prefixedSamples, state.chunkSize);
   return {
@@ -30,7 +31,7 @@ export function modelInput(state: EcsMappingState): Partial<EcsMappingState> {
   };
 }
 
-export function modelOutput(state: EcsMappingState): Partial<EcsMappingState> {
+export function modelOutput({ state }: EcsBaseNodeParams): Partial<EcsMappingState> {
   const currentPipeline = createPipeline(state);
   return {
     finalized: true,

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/types.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { EcsMappingState, ChatModels } from '../../types';
+
+export interface EcsBaseNodeParams {
+  state: EcsMappingState;
+}
+
+export interface EcsNodeParams extends EcsBaseNodeParams {
+  model: ChatModels;
+}
+
+export interface EcsGraphParams {
+  model: ChatModels;
+}

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/validate.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/validate.ts
@@ -6,7 +6,7 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ECS_FULL } from '../../../common/ecs';
-import type { EcsMappingState } from '../../types';
+import type { EcsBaseNodeParams } from './types';
 import { ECS_RESERVED } from './constants';
 
 const valueFieldKeys = new Set(['target', 'confidence', 'date_formats', 'type']);
@@ -152,7 +152,7 @@ export function findInvalidEcsFields(currentMapping: AnyObject): string[] {
   return results;
 }
 
-export function handleValidateMappings(state: EcsMappingState): AnyObject {
+export function handleValidateMappings({ state }: EcsBaseNodeParams): AnyObject {
   const missingKeys = findMissingFields(state?.combinedSamples, state?.currentMapping);
   const duplicateFields = findDuplicateFields(state?.prefixedSamples, state?.currentMapping);
   const invalidEcsFields = findInvalidEcsFields(state?.currentMapping);

--- a/x-pack/plugins/integration_assistant/server/graphs/related/errors.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/errors.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(relatedMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: RelatedState = relatedTestState;
+const state: RelatedState = relatedTestState;
 
 describe('Testing related handler', () => {
   it('handleErrors()', async () => {
-    const response = await handleErrors(testState, mockLlm);
+    const response = await handleErrors({ state, model });
     expect(response.currentPipeline).toStrictEqual(relatedExpectedHandlerResponse.currentPipeline);
     expect(response.lastExecutedChain).toBe('error');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/related/errors.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/errors.ts
@@ -4,21 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { Pipeline } from '../../../common';
 import type { RelatedState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { RelatedNodeParams } from './types';
 import { combineProcessors } from '../../util/processors';
 import { RELATED_ERROR_PROMPT } from './prompts';
 import { COMMON_ERRORS } from './constants';
 
-export async function handleErrors(
-  state: RelatedState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleErrors({
+  state,
+  model,
+}: RelatedNodeParams): Promise<Partial<RelatedState>> {
   const relatedErrorPrompt = RELATED_ERROR_PROMPT;
   const outputParser = new JsonOutputParser();
   const relatedErrorGraph = relatedErrorPrompt.pipe(model).pipe(outputParser);

--- a/x-pack/plugins/integration_assistant/server/graphs/related/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/graph.ts
@@ -5,14 +5,10 @@
  * 2.0.
  */
 
-import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { StateGraphArgs } from '@langchain/langgraph';
 import { StateGraph, END, START } from '@langchain/langgraph';
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
 import type { RelatedState } from '../../types';
+import type { RelatedGraphParams, RelatedBaseNodeParams } from './types';
 import { prefixSamples, formatSamples } from '../../util/samples';
 import { handleValidatePipeline } from '../../util/graph';
 import { handleRelated } from './related';
@@ -91,7 +87,7 @@ const graphState: StateGraphArgs<RelatedState>['channels'] = {
   },
 };
 
-function modelInput(state: RelatedState): Partial<RelatedState> {
+function modelInput({ state }: RelatedBaseNodeParams): Partial<RelatedState> {
   const samples = prefixSamples(state);
   const formattedSamples = formatSamples(samples);
   const initialPipeline = JSON.parse(JSON.stringify(state.currentPipeline));
@@ -107,7 +103,7 @@ function modelInput(state: RelatedState): Partial<RelatedState> {
   };
 }
 
-function modelOutput(state: RelatedState): Partial<RelatedState> {
+function modelOutput({ state }: RelatedBaseNodeParams): Partial<RelatedState> {
   return {
     finalized: true,
     lastExecutedChain: 'modelOutput',
@@ -118,14 +114,14 @@ function modelOutput(state: RelatedState): Partial<RelatedState> {
   };
 }
 
-function inputRouter(state: RelatedState): string {
+function inputRouter({ state }: RelatedBaseNodeParams): string {
   if (Object.keys(state.pipelineResults).length === 0) {
     return 'validatePipeline';
   }
   return 'related';
 }
 
-function chainRouter(state: RelatedState): string {
+function chainRouter({ state }: RelatedBaseNodeParams): string {
   if (Object.keys(state.currentProcessors).length === 0) {
     return 'related';
   }
@@ -141,34 +137,35 @@ function chainRouter(state: RelatedState): string {
   return END;
 }
 
-export async function getRelatedGraph(
-  client: IScopedClusterClient,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function getRelatedGraph({ client, model }: RelatedGraphParams) {
   const workflow = new StateGraph({ channels: graphState })
-    .addNode('modelInput', modelInput)
-    .addNode('modelOutput', modelOutput)
-    .addNode('handleRelated', (state: RelatedState) => handleRelated(state, model))
+    .addNode('modelInput', (state: RelatedState) => modelInput({ state }))
+    .addNode('modelOutput', (state: RelatedState) => modelOutput({ state }))
+    .addNode('handleRelated', (state: RelatedState) => handleRelated({ state, model }))
     .addNode('handleValidatePipeline', (state: RelatedState) =>
-      handleValidatePipeline(state, client)
+      handleValidatePipeline({ state, client })
     )
-    .addNode('handleErrors', (state: RelatedState) => handleErrors(state, model))
-    .addNode('handleReview', (state: RelatedState) => handleReview(state, model))
+    .addNode('handleErrors', (state: RelatedState) => handleErrors({ state, model }))
+    .addNode('handleReview', (state: RelatedState) => handleReview({ state, model }))
     .addEdge(START, 'modelInput')
     .addEdge('modelOutput', END)
     .addEdge('handleRelated', 'handleValidatePipeline')
     .addEdge('handleErrors', 'handleValidatePipeline')
     .addEdge('handleReview', 'handleValidatePipeline')
-    .addConditionalEdges('modelInput', inputRouter, {
+    .addConditionalEdges('modelInput', (state: RelatedState) => inputRouter({ state }), {
       related: 'handleRelated',
       validatePipeline: 'handleValidatePipeline',
     })
-    .addConditionalEdges('handleValidatePipeline', chainRouter, {
-      related: 'handleRelated',
-      errors: 'handleErrors',
-      review: 'handleReview',
-      modelOutput: 'modelOutput',
-    });
+    .addConditionalEdges(
+      'handleValidatePipeline',
+      (state: RelatedState) => chainRouter({ state }),
+      {
+        related: 'handleRelated',
+        errors: 'handleErrors',
+        review: 'handleReview',
+        modelOutput: 'modelOutput',
+      }
+    );
 
   const compiledRelatedGraph = workflow.compile();
   return compiledRelatedGraph;

--- a/x-pack/plugins/integration_assistant/server/graphs/related/related.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/related.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(relatedMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: RelatedState = relatedTestState;
+const state: RelatedState = relatedTestState;
 
 describe('Testing related handler', () => {
   it('handleRelated()', async () => {
-    const response = await handleRelated(testState, mockLlm);
+    const response = await handleRelated({ state, model });
     expect(response.currentPipeline).toStrictEqual(relatedExpectedHandlerResponse.currentPipeline);
     expect(response.lastExecutedChain).toBe('related');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/related/related.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/related.ts
@@ -4,20 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { Pipeline } from '../../../common';
 import type { RelatedState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { RelatedNodeParams } from './types';
 import { combineProcessors } from '../../util/processors';
 import { RELATED_MAIN_PROMPT } from './prompts';
 
-export async function handleRelated(
-  state: RelatedState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleRelated({
+  state,
+  model,
+}: RelatedNodeParams): Promise<Partial<RelatedState>> {
   const relatedMainPrompt = RELATED_MAIN_PROMPT;
   const outputParser = new JsonOutputParser();
   const relatedMainGraph = relatedMainPrompt.pipe(model).pipe(outputParser);

--- a/x-pack/plugins/integration_assistant/server/graphs/related/review.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/review.test.ts
@@ -18,15 +18,15 @@ import {
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
 
-const mockLlm = new FakeLLM({
+const model = new FakeLLM({
   response: JSON.stringify(relatedMockProcessors, null, 2),
 }) as unknown as ActionsClientChatOpenAI | ActionsClientSimpleChatModel;
 
-const testState: RelatedState = relatedTestState;
+const state: RelatedState = relatedTestState;
 
 describe('Testing related handler', () => {
   it('handleReview()', async () => {
-    const response = await handleReview(testState, mockLlm);
+    const response = await handleReview({ state, model });
     expect(response.currentPipeline).toStrictEqual(relatedExpectedHandlerResponse.currentPipeline);
     expect(response.lastExecutedChain).toBe('review');
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/related/review.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/review.ts
@@ -4,20 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type {
-  ActionsClientChatOpenAI,
-  ActionsClientSimpleChatModel,
-} from '@kbn/langchain/server/language_models';
+
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { Pipeline } from '../../../common';
 import type { RelatedState, SimplifiedProcessors, SimplifiedProcessor } from '../../types';
+import type { RelatedNodeParams } from './types';
 import { combineProcessors } from '../../util/processors';
 import { RELATED_REVIEW_PROMPT } from './prompts';
 
-export async function handleReview(
-  state: RelatedState,
-  model: ActionsClientChatOpenAI | ActionsClientSimpleChatModel
-) {
+export async function handleReview({
+  state,
+  model,
+}: RelatedNodeParams): Promise<Partial<RelatedState>> {
   const relatedReviewPrompt = RELATED_REVIEW_PROMPT;
   const outputParser = new JsonOutputParser();
   const relatedReviewGraph = relatedReviewPrompt.pipe(model).pipe(outputParser);

--- a/x-pack/plugins/integration_assistant/server/graphs/related/types.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+import { RelatedState, ChatModels } from '../../types';
+
+export interface RelatedBaseNodeParams {
+  state: RelatedState;
+}
+
+export interface RelatedNodeParams extends RelatedBaseNodeParams {
+  model: ChatModels;
+}
+
+export interface RelatedGraphParams {
+  client: IScopedClusterClient;
+  model: ChatModels;
+}

--- a/x-pack/plugins/integration_assistant/server/routes/categorization_routes.ts
+++ b/x-pack/plugins/integration_assistant/server/routes/categorization_routes.ts
@@ -92,7 +92,7 @@ export function registerCategorizationRoutes(
               ],
             };
 
-            const graph = await getCategorizationGraph(client, model);
+            const graph = await getCategorizationGraph({ client, model });
             const results = await graph.invoke(parameters, options);
 
             return res.ok({ body: CategorizationResponse.parse(results) });

--- a/x-pack/plugins/integration_assistant/server/routes/ecs_routes.ts
+++ b/x-pack/plugins/integration_assistant/server/routes/ecs_routes.ts
@@ -84,7 +84,7 @@ export function registerEcsRoutes(router: IRouter<IntegrationAssistantRouteHandl
             ],
           };
 
-          const graph = await getEcsGraph(model);
+          const graph = await getEcsGraph({ model });
           const results = await graph.invoke(parameters, options);
 
           return res.ok({ body: EcsMappingResponse.parse(results) });

--- a/x-pack/plugins/integration_assistant/server/routes/related_routes.ts
+++ b/x-pack/plugins/integration_assistant/server/routes/related_routes.ts
@@ -84,7 +84,7 @@ export function registerRelatedRoutes(router: IRouter<IntegrationAssistantRouteH
             ],
           };
 
-          const graph = await getRelatedGraph(client, model);
+          const graph = await getRelatedGraph({ client, model });
           const results = await graph.invoke(parameters, options);
           return res.ok({ body: RelatedResponse.parse(results) });
         } catch (e) {

--- a/x-pack/plugins/integration_assistant/server/types.ts
+++ b/x-pack/plugins/integration_assistant/server/types.ts
@@ -6,6 +6,12 @@
  */
 
 import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-plugin/server';
+import {
+  ActionsClientChatOpenAI,
+  ActionsClientBedrockChatModel,
+  ActionsClientSimpleChatModel,
+  ActionsClientGeminiChatModel,
+} from '@kbn/langchain/server';
 
 export interface IntegrationAssistantPluginSetup {
   setIsAvailable: (isAvailable: boolean) => void;
@@ -97,3 +103,9 @@ export interface RelatedState {
   results: object;
   lastExecutedChain: string;
 }
+
+export type ChatModels =
+  | ActionsClientChatOpenAI
+  | ActionsClientBedrockChatModel
+  | ActionsClientSimpleChatModel
+  | ActionsClientGeminiChatModel;

--- a/x-pack/plugins/integration_assistant/server/util/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/util/graph.ts
@@ -8,10 +8,15 @@ import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { CategorizationState, RelatedState } from '../types';
 import { testPipeline } from './pipeline';
 
-export async function handleValidatePipeline(
-  state: CategorizationState | RelatedState,
-  client: IScopedClusterClient
-): Promise<Partial<CategorizationState> | Partial<RelatedState>> {
+interface HandleValidateNodeParams {
+  state: CategorizationState | RelatedState;
+  client: IScopedClusterClient;
+}
+
+export async function handleValidatePipeline({
+  state,
+  client,
+}: HandleValidateNodeParams): Promise<Partial<CategorizationState> | Partial<RelatedState>> {
   const previousError = JSON.stringify(state.errors, null, 2);
   const results = await testPipeline(state.rawSamples, state.currentPipeline, client);
   return {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Automatic Import] Prepare to support more connectors (#191278)](https://github.com/elastic/kibana/pull/191278)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marius Iversen","email":"marius.iversen@elastic.co"},"sourceCommit":{"committedDate":"2024-08-26T17:29:30Z","message":"[Automatic Import] Prepare to support more connectors (#191278)\n\nThis PR does not add any functionality, it adds interfaces to the\nexpected parameters from get*Graph and its graph nodes.\nThis is so it will be much easier extend this later when we might need\nto add/switch types over a whole graph like we would have needed when\nadding more connectors.\n\nThe PR touches a lot of files, but does not add/remove/change any\nfunctionality at all, and the current expected function arguments are\nthe same, just the format is a bit different to better align with how\nother plugins are doing it.\n\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios.","sha":"791f638823820e8c8cc5af31e56a4f0875356dc9","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["enhancement","release_note:skip","backport:prev-minor","v8.16.0","Team:Security-Scalability","v8.15.1"],"number":191278,"url":"https://github.com/elastic/kibana/pull/191278","mergeCommit":{"message":"[Automatic Import] Prepare to support more connectors (#191278)\n\nThis PR does not add any functionality, it adds interfaces to the\nexpected parameters from get*Graph and its graph nodes.\nThis is so it will be much easier extend this later when we might need\nto add/switch types over a whole graph like we would have needed when\nadding more connectors.\n\nThe PR touches a lot of files, but does not add/remove/change any\nfunctionality at all, and the current expected function arguments are\nthe same, just the format is a bit different to better align with how\nother plugins are doing it.\n\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios.","sha":"791f638823820e8c8cc5af31e56a4f0875356dc9"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/191278","number":191278,"mergeCommit":{"message":"[Automatic Import] Prepare to support more connectors (#191278)\n\nThis PR does not add any functionality, it adds interfaces to the\nexpected parameters from get*Graph and its graph nodes.\nThis is so it will be much easier extend this later when we might need\nto add/switch types over a whole graph like we would have needed when\nadding more connectors.\n\nThe PR touches a lot of files, but does not add/remove/change any\nfunctionality at all, and the current expected function arguments are\nthe same, just the format is a bit different to better align with how\nother plugins are doing it.\n\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios.","sha":"791f638823820e8c8cc5af31e56a4f0875356dc9"}},{"branch":"8.15","label":"v8.15.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->