### PR TITLE
[Reporting/Docs] update mention of Japanese font package requirement

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -214,13 +214,13 @@ If using PNG/PDF {report-features}, make sure the {kib} server operating system 
 
 If you are using RHEL operating systems, install the following packages:
 
-* `ipa-gothic-fonts`
 * `xorg-x11-fonts-100dpi`
 * `xorg-x11-fonts-75dpi`
 * `xorg-x11-utils`
 * `xorg-x11-fonts-cyrillic`
 * `xorg-x11-fonts-Type1`
 * `xorg-x11-fonts-misc`
+* `vlgothic-fonts`
 * `fontconfig`
 * `freetype`
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/68823

`vlgothic-fonts` is a package which is listed in the default package repositories for CentOS/RHEL.
* [Github](https://github.com/daisukesuzuki/VLGothic)
* [Home page](https://vlgothic.dicey.org/)

<!--ONMERGE {"backportTargets":["7.17","8.13","8.14","8.15"]} ONMERGE-->