### PR TITLE
Adds missing @testing-library/dom peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1478,6 +1478,7 @@
     "@storybook/react": "^6.5.16",
     "@storybook/testing-react": "^1.3.0",
     "@storybook/theming": "^6.5.16",
+    "@testing-library/dom": "^8.19.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9664,7 +9664,7 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.1.4.tgz#86e04e677cd6c05fa230dd15ac223fa72d1d7090"
   integrity sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==
 
-"@testing-library/dom@^8.0.0":
+"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.19.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
   integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==


### PR DESCRIPTION
## Summary

During `yarn kbn bootstrap` we get the following message:

> @testing-library/user-event@13.5.0" has unmet peer dependency "@testing-library/dom@>=7.21.4".

This PR adds `@testing-library/dom` version `8.19.0` to `package.json` to match the version used by `@testing-library/react`. Future versions of `@testing-library/react` switched to requiring this dependency to be a peer dependency too. This PR is in preparation for https://github.com/elastic/kibana/pull/189949.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
