### PR TITLE
[OAS][DOCS] Adds linting rule for missing property descriptions

### DIFF
--- a/oas_docs/.spectral.yaml
+++ b/oas_docs/.spectral.yaml
@@ -47,6 +47,14 @@ rules:
       function: pattern
       functionOptions:
         notMatch: /(blacklist|whitelist|execute|kill)/i
+  property-description:
+    description: Properties should have descriptions.
+    message: "Each property should have a description"
+    severity: warn
+    given: $.components.schemas.*.properties.*
+    then:
+      field: description
+      function: defined 
   # Examples
   operation-success-examples:
     formats: ['oas3_1']

--- a/oas_docs/makefile
+++ b/oas_docs/makefile
@@ -35,6 +35,10 @@ api-docs-serverless: ## Generate only kibana.serverless.yaml
 api-docs-lint: ## Run spectral API docs linter 
 	@npx @stoplight/spectral-cli lint "output/*.yaml" --ruleset ".spectral.yaml"
 
+.PHONY: api-docs-lint-errs
+api-docs-lint-errs: ## Run spectral API docs linter and return only errors
+	@npx @stoplight/spectral-cli lint "output/*.yaml" --ruleset ".spectral.yaml" -D
+
 .PHONY: api-docs-lint-stateful
 api-docs-lint-stateful: ## Run spectral API docs linter on kibana.yaml
 	@npx @stoplight/spectral-cli lint "output/kibana.yaml" --ruleset ".spectral.yaml"


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/docs-projects/issues/237 by adding a custom linting rule for missing property descriptions.

