### PR TITLE
[Defend Workflows] Always allow tab select for event filter fields

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
@@ -49,7 +49,7 @@ describe('Event Filters', { tags: ['@ess', '@serverless'] }, () => {
       cy.get('body').realPress('ArrowDown').realPress('Enter');
 
       // Value input should be enabled after successfully selecting a field
-      cy.getByTestSubj(CONDITION_VALUE).get('input').should('not.have.attr', 'disabled');
+      cy.getByTestSubj(CONDITION_VALUE).find('input').should('not.have.attr', 'disabled');
 
       cy.getByTestSubj(CONDITION_VALUE).type('random.exe');
       cy.get('body').realPress('Tab');
@@ -57,18 +57,42 @@ describe('Event Filters', { tags: ['@ess', '@serverless'] }, () => {
       cy.getByTestSubj(SUBMIT_BUTTON).should('not.have.attr', 'disabled');
     });
 
-    it.skip('should be able to select field by {tab}', () => {
-      cy.getByTestSubj(CONDITION_FIELD_NAME).type('process.name');
+    it('should be able to select field by {tab} if typing narrows to one option', () => {
+      cy.getByTestSubj(CONDITION_FIELD_NAME).type('process.name.caseless');
 
       cy.get('body').realPress('Tab');
 
       // Value input should be enabled after successfully selecting a field
-      cy.getByTestSubj(CONDITION_VALUE).get('input').should('not.have.attr', 'disabled');
+      cy.getByTestSubj(CONDITION_VALUE).find('input').should('not.have.attr', 'disabled');
 
       cy.getByTestSubj(CONDITION_VALUE).type('random.exe');
       cy.get('body').realPress('Tab');
 
       cy.getByTestSubj(SUBMIT_BUTTON).should('not.have.attr', 'disabled');
+    });
+
+    it('should be able to select field by {tab} if typing leaves more than one option but there is a match', () => {
+      cy.getByTestSubj(CONDITION_FIELD_NAME).type('process.name'); // process.name, process.name.caseless, process.name.text
+
+      cy.get('body').realPress('Tab');
+
+      // Value input should be enabled after successfully selecting a field
+      cy.getByTestSubj(CONDITION_VALUE).find('input').should('not.have.attr', 'disabled');
+
+      cy.getByTestSubj(CONDITION_VALUE).type('random.exe');
+      cy.get('body').realPress('Tab');
+
+      cy.getByTestSubj(SUBMIT_BUTTON).should('not.have.attr', 'disabled');
+    });
+
+    it('should not be able to select field by {tab} if there is no exact match', () => {
+      cy.getByTestSubj(CONDITION_FIELD_NAME).type('process.name.caseles');
+
+      cy.get('body').realPress('Tab');
+
+      // Value input should be enabled after successfully selecting a field
+      cy.getByTestSubj(CONDITION_VALUE).find('input').should('have.attr', 'disabled');
+      cy.getByTestSubj(SUBMIT_BUTTON).should('have.attr', 'disabled');
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { APP_EVENT_FILTERS_PATH } from '../../../../../common/constants';
+import { removeAllArtifacts } from '../../tasks/artifacts';
+import { loadPage } from '../../tasks/common';
+import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
+import { login } from '../../tasks/login';
+import type { ReturnTypeFromChainable } from '../../types';
+
+describe('Event Filters', { tags: ['@ess', '@serverless'] }, () => {
+  let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
+  const CONDITION_FIELD_NAME = 'fieldAutocompleteComboBox';
+  const CONDITION_VALUE = 'valuesAutocompleteMatch';
+  const SUBMIT_BUTTON = 'EventFiltersListPage-flyout-submitButton';
+
+  before(() => {
+    indexEndpointHosts().then((indexEndpoints) => {
+      endpointData = indexEndpoints;
+    });
+  });
+
+  after(() => {
+    removeAllArtifacts();
+
+    endpointData?.cleanup();
+    endpointData = undefined;
+  });
+
+  beforeEach(() => {
+    removeAllArtifacts();
+  });
+
+  describe('when selecting condition field name', () => {
+    beforeEach(() => {
+      login();
+      loadPage(APP_EVENT_FILTERS_PATH);
+      cy.getByTestSubj('EventFiltersListPage-emptyState-addButton').click();
+
+      cy.getByTestSubj('eventFilters-form-name-input').type('filter name');
+    });
+
+    it('should be able to select field by {down} + {enter}', () => {
+      cy.getByTestSubj(CONDITION_FIELD_NAME).type('process.name');
+
+      cy.get('body').realPress('ArrowDown').realPress('Enter');
+
+      // Value input should be enabled after successfully selecting a field
+      cy.getByTestSubj(CONDITION_VALUE).get('input').should('not.have.attr', 'disabled');
+
+      cy.getByTestSubj(CONDITION_VALUE).type('random.exe');
+      cy.get('body').realPress('Tab');
+
+      cy.getByTestSubj(SUBMIT_BUTTON).should('not.have.attr', 'disabled');
+    });
+
+    it.skip('should be able to select field by {tab}', () => {
+      cy.getByTestSubj(CONDITION_FIELD_NAME).type('process.name');
+
+      cy.get('body').realPress('Tab');
+
+      // Value input should be enabled after successfully selecting a field
+      cy.getByTestSubj(CONDITION_VALUE).get('input').should('not.have.attr', 'disabled');
+
+      cy.getByTestSubj(CONDITION_VALUE).type('random.exe');
+      cy.get('body').realPress('Tab');
+
+      cy.getByTestSubj(SUBMIT_BUTTON).should('not.have.attr', 'disabled');
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts
@@ -26,6 +26,7 @@ import { subj as testSubjSelector } from '@kbn/test-subj-selector';
 import 'cypress-data-session';
 // @ts-ignore
 import registerCypressGrep from '@cypress/grep';
+import 'cypress-real-events/support';
 
 import { login, ROLE } from '../tasks/login';
 import { loadPage } from '../tasks/common';

--- a/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
+++ b/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
@@ -11,6 +11,7 @@
     "types": [
       "cypress",
       "node",
+      "cypress-real-events"
     ],
   },
   "kbn_references": [


### PR DESCRIPTION
## Summary

The (not so sure) goal is to allow tab select, when there is one exact match, even if there are multiple matches, to avoid this:
![rgsrgsrgh](https://github.com/user-attachments/assets/df2dc82f-b53c-499c-a7cc-0353626a148d)

> [!note]
> `EuiComboBox` does not allow this at the moment, and no decision yet to go down on this path.

> [!note]
> At the moment this draft PR's only goal is to store acceptance tests for {tab} selecting event filter fields even if there are multiple matches, in case we go forward.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
