### PR TITLE
[Fleet] add back monitoring for agentless policies

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -102,7 +102,6 @@ export function useSetupTechnology({
   const [newAgentlessPolicy, setNewAgentlessPolicy] = useState<AgentPolicy | NewAgentPolicy>(
     generateNewAgentPolicyWithDefaults({
       supports_agentless: true,
-      monitoring_enabled: [],
     })
   );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -102,6 +102,7 @@ export function useSetupTechnology({
   const [newAgentlessPolicy, setNewAgentlessPolicy] = useState<AgentPolicy | NewAgentPolicy>(
     generateNewAgentPolicyWithDefaults({
       supports_agentless: true,
+      monitoring_enabled: ['logs', 'metrics'],
     })
   );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -848,7 +848,7 @@ describe('When on the package policy create page', () => {
 
         expect(sendCreateAgentPolicy).toHaveBeenCalledWith(
           expect.objectContaining({
-            monitoring_enabled: ['logs', 'metrics', 'traces'],
+            monitoring_enabled: ['logs', 'metrics'],
             name: 'Agentless policy for nginx-1',
             supports_agentless: true,
           }),

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -848,7 +848,7 @@ describe('When on the package policy create page', () => {
 
         expect(sendCreateAgentPolicy).toHaveBeenCalledWith(
           expect.objectContaining({
-            monitoring_enabled: [],
+            monitoring_enabled: ['logs', 'metrics', 'traces'],
             name: 'Agentless policy for nginx-1',
             supports_agentless: true,
           }),


### PR DESCRIPTION
Added back agent monitoring on agentless policies as requested. It was incorrectly removed in https://github.com/elastic/kibana/pull/189612