### PR TITLE
[8.15] [Automatic Import] Resolving issues with ECS chunking not producing expected results. (#191630)

### DIFF
--- a/x-pack/plugins/integration_assistant/__jest__/fixtures/ecs_mapping.ts
+++ b/x-pack/plugins/integration_assistant/__jest__/fixtures/ecs_mapping.ts
@@ -452,6 +452,8 @@ export const ecsTestState = {
   results: { test: 'testresults' },
   samplesFormat: 'testsamplesFormat',
   ecsVersion: 'testversion',
+  chunkMapping: { test1: 'test1' },
+  useFinalMapping: false,
   currentMapping: { test1: 'test1' },
   lastExecutedChain: 'testchain',
   rawSamples: ['{"test1": "test1"}'],

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/duplicates.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/duplicates.test.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { FakeLLM } from '@langchain/core/utils/testing';
-import { handleDuplicates } from './duplicates';
-import type { EcsMappingState } from '../../types';
-import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
 import {
   ActionsClientChatOpenAI,
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
+import { FakeLLM } from '@langchain/core/utils/testing';
+import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
+import type { EcsMappingState } from '../../types';
+import { handleDuplicates } from './duplicates';
 
 const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import { END, START, StateGraph, Send } from '@langchain/langgraph';
+import { END, Send, START, StateGraph } from '@langchain/langgraph';
 import type { EcsMappingState } from '../../types';
-import type { EcsGraphParams, EcsBaseNodeParams } from './types';
-import { modelInput, modelOutput, modelSubOutput } from './model';
 import { handleDuplicates } from './duplicates';
 import { handleInvalidEcs } from './invalid';
 import { handleEcsMapping } from './mapping';
 import { handleMissingKeys } from './missing';
-import { handleValidateMappings } from './validate';
+import { modelInput, modelMergedInputFromSubGraph, modelOutput, modelSubOutput } from './model';
 import { graphState } from './state';
+import type { EcsBaseNodeParams, EcsGraphParams } from './types';
+import { handleValidateMappings } from './validate';
 
 const handleCreateMappingChunks = async ({ state }: EcsBaseNodeParams) => {
   // Cherrypick a shallow copy of state to pass to subgraph
@@ -44,7 +44,7 @@ function chainRouter({ state }: EcsBaseNodeParams): string {
     return 'invalidEcsFields';
   }
   if (!state.finalized) {
-    return 'modelSubOutput';
+    return 'modelOutput';
   }
   return END;
 }
@@ -69,7 +69,7 @@ async function getEcsSubGraph({ model }: EcsGraphParams) {
       duplicateFields: 'handleDuplicates',
       missingKeys: 'handleMissingKeys',
       invalidEcsFields: 'handleInvalidEcs',
-      modelSubOutput: 'modelSubOutput',
+      modelOutput: 'modelSubOutput',
     })
     .addEdge('modelSubOutput', END);
 
@@ -85,12 +85,29 @@ export async function getEcsGraph({ model }: EcsGraphParams) {
   })
     .addNode('modelInput', (state: EcsMappingState) => modelInput({ state }))
     .addNode('modelOutput', (state: EcsMappingState) => modelOutput({ state }))
+    .addNode('handleValidation', (state: EcsMappingState) => handleValidateMappings({ state }))
+    .addNode('handleDuplicates', (state: EcsMappingState) => handleDuplicates({ state, model }))
+    .addNode('handleMissingKeys', (state: EcsMappingState) => handleMissingKeys({ state, model }))
+    .addNode('handleInvalidEcs', (state: EcsMappingState) => handleInvalidEcs({ state, model }))
+    .addNode('handleMergedSubGraphResponse', (state: EcsMappingState) =>
+      modelMergedInputFromSubGraph({ state })
+    )
     .addNode('subGraph', subGraph)
     .addEdge(START, 'modelInput')
-    .addEdge('subGraph', 'modelOutput')
+    .addEdge('subGraph', 'handleMergedSubGraphResponse')
+    .addEdge('handleDuplicates', 'handleValidation')
+    .addEdge('handleMissingKeys', 'handleValidation')
+    .addEdge('handleInvalidEcs', 'handleValidation')
+    .addEdge('handleMergedSubGraphResponse', 'handleValidation')
     .addConditionalEdges('modelInput', (state: EcsMappingState) =>
       handleCreateMappingChunks({ state })
     )
+    .addConditionalEdges('handleValidation', (state: EcsMappingState) => chainRouter({ state }), {
+      duplicateFields: 'handleDuplicates',
+      missingKeys: 'handleMissingKeys',
+      invalidEcsFields: 'handleInvalidEcs',
+      modelOutput: 'modelOutput',
+    })
     .addEdge('modelOutput', END);
 
   const compiledEcsGraph = workflow.compile();

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/invalid.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/invalid.test.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { FakeLLM } from '@langchain/core/utils/testing';
-import { handleInvalidEcs } from './invalid';
-import type { EcsMappingState } from '../../types';
-import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
 import {
   ActionsClientChatOpenAI,
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
+import { FakeLLM } from '@langchain/core/utils/testing';
+import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
+import type { EcsMappingState } from '../../types';
+import { handleInvalidEcs } from './invalid';
 
 const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/mapping.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/mapping.test.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { FakeLLM } from '@langchain/core/utils/testing';
-import { handleEcsMapping } from './mapping';
-import type { EcsMappingState } from '../../types';
-import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
 import {
   ActionsClientChatOpenAI,
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
+import { FakeLLM } from '@langchain/core/utils/testing';
+import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
+import type { EcsMappingState } from '../../types';
+import { handleEcsMapping } from './mapping';
 
 const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.test.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { FakeLLM } from '@langchain/core/utils/testing';
-import { handleMissingKeys } from './missing';
-import type { EcsMappingState } from '../../types';
-import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
 import {
   ActionsClientChatOpenAI,
   ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server/language_models';
+import { FakeLLM } from '@langchain/core/utils/testing';
+import { ecsTestState } from '../../../__jest__/fixtures/ecs_mapping';
+import type { EcsMappingState } from '../../types';
+import { handleMissingKeys } from './missing';
 
 const model = new FakeLLM({
   response: '{ "message": "ll callback later."}',

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/missing.ts
@@ -6,9 +6,9 @@
  */
 
 import { JsonOutputParser } from '@langchain/core/output_parsers';
-import { EcsNodeParams } from './types';
 import { EcsMappingState } from '../../types';
 import { ECS_MISSING_KEYS_PROMPT } from './prompts';
+import { EcsNodeParams } from './types';
 
 export async function handleMissingKeys({
   state,
@@ -16,14 +16,19 @@ export async function handleMissingKeys({
 }: EcsNodeParams): Promise<Partial<EcsMappingState>> {
   const outputParser = new JsonOutputParser();
   const ecsMissingGraph = ECS_MISSING_KEYS_PROMPT.pipe(model).pipe(outputParser);
+  const usesFinalMapping = state?.useFinalMapping;
+  const mapping = usesFinalMapping ? state.finalMapping : state.currentMapping;
 
-  const currentMapping = await ecsMissingGraph.invoke({
+  const result = await ecsMissingGraph.invoke({
     ecs: state.ecs,
-    current_mapping: JSON.stringify(state.currentMapping, null, 2),
+    current_mapping: JSON.stringify(mapping, null, 2),
     ex_answer: state.exAnswer,
     combined_samples: state.combinedSamples,
     missing_keys: state?.missingKeys,
   });
 
-  return { currentMapping, lastExecutedChain: 'missingKeys' };
+  return {
+    [usesFinalMapping ? 'finalMapping' : 'currentMapping']: result,
+    lastExecutedChain: 'missingKeys',
+  };
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/model.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/model.ts
@@ -4,17 +4,27 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { EcsMappingState } from '../../types';
 import { prefixSamples } from '../../util/samples';
+import { mergeAndChunkSamples } from './chunk';
 import { ECS_EXAMPLE_ANSWER, ECS_FIELDS } from './constants';
 import { createPipeline } from './pipeline';
-import { mergeAndChunkSamples } from './chunk';
-import type { EcsMappingState } from '../../types';
 import type { EcsBaseNodeParams } from './types';
 
 export function modelSubOutput({ state }: EcsBaseNodeParams): Partial<EcsMappingState> {
   return {
-    lastExecutedChain: 'ModelSubOutput',
-    finalMapping: state.currentMapping,
+    lastExecutedChain: 'modelSubOutput',
+    chunkMapping: state.currentMapping,
+  };
+}
+
+export function modelMergedInputFromSubGraph({
+  state,
+}: EcsBaseNodeParams): Partial<EcsMappingState> {
+  return {
+    lastExecutedChain: 'modelMergedInputFromSubGraph',
+    useFinalMapping: true,
+    finalMapping: state.chunkMapping,
   };
 }
 

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/pipeline.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/pipeline.ts
@@ -163,7 +163,7 @@ function generateProcessors(ecsMapping: object, samples: object, basePath: strin
 export function createPipeline(state: EcsMappingState): IngestPipeline {
   const samples = JSON.parse(state.combinedSamples);
 
-  const processors = generateProcessors(state.currentMapping, samples);
+  const processors = generateProcessors(state.finalMapping, samples);
   // Retrieve all source field names from convert processors to populate single remove processor:
   const fieldsToRemove = processors
     .map((p: any) => p.convert?.field)

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/prompts.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/prompts.ts
@@ -166,10 +166,17 @@ Here is some context for you to reference for your task, read it carefully as yo
 <duplicate_fields>
 {duplicate_fields}
 </duplicate_fields>
-  
+
+Go through each ECS field in the above list of duplicate fields step by step and and modify the current mapping following this process:
+1. For each duplicate ECS field there is 2 or more source fields that has target set to the same ECS field, identify which of these it is.
+2. For each of the source fields that has the same target set, choose only one of them to have the target set to the ECS field, for the rest you should either find another matching ECS field or set the source to be null.
+3. Make sure that all of the ECS fields mentioned in the duplicate fields above have been resolved and return the updated current mapping object.
+
 To resolve the duplicate mappings, go through each key and value defined in the duplicate fields, and modify the current mapping step by step, and ensure they follow these guidelines:
 <guidelines>
-- Multiple keys should not have the same value (ECS field it will be mapped to). If multiple keys do have the same value then always choose the best match for the ECS field, while the other duplicates should have their value changed to null.
+- Only focus on ECS fields reported as duplicate fields, do not modify any other fields.
+- For all fields that are marked duplicate, when the best target is choosen, remember to set the value of the source field to null.
+- The value "target" should not have a null value, but rather the source object itself should be set to null, use the existing current mapping for reference.
 - Do not respond with anything except the updated current mapping JSON object enclosed with 3 backticks (\`). See example response below.
 </guidelines>
 

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/state.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/state.ts
@@ -16,7 +16,7 @@ export const graphState: StateGraphArgs<EcsMappingState>['channels'] = {
   },
   chunkSize: {
     value: (x: number, y?: number) => y ?? x,
-    default: () => 10,
+    default: () => 25,
   },
   lastExecutedChain: {
     value: (x: string, y?: string) => y ?? x,
@@ -58,9 +58,17 @@ export const graphState: StateGraphArgs<EcsMappingState>['channels'] = {
     value: (x: object, y?: object) => y ?? x,
     default: () => ({}),
   },
-  finalMapping: {
+  chunkMapping: {
     reducer: merge,
     default: () => ({}),
+  },
+  finalMapping: {
+    value: (x: object, y?: object) => y ?? x,
+    default: () => ({}),
+  },
+  useFinalMapping: {
+    value: (x: boolean, y?: boolean) => y ?? x,
+    default: () => false,
   },
   currentPipeline: {
     value: (x: object, y?: object) => y ?? x,

--- a/x-pack/plugins/integration_assistant/server/types.ts
+++ b/x-pack/plugins/integration_assistant/server/types.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import {
-  ActionsClientChatOpenAI,
   ActionsClientBedrockChatModel,
-  ActionsClientSimpleChatModel,
+  ActionsClientChatOpenAI,
   ActionsClientGeminiChatModel,
+  ActionsClientSimpleChatModel,
 } from '@kbn/langchain/server';
+import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-plugin/server';
 
 export interface IntegrationAssistantPluginSetup {
   setIsAvailable: (isAvailable: boolean) => void;
@@ -75,6 +75,8 @@ export interface EcsMappingState {
   finalized: boolean;
   currentMapping: object;
   finalMapping: object;
+  chunkMapping: object;
+  useFinalMapping: boolean;
   currentPipeline: object;
   duplicateFields: string[];
   missingKeys: string[];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Automatic Import] Resolving issues with ECS chunking not producing expected results. (#191630)](https://github.com/elastic/kibana/pull/191630)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marius Iversen","email":"marius.iversen@elastic.co"},"sourceCommit":{"committedDate":"2024-08-28T16:53:44Z","message":"[Automatic Import] Resolving issues with ECS chunking not producing expected results. (#191630)\n\n## Summary\n\nWhen we merge the results from all the ECS graphs we did not correctly\npass the correct state items, this PR resolves that.\n\nChanges:\nBump chunk size from 10 to 25 to handle less duplicates.\nBetter duplicate prompt.\nChange the mapping state usage a bit, since we can't have a reducer on\nfinalMapping, as its reused in the main graph validation.\nAdd same validation steps to run after the sub graphs have all finished.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b56d7dc135b1457d413b351e688c2a99f3435ad1","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:prev-minor","v8.16.0","Team:Security-Scalability","v8.15.1"],"number":191630,"url":"https://github.com/elastic/kibana/pull/191630","mergeCommit":{"message":"[Automatic Import] Resolving issues with ECS chunking not producing expected results. (#191630)\n\n## Summary\n\nWhen we merge the results from all the ECS graphs we did not correctly\npass the correct state items, this PR resolves that.\n\nChanges:\nBump chunk size from 10 to 25 to handle less duplicates.\nBetter duplicate prompt.\nChange the mapping state usage a bit, since we can't have a reducer on\nfinalMapping, as its reused in the main graph validation.\nAdd same validation steps to run after the sub graphs have all finished.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b56d7dc135b1457d413b351e688c2a99f3435ad1"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/191630","number":191630,"mergeCommit":{"message":"[Automatic Import] Resolving issues with ECS chunking not producing expected results. (#191630)\n\n## Summary\n\nWhen we merge the results from all the ECS graphs we did not correctly\npass the correct state items, this PR resolves that.\n\nChanges:\nBump chunk size from 10 to 25 to handle less duplicates.\nBetter duplicate prompt.\nChange the mapping state usage a bit, since we can't have a reducer on\nfinalMapping, as its reused in the main graph validation.\nAdd same validation steps to run after the sub graphs have all finished.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b56d7dc135b1457d413b351e688c2a99f3435ad1"}},{"branch":"8.15","label":"v8.15.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->