### PR TITLE
[UII] Fix typo causing agent activity page to error out

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/helpers.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout/helpers.tsx
@@ -69,7 +69,7 @@ export const getAction = (type?: string, actionId?: string) => {
   // handling a special case of force unenrollment coming from an automatic task
   // we know what kind of action is from the actionId prefix
   if (actionId?.includes('UnenrollInactiveAgentsTask-'))
-    return actionNames.AUTOMATICAL_FORCE_UNENROLL;
+    return actionNames.AUTOMATIC_FORCE_UNENROLL;
   return actionNames[type ?? 'ACTION'] ?? actionNames.ACTION;
 };
 


### PR DESCRIPTION
## Summary

Resolves #191387. Fix typo introduced in #189861.
