### PR TITLE
[FTR][ML] Drop skip firefox tags from ml area ui tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/index.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/index.ts
@@ -12,7 +12,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const ml = getService('ml');
 
   describe('machine learning - data frame analytics', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
 
     before(async () => {
       await ml.securityCommon.createMlRoles();

--- a/x-pack/test/functional/apps/ml/permissions/index.ts
+++ b/x-pack/test/functional/apps/ml/permissions/index.ts
@@ -12,7 +12,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const ml = getService('ml');
 
   describe('machine learning - permissions', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
 
     before(async () => {
       await ml.securityCommon.createMlRoles();

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/index.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('model management', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
 
     loadTestFile(require.resolve('./model_list'));
   });

--- a/x-pack/test/functional/apps/ml/short_tests/notifications/index.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/notifications/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Notifcations', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
 
     loadTestFile(require.resolve('./notification_list'));
   });

--- a/x-pack/test/functional/apps/ml/short_tests/settings/index.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/settings/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('settings', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
 
     loadTestFile(require.resolve('./calendar_creation'));
     loadTestFile(require.resolve('./calendar_edit'));

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/index.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/index.ts
@@ -12,7 +12,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
   const ml = getService('ml');
 
   describe('machine learning - stack management jobs', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
     before(async () => {
       await ml.securityCommon.createMlRoles();
       await ml.securityCommon.createMlUsers();

--- a/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/index.ts
@@ -12,7 +12,7 @@ export default ({ loadTestFile, getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
 
   describe('ML app', function () {
-    this.tags(['ml', 'skipFirefox']);
+    this.tags(['ml']);
 
     before(async () => {
       await ml.securityCommon.createMlRoles();


### PR DESCRIPTION
## Summary 

Previously, the ML area was included in the Firefox config.
Over time, we have reduced the set of tests that we run on Firefox due to stability issues with the geckodriver.

Today, ML tests are not included in the [Firefox config](https://github.com/elastic/kibana/blob/main/x-pack/test/functional/config.firefox.js) at all, so the skipFirefox tags have no effect.
