### PR TITLE
[kbn/server-route-repository] Make params optional for Zod schema with only optional keys

### DIFF
--- a/packages/kbn-server-route-repository-client/src/is_http_fetch_error.ts
+++ b/packages/kbn-server-route-repository-client/src/is_http_fetch_error.ts
@@ -6,11 +6,14 @@
  * Side Public License, v 1.
  */
 
-export { createRepositoryClient } from './src/create_repository_client';
-export { isHttpFetchError } from './src/is_http_fetch_error';
+import { IHttpFetchError, isHttpFetchError as coreIsHttpFetchError } from '@kbn/core-http-browser';
 
-export type {
-  DefaultClientOptions,
-  ClientRequestParamsOf,
-  RouteRepositoryClient,
-} from '@kbn/server-route-repository-utils';
+interface ErrorBody {
+  statusCode: number;
+  message: string;
+  error: string;
+}
+
+export function isHttpFetchError(error: unknown): error is IHttpFetchError<ErrorBody> {
+  return coreIsHttpFetchError(error);
+}

--- a/packages/kbn-server-route-repository-client/tsconfig.json
+++ b/packages/kbn-server-route-repository-client/tsconfig.json
@@ -16,5 +16,6 @@
   "kbn_references": [
     "@kbn/server-route-repository-utils",
     "@kbn/core-lifecycle-browser",
+    "@kbn/core-http-browser",
   ]
 }

--- a/packages/kbn-server-route-repository-utils/src/typings.ts
+++ b/packages/kbn-server-route-repository-utils/src/typings.ts
@@ -20,6 +20,38 @@ import { z } from '@kbn/zod';
 import * as t from 'io-ts';
 import { RequiredKeys } from 'utility-types';
 
+type PathMaybeOptional<T extends { path: Record<string, any> }> = RequiredKeys<
+  T['path']
+> extends never
+  ? { path?: T['path'] }
+  : { path: T['path'] };
+
+type QueryMaybeOptional<T extends { query: Record<string, any> }> = RequiredKeys<
+  T['query']
+> extends never
+  ? { query?: T['query'] }
+  : { query: T['query'] };
+
+type BodyMaybeOptional<T extends { body: Record<string, any> }> = RequiredKeys<
+  T['body']
+> extends never
+  ? { body?: T['body'] }
+  : { body: T['body'] };
+
+type ParamsMaybeOptional<
+  TPath extends Record<string, any>,
+  TQuery extends Record<string, any>,
+  TBody extends Record<string, any>
+> = PathMaybeOptional<{ path: TPath }> &
+  QueryMaybeOptional<{ query: TQuery }> &
+  BodyMaybeOptional<{ body: TBody }>;
+
+type ZodMaybeOptional<T extends { path: any; query: any; body: any }> = ParamsMaybeOptional<
+  T['path'],
+  T['query'],
+  T['body']
+>;
+
 type MaybeOptional<T extends { params: Record<string, any> }> = RequiredKeys<
   T['params']
 > extends never
@@ -93,7 +125,7 @@ type ClientRequestParamsOfType<TRouteParamsRT extends RouteParamsRT> =
       }>
     : TRouteParamsRT extends z.Schema
     ? MaybeOptional<{
-        params: z.TypeOf<TRouteParamsRT>;
+        params: ZodMaybeOptional<z.input<TRouteParamsRT>>;
       }>
     : {};
 
@@ -104,7 +136,7 @@ type DecodedRequestParamsOfType<TRouteParamsRT extends RouteParamsRT> =
       }>
     : TRouteParamsRT extends z.Schema
     ? MaybeOptional<{
-        params: z.TypeOf<TRouteParamsRT>;
+        params: ZodMaybeOptional<z.output<TRouteParamsRT>>;
       }>
     : {};
 
@@ -162,7 +194,7 @@ type MaybeOptionalArgs<T extends Record<string, any>> = RequiredKeys<T> extends 
 
 export type RouteRepositoryClient<
   TServerRouteRepository extends ServerRouteRepository,
-  TAdditionalClientOptions extends Record<string, any>
+  TAdditionalClientOptions extends Record<string, any> = DefaultClientOptions
 > = <TEndpoint extends Extract<keyof TServerRouteRepository, string>>(
   endpoint: TEndpoint,
   ...args: MaybeOptionalArgs<

--- a/packages/kbn-server-route-repository/README.md
+++ b/packages/kbn-server-route-repository/README.md
@@ -88,9 +88,7 @@ The client can be created either in `setup` or `start`.
 
 > browser/plugin.ts
 ```javascript
-import { isHttpFetchError } from '@kbn/core-http-browser';
-import { DefaultClientOptions } from '@kbn/server-route-repository-utils';
-import { createRepositoryClient } from '@kbn/server-route-repository-client';
+import { createRepositoryClient, isHttpFetchError, DefaultClientOptions } from '@kbn/server-route-repository-client';
 import type { MyPluginRouteRepository } from '../server/plugin';
 
 export type MyPluginRepositoryClient = 


### PR DESCRIPTION
`io-ts` and `zod` have differences in how they usually define optional keys.

In `io-ts`, we usually define a union between a type and a partial, and if all keys are optional we only provide the partial type.
While in `zod` if all keys are optional, it's more common to simply put each key as optional while the wrapping object is not.

The way the type inference works in the route repository leads to this two cases having different results.
For `io-ts`, when it sees a partial, it marks the query/path/body and thus params object as fully optional, while for `zod` since query/path/body are **not** optional but all their keys are, the chain is still marked as required.

This PR aims to align these behaviours by checking if the `zod` schema only specifies optional field, and if it does it marks the query/path/body level as optional so that params also can become optional.

This way, when calling the API via the client, if all params are optional, the second options argument can be omitted.
Similarly, the types in the handler are marked correctly as possibly undefined to prevent bugs.

The PR also adds a little `isHttpFetchError` helper with slightly better type support than what the Core version has.