### PR TITLE
[Console] Add button to clear editor input

### DIFF
--- a/src/plugins/console/public/application/containers/editor/monaco/hooks/use_set_initial_value.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/hooks/use_set_initial_value.ts
@@ -106,7 +106,7 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
     if (loadFromParam) {
       loadBufferFromRemote(loadFromParam);
     } else {
-      setValue(initialTextValue || DEFAULT_INPUT_VALUE);
+      setValue(initialTextValue ?? DEFAULT_INPUT_VALUE);
     }
 
     return () => {

--- a/src/plugins/console/public/application/containers/editor/monaco/hooks/use_set_initial_value.ts
+++ b/src/plugins/console/public/application/containers/editor/monaco/hooks/use_set_initial_value.ts
@@ -20,7 +20,7 @@ interface QueryParams {
 
 interface SetInitialValueParams {
   /** The text value that is initially in the console editor. */
-  initialTextValue?: string;
+  localStorageValue?: string;
   /** The function that sets the state of the value in the console editor. */
   setValue: (value: string) => void;
   /** The toasts service. */
@@ -44,7 +44,7 @@ export const readLoadFromParam = () => {
  * @param params The {@link SetInitialValueParams} to use.
  */
 export const useSetInitialValue = (params: SetInitialValueParams) => {
-  const { initialTextValue, setValue, toasts } = params;
+  const { localStorageValue, setValue, toasts } = params;
 
   useEffect(() => {
     const loadBufferFromRemote = async (url: string) => {
@@ -60,7 +60,7 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
         if (parsedURL.origin === 'https://www.elastic.co') {
           const resp = await fetch(parsedURL);
           const data = await resp.text();
-          setValue(`${initialTextValue}\n\n${data}`);
+          setValue(`${localStorageValue}\n\n${data}`);
         } else {
           toasts.addWarning(
             i18n.translate('console.monaco.loadFromDataUnrecognizedUrlErrorMessage', {
@@ -106,11 +106,11 @@ export const useSetInitialValue = (params: SetInitialValueParams) => {
     if (loadFromParam) {
       loadBufferFromRemote(loadFromParam);
     } else {
-      setValue(initialTextValue ?? DEFAULT_INPUT_VALUE);
+      setValue(localStorageValue || DEFAULT_INPUT_VALUE);
     }
 
     return () => {
       window.removeEventListener('hashchange', onHashChange);
     };
-  }, [initialTextValue, setValue, toasts]);
+  }, [localStorageValue, setValue, toasts]);
 };

--- a/src/plugins/console/public/application/containers/editor/monaco/monaco_editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/monaco/monaco_editor.tsx
@@ -128,6 +128,7 @@ export const MonacoEditor = ({ initialTextValue }: EditorProps) => {
     <div
       css={css`
         width: 100%;
+        height: 100%;
       `}
       ref={divRef}
       data-test-subj="consoleMonacoEditorContainer"

--- a/src/plugins/console/public/application/containers/editor/monaco/monaco_editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/monaco/monaco_editor.tsx
@@ -31,10 +31,12 @@ import { MonacoEditorActionsProvider } from './monaco_editor_actions_provider';
 import { getSuggestionProvider } from './monaco_editor_suggestion_provider';
 
 export interface EditorProps {
-  initialTextValue: string;
+  localStorageValue: string | undefined;
+  value: string;
+  setValue: (value: string) => void;
 }
 
-export const MonacoEditor = ({ initialTextValue }: EditorProps) => {
+export const MonacoEditor = ({ localStorageValue, value, setValue }: EditorProps) => {
   const context = useServicesContext();
   const {
     services: { notifications, settings: settingsService, autocompleteInfo },
@@ -116,9 +118,8 @@ export const MonacoEditor = ({ initialTextValue }: EditorProps) => {
   const suggestionProvider = useMemo(() => {
     return getSuggestionProvider(actionsProvider);
   }, []);
-  const [value, setValue] = useState(initialTextValue);
 
-  useSetInitialValue({ initialTextValue, setValue, toasts });
+  useSetInitialValue({ localStorageValue, setValue, toasts });
 
   useSetupAutocompletePolling({ autocompleteInfo, settingsService });
 

--- a/src/plugins/console/public/application/stores/request.ts
+++ b/src/plugins/console/public/application/stores/request.ts
@@ -14,7 +14,7 @@ import { RequestResult } from '../hooks/use_send_current_request/send_request';
 
 export type Actions =
   | { type: 'sendRequest'; payload: undefined }
-  | { type: 'cleanResponse'; payload: undefined }
+  | { type: 'cleanRequest'; payload: undefined }
   | { type: 'requestSuccess'; payload: { data: RequestResult[] } }
   | { type: 'requestFail'; payload: RequestResult<string> | undefined };
 
@@ -59,7 +59,7 @@ export const reducer: Reducer<Store, Actions> = (state, action) =>
       return;
     }
 
-    if (action.type === 'cleanResponse') {
+    if (action.type === 'cleanRequest') {
       draft.requestInFlight = false;
       draft.lastResult = initialResultValue;
       return;

--- a/src/plugins/console/public/application/stores/request.ts
+++ b/src/plugins/console/public/application/stores/request.ts
@@ -14,7 +14,7 @@ import { RequestResult } from '../hooks/use_send_current_request/send_request';
 
 export type Actions =
   | { type: 'sendRequest'; payload: undefined }
-  | { type: 'cleanRequest'; payload: undefined }
+  | { type: 'cleanResponse'; payload: undefined }
   | { type: 'requestSuccess'; payload: { data: RequestResult[] } }
   | { type: 'requestFail'; payload: RequestResult<string> | undefined };
 
@@ -59,7 +59,7 @@ export const reducer: Reducer<Store, Actions> = (state, action) =>
       return;
     }
 
-    if (action.type === 'cleanRequest') {
+    if (action.type === 'cleanResponse') {
       draft.requestInFlight = false;
       draft.lastResult = initialResultValue;
       return;

--- a/test/functional/apps/console/monaco/_console.ts
+++ b/test/functional/apps/console/monaco/_console.ts
@@ -62,6 +62,20 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(initialSize.width).to.be.greaterThan(afterSize.width);
     });
 
+    it('should allow clearing the input editor', async () => {
+      await PageObjects.console.monaco.enterText('GET _all');
+
+      // Check current input is not empty
+      const input = await PageObjects.console.monaco.getEditorText();
+      expect(input).to.not.be.empty();
+
+      // Clear the output
+      await PageObjects.console.clickClearInput();
+
+      // Check that after clearing the input, the editor is empty
+      expect(await PageObjects.console.monaco.getEditorText()).to.be.empty();
+    });
+
     it('should return statusCode 400 to unsupported HTTP verbs', async () => {
       const expectedResponseContains = '"statusCode": 400';
       await PageObjects.console.monaco.clearEditorText();

--- a/test/functional/apps/console/monaco/index.ts
+++ b/test/functional/apps/console/monaco/index.ts
@@ -19,17 +19,17 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     if (config.get('esTestCluster.ccs')) {
       loadTestFile(require.resolve('./_console_ccs'));
     } else {
-      // loadTestFile(require.resolve('./_console'));
-      // loadTestFile(require.resolve('./_autocomplete'));
-      // loadTestFile(require.resolve('./_vector_tile'));
-      // loadTestFile(require.resolve('./_comments'));
-      // loadTestFile(require.resolve('./_variables'));
-      // loadTestFile(require.resolve('./_xjson'));
-      // loadTestFile(require.resolve('./_misc_console_behavior'));
-      // loadTestFile(require.resolve('./_context_menu'));
-      // loadTestFile(require.resolve('./_text_input'));
-      // loadTestFile(require.resolve('./_settings'));
-      // loadTestFile(require.resolve('./_output_panel'));
+      loadTestFile(require.resolve('./_console'));
+      loadTestFile(require.resolve('./_autocomplete'));
+      loadTestFile(require.resolve('./_vector_tile'));
+      loadTestFile(require.resolve('./_comments'));
+      loadTestFile(require.resolve('./_variables'));
+      loadTestFile(require.resolve('./_xjson'));
+      loadTestFile(require.resolve('./_misc_console_behavior'));
+      loadTestFile(require.resolve('./_context_menu'));
+      loadTestFile(require.resolve('./_text_input'));
+      loadTestFile(require.resolve('./_settings'));
+      loadTestFile(require.resolve('./_output_panel'));
       loadTestFile(require.resolve('./_onboarding_tour'));
     }
   });

--- a/test/functional/page_objects/console_page.ts
+++ b/test/functional/page_objects/console_page.ts
@@ -210,6 +210,14 @@ export class ConsolePageObject extends FtrService {
     await this.testSubjects.click('copyOutputButton');
   }
 
+  public async clickClearInput() {
+    const hasClearButton = await this.testSubjects.exists('clearConsoleInput');
+
+    if (hasClearButton) {
+      await this.testSubjects.click('clearConsoleInput');
+    }
+  }
+
   public async clickClearOutput() {
     const hasClearButton = await this.testSubjects.exists('clearConsoleOutput');
 


### PR DESCRIPTION
## Summary

This PR adds a "Clear this input" button to the input editor in Console.

<img width="1491" alt="Screenshot 2024-08-29 at 14 16 54" src="https://github.com/user-attachments/assets/3c7dc201-743e-49f7-b410-690e5de92ef2">


https://github.com/user-attachments/assets/d5868c77-ca04-451c-875c-4191881f2930


<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
-->
