### PR TITLE
[ES|QL] Support argument precedence in `BasicPrettyPrinter`

### DIFF
--- a/packages/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
+++ b/packages/kbn-esql-ast/src/pretty_print/__tests__/basic_pretty_printer.test.ts
@@ -211,7 +211,7 @@ describe('single line query', () => {
         });
       });
 
-      describe('binary expression expression', () => {
+      describe('binary expression', () => {
         test('arithmetic expression', () => {
           const { text } = reprint('ROW 1 + 2');
 
@@ -234,6 +234,36 @@ describe('single line query', () => {
           const { text } = reprint('FROM a | WHERE a LIKE "b"');
 
           expect(text).toBe('FROM a | WHERE a LIKE "b"');
+        });
+
+        test('inserts brackets where necessary due precedence', () => {
+          const { text } = reprint('FROM a | WHERE (1 + 2) * 3');
+
+          expect(text).toBe('FROM a | WHERE (1 + 2) * 3');
+        });
+
+        test('inserts brackets where necessary due precedence - 2', () => {
+          const { text } = reprint('FROM a | WHERE (1 + 2) * (3 - 4)');
+
+          expect(text).toBe('FROM a | WHERE (1 + 2) * (3 - 4)');
+        });
+
+        test('inserts brackets where necessary due precedence - 3', () => {
+          const { text } = reprint('FROM a | WHERE (1 + 2) * (3 - 4) / (5 + 6 + 7)');
+
+          expect(text).toBe('FROM a | WHERE (1 + 2) * (3 - 4) / (5 + 6 + 7)');
+        });
+
+        test('inserts brackets where necessary due precedence - 4', () => {
+          const { text } = reprint('FROM a | WHERE (1 + (1 + 2)) * ((3 - 4) / (5 + 6 + 7))');
+
+          expect(text).toBe('FROM a | WHERE (1 + 1 + 2) * (3 - 4) / (5 + 6 + 7)');
+        });
+
+        test('inserts brackets where necessary due precedence - 5', () => {
+          const { text } = reprint('FROM a | WHERE (1 + (1 + 2)) * (((3 - 4) / (5 + 6 + 7)) + 1)');
+
+          expect(text).toBe('FROM a | WHERE (1 + 1 + 2) * ((3 - 4) / (5 + 6 + 7) + 1)');
         });
       });
     });

--- a/packages/kbn-esql-ast/src/pretty_print/wrapping_pretty_printer.ts
+++ b/packages/kbn-esql-ast/src/pretty_print/wrapping_pretty_printer.ts
@@ -332,6 +332,7 @@ export class WrappingPrettyPrinter {
 
     .on('visitRenameExpression', (ctx, inp: Input): Output => {
       const operator = this.keyword('AS');
+
       return this.visitBinaryExpression(ctx, operator, inp);
     })
 


### PR DESCRIPTION
## Summary

Inserts brackets where necessary, if binary expressions have different precedence. For example:

```
FROM a | WHERE (1 + 2) * (3 - 4)
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
