### PR TITLE
[Security Solution] [Attack discovery] Fixes a flakey jest test

### DIFF
--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
@@ -63,24 +63,22 @@ describe('Countdown', () => {
     expect(screen.getByTestId('prefix')).toHaveTextContent(APPROXIMATE_TIME_REMAINING);
   });
 
-  for (let i = 0; i < 10_000; i++) {
-    it(`renders the expected the timer text - iteration ${i + 1}`, () => {
-      const approximateFutureTime = moment().add(1, 'minute').toDate();
+  it('renders the expected the timer text', () => {
+    const approximateFutureTime = moment().add(1, 'minute').toDate();
 
-      render(
-        <TestProviders>
-          <Countdown
-            approximateFutureTime={approximateFutureTime}
-            connectorIntervals={connectorIntervals}
-          />
-        </TestProviders>
-      );
+    render(
+      <TestProviders>
+        <Countdown
+          approximateFutureTime={approximateFutureTime}
+          connectorIntervals={connectorIntervals}
+        />
+      </TestProviders>
+    );
 
-      act(() => {
-        jest.advanceTimersByTime(1000);
-      });
-
-      expect(screen.getByTestId('timerText')).toHaveTextContent('00:59');
+    act(() => {
+      jest.advanceTimersByTime(1000);
     });
-  }
+
+    expect(screen.getByTestId('timerText')).toHaveTextContent('00:59');
+  });
 });

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
@@ -76,7 +76,7 @@ describe('Countdown', () => {
     );
 
     act(() => {
-      jest.runOnlyPendingTimers();
+      jest.advanceTimersByTime(1000);
     });
 
     expect(screen.getByTestId('timerText')).toHaveTextContent('00:59');

--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx
@@ -32,7 +32,7 @@ describe('Countdown', () => {
   ];
 
   beforeAll(() => {
-    jest.useFakeTimers({ legacyFakeTimers: true });
+    jest.useFakeTimers();
   });
 
   beforeEach(() => {
@@ -63,22 +63,24 @@ describe('Countdown', () => {
     expect(screen.getByTestId('prefix')).toHaveTextContent(APPROXIMATE_TIME_REMAINING);
   });
 
-  it('renders the expected the timer text', () => {
-    const approximateFutureTime = moment().add(1, 'minute').toDate();
+  for (let i = 0; i < 10_000; i++) {
+    it(`renders the expected the timer text - iteration ${i + 1}`, () => {
+      const approximateFutureTime = moment().add(1, 'minute').toDate();
 
-    render(
-      <TestProviders>
-        <Countdown
-          approximateFutureTime={approximateFutureTime}
-          connectorIntervals={connectorIntervals}
-        />
-      </TestProviders>
-    );
+      render(
+        <TestProviders>
+          <Countdown
+            approximateFutureTime={approximateFutureTime}
+            connectorIntervals={connectorIntervals}
+          />
+        </TestProviders>
+      );
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(screen.getByTestId('timerText')).toHaveTextContent('00:59');
     });
-
-    expect(screen.getByTestId('timerText')).toHaveTextContent('00:59');
-  });
+  }
 });


### PR DESCRIPTION
Fixes a flakey jest test that failed twice since it was introduced ~2 months ago in [this pr](https://github.com/elastic/kibana/pull/186679), as tracked by https://github.com/elastic/kibana/issues/189757

### CI and desk flake testing

To test the fix for fakyness, it ran `10,000` times in CI, and locally, with a `100%` success rate. (The test was wrapped in a loop to execute 10,000 times.)

- Tested in CI 10,000 times via following Buildkite build:

:green_heart: Build Succeeded
[Buildkite Build](https://buildkite.com/elastic/kibana-pull-request/builds/230901)

The 10,000 passing test runs are included in the following (abbreviated) build log output:

```
Ran all test suites.
$ node scripts/jest --config x-pack/plugins/security_solution/public/attack_discovery/jest.config.js
actual full command is:
NODE_OPTIONS="--max-old-space-size=12288 --trace-warnings" node ./scripts/jest --config="x-pack/plugins/security_solution/public/attack_discovery/jest.config.js" --runInBand --coverage=false --passWithNoTests
 PASS  x-pack/plugins/security_solution/public/attack_discovery/pages/loading_callout/countdown/index.test.tsx (742.054 s)
# other passing tests...

Test Suites: 54 passed, 54 total
Tests:       10297 passed, 10297 total
Snapshots:   0 total
Time:        962.106 s
```

- Tested locally 10,000 times, as illustrated by the following console output:

```
    ✓ renders the expected the timer text - iteration 9996 (43 ms)
    ✓ renders the expected the timer text - iteration 9997 (44 ms)
    ✓ renders the expected the timer text - iteration 9998 (48 ms)
    ✓ renders the expected the timer text - iteration 9999 (49 ms)
    ✓ renders the expected the timer text - iteration 10000 (46 ms)

Test Suites: 1 passed, 1 total
Tests:       10002 passed, 10002 total
Snapshots:   0 total
Time:        294.54 s
Ran all test suites matching /x-pack\/plugins\/security_solution\/public\/attack_discovery\/pages\/loading_callout\/countdown\/index.test.tsx/i.
```



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->