### PR TITLE
[Infra][Flaky Test Fix] Failing test: Single Host Flyout Tabs Metadata Tab should render metadata tab, add and remove filter

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/metadata/add_metadata_filter_button.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/metadata/add_metadata_filter_button.tsx
@@ -90,7 +90,7 @@ export const AddMetadataFilterButton = ({ item }: AddMetadataFilterButtonProps) 
   }
 
   return (
-    <span>
+    <span data-test-subj={`infraAssetDetailsMetadataField.${item.name}`}>
       <EuiToolTip
         content={i18n.translate('xpack.infra.metadataEmbeddable.setFilterByValueTooltip', {
           defaultMessage: 'Filter by value',

--- a/x-pack/test/functional/page_objects/asset_details.ts
+++ b/x-pack/test/functional/page_objects/asset_details.ts
@@ -180,7 +180,9 @@ export function AssetDetailsProvider({ getService }: FtrProviderContext) {
     },
 
     async clickAddMetadataFilter() {
-      return testSubjects.click('infraAssetDetailsMetadataAddFilterButton');
+      // Make this selector tied to the field to avoid flakiness
+      // https://github.com/elastic/kibana/issues/191565
+      return testSubjects.click('infraAssetDetailsMetadataField.host.name');
     },
 
     async clickRemoveMetadataFilter() {


### PR DESCRIPTION
Closes [#191565](https://github.com/elastic/kibana/issues/191565)

## Summary

This PR fixes a flaky test - I couldn't reproduce it locally (tried many times) but I saw in the build screenshot that a different field was added to the filters (`host.hostname` instead of `host.name`) so I made the selector stricter to make sure that it will always click on the correct button (using `host.name`)
