### PR TITLE
[8.15] [UII] Fix client-side validation for agent policy timeout fields (#191674)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_validation.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_validation.tsx
@@ -33,20 +33,20 @@ export const agentPolicyFormValidation = (
     errors.namespace = [namespaceValidation.error];
   }
 
-  if (agentPolicy.unenroll_timeout && agentPolicy.unenroll_timeout < 0) {
+  if (agentPolicy.unenroll_timeout !== undefined && agentPolicy.unenroll_timeout <= 0) {
     errors.unenroll_timeout = [
       <FormattedMessage
         id="xpack.fleet.agentPolicyForm.unenrollTimeoutMinValueErrorMessage"
-        defaultMessage="Unenroll timeout must be greater than zero."
+        defaultMessage="Unenroll timeout must be an integer greater than zero."
       />,
     ];
   }
 
-  if (agentPolicy.inactivity_timeout && agentPolicy.inactivity_timeout < 0) {
+  if (agentPolicy.inactivity_timeout !== undefined && agentPolicy.inactivity_timeout <= 0) {
     errors.inactivity_timeout = [
       <FormattedMessage
         id="xpack.fleet.agentPolicyForm.inactivityTimeoutMinValueErrorMessage"
-        defaultMessage="Inactivity timeout must be greater than zero."
+        defaultMessage="Inactivity timeout must be an integer greater than zero."
       />,
     ];
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[UII] Fix client-side validation for agent policy timeout fields (#191674)](https://github.com/elastic/kibana/pull/191674)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2024-08-28T21:05:11Z","message":"[UII] Fix client-side validation for agent policy timeout fields (#191674)\n\n## Summary\r\n\r\nResolves #191583. Adjusts the client-side validation for agent policy\r\ntimeout fields so that it correctly returns an error when non-numeric\r\ninput is encountered, or when input is 0.","sha":"f29bf1c3113de90fc0ca08bf7a59a33d53638940","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:prev-minor","v8.16.0"],"number":191674,"url":"https://github.com/elastic/kibana/pull/191674","mergeCommit":{"message":"[UII] Fix client-side validation for agent policy timeout fields (#191674)\n\n## Summary\r\n\r\nResolves #191583. Adjusts the client-side validation for agent policy\r\ntimeout fields so that it correctly returns an error when non-numeric\r\ninput is encountered, or when input is 0.","sha":"f29bf1c3113de90fc0ca08bf7a59a33d53638940"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/191674","number":191674,"mergeCommit":{"message":"[UII] Fix client-side validation for agent policy timeout fields (#191674)\n\n## Summary\r\n\r\nResolves #191583. Adjusts the client-side validation for agent policy\r\ntimeout fields so that it correctly returns an error when non-numeric\r\ninput is encountered, or when input is 0.","sha":"f29bf1c3113de90fc0ca08bf7a59a33d53638940"}}]}] BACKPORT-->