### PR TITLE
Improves Osquery API docs content

### DIFF
--- a/x-pack/plugins/osquery/common/api/live_query/live_queries.schema.yaml
+++ b/x-pack/plugins/osquery/common/api/live_query/live_queries.schema.yaml
@@ -5,7 +5,8 @@ info:
 paths:
   /api/osquery/live_queries:
     get:
-      summary: Find live queries
+      summary: Get live queries
+      description: Get a list of all live queries.
       operationId: OsqueryFindLiveQueries
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -25,6 +26,7 @@ paths:
 
     post:
       summary: Create a live query
+      description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -45,6 +47,7 @@ paths:
   /api/osquery/live_queries/{id}:
     get:
       summary: Get live query details
+      description: Get the details of a live query using the query ID.
       operationId: OsqueryGetLiveQueryDetails
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -70,6 +73,7 @@ paths:
   /api/osquery/live_queries/{id}/results/{actionId}:
     get:
       summary: Get live query results
+      description: Get the results of a live query using the query action ID.
       operationId: OsqueryGetLiveQueryResults
       x-codegen-enabled: true
       x-labels: [serverless, ess]

--- a/x-pack/plugins/osquery/common/api/packs/packs.schema.yaml
+++ b/x-pack/plugins/osquery/common/api/packs/packs.schema.yaml
@@ -5,7 +5,8 @@ info:
 paths:
   /api/osquery/packs:
     get:
-      summary: Find packs
+      summary: Get packs
+      description: Get a list of all query packs.
       operationId: OsqueryFindPacks
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -23,7 +24,8 @@ paths:
               schema:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
     post:
-      summary: Create a packs
+      summary: Create a pack
+      description: Create a query pack.
       operationId: OsqueryCreatePacks
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -42,7 +44,8 @@ paths:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
   /api/osquery/packs/{id}:
     get:
-      summary: Get packs details
+      summary: Get pack details
+      description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -60,7 +63,8 @@ paths:
               schema:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
     delete:
-      summary: Delete packs
+      summary: Delete a pack
+      description: Delete a query pack using the pack ID.
       operationId: OsqueryDeletePacks
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -78,7 +82,11 @@ paths:
               schema:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
     put:
-      summary: Update packs
+      summary: Update a pack
+      description: |
+        Update a query pack using the pack ID.
+        > info
+        > You cannot update a prebuilt pack.
       operationId: OsqueryUpdatePacks
       x-codegen-enabled: true
       x-labels: [serverless, ess]

--- a/x-pack/plugins/osquery/common/api/saved_query/saved_query.schema.yaml
+++ b/x-pack/plugins/osquery/common/api/saved_query/saved_query.schema.yaml
@@ -5,7 +5,8 @@ info:
 paths:
   /api/osquery/saved_queries:
     get:
-      summary: Find saved queries
+      summary: Get saved queries
+      description: Get a list of all saved queries.
       operationId: OsqueryFindSavedQueries
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -24,6 +25,7 @@ paths:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
     post:
       summary: Create a saved query
+      description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -43,6 +45,7 @@ paths:
   /api/osquery/saved_queries/{id}:
     get:
       summary: Get saved query details
+      description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -60,7 +63,8 @@ paths:
               schema:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
     delete:
-      summary: Delete saved query
+      summary: Delete a saved query
+      description: Delete a saved query using the query ID.
       operationId: OsqueryDeleteSavedQuery
       x-codegen-enabled: true
       x-labels: [serverless, ess]
@@ -78,7 +82,11 @@ paths:
               schema:
                 $ref: '../model/schema/common_attributes.schema.yaml#/components/schemas/DefaultSuccessResponse'
     put:
-      summary: Update saved query
+      summary: Update a saved query
+      description: |
+        Update a saved query using the query ID.
+        > info
+        > You cannot update a prebuilt saved query.
       operationId: OsqueryUpdateSavedQuery
       x-codegen-enabled: true
       x-labels: [serverless, ess]

--- a/x-pack/plugins/osquery/docs/openapi/ess/osquery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/osquery/docs/openapi/ess/osquery_api_2023_10_31.bundled.schema.yaml
@@ -13,6 +13,7 @@ servers:
 paths:
   /api/osquery/live_queries:
     get:
+      description: Get a list of all live queries.
       operationId: OsqueryFindLiveQueries
       parameters:
         - in: query
@@ -27,10 +28,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Find live queries
+      summary: Get live queries
       tags:
         - Security Solution Osquery API
     post:
+      description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
       requestBody:
         content:
@@ -50,6 +52,7 @@ paths:
         - Security Solution Osquery API
   '/api/osquery/live_queries/{id}':
     get:
+      description: Get the details of a live query using the query ID.
       operationId: OsqueryGetLiveQueryDetails
       parameters:
         - in: path
@@ -74,6 +77,7 @@ paths:
         - Security Solution Osquery API
   '/api/osquery/live_queries/{id}/results/{actionId}':
     get:
+      description: Get the results of a live query using the query action ID.
       operationId: OsqueryGetLiveQueryResults
       parameters:
         - in: path
@@ -103,6 +107,7 @@ paths:
         - Security Solution Osquery API
   /api/osquery/packs:
     get:
+      description: Get a list of all query packs.
       operationId: OsqueryFindPacks
       parameters:
         - in: query
@@ -117,10 +122,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Find packs
+      summary: Get packs
       tags:
         - Security Solution Osquery API
     post:
+      description: Create a query pack.
       operationId: OsqueryCreatePacks
       requestBody:
         content:
@@ -135,11 +141,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Create a packs
+      summary: Create a pack
       tags:
         - Security Solution Osquery API
   '/api/osquery/packs/{id}':
     delete:
+      description: Delete a query pack using the pack ID.
       operationId: OsqueryDeletePacks
       parameters:
         - in: path
@@ -154,10 +161,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Delete packs
+      summary: Delete a pack
       tags:
         - Security Solution Osquery API
     get:
+      description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
       parameters:
         - in: path
@@ -172,10 +180,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Get packs details
+      summary: Get pack details
       tags:
         - Security Solution Osquery API
     put:
+      description: |
+        Update a query pack using the pack ID.
+        > info
+        > You cannot update a prebuilt pack.
       operationId: OsqueryUpdatePacks
       parameters:
         - in: path
@@ -196,11 +208,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Update packs
+      summary: Update a pack
       tags:
         - Security Solution Osquery API
   /api/osquery/saved_queries:
     get:
+      description: Get a list of all saved queries.
       operationId: OsqueryFindSavedQueries
       parameters:
         - in: query
@@ -215,10 +228,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Find saved queries
+      summary: Get saved queries
       tags:
         - Security Solution Osquery API
     post:
+      description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
       requestBody:
         content:
@@ -238,6 +252,7 @@ paths:
         - Security Solution Osquery API
   '/api/osquery/saved_queries/{id}':
     delete:
+      description: Delete a saved query using the query ID.
       operationId: OsqueryDeleteSavedQuery
       parameters:
         - in: path
@@ -252,10 +267,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Delete saved query
+      summary: Delete a saved query
       tags:
         - Security Solution Osquery API
     get:
+      description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
       parameters:
         - in: path
@@ -274,6 +290,10 @@ paths:
       tags:
         - Security Solution Osquery API
     put:
+      description: |
+        Update a saved query using the query ID.
+        > info
+        > You cannot update a prebuilt saved query.
       operationId: OsqueryUpdateSavedQuery
       parameters:
         - in: path
@@ -294,7 +314,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Update saved query
+      summary: Update a saved query
       tags:
         - Security Solution Osquery API
 components:

--- a/x-pack/plugins/osquery/docs/openapi/serverless/osquery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/osquery/docs/openapi/serverless/osquery_api_2023_10_31.bundled.schema.yaml
@@ -13,6 +13,7 @@ servers:
 paths:
   /api/osquery/live_queries:
     get:
+      description: Get a list of all live queries.
       operationId: OsqueryFindLiveQueries
       parameters:
         - in: query
@@ -27,10 +28,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Find live queries
+      summary: Get live queries
       tags:
         - Security Solution Osquery API
     post:
+      description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
       requestBody:
         content:
@@ -50,6 +52,7 @@ paths:
         - Security Solution Osquery API
   '/api/osquery/live_queries/{id}':
     get:
+      description: Get the details of a live query using the query ID.
       operationId: OsqueryGetLiveQueryDetails
       parameters:
         - in: path
@@ -74,6 +77,7 @@ paths:
         - Security Solution Osquery API
   '/api/osquery/live_queries/{id}/results/{actionId}':
     get:
+      description: Get the results of a live query using the query action ID.
       operationId: OsqueryGetLiveQueryResults
       parameters:
         - in: path
@@ -103,6 +107,7 @@ paths:
         - Security Solution Osquery API
   /api/osquery/packs:
     get:
+      description: Get a list of all query packs.
       operationId: OsqueryFindPacks
       parameters:
         - in: query
@@ -117,10 +122,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Find packs
+      summary: Get packs
       tags:
         - Security Solution Osquery API
     post:
+      description: Create a query pack.
       operationId: OsqueryCreatePacks
       requestBody:
         content:
@@ -135,11 +141,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Create a packs
+      summary: Create a pack
       tags:
         - Security Solution Osquery API
   '/api/osquery/packs/{id}':
     delete:
+      description: Delete a query pack using the pack ID.
       operationId: OsqueryDeletePacks
       parameters:
         - in: path
@@ -154,10 +161,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Delete packs
+      summary: Delete a pack
       tags:
         - Security Solution Osquery API
     get:
+      description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
       parameters:
         - in: path
@@ -172,10 +180,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Get packs details
+      summary: Get pack details
       tags:
         - Security Solution Osquery API
     put:
+      description: |
+        Update a query pack using the pack ID.
+        > info
+        > You cannot update a prebuilt pack.
       operationId: OsqueryUpdatePacks
       parameters:
         - in: path
@@ -196,11 +208,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Update packs
+      summary: Update a pack
       tags:
         - Security Solution Osquery API
   /api/osquery/saved_queries:
     get:
+      description: Get a list of all saved queries.
       operationId: OsqueryFindSavedQueries
       parameters:
         - in: query
@@ -215,10 +228,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Find saved queries
+      summary: Get saved queries
       tags:
         - Security Solution Osquery API
     post:
+      description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
       requestBody:
         content:
@@ -238,6 +252,7 @@ paths:
         - Security Solution Osquery API
   '/api/osquery/saved_queries/{id}':
     delete:
+      description: Delete a saved query using the query ID.
       operationId: OsqueryDeleteSavedQuery
       parameters:
         - in: path
@@ -252,10 +267,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Delete saved query
+      summary: Delete a saved query
       tags:
         - Security Solution Osquery API
     get:
+      description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
       parameters:
         - in: path
@@ -274,6 +290,10 @@ paths:
       tags:
         - Security Solution Osquery API
     put:
+      description: |
+        Update a saved query using the query ID.
+        > info
+        > You cannot update a prebuilt saved query.
       operationId: OsqueryUpdateSavedQuery
       parameters:
         - in: path
@@ -294,7 +314,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/DefaultSuccessResponse'
           description: OK
-      summary: Update saved query
+      summary: Update a saved query
       tags:
         - Security Solution Osquery API
 components:

--- a/x-pack/test/api_integration/services/security_solution_osquery_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_osquery_api.gen.ts
@@ -93,6 +93,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Create and run a live query.
+     */
     osqueryCreateLiveQuery(props: OsqueryCreateLiveQueryProps) {
       return supertest
         .post('/api/osquery/live_queries')
@@ -101,6 +104,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
+    /**
+     * Create a query pack.
+     */
     osqueryCreatePacks(props: OsqueryCreatePacksProps) {
       return supertest
         .post('/api/osquery/packs')
@@ -109,6 +115,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
+    /**
+     * Create and run a saved query.
+     */
     osqueryCreateSavedQuery(props: OsqueryCreateSavedQueryProps) {
       return supertest
         .post('/api/osquery/saved_queries')
@@ -117,6 +126,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
+    /**
+     * Delete a query pack using the pack ID.
+     */
     osqueryDeletePacks(props: OsqueryDeletePacksProps) {
       return supertest
         .delete(replaceParams('/api/osquery/packs/{id}', props.params))
@@ -124,6 +136,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
+    /**
+     * Delete a saved query using the query ID.
+     */
     osqueryDeleteSavedQuery(props: OsqueryDeleteSavedQueryProps) {
       return supertest
         .delete(replaceParams('/api/osquery/saved_queries/{id}', props.params))
@@ -131,6 +146,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
+    /**
+     * Get a list of all live queries.
+     */
     osqueryFindLiveQueries(props: OsqueryFindLiveQueriesProps) {
       return supertest
         .get('/api/osquery/live_queries')
@@ -139,6 +157,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get a list of all query packs.
+     */
     osqueryFindPacks(props: OsqueryFindPacksProps) {
       return supertest
         .get('/api/osquery/packs')
@@ -147,6 +168,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get a list of all saved queries.
+     */
     osqueryFindSavedQueries(props: OsqueryFindSavedQueriesProps) {
       return supertest
         .get('/api/osquery/saved_queries')
@@ -155,6 +179,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get the details of a live query using the query ID.
+     */
     osqueryGetLiveQueryDetails(props: OsqueryGetLiveQueryDetailsProps) {
       return supertest
         .get(replaceParams('/api/osquery/live_queries/{id}', props.params))
@@ -163,6 +190,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get the results of a live query using the query action ID.
+     */
     osqueryGetLiveQueryResults(props: OsqueryGetLiveQueryResultsProps) {
       return supertest
         .get(replaceParams('/api/osquery/live_queries/{id}/results/{actionId}', props.params))
@@ -171,6 +201,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get the details of a query pack using the pack ID.
+     */
     osqueryGetPacksDetails(props: OsqueryGetPacksDetailsProps) {
       return supertest
         .get(replaceParams('/api/osquery/packs/{id}', props.params))
@@ -178,6 +211,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
+    /**
+     * Get the details of a saved query using the query ID.
+     */
     osqueryGetSavedQueryDetails(props: OsqueryGetSavedQueryDetailsProps) {
       return supertest
         .get(replaceParams('/api/osquery/saved_queries/{id}', props.params))
@@ -185,6 +221,12 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
+    /**
+      * Update a query pack using the pack ID.
+> info
+> You cannot update a prebuilt pack.
+
+      */
     osqueryUpdatePacks(props: OsqueryUpdatePacksProps) {
       return supertest
         .put(replaceParams('/api/osquery/packs/{id}', props.params))
@@ -193,6 +235,12 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
+    /**
+      * Update a saved query using the query ID.
+> info
+> You cannot update a prebuilt saved query.
+
+      */
     osqueryUpdateSavedQuery(props: OsqueryUpdateSavedQueryProps) {
       return supertest
         .put(replaceParams('/api/osquery/saved_queries/{id}', props.params))


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/security-docs-internal/issues/38 by improving the Osquery API docs content. Adds missing and improves existing operation summaries and operation descriptions to adhere to our [OAS standards](https://elasticco.atlassian.net/wiki/spaces/DOC/pages/450494532/API+reference+docs).

