### PR TITLE
[8.15] fix issue with viewing watcher execution history (#188654)

### DIFF
--- a/x-pack/plugins/watcher/public/application/sections/watch_status_page/components/execution_history_panel.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_status_page/components/execution_history_panel.tsx
@@ -314,7 +314,7 @@ export const ExecutionHistoryPanel = () => {
                 <FormattedMessage
                   id="xpack.watcher.sections.watchHistory.watchHistoryDetail.title"
                   defaultMessage="Executed on {date}"
-                  values={{ date: watchHistoryDetails.startTime }}
+                  values={{ date: watchHistoryDetails.startTime?.format() }}
                 />
               </h3>
             </EuiTitle>


### PR DESCRIPTION
This is a backport of this PR  #188654 to `8.15`