### PR TITLE
[DOCS][ResponseOps][Connectors] Add support of additional fields for ServiceNow ITSM and SecOps

### DIFF
--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_pushtoservice.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_pushtoservice.yaml
@@ -30,6 +30,13 @@ properties:
         type: object
         description: Information necessary to create or update a Jira, ServiceNow ITSM, ServiveNow SecOps, Swimlane, or TheHive incident.
         properties:
+          additional_fields:
+            type: string
+            nullable: true
+            maxLength: 20
+            description: >
+              Additional fields for ServiceNow ITSM and ServiveNow SecOps connectors.
+              The fields must exist in the Elastic ServiceNow application and must be specified in JSON format.
           alertId:
             type: string
             description: The alert identifier for Swimlane connectors.


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/171320

This PR adds the `additional_fields` property to the run connector API for ServiceNow connectors. 

### Preview

![image](https://github.com/user-attachments/assets/dbb5cc49-ea38-4a57-819e-8358b6f44c35)


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->