### PR TITLE
[Move `@kbn/config-schema` to server] `maps_ems`

### DIFF
--- a/src/plugins/maps_ems/public/index.ts
+++ b/src/plugins/maps_ems/public/index.ts
@@ -9,14 +9,14 @@
 import type { PluginInitializerContext } from '@kbn/core/public';
 import type { EMSClient } from '@elastic/ems-client';
 import { MapsEmsPlugin } from './plugin';
-import type { MapConfig } from '../config';
+import type { MapConfig } from '../server/config';
 import type { EMSSettings } from '../common';
 
 export function plugin(initializerContext: PluginInitializerContext) {
   return new MapsEmsPlugin(initializerContext);
 }
 
-export type { MapConfig, TileMapConfig } from '../config';
+export type { MapConfig, TileMapConfig } from '../server/config';
 export type { EMSConfig } from '../common';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/plugins/maps_ems/public/kibana_services.ts
+++ b/src/plugins/maps_ems/public/kibana_services.ts
@@ -8,7 +8,7 @@
 
 import { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import { ILicense } from '@kbn/licensing-plugin/common/types';
-import type { MapConfig } from '../config';
+import type { MapConfig } from '../server/config';
 import { LICENSE_CHECK_ID } from '../common';
 
 let kibanaVersion: string;

--- a/src/plugins/maps_ems/public/plugin.ts
+++ b/src/plugins/maps_ems/public/plugin.ts
@@ -15,7 +15,7 @@ import {
   getIsEnterprisePlus,
 } from './kibana_services';
 import type { MapsEmsPluginPublicSetup, MapsEmsPluginPublicStart } from '.';
-import type { MapConfig } from '../config';
+import type { MapConfig } from '../server/config';
 import { createEMSSettings } from '../common/ems_settings';
 import { createEMSClientLazy } from './lazy_load_bundle';
 

--- a/src/plugins/maps_ems/server/config.ts
+++ b/src/plugins/maps_ems/server/config.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_EMS_ROADMAP_ID,
   DEFAULT_EMS_ROADMAP_DESATURATED_ID,
   DEFAULT_EMS_DARKMAP_ID,
-} from './common';
+} from '../common';
 
 const tileMapConfigOptionsSchema = schema.object({
   attribution: schema.string({ defaultValue: '' }),

--- a/src/plugins/maps_ems/server/index.ts
+++ b/src/plugins/maps_ems/server/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { PluginInitializerContext, PluginConfigDescriptor } from '@kbn/core/server';
-import { MapConfig, mapConfigSchema } from '../config';
+import { MapConfig, mapConfigSchema } from './config';
 export type { EMSSettings } from '../common';
 export type { MapsEmsPluginServerSetup } from './plugin';
 

--- a/src/plugins/maps_ems/server/plugin.ts
+++ b/src/plugins/maps_ems/server/plugin.ts
@@ -9,7 +9,7 @@
 import { ILicense, LicensingPluginSetup } from '@kbn/licensing-plugin/server';
 import { Plugin, PluginInitializerContext } from '@kbn/core-plugins-server';
 import { CoreSetup } from '@kbn/core-lifecycle-server';
-import { MapConfig } from '../config';
+import { MapConfig } from './config';
 import { LICENSE_CHECK_ID, EMSSettings } from '../common';
 
 export interface MapsEmsPluginServerSetup {

--- a/src/plugins/maps_ems/tsconfig.json
+++ b/src/plugins/maps_ems/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types",
   },
-  "include": ["common/**/*", "public/**/*", "server/**/*", "./config.ts"],
+  "include": ["common/**/*", "public/**/*", "server/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/licensing-plugin",


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/189476.

We want to avoid `@kbn/config-schema` from leaking to the browser, and this plugin is using it outside the `./server` directory.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
