### PR TITLE
[ES|QL] Add a helper to retrieve the metadata columns

### DIFF
--- a/packages/kbn-esql-utils/README.md
+++ b/packages/kbn-esql-utils/README.md
@@ -8,4 +8,4 @@ This package contains utilities for ES|QL.
 - *removeDropCommandsFromESQLQuery*: Use this function to remove all the occurences of the `drop` command from the query.
 - *appendToESQLQuery*: Use this function to append more pipes in an existing ES|QL query. It adds the additional commands in a new line. 
 - *appendWhereClauseToESQLQuery*: Use this function to append where clause in an existing query. 
-
+- *retieveMetadataColumns*: Use this function to get if there is a metadata option in the from command, and retrieve the columns if so

--- a/packages/kbn-esql-utils/index.ts
+++ b/packages/kbn-esql-utils/index.ts
@@ -24,6 +24,7 @@ export {
   getTimeFieldFromESQLQuery,
   getStartEndParams,
   hasStartEndParams,
+  retieveMetadataColumns,
   TextBasedLanguages,
 } from './src';
 

--- a/packages/kbn-esql-utils/src/index.ts
+++ b/packages/kbn-esql-utils/src/index.ts
@@ -16,6 +16,7 @@ export {
   removeDropCommandsFromESQLQuery,
   hasTransformationalCommand,
   getTimeFieldFromESQLQuery,
+  retieveMetadataColumns,
 } from './utils/query_parsing_helpers';
 export { appendToESQLQuery, appendWhereClauseToESQLQuery } from './utils/append_to_query';
 export {

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -12,6 +12,7 @@ import {
   removeDropCommandsFromESQLQuery,
   hasTransformationalCommand,
   getTimeFieldFromESQLQuery,
+  retieveMetadataColumns,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -173,6 +174,19 @@ describe('esql query helpers', () => {
           'from a | stats meow = avg(bytes) by bucket(event.timefield, 200, ?t_start, ?t_end)'
         )
       ).toBe('event.timefield');
+    });
+  });
+
+  describe('retieveMetadataColumns', () => {
+    it('should return metadata columns if they exist', () => {
+      expect(retieveMetadataColumns('from a  metadata _id, _ignored | eval b = 1')).toStrictEqual([
+        '_id',
+        '_ignored',
+      ]);
+    });
+
+    it('should return empty columns if metadata doesnt exist', () => {
+      expect(retieveMetadataColumns('from a | eval b = 1')).toStrictEqual([]);
     });
   });
 });

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -5,7 +5,13 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type { ESQLSource, ESQLFunction, ESQLColumn, ESQLSingleAstItem } from '@kbn/esql-ast';
+import type {
+  ESQLSource,
+  ESQLFunction,
+  ESQLColumn,
+  ESQLSingleAstItem,
+  ESQLCommandOption,
+} from '@kbn/esql-ast';
 import { getAstAndSyntaxErrors, Walker, walk } from '@kbn/esql-ast';
 
 const DEFAULT_ESQL_LIMIT = 1000;
@@ -104,4 +110,15 @@ export const getTimeFieldFromESQLQuery = (esql: string) => {
   }) as ESQLColumn;
 
   return column?.name;
+};
+
+export const retieveMetadataColumns = (esql: string): string[] => {
+  const { ast } = getAstAndSyntaxErrors(esql);
+  const options: ESQLCommandOption[] = [];
+
+  walk(ast, {
+    visitCommandOption: (node) => options.push(node),
+  });
+  const metadataOptions = options.find(({ name }) => name === 'metadata');
+  return metadataOptions?.args.map((column) => (column as ESQLColumn).name) ?? [];
 };


### PR DESCRIPTION
## Summary

Create a helper to retrieve the metadata columns (will come in handy for one discover project)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios