### PR TITLE
[Move `@kbn/config-schema` to server] `content_management`

### DIFF
--- a/src/plugins/content_management/common/rpc/bulk_get.ts
+++ b/src/plugins/content_management/common/rpc/bulk_get.ts
@@ -5,31 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { versionSchema } from './constants';
-import { GetResult, getResultSchema } from './get';
-
-import type { ProcedureSchemas } from './types';
-
-export const bulkGetSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypeId: schema.string(),
-      version: versionSchema,
-      ids: schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1 }),
-      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: schema.object(
-    {
-      hits: schema.arrayOf(getResultSchema),
-      meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-};
+import { GetResult } from './get';
 
 export interface BulkGetIn<T extends string = string, Options extends void | object = object> {
   contentTypeId: T;

--- a/src/plugins/content_management/common/rpc/constants.ts
+++ b/src/plugins/content_management/common/rpc/constants.ts
@@ -5,9 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
-import { validateVersion } from '@kbn/object-versioning-utils';
-
 export const procedureNames = [
   'get',
   'bulkGet',
@@ -19,12 +16,3 @@ export const procedureNames = [
 ] as const;
 
 export type ProcedureName = (typeof procedureNames)[number];
-
-export const versionSchema = schema.number({
-  validate: (value) => {
-    const { result } = validateVersion(value);
-    if (!result) {
-      return 'must be an integer';
-    }
-  },
-});

--- a/src/plugins/content_management/common/rpc/create.ts
+++ b/src/plugins/content_management/common/rpc/create.ts
@@ -5,32 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { itemResultSchema } from './common';
-import { versionSchema } from './constants';
-
-import type { ItemResult, ProcedureSchemas } from './types';
-
-export const createSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypeId: schema.string(),
-      version: versionSchema,
-      // --> "data" to create a content will be defined by each content type
-      data: schema.recordOf(schema.string(), schema.any()),
-      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: schema.object(
-    {
-      contentTypeId: schema.string(),
-      result: itemResultSchema,
-    },
-    { unknowns: 'forbid' }
-  ),
-};
+import type { ItemResult } from './types';
 
 export interface CreateIn<
   T extends string = string,

--- a/src/plugins/content_management/common/rpc/delete.ts
+++ b/src/plugins/content_management/common/rpc/delete.ts
@@ -5,35 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { versionSchema } from './constants';
-
-import type { ProcedureSchemas } from './types';
-
-export const deleteSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypeId: schema.string(),
-      id: schema.string({ minLength: 1 }),
-      version: versionSchema,
-      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: schema.object(
-    {
-      contentTypeId: schema.string(),
-      result: schema.object(
-        {
-          success: schema.boolean(),
-        },
-        { unknowns: 'forbid' }
-      ),
-    },
-    { unknowns: 'forbid' }
-  ),
-};
 
 export interface DeleteIn<T extends string = string, Options extends void | object = object> {
   contentTypeId: T;

--- a/src/plugins/content_management/common/rpc/get.ts
+++ b/src/plugins/content_management/common/rpc/get.ts
@@ -5,33 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { itemResultSchema } from './common';
-import { versionSchema } from './constants';
-
-import type { ItemResult, ProcedureSchemas } from './types';
-
-export const getResultSchema = schema.object(
-  {
-    contentTypeId: schema.string(),
-    result: itemResultSchema,
-  },
-  { unknowns: 'forbid' }
-);
-
-export const getSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypeId: schema.string(),
-      id: schema.string({ minLength: 1 }),
-      version: versionSchema,
-      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: getResultSchema,
-};
+import type { ItemResult } from './types';
 
 export interface GetIn<T extends string = string, Options extends void | object = object> {
   id: string;

--- a/src/plugins/content_management/common/rpc/index.ts
+++ b/src/plugins/content_management/common/rpc/index.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-export { schemas } from './rpc';
 export { procedureNames } from './constants';
 
 export type { GetIn, GetResult } from './get';

--- a/src/plugins/content_management/common/rpc/msearch.ts
+++ b/src/plugins/content_management/common/rpc/msearch.ts
@@ -5,36 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { versionSchema } from './constants';
-import { searchQuerySchema, searchResultSchema, SearchQuery, SearchResult } from './search';
-
-import type { ProcedureSchemas } from './types';
-
-export const mSearchSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypes: schema.arrayOf(
-        schema.object({ contentTypeId: schema.string(), version: versionSchema }),
-        {
-          minSize: 1,
-        }
-      ),
-      query: searchQuerySchema,
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: schema.object(
-    {
-      contentTypes: schema.arrayOf(
-        schema.object({ contentTypeId: schema.string(), version: versionSchema })
-      ),
-      result: searchResultSchema,
-    },
-    { unknowns: 'forbid' }
-  ),
-};
+import { SearchQuery, SearchResult } from './search';
 
 export type MSearchQuery = SearchQuery;
 

--- a/src/plugins/content_management/common/rpc/search.ts
+++ b/src/plugins/content_management/common/rpc/search.ts
@@ -5,58 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { versionSchema } from './constants';
-
-import type { ProcedureSchemas } from './types';
-
-export const searchQuerySchema = schema.oneOf([
-  schema.object(
-    {
-      text: schema.maybe(schema.string()),
-      tags: schema.maybe(
-        schema.object({
-          included: schema.maybe(schema.arrayOf(schema.string())),
-          excluded: schema.maybe(schema.arrayOf(schema.string())),
-        })
-      ),
-      limit: schema.maybe(schema.number()),
-      cursor: schema.maybe(schema.string()),
-    },
-    {
-      unknowns: 'forbid',
-    }
-  ),
-]);
-
-export const searchResultSchema = schema.object({
-  hits: schema.arrayOf(schema.any()),
-  pagination: schema.object({
-    total: schema.number(),
-    cursor: schema.maybe(schema.string()),
-  }),
-});
-
-export const searchSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypeId: schema.string(),
-      version: versionSchema,
-      query: searchQuerySchema,
-      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: schema.object(
-    {
-      contentTypeId: schema.string(),
-      result: searchResultSchema,
-      meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-};
 
 export interface SearchQuery {
   /** The text to search for */

--- a/src/plugins/content_management/common/rpc/update.ts
+++ b/src/plugins/content_management/common/rpc/update.ts
@@ -5,33 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { schema } from '@kbn/config-schema';
 import type { Version } from '@kbn/object-versioning';
-import { itemResultSchema } from './common';
-import { versionSchema } from './constants';
-
-import type { ItemResult, ProcedureSchemas } from './types';
-
-export const updateSchemas: ProcedureSchemas = {
-  in: schema.object(
-    {
-      contentTypeId: schema.string(),
-      id: schema.string({ minLength: 1 }),
-      version: versionSchema,
-      // --> "data" to update a content will be defined by each content type
-      data: schema.recordOf(schema.string(), schema.any()),
-      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
-    },
-    { unknowns: 'forbid' }
-  ),
-  out: schema.object(
-    {
-      contentTypeId: schema.string(),
-      result: itemResultSchema,
-    },
-    { unknowns: 'forbid' }
-  ),
-};
+import type { ItemResult } from './types';
 
 export interface UpdateIn<
   T extends string = string,

--- a/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/bulk_get.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { BulkGetIn } from '../../../common';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';

--- a/src/plugins/content_management/server/rpc/procedures/create.ts
+++ b/src/plugins/content_management/server/rpc/procedures/create.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { CreateIn } from '../../../common';
 import { getContentClientFactory } from '../../content_client';
 import type { ProcedureDefinition } from '../rpc_service';

--- a/src/plugins/content_management/server/rpc/procedures/delete.ts
+++ b/src/plugins/content_management/server/rpc/procedures/delete.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { DeleteIn } from '../../../common';
 import { getContentClientFactory } from '../../content_client';
 import type { ProcedureDefinition } from '../rpc_service';

--- a/src/plugins/content_management/server/rpc/procedures/get.ts
+++ b/src/plugins/content_management/server/rpc/procedures/get.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { GetIn } from '../../../common';
 import { getContentClientFactory } from '../../content_client';
 import type { ProcedureDefinition } from '../rpc_service';

--- a/src/plugins/content_management/server/rpc/procedures/msearch.ts
+++ b/src/plugins/content_management/server/rpc/procedures/msearch.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { MSearchIn, MSearchOut } from '../../../common';
 import type { ProcedureDefinition } from '../rpc_service';
 import type { Context } from '../types';

--- a/src/plugins/content_management/server/rpc/procedures/search.ts
+++ b/src/plugins/content_management/server/rpc/procedures/search.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { SearchIn } from '../../../common';
 import { getContentClientFactory } from '../../content_client';
 import type { ProcedureDefinition } from '../rpc_service';

--- a/src/plugins/content_management/server/rpc/procedures/update.ts
+++ b/src/plugins/content_management/server/rpc/procedures/update.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { rpcSchemas } from '../../../common/schemas';
+import { rpcSchemas } from '../schemas';
 import type { UpdateIn } from '../../../common';
 import { getContentClientFactory } from '../../content_client';
 import type { ProcedureDefinition } from '../rpc_service';

--- a/src/plugins/content_management/server/rpc/schemas/bulk_get.ts
+++ b/src/plugins/content_management/server/rpc/schemas/bulk_get.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { getResultSchema } from './get';
+import { versionSchema } from './common';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const bulkGetSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypeId: schema.string(),
+      version: versionSchema,
+      ids: schema.arrayOf(schema.string({ minLength: 1 }), { minSize: 1 }),
+      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: schema.object(
+    {
+      hits: schema.arrayOf(getResultSchema),
+      meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+};

--- a/src/plugins/content_management/server/rpc/schemas/common.ts
+++ b/src/plugins/content_management/server/rpc/schemas/common.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 import { schema } from '@kbn/config-schema';
+import { validateVersion } from '@kbn/object-versioning-utils';
 
 export const itemResultSchema = schema.object(
   {
@@ -14,3 +15,12 @@ export const itemResultSchema = schema.object(
   },
   { unknowns: 'forbid' }
 );
+
+export const versionSchema = schema.number({
+  validate: (value) => {
+    const { result } = validateVersion(value);
+    if (!result) {
+      return 'must be an integer';
+    }
+  },
+});

--- a/src/plugins/content_management/server/rpc/schemas/create.ts
+++ b/src/plugins/content_management/server/rpc/schemas/create.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { itemResultSchema, versionSchema } from './common';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const createSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypeId: schema.string(),
+      version: versionSchema,
+      // --> "data" to create a content will be defined by each content type
+      data: schema.recordOf(schema.string(), schema.any()),
+      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: schema.object(
+    {
+      contentTypeId: schema.string(),
+      result: itemResultSchema,
+    },
+    { unknowns: 'forbid' }
+  ),
+};

--- a/src/plugins/content_management/server/rpc/schemas/delete.ts
+++ b/src/plugins/content_management/server/rpc/schemas/delete.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { versionSchema } from './common';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const deleteSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypeId: schema.string(),
+      id: schema.string({ minLength: 1 }),
+      version: versionSchema,
+      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: schema.object(
+    {
+      contentTypeId: schema.string(),
+      result: schema.object(
+        {
+          success: schema.boolean(),
+        },
+        { unknowns: 'forbid' }
+      ),
+    },
+    { unknowns: 'forbid' }
+  ),
+};

--- a/src/plugins/content_management/server/rpc/schemas/get.ts
+++ b/src/plugins/content_management/server/rpc/schemas/get.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { itemResultSchema, versionSchema } from './common';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const getResultSchema = schema.object(
+  {
+    contentTypeId: schema.string(),
+    result: itemResultSchema,
+  },
+  { unknowns: 'forbid' }
+);
+
+export const getSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypeId: schema.string(),
+      id: schema.string({ minLength: 1 }),
+      version: versionSchema,
+      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: getResultSchema,
+};

--- a/src/plugins/content_management/server/rpc/schemas/index.ts
+++ b/src/plugins/content_management/server/rpc/schemas/index.ts
@@ -6,6 +6,4 @@
  * Side Public License, v 1.
  */
 
-// exporting schemas separately from the index.ts file to not include @kbn/schema in the public bundle
-// should be only used server-side or in jest tests
 export { schemas as rpcSchemas } from './rpc';

--- a/src/plugins/content_management/server/rpc/schemas/msearch.ts
+++ b/src/plugins/content_management/server/rpc/schemas/msearch.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { versionSchema } from './common';
+import { searchQuerySchema, searchResultSchema } from './search';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const mSearchSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypes: schema.arrayOf(
+        schema.object({ contentTypeId: schema.string(), version: versionSchema }),
+        {
+          minSize: 1,
+        }
+      ),
+      query: searchQuerySchema,
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: schema.object(
+    {
+      contentTypes: schema.arrayOf(
+        schema.object({ contentTypeId: schema.string(), version: versionSchema })
+      ),
+      result: searchResultSchema,
+    },
+    { unknowns: 'forbid' }
+  ),
+};

--- a/src/plugins/content_management/server/rpc/schemas/rpc.ts
+++ b/src/plugins/content_management/server/rpc/schemas/rpc.ts
@@ -6,8 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { ProcedureName } from './constants';
-import type { ProcedureSchemas } from './types';
+import type { ProcedureName, ProcedureSchemas } from '../../../common';
 import { getSchemas } from './get';
 import { bulkGetSchemas } from './bulk_get';
 import { createSchemas } from './create';

--- a/src/plugins/content_management/server/rpc/schemas/search.ts
+++ b/src/plugins/content_management/server/rpc/schemas/search.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { versionSchema } from './common';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const searchQuerySchema = schema.oneOf([
+  schema.object(
+    {
+      text: schema.maybe(schema.string()),
+      tags: schema.maybe(
+        schema.object({
+          included: schema.maybe(schema.arrayOf(schema.string())),
+          excluded: schema.maybe(schema.arrayOf(schema.string())),
+        })
+      ),
+      limit: schema.maybe(schema.number()),
+      cursor: schema.maybe(schema.string()),
+    },
+    {
+      unknowns: 'forbid',
+    }
+  ),
+]);
+
+export const searchResultSchema = schema.object({
+  hits: schema.arrayOf(schema.any()),
+  pagination: schema.object({
+    total: schema.number(),
+    cursor: schema.maybe(schema.string()),
+  }),
+});
+
+export const searchSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypeId: schema.string(),
+      version: versionSchema,
+      query: searchQuerySchema,
+      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: schema.object(
+    {
+      contentTypeId: schema.string(),
+      result: searchResultSchema,
+      meta: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+};

--- a/src/plugins/content_management/server/rpc/schemas/update.ts
+++ b/src/plugins/content_management/server/rpc/schemas/update.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { schema } from '@kbn/config-schema';
+import { itemResultSchema, versionSchema } from './common';
+
+import type { ProcedureSchemas } from '../../../common';
+
+export const updateSchemas: ProcedureSchemas = {
+  in: schema.object(
+    {
+      contentTypeId: schema.string(),
+      id: schema.string({ minLength: 1 }),
+      version: versionSchema,
+      // --> "data" to update a content will be defined by each content type
+      data: schema.recordOf(schema.string(), schema.any()),
+      options: schema.maybe(schema.object({}, { unknowns: 'allow' })),
+    },
+    { unknowns: 'forbid' }
+  ),
+  out: schema.object(
+    {
+      contentTypeId: schema.string(),
+      result: itemResultSchema,
+    },
+    { unknowns: 'forbid' }
+  ),
+};


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/189476.

We want to avoid `@kbn/config-schema` from leaking to the browser, and this plugin is using it outside of `./server`.

This PR moves all the files depending on `@kbn/config-schema`'s runtime inside `./server`.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
