### PR TITLE
[Dataset quality] 🐞 defaulting all known types for nonAggregatable dataset when no type is selected in the UI

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/services/data_streams_stats/data_streams_stats_client.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/services/data_streams_stats/data_streams_stats_client.ts
@@ -85,11 +85,12 @@ export class DataStreamsStatsClient implements IDataStreamsStatsClient {
   }
 
   public async getNonAggregatableDatasets(params: GetNonAggregatableDataStreamsParams) {
+    const types = params.types.length === 0 ? KNOWN_TYPES : params.types;
     const response = await this.http
       .get<NonAggregatableDatasets>('/internal/dataset_quality/data_streams/non_aggregatable', {
         query: {
           ...params,
-          types: rison.encodeArray(params.types),
+          types: rison.encodeArray(types),
         },
       })
       .catch((error) => {


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/190043 we enabled `GET /internal/dataset_quality/data_streams/stats` and `GET /internal/dataset_quality/data_streams/non_aggregatable` for work with multiple dataStream types, but we left out the case where in the UI no type is selected.

The solution is the same we applied to [`GET /internal/dataset_quality/data_streams/stats`](https://github.com/yngrdyn/kibana/blob/b1f9e290213368e550ab692124a419683409c937/x-pack/plugins/observability_solution/dataset_quality/public/services/data_streams_stats/data_streams_stats_client.ts#L38), when no type is selected in the UI we should send all known types.

### Before

https://github.com/user-attachments/assets/da83c3c2-6d6d-4401-bd12-99d6ab1da7ea

### After

https://github.com/user-attachments/assets/cf17594f-d4a9-4d83-8a9a-6252e102b475
