### PR TITLE
Fixes serverless feature flag org member navigation cards test

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
@@ -54,13 +54,16 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         expect(url).to.contain('/management/security/roles');
       });
 
-      it('displays the Organization members management card, and will navigate to the cloud organization URL', async () => {
-        await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();
-        await pageObjects.svlManagementPage.clickOrgMembersManagementCard();
+      describe('Organization members', function () {
+        this.tags('skipSvlOblt'); // Observability will not support custom roles
+        it('displays the Organization members management card, and will navigate to the cloud organization URL', async () => {
+          await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();
+          await pageObjects.svlManagementPage.clickOrgMembersManagementCard();
 
-        const url = await browser.getCurrentUrl();
-        // `--xpack.cloud.organization_url: '/account/members'`,
-        expect(url).to.contain('/account/members');
+          const url = await browser.getCurrentUrl();
+          // `--xpack.cloud.organization_url: '/account/members'`,
+          expect(url).to.contain('/account/members');
+        });
       });
 
       it('displays the spaces management card, and will navigate to the spaces management UI', async () => {
@@ -97,14 +100,17 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.svlManagementPage.assertRoleManagementCardDoesNotExist();
       });
 
-      it('displays the organization members management card, and will navigate to the cloud organization URL', async () => {
-        // The org members nav card is always visible because there is no way to check if a user has approprite privileges
-        await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();
-        await pageObjects.svlManagementPage.clickOrgMembersManagementCard();
+      describe('Organization members', function () {
+        this.tags('skipSvlOblt'); // Observability will not support custom roles
+        it('displays the organization members management card, and will navigate to the cloud organization URL', async () => {
+          // The org members nav card is always visible because there is no way to check if a user has approprite privileges
+          await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();
+          await pageObjects.svlManagementPage.clickOrgMembersManagementCard();
 
-        const url = await browser.getCurrentUrl();
-        // `--xpack.cloud.organization_url: '/account/members'`,
-        expect(url).to.contain('/account/members');
+          const url = await browser.getCurrentUrl();
+          // `--xpack.cloud.organization_url: '/account/members'`,
+          expect(url).to.contain('/account/members');
+        });
       });
 
       it('should not display the spaces management card', async () => {

--- a/x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts
@@ -10,9 +10,9 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless observability UI - feature flags', function () {
     // add tests that require feature flags, defined in config.feature_flags.ts
-    loadTestFile(require.resolve('./infra'));
+    // loadTestFile(require.resolve('./infra'));
     loadTestFile(require.resolve('../common/platform_security/navigation/management_nav_cards.ts'));
-    loadTestFile(require.resolve('../common/platform_security/roles.ts'));
-    loadTestFile(require.resolve('../common/spaces/spaces_selection_enabled.ts'));
+    // loadTestFile(require.resolve('../common/platform_security/roles.ts'));
+    // loadTestFile(require.resolve('../common/spaces/spaces_selection_enabled.ts'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts
@@ -10,9 +10,9 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless observability UI - feature flags', function () {
     // add tests that require feature flags, defined in config.feature_flags.ts
-    // loadTestFile(require.resolve('./infra'));
+    loadTestFile(require.resolve('./infra'));
     loadTestFile(require.resolve('../common/platform_security/navigation/management_nav_cards.ts'));
-    // loadTestFile(require.resolve('../common/platform_security/roles.ts'));
-    // loadTestFile(require.resolve('../common/spaces/spaces_selection_enabled.ts'));
+    loadTestFile(require.resolve('../common/platform_security/roles.ts'));
+    loadTestFile(require.resolve('../common/spaces/spaces_selection_enabled.ts'));
   });
 }


### PR DESCRIPTION
Closes #191856

## Summary

Skips serverlesss observability project for the org members nav card. This is a custom roles related feature, and custom roles do not apply to observability projects at this time.


### Tests
- x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
Note: will have to comment out the infra test file in the feature flag index file in order to run (x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts ln 12 `require.resolve('./infra'));`)  See https://github.com/elastic/kibana/issues/191809.