### PR TITLE
[Automatic Import] Resolve a type issue on draw_graph after func argument updates

### DIFF
--- a/x-pack/plugins/integration_assistant/scripts/draw_graphs_script.ts
+++ b/x-pack/plugins/integration_assistant/scripts/draw_graphs_script.ts
@@ -46,7 +46,7 @@ async function drawGraph(compiledGraph: RunnableGraph, graphName: string) {
 
 export async function drawGraphs() {
   const relatedGraph = (await getRelatedGraph({ client, model })).getGraph();
-  const logFormatDetectionGraph = (await getLogFormatDetectionGraph(model)).getGraph();
+  const logFormatDetectionGraph = (await getLogFormatDetectionGraph({ model })).getGraph();
   const categorizationGraph = (await getCategorizationGraph({ client, model })).getGraph();
   const ecsSubGraph = (await getEcsSubGraph({ model })).getGraph();
   const ecsGraph = (await getEcsGraph({ model })).getGraph();


### PR DESCRIPTION
## Summary

Resolves a type issue that happened after 2 separate PR's got merged at similar times, causing the type error to not be caught by CI.



