### PR TITLE
[7.17] [Logs UI] Make version dependent test only run for intended version. (#188901)

### DIFF
--- a/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
@@ -79,7 +79,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         it('highlights built-in message column', async () => {
-          const esInfo = await es.info();
+          const esInfo = (await es.info()).body;
           const highlightTerms = 'message of document 0';
           const { body } = await supertest
             .post(LOG_ENTRIES_HIGHLIGHTS_PATH)

--- a/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
@@ -45,8 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(() => esArchiver.unload('x-pack/test/functional/es_archives/infra/simple_logs'));
 
     describe('/log_entries/highlights', () => {
-      // FAILING ES 8.10 FORWARD COMPATIBILITY: https://github.com/elastic/kibana/issues/163845
-      describe.skip('with the default source', () => {
+      describe('with the default source', () => {
         before(() => esArchiver.load('x-pack/test/functional/es_archives/empty_kibana'));
         after(() => esArchiver.unload('x-pack/test/functional/es_archives/empty_kibana'));
 

--- a/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 
+import semver from 'semver';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { identity } from 'fp-ts/lib/function';
 import { fold } from 'fp-ts/lib/Either';
@@ -35,6 +36,7 @@ const COMMON_HEADERS = {
 };
 
 export default function ({ getService }: FtrProviderContext) {
+  const es = getService('es');
   const esArchiver = getService('esArchiver');
   const supertest = getService('supertest');
 
@@ -77,6 +79,8 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         it('highlights built-in message column', async () => {
+          const esInfo = await es.info();
+          const highlightTerms = 'message of document 0';
           const { body } = await supertest
             .post(LOG_ENTRIES_HIGHLIGHTS_PATH)
             .set(COMMON_HEADERS)
@@ -85,7 +89,7 @@ export default function ({ getService }: FtrProviderContext) {
                 sourceId: 'default',
                 startTimestamp: KEY_BEFORE_START.time,
                 endTimestamp: KEY_AFTER_END.time,
-                highlightTerms: ['message of document 0'],
+                highlightTerms: [highlightTerms],
               })
             )
             .expect(200);
@@ -118,7 +122,10 @@ export default function ({ getService }: FtrProviderContext) {
           entries.forEach((entry) => {
             entry.columns.forEach((column) => {
               if ('message' in column && 'highlights' in column.message[0]) {
-                expect(column.message[0].highlights).to.eql(['message', 'of', 'document', '0']);
+                const expectation = semver.gte(esInfo.version.number, '8.10.0')
+                  ? [highlightTerms]
+                  : highlightTerms.split(' ');
+                expect(column.message[0].highlights).to.eql(expectation);
               }
             });
           });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Logs UI] Make version dependent test only run for intended version. (#188901)](https://github.com/elastic/kibana/pull/188901)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2024-09-02T12:24:27Z","message":"[Logs UI] Make version dependent test only run for intended version. (#188901)\n\nFixes #163845\r\n\r\n## Summary\r\n\r\nA test in 7.17 is skipped because an ES API in the later versions has\r\nchanged. The PR branches the test to handle both cases, before and after\r\nthe API change. The PR should be backported to 7.17 once merged in main.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ccbef9f9a5aec5a3abb5c7d4a3574c896bc55f8b","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-logs","v8.16.0","v7.17.24","backport:version"],"number":188901,"url":"https://github.com/elastic/kibana/pull/188901","mergeCommit":{"message":"[Logs UI] Make version dependent test only run for intended version. (#188901)\n\nFixes #163845\r\n\r\n## Summary\r\n\r\nA test in 7.17 is skipped because an ES API in the later versions has\r\nchanged. The PR branches the test to handle both cases, before and after\r\nthe API change. The PR should be backported to 7.17 once merged in main.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ccbef9f9a5aec5a3abb5c7d4a3574c896bc55f8b"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188901","number":188901,"mergeCommit":{"message":"[Logs UI] Make version dependent test only run for intended version. (#188901)\n\nFixes #163845\r\n\r\n## Summary\r\n\r\nA test in 7.17 is skipped because an ES API in the later versions has\r\nchanged. The PR branches the test to handle both cases, before and after\r\nthe API change. The PR should be backported to 7.17 once merged in main.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ccbef9f9a5aec5a3abb5c7d4a3574c896bc55f8b"}},{"branch":"7.17","label":"v7.17.24","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->