### PR TITLE
[docs] document internal API restriction in 9

### DIFF
--- a/docs/user/api.asciidoc
+++ b/docs/user/api.asciidoc
@@ -5,6 +5,8 @@ Some {kib} features are provided via a REST API, which is ideal for creating an
 integration with {kib}, or automating certain aspects of configuring and
 deploying {kib}.
 
+NOTE: APIs in technical preview are not subject to the support SLA of official GA APIs.
+
 NOTE: For the latest details, refer to {api-kibana}[{kib} API].
 
 [float]

--- a/docs/user/api.asciidoc
+++ b/docs/user/api.asciidoc
@@ -5,7 +5,7 @@ Some {kib} features are provided via a REST API, which is ideal for creating an
 integration with {kib}, or automating certain aspects of configuring and
 deploying {kib}.
 
-NOTE: APIs in technical preview are not subject to the support SLA of official GA APIs.
+NOTE: Access to internal {kib} API endpoints will be restricted in 9.0. For more information, refer to https://github.com/elastic/kibana/issues/163654.
 
 NOTE: For the latest details, refer to {api-kibana}[{kib} API].
 

--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.3
 info:
   title: Kibana APIs
   description: |
+    APIs in technical preview are not subject to the support SLA of official GA APIs.
     The Kibana REST APIs enable you to manage resources such as connectors, data views, and saved objects.
     The API calls are stateless.
     Each request that you make happens in isolation from other calls and must include all of the necessary information for Kibana to fulfill the

--- a/oas_docs/kibana.info.yaml
+++ b/oas_docs/kibana.info.yaml
@@ -2,7 +2,8 @@ openapi: 3.0.3
 info:
   title: Kibana APIs
   description: |
-    APIs in technical preview are not subject to the support SLA of official GA APIs.
+    NOTE: Access to internal {kib} API endpoints will be restricted in Kibana version 9.0. For more information, refer to https://github.com/elastic/kibana/issues/163654.
+
     The Kibana REST APIs enable you to manage resources such as connectors, data views, and saved objects.
     The API calls are stateless.
     Each request that you make happens in isolation from other calls and must include all of the necessary information for Kibana to fulfill the

--- a/x-pack/plugins/upgrade_assistant/README.md
+++ b/x-pack/plugins/upgrade_assistant/README.md
@@ -11,7 +11,7 @@ Its primary purposes are to:
 
 ### UA feature set
 Since Kibana version `8.6` UA is enabled to assist users during all upgrades including minor versions of the Elastic Stack.
-Some features of the UA are only needed when upgrading to a new major version, controlled by the config `featureSet`. These are the following features:
+Some features of the UA are only needed when upgrading to a new major version. These are the following features are controlled by the config `featureSet`:
 * ML Snapshots (`featureSet.mlSnapshots`): Machine learning Upgrade mode can be toggled from outside Kibana, the purpose of this feature guard is to hide all ML related deprecations from the end user until the next major upgrade.
 When we want to enable ML model snapshot deprecation warnings again we need to change the constant `MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION` to something higher than 7.0.0 in the Elasticsearch code.
 * Migrating system indices (`featureSet.migrateSystemIndices`): Migrating system indices should only be enabled for major version upgrades. This config hides the second step from the UA UI for migrating system indices.

--- a/x-pack/plugins/upgrade_assistant/README.md
+++ b/x-pack/plugins/upgrade_assistant/README.md
@@ -11,7 +11,7 @@ Its primary purposes are to:
 
 ### UA feature set
 Since Kibana version `8.6` UA is enabled to assist users during all upgrades including minor versions of the Elastic Stack.
-Some features of the UA are only needed when upgrading to a new major version. These are the following features are controlled by the config `featureSet`:
+Some features of the UA are only needed when upgrading to a new major version, controlled by the config `featureSet`. These are the following features:
 * ML Snapshots (`featureSet.mlSnapshots`): Machine learning Upgrade mode can be toggled from outside Kibana, the purpose of this feature guard is to hide all ML related deprecations from the end user until the next major upgrade.
 When we want to enable ML model snapshot deprecation warnings again we need to change the constant `MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION` to something higher than 7.0.0 in the Elasticsearch code.
 * Migrating system indices (`featureSet.migrateSystemIndices`): Migrating system indices should only be enabled for major version upgrades. This config hides the second step from the UA UI for migrating system indices.


### PR DESCRIPTION
fix: https://github.com/elastic/kibana/issues/191941

As per the title, this PR documents that access to internal APIs will be restricted as of 9.0.

![document-restricted-internal-API-access](https://github.com/user-attachments/assets/01273fad-d72f-4db8-a39b-b2b163aed87f)


- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials|