### PR TITLE
[APM] Update Cypress command to access super date picker

### DIFF
--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/support/commands.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/support/commands.ts
@@ -88,18 +88,14 @@ Cypress.Commands.add('selectAbsoluteTimeRange', (start: string, end: string) => 
   const format = 'MMM D, YYYY @ HH:mm:ss.SSS';
 
   cy.getByTestSubj('superDatePickerstartDatePopoverButton').click();
-  cy.contains('Start date')
-    .nextAll()
-    .find('[data-test-subj="superDatePickerAbsoluteDateInput"]')
-    .clear({ force: true })
+  cy.getByTestSubj('superDatePickerAbsoluteDateInput').clear({ force: true });
+  cy.getByTestSubj('superDatePickerAbsoluteDateInput')
     .type(moment(start).format(format), { force: true })
     .type('{enter}');
 
   cy.getByTestSubj('superDatePickerendDatePopoverButton').click();
-  cy.contains('End date')
-    .nextAll()
-    .find('[data-test-subj="superDatePickerAbsoluteDateInput"]')
-    .clear({ force: true })
+  cy.getByTestSubj('superDatePickerAbsoluteDateInput').clear({ force: true });
+  cy.getByTestSubj('superDatePickerAbsoluteDateInput')
     .type(moment(end).format(format), { force: true })
     .type('{enter}');
 });


### PR DESCRIPTION
## 📓 Summary

Given a change in the HTML structure of the SuperDatePicker component from EUI, the `selectAbsoluteTimeRange` was no longer capable of typing the passed date.

Once the PR to update EUI was merged, it didn't go through the APM Cypress suite since those files where not touched, causing the false positive in the CI step.

This change directly accesses the input field without relying on sibling elements.