### PR TITLE
fix archive path for chromium download

### DIFF
--- a/packages/kbn-screenshotting-server/src/paths.test.ts
+++ b/packages/kbn-screenshotting-server/src/paths.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ChromiumArchivePaths } from './paths';
+
+describe('ChromiumArchivePaths', () => {
+  it('should download chromium archive to a specific path', () => {
+    const ChromiumArchivePathsInstance = new ChromiumArchivePaths();
+    expect(ChromiumArchivePathsInstance.archivesPath).toEqual(
+      expect.stringContaining('kibana/.chromium')
+    );
+  });
+});

--- a/packages/kbn-screenshotting-server/src/paths.ts
+++ b/packages/kbn-screenshotting-server/src/paths.ts
@@ -102,7 +102,7 @@ export class ChromiumArchivePaths {
   ];
 
   // zip files get downloaded to a .chromium directory in the kibana root
-  public readonly archivesPath = path.resolve(__dirname, '../../../../../../.chromium');
+  public readonly archivesPath = path.resolve(__dirname, '../../../.chromium');
 
   public find(platform: string, architecture: string, packages: PackageInfo[] = this.packages) {
     return packages.find((p) => p.platform === platform && p.architecture === architecture);


### PR DESCRIPTION
## Summary

This PR is a follow up to the work that's been done to make it relatively straight forward to backport puppeteer updates to  the 7.17 branch in https://github.com/elastic/kibana/pull/188390. 

This change ensures the archive path for chromium doesn't get installed outside of the kibana directory, the previous expression resulted in an archive path outside of the kibana directory which unfortunately could result in a resolution of a path that kibana has no permissions to write to, depending on where kibana is being executed from. 

## How to test
 
- Pull this PR and delete the `.chromium` directory, for whatever platform this PR is is been tested on we should get no errors about installing the chromium and we should see the appropriate chromium archive for the os platform available in the `.chromium` that would get created.


<!--

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->

<!--ONMERGE {"backportTargets":["7.17"]} ONMERGE-->