### PR TITLE
[ML] Fix trained models stats in serverless 

### DIFF
--- a/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/ml_client.ts
@@ -30,7 +30,7 @@ export function getMlClient(
   client: IScopedClusterClient,
   mlSavedObjectService: MLSavedObjectService
 ): MlClient {
-  const mlClient = client.asInternalUser.ml;
+  let mlClient = client.asInternalUser.ml;
 
   async function jobIdsCheck(jobType: JobType, p: MlClientParams, allowWildcards: boolean = false) {
     const jobIds =
@@ -158,6 +158,16 @@ export function getMlClient(
 
   // @ts-expect-error promise and TransportRequestPromise are incompatible. missing abort
   return {
+    asCurrentUser() {
+      mlClient = client.asCurrentUser.ml;
+      return this;
+    },
+
+    asInternalUser() {
+      mlClient = client.asInternalUser.ml;
+      return this;
+    },
+
     async closeJob(...p: Parameters<MlClient['closeJob']>) {
       await jobIdsCheck('anomaly-detector', p);
       return mlClient.closeJob(...p);

--- a/x-pack/plugins/ml/server/lib/ml_client/types.ts
+++ b/x-pack/plugins/ml/server/lib/ml_client/types.ts
@@ -44,6 +44,14 @@ export interface MlClient
     p: MlInferTrainedModelRequest,
     options?: TransportRequestOptionsWithMeta
   ) => Promise<estypes.MlInferTrainedModelResponse>;
+  /**
+   * Changes client to the current user
+   */
+  asCurrentUser(): MlClient;
+  /**
+   * Change client to the internal user
+   */
+  asInternalUser(): MlClient;
 }
 
 export type MlClientParams =

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -290,7 +290,7 @@ export function trainedModelsRoutes(
       },
       routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
         try {
-          const body = await mlClient.getTrainedModelsStats({
+          const body = await mlClient.asCurrentUser().getTrainedModelsStats({
             size: DEFAULT_TRAINED_MODELS_PAGE_SIZE,
           });
           return response.ok({


### PR DESCRIPTION
## Summary

In a serverless environment, the trained model stats endpoint uses an action filter to aggregate information from actual nodes into a single virtual "serverless" node. This filter is only applied when the endpoint is called as the current user.

The ML client in Kibana perform all calls as an internal user, which results in the UI displaying deployment stats from the actual underlying nodes.

This PR introduces methods for udpating the client before making a call, e.g.

```typescript
const body = await mlClient.asCurrentUser().getTrainedModelsStats();
```
