### PR TITLE
[Automatic Import] Resolve http_endpoint config not loading correctly

### DIFF
--- a/x-pack/plugins/integration_assistant/common/api/model/common_attributes.schema.yaml
+++ b/x-pack/plugins/integration_assistant/common/api/model/common_attributes.schema.yaml
@@ -109,7 +109,7 @@ components:
         - filestream
         - gcp-pubsub
         - gcs
-        - http-endpoint
+        - http_endpoint
         - journald
         - kafka
         - tcp

--- a/x-pack/plugins/integration_assistant/common/api/model/common_attributes.ts
+++ b/x-pack/plugins/integration_assistant/common/api/model/common_attributes.ts
@@ -123,7 +123,7 @@ export const InputType = z.enum([
   'filestream',
   'gcp-pubsub',
   'gcs',
-  'http-endpoint',
+  'http_endpoint',
   'journald',
   'kafka',
   'tcp',

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
@@ -36,7 +36,7 @@ export const InputTypeOptions: Array<EuiComboBoxOptionOption<InputType>> = [
   { value: 'filestream', label: 'File Stream' },
   { value: 'gcp-pubsub', label: 'GCP Pub/Sub' },
   { value: 'gcs', label: 'Google Cloud Storage' },
-  { value: 'http-endpoint', label: 'HTTP Endpoint' },
+  { value: 'http_endpoint', label: 'HTTP Endpoint' },
   { value: 'journald', label: 'Journald' },
   { value: 'kafka', label: 'Kafka' },
   { value: 'tcp', label: 'TCP' },


### PR DESCRIPTION
## Release note

Fixes issue with the `http_endpoint` input config loading incorrectly in an Automatic Import workflow.

## Summary

This resolves a regression from `https://github.com/elastic/kibana/pull/188695` where the http_endpoint input was also modified together with the rest of the inputs with multiple words, however `http_endpoint` uses `_` rather than `-` in its actual name.

While this modifies the API, it is an internal API and under tech preview. The only consumer of this API is our own UI, which is also modified in this PR to pass the correct parameter.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->