### PR TITLE
[Automatic Import] Remove UI text on supported models

### DIFF
--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
@@ -100,7 +100,6 @@ export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
           <EuiFlexItem grow={false} css={{ margin: euiTheme.size.xxs }}>
             <EuiIcon type="iInCircle" />
           </EuiFlexItem>
-          <EuiFlexItem>{i18n.SUPPORTED_MODELS_INFO}</EuiFlexItem>
         </EuiFlexGroup>
       </EuiText>
     </StepContentWrapper>

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/translations.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/translations.ts
@@ -24,11 +24,3 @@ export const CREATE_CONNECTOR = i18n.translate(
     defaultMessage: 'Create new connector',
   }
 );
-
-export const SUPPORTED_MODELS_INFO = i18n.translate(
-  'xpack.integrationAssistant.steps.connector.supportedModelsInfo',
-  {
-    defaultMessage:
-      "We currently recommend using a provider that supports the newer Claude models for the best experience. We're currently working on adding better support for GPT-4 and similar models",
-  }
-);


### PR DESCRIPTION
## Summary

The initial UI text related to only supporting Bedrock was supposed to be removed, so this PR is a follow-up to remove that part.

