### PR TITLE
[ResponseOps][Connectors] Update deprecation warning for the Teams Connector

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/teams/translations.ts
@@ -32,6 +32,6 @@ export const WEBHOOK_DEPRECATION_WARNING = i18n.translate(
   'xpack.stackConnectors.components.teams.warning.webhookDeprecation',
   {
     defaultMessage:
-      'Microsoft Teams deprecated some methods for configuring webhooks. Follow the documentation link to create a supported webhook URL. If the URL is not updated by December 31, 2024, notifications will stop.',
+      'Microsoft Teams deprecated some methods for configuring webhooks. Follow the documentation link to create a supported webhook URL. If the URL is not updated by December 31, 2025, notifications will stop.',
   }
 );


### PR DESCRIPTION
## Summary

Changed the date to `December 31, 2025`.