### PR TITLE
[APM UI] Fix Latency distribution chart breaks due to transaction durations of value 0

### DIFF
--- a/x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
@@ -48,8 +48,8 @@ export const fetchDurationHistogramRangeSteps = async ({
 
   if (durationMinOverride && durationMaxOverride) {
     // these values should never be 0, so if they are we set them to 1
-    const durationMin = Math.min(1, durationMinOverride);
-    const durationMax = Math.min(1, durationMaxOverride);
+    const durationMin = Math.max(1, durationMinOverride);
+    const durationMax = Math.max(1, durationMaxOverride);
 
     return {
       durationMin,
@@ -105,8 +105,8 @@ export const fetchDurationHistogramRangeSteps = async ({
   }
 
   // these values should never be 0, so if they are we set them to 1
-  const durationMin = Math.min(1, resp.aggregations.duration_min.value);
-  const durationMax = Math.min(1, resp.aggregations.duration_max.value * 2);
+  const durationMin = Math.max(1, resp.aggregations.duration_min.value);
+  const durationMax = Math.max(1, resp.aggregations.duration_max.value * 2);
 
   return {
     durationMin,

--- a/x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
@@ -22,10 +22,6 @@ const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
   return [...Array(steps).keys()].map(logFn.invert).map((d) => (isNaN(d) ? 0 : Math.round(d)));
 };
 
-const calculateDefaultDuration = (value: number) => {
-  return value === 0 ? 1 : value;
-};
-
 export const fetchDurationHistogramRangeSteps = async ({
   chartType,
   apmEventClient,
@@ -52,8 +48,8 @@ export const fetchDurationHistogramRangeSteps = async ({
 
   if (durationMinOverride && durationMaxOverride) {
     // these values should never be 0, so if they are we set them to 1
-    const durationMin = calculateDefaultDuration(durationMinOverride);
-    const durationMax = calculateDefaultDuration(durationMaxOverride);
+    const durationMin = Math.min(1, durationMinOverride);
+    const durationMax = Math.min(1, durationMaxOverride);
 
     return {
       durationMin,
@@ -109,8 +105,8 @@ export const fetchDurationHistogramRangeSteps = async ({
   }
 
   // these values should never be 0, so if they are we set them to 1
-  const durationMin = calculateDefaultDuration(resp.aggregations.duration_min.value);
-  const durationMax = calculateDefaultDuration(resp.aggregations.duration_max.value * 2);
+  const durationMin = Math.min(1, resp.aggregations.duration_min.value);
+  const durationMax = Math.min(1, resp.aggregations.duration_max.value * 2);
 
   return {
     durationMin,

--- a/x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts
@@ -22,6 +22,10 @@ const getHistogramRangeSteps = (min: number, max: number, steps: number) => {
   return [...Array(steps).keys()].map(logFn.invert).map((d) => (isNaN(d) ? 0 : Math.round(d)));
 };
 
+const calculateDefaultDuration = (value: number) => {
+  return value === 0 ? 1 : value;
+};
+
 export const fetchDurationHistogramRangeSteps = async ({
   chartType,
   apmEventClient,
@@ -47,10 +51,14 @@ export const fetchDurationHistogramRangeSteps = async ({
   const steps = 100;
 
   if (durationMinOverride && durationMaxOverride) {
+    // these values should never be 0, so if they are we set them to 1
+    const durationMin = calculateDefaultDuration(durationMinOverride);
+    const durationMax = calculateDefaultDuration(durationMaxOverride);
+
     return {
-      durationMin: durationMinOverride,
-      durationMax: durationMaxOverride,
-      rangeSteps: getHistogramRangeSteps(durationMinOverride, durationMaxOverride, steps),
+      durationMin,
+      durationMax,
+      rangeSteps: getHistogramRangeSteps(durationMin, durationMax, steps),
     };
   }
 
@@ -100,8 +108,9 @@ export const fetchDurationHistogramRangeSteps = async ({
     return { rangeSteps: [] };
   }
 
-  const durationMin = resp.aggregations.duration_min.value;
-  const durationMax = resp.aggregations.duration_max.value * 2;
+  // these values should never be 0, so if they are we set them to 1
+  const durationMin = calculateDefaultDuration(resp.aggregations.duration_min.value);
+  const durationMax = calculateDefaultDuration(resp.aggregations.duration_max.value * 2);
 
   return {
     durationMin,


### PR DESCRIPTION
## Summary
Fixes: https://github.com/elastic/kibana/issues/184256

This PR fixes the APM latency distribution chart not being able to render when we had any duration value as 0, to fix it, we now check if it's 0 and override it with 1.

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/df224a1d-a669-4ea8-ad0e-9f81a82b904a)|![image](https://github.com/user-attachments/assets/cbf6957c-df6f-4f71-8f96-7985279912fa)|

## Test steps
1. Open the following file `x-pack/plugins/observability_solution/apm/server/routes/correlations/queries/fetch_duration_histogram_range_steps.ts`
2. Modify L61 and L118 changing the initial two values passed to `getHistogramRangeSteps` to 0.
Like `getHistogramRangeSteps(0, 0, steps)`.
It doesn't matter the order, if one of the params is at 0 it won't render anything.
3. Revert the change and check if the chart is being rendered.



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->