### PR TITLE
[Security solution] Bedrock chat fix

### DIFF
--- a/x-pack/plugins/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
+++ b/x-pack/plugins/inference/server/chat_complete/adapters/bedrock/bedrock_claude_adapter.ts
@@ -13,7 +13,7 @@ import { Message, MessageRole } from '../../../../common/chat_complete';
 import { createInferenceInternalError } from '../../../../common/errors';
 import { ToolChoiceType, type ToolOptions } from '../../../../common/chat_complete/tools';
 import { InferenceConnectorAdapter } from '../../types';
-import type { BedRockMessage, BedrockToolChoice } from './types';
+import type { BedrockMessage, BedrockToolChoice } from './types';
 import {
   BedrockChunkMember,
   serdeEventstreamIntoObservable,
@@ -97,8 +97,8 @@ const toolsToBedrock = (tools: ToolOptions['tools']) => {
     : undefined;
 };
 
-const messagesToBedrock = (messages: Message[]): BedRockMessage[] => {
-  return messages.map<BedRockMessage>((message) => {
+const messagesToBedrock = (messages: Message[]): BedrockMessage[] => {
+  return messages.map<BedrockMessage>((message) => {
     switch (message.role) {
       case MessageRole.User:
         return {

--- a/x-pack/plugins/inference/server/chat_complete/adapters/bedrock/types.ts
+++ b/x-pack/plugins/inference/server/chat_complete/adapters/bedrock/types.ts
@@ -6,18 +6,18 @@
  */
 
 /**
- * BedRock message as expected by the bedrock connector
+ * Bedrock message as expected by the bedrock connector
  */
-export interface BedRockMessage {
+export interface BedrockMessage {
   role: 'user' | 'assistant';
   content?: string;
-  rawContent?: BedRockMessagePart[];
+  rawContent?: BedrockMessagePart[];
 }
 
 /**
  * Bedrock message parts
  */
-export type BedRockMessagePart =
+export type BedrockMessagePart =
   | { type: 'text'; text: string }
   | {
       type: 'tool_use';

--- a/x-pack/plugins/stack_connectors/common/bedrock/types.ts
+++ b/x-pack/plugins/stack_connectors/common/bedrock/types.ts
@@ -35,5 +35,5 @@ export type RunActionResponse = TypeOf<typeof RunActionResponseSchema>;
 export type StreamingResponse = TypeOf<typeof StreamingResponseSchema>;
 export type DashboardActionParams = TypeOf<typeof DashboardActionParamsSchema>;
 export type DashboardActionResponse = TypeOf<typeof DashboardActionResponseSchema>;
-export type BedRockMessage = TypeOf<typeof BedrockMessageSchema>;
+export type BedrockMessage = TypeOf<typeof BedrockMessageSchema>;
 export type BedrockToolChoice = TypeOf<typeof BedrockToolChoiceSchema>;


### PR DESCRIPTION
## Summary

A change to the schema resulted in an error in Security AI Assistant:
<img width="683" alt="Screenshot 2024-09-03 at 9 07 36 AM" src="https://github.com/user-attachments/assets/95e2b7e2-4ef7-45cf-98d3-d1c2aa34bac1">

I updated our formatting to use the new `rawContent` property, and also added the formatting method to `invokeAIRaw` to ensure the body is properly formatted