### PR TITLE
[Fleet] Fix fetching uninstall token without space awareness enabled

### DIFF
--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -193,9 +193,11 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
   }
 
   public async getToken(id: string): Promise<UninstallToken | null> {
-    const namespacePrefix = this.soClient.getCurrentNamespace()
-      ? `${this.soClient.getCurrentNamespace()}:`
-      : '';
+    const namespacePrefix =
+      appContextService.getExperimentalFeatures().useSpaceAwareness &&
+      this.soClient.getCurrentNamespace()
+        ? `${this.soClient.getCurrentNamespace()}:`
+        : '';
     const filter = `${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}.id: "${namespacePrefix}${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}:${id}"`;
     const tokenObjects = await this.getDecryptedTokenObjects({ filter });
     return tokenObjects.length === 1
@@ -280,9 +282,11 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
         this.assertCreatedAt(_source.created_at);
         const policyId = _source[UNINSTALL_TOKENS_SAVED_OBJECT_TYPE].policy_id;
 
-        const namespacePrefix = this.soClient.getCurrentNamespace()
-          ? `${this.soClient.getCurrentNamespace()}:`
-          : '';
+        const namespacePrefix =
+          appContextService.getExperimentalFeatures().useSpaceAwareness &&
+          this.soClient.getCurrentNamespace()
+            ? `${this.soClient.getCurrentNamespace()}:`
+            : '';
         return {
           id: _id!.replace(`${namespacePrefix}${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}:`, ''),
           policy_id: policyId,


### PR DESCRIPTION
## Summary

Resolve #191919

Fix fetching individual uninstall tokens when not in the default space, the bug is only present in 8.15 as the relevant code has been changed in 8.16

## How to test/reproduce 

1. Create a policy 
2. Try to navigate to the uninstall tokens and show the token

#### Before
<img width="800" alt="Screenshot 2024-09-03 at 3 35 30 PM" src="https://github.com/user-attachments/assets/8d356cc3-beab-4424-986d-5ca6a80eca82">

#### After

<img width="800" alt="Screenshot 2024-09-03 at 3 34 35 PM" src="https://github.com/user-attachments/assets/1f27bb71-54ba-47e5-88b0-14c6f558d81c">

## Questions 

Should we write a known issues for that one? The workaround will be to access the token in the default space

