### PR TITLE
[Reporting] Improve errors from failed resolutions in Upgrade Assistant

### DIFF
--- a/x-pack/plugins/reporting/server/deprecations/migrate_existing_indices_ilm_policy.test.ts
+++ b/x-pack/plugins/reporting/server/deprecations/migrate_existing_indices_ilm_policy.test.ts
@@ -54,7 +54,7 @@ describe("Migrate existing indices' ILM policy deprecations", () => {
             ],
           },
           "level": "warning",
-          "message": "New reporting indices will be managed by the \\"kibana-reporting\\" provisioned ILM policy. You must edit this policy to manage the report lifecycle. This change targets the hidden system index pattern \\".kibana-reporting*\\".",
+          "message": "New reporting indices will be managed by the \\"kibana-reporting\\" provisioned ILM policy. You must edit this policy to manage the report lifecycle. This change targets the hidden system index pattern \\".reporting-*,.kibana-reporting*\\".",
           "title": "Found reporting indices managed by custom ILM policy.",
         },
       ]

--- a/x-pack/plugins/reporting/server/deprecations/migrate_existing_indices_ilm_policy.ts
+++ b/x-pack/plugins/reporting/server/deprecations/migrate_existing_indices_ilm_policy.ts
@@ -8,7 +8,7 @@
 import { DeprecationsDetails, GetDeprecationsContext } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import { ILM_POLICY_NAME, INTERNAL_ROUTES } from '@kbn/reporting-common';
-import { REPORTING_DATA_STREAM_WILDCARD } from '@kbn/reporting-server';
+import { REPORTING_DATA_STREAM_WILDCARD_WITH_LEGACY } from '@kbn/reporting-server';
 import { IlmPolicyManager } from '../lib/store';
 
 export const getDeprecationsInfo = async ({
@@ -28,7 +28,7 @@ export const getDeprecationsInfo = async ({
           defaultMessage: `New reporting indices will be managed by the "{reportingIlmPolicy}" provisioned ILM policy. You must edit this policy to manage the report lifecycle. This change targets the hidden system index pattern "{indexPattern}".`,
           values: {
             reportingIlmPolicy: ILM_POLICY_NAME,
-            indexPattern: REPORTING_DATA_STREAM_WILDCARD,
+            indexPattern: REPORTING_DATA_STREAM_WILDCARD_WITH_LEGACY,
           },
         }),
         correctiveActions: {

--- a/x-pack/plugins/reporting/server/lib/deprecations/index.ts
+++ b/x-pack/plugins/reporting/server/lib/deprecations/index.ts
@@ -19,7 +19,7 @@ function deprecationError(
     return [
       {
         title,
-        level: 'fetch_error', // NOTE: is fetch_error not shown in the Upgrade Assistant UI?
+        level: 'fetch_error',
         deprecationType: 'feature',
         message: i18n.translate(
           'xpack.reporting.deprecations.reportingRole.forbiddenErrorMessage',
@@ -44,7 +44,7 @@ function deprecationError(
   return [
     {
       title,
-      level: 'fetch_error', // NOTE: is fetch_error not shown in the Upgrade Assistant UI?
+      level: 'fetch_error',
       deprecationType: 'feature',
       message: i18n.translate('xpack.reporting.deprecations.reportingRole.unknownErrorMessage', {
         defaultMessage: 'Failed to perform deprecation check. Check Kibana logs for more details.',

--- a/x-pack/plugins/reporting/server/routes/internal/deprecations/deprecations.ts
+++ b/x-pack/plugins/reporting/server/routes/internal/deprecations/deprecations.ts
@@ -38,7 +38,13 @@ const getAuthzWrapper =
         });
 
         if (!body.has_all_requested) {
-          return res.notFound();
+          const responseString = JSON.stringify(body);
+          logger.debug(
+            `Current user does not have manage privilege for Reporting indices: ${responseString}`
+          );
+          return res.forbidden({
+            body: `The current user requires "manage" privilege on the "${REPORTING_DATA_STREAM_WILDCARD_WITH_LEGACY}" indices.`,
+          });
         }
       } catch (e) {
         logger.error(e);

--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -200,7 +200,7 @@ export default function ({ getService }: FtrProviderContext) {
           .auth(UNAUTHZD_TEST_USERNAME, UNAUTHZD_TEST_USER_PASSWORD)
           .set('kbn-xsrf', 'xxx')
           .expect(403)
-          .then(({ body }) => {
+          .then(({ body }: any) => {
             expect(body).to.eql({
               statusCode: 403,
               error: 'Forbidden',
@@ -214,7 +214,7 @@ export default function ({ getService }: FtrProviderContext) {
           .auth(UNAUTHZD_TEST_USERNAME, UNAUTHZD_TEST_USER_PASSWORD)
           .set('kbn-xsrf', 'xxx')
           .expect(403)
-          .then(({ body }) => {
+          .then(({ body }: any) => {
             expect(body).to.eql({
               statusCode: 403,
               error: 'Forbidden',

--- a/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
+++ b/x-pack/test/reporting_api_integration/reporting_and_security/ilm_migration_apis.ts
@@ -199,13 +199,29 @@ export default function ({ getService }: FtrProviderContext) {
           .put(INTERNAL_ROUTES.MIGRATE.MIGRATE_ILM_POLICY)
           .auth(UNAUTHZD_TEST_USERNAME, UNAUTHZD_TEST_USER_PASSWORD)
           .set('kbn-xsrf', 'xxx')
-          .expect(404);
+          .expect(403)
+          .then(({ body }) => {
+            expect(body).to.eql({
+              statusCode: 403,
+              error: 'Forbidden',
+              message:
+                'The current user requires "manage" privilege on the ".reporting-*,.kibana-reporting*" indices.',
+            });
+          });
 
         await supertestWithoutAuth
           .get(INTERNAL_ROUTES.MIGRATE.GET_ILM_POLICY_STATUS)
           .auth(UNAUTHZD_TEST_USERNAME, UNAUTHZD_TEST_USER_PASSWORD)
           .set('kbn-xsrf', 'xxx')
-          .expect(404);
+          .expect(403)
+          .then(({ body }) => {
+            expect(body).to.eql({
+              statusCode: 403,
+              error: 'Forbidden',
+              message:
+                'The current user requires "manage" privilege on the ".reporting-*,.kibana-reporting*" indices.',
+            });
+          });
       } finally {
         await security.user.delete(UNAUTHZD_TEST_USERNAME);
       }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/192049

## Summary

This change gives more logging and user-friendly error message in the event that the current user does not have the privilege to manage the reporting indices. Previously, there would be a mysterious 404 message. After this change, the server response is a 403 with a more meaningful error message in the response body.

## Screen recording
https://github.com/user-attachments/assets/79a9ae3d-09bb-429e-b7c2-e6bf5fecf67d

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
