### PR TITLE
[Infra] Replace infra aggregation runtime types with the types in `estypes`

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.test.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MetricsUIAggregation } from '@kbn/metrics-data-access-plugin/common';
+import { isCustomMetricRate, isInterfaceRateAgg, isMetricRate, isRate } from './is_rate';
+import { SnapshotCustomMetricInput } from '../../../../../common/http_api';
+
+const customMaxMetricMock: SnapshotCustomMetricInput = {
+  type: 'custom',
+  aggregation: 'max',
+  field: '',
+  id: '',
+};
+
+const customRateMetricMock: SnapshotCustomMetricInput = {
+  type: 'custom',
+  aggregation: 'rate',
+  field: '',
+  id: '',
+};
+
+const metricMock: MetricsUIAggregation = {
+  mock1: { derivative: {} },
+  mock2: { max: null, mock: { field: '' } },
+  mock3: {
+    aggregations: {},
+    terms: {},
+    sum_bucket: {},
+  },
+};
+
+describe('isRate', () => {
+  describe('isMetricRate', () => {
+    it('should return false when metric is undefined', () => {
+      expect(isMetricRate(undefined)).toEqual(false);
+    });
+    it('should return true when correct metric is passed', () => {
+      expect(isMetricRate(metricMock)).toEqual(true);
+    });
+  });
+
+  describe('isCustomMetricRate', () => {
+    it("should return false when aggregation isn't 'rate'", () => {
+      expect(isCustomMetricRate(customMaxMetricMock)).toEqual(false);
+    });
+    it("should return true when aggregation is equal to 'rate'", () => {
+      expect(isCustomMetricRate(customRateMetricMock)).toEqual(true);
+    });
+
+    describe('isInterfaceRateAgg', () => {
+      it('should return false if metric is undefined', () => {
+        expect(isInterfaceRateAgg(undefined)).toEqual(false);
+      });
+      it('should return true when correct metric is passed', () => {
+        expect(isInterfaceRateAgg(metricMock)).toEqual(true);
+      });
+    });
+
+    describe('isRate', () => {
+      it('should return false when incorrect metrics are provided', () => {
+        expect(isRate({} as MetricsUIAggregation, {} as SnapshotCustomMetricInput)).toEqual(false);
+      });
+
+      it('should return true when proper metric are provided', () => {
+        expect(isRate(metricMock, customRateMetricMock)).toEqual(true);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.ts
@@ -9,9 +9,9 @@ import { has } from 'lodash';
 import {
   MetricsUIAggregation,
   ESSumBucketAggRT,
-  ESDerivativeAggRT,
-  ESBasicMetricAggRT,
   ESTermsWithAggregationRT,
+  isBasicMetricAgg,
+  isDerivativeAgg,
 } from '@kbn/metrics-data-access-plugin/common';
 import { SnapshotCustomMetricInput } from '../../../../../common/http_api';
 
@@ -21,8 +21,8 @@ export const isMetricRate = (metric: MetricsUIAggregation | undefined): boolean 
   }
   const values = Object.values(metric);
   return (
-    values.some((agg) => ESDerivativeAggRT.is(agg)) &&
-    values.some((agg) => ESBasicMetricAggRT.is(agg) && has(agg, 'max'))
+    values.some((agg) => isDerivativeAgg(agg)) &&
+    values.some((agg) => isBasicMetricAgg(agg) && has(agg, 'max'))
   );
 };
 

--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.ts
@@ -8,10 +8,10 @@
 import { has } from 'lodash';
 import {
   MetricsUIAggregation,
-  ESTermsWithAggregationRT,
   isBasicMetricAgg,
   isDerivativeAgg,
   isSumBucketAgg,
+  isTermsWithAggregation,
 } from '@kbn/metrics-data-access-plugin/common';
 import { SnapshotCustomMetricInput } from '../../../../../common/http_api';
 
@@ -36,8 +36,7 @@ export const isInterfaceRateAgg = (metric: MetricsUIAggregation | undefined) => 
   }
   const values = Object.values(metric);
   return (
-    values.some((agg) => ESTermsWithAggregationRT.is(agg)) &&
-    values.some((agg) => isSumBucketAgg(agg))
+    values.some((agg) => isTermsWithAggregation(agg)) && values.some((agg) => isSumBucketAgg(agg))
   );
 };
 

--- a/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/alerting/inventory_metric_threshold/lib/is_rate.ts
@@ -8,10 +8,10 @@
 import { has } from 'lodash';
 import {
   MetricsUIAggregation,
-  ESSumBucketAggRT,
   ESTermsWithAggregationRT,
   isBasicMetricAgg,
   isDerivativeAgg,
+  isSumBucketAgg,
 } from '@kbn/metrics-data-access-plugin/common';
 import { SnapshotCustomMetricInput } from '../../../../../common/http_api';
 
@@ -37,7 +37,7 @@ export const isInterfaceRateAgg = (metric: MetricsUIAggregation | undefined) => 
   const values = Object.values(metric);
   return (
     values.some((agg) => ESTermsWithAggregationRT.is(agg)) &&
-    values.some((agg) => ESSumBucketAggRT.is(agg))
+    values.some((agg) => isSumBucketAgg(agg))
   );
 };
 

--- a/x-pack/plugins/observability_solution/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/snapshot/lib/create_timerange_with_interval.ts
@@ -8,8 +8,8 @@
 import { uniq } from 'lodash';
 import {
   type MetricsUIAggregation,
-  ESBasicMetricAggRT,
   type MetricsAPITimerange,
+  isBasicMetricAgg,
 } from '@kbn/metrics-data-access-plugin/common';
 import { ESSearchClient } from '../../../lib/metrics/types';
 import { calculateMetricInterval } from '../../../utils/calculate_metric_interval';
@@ -74,7 +74,7 @@ const aggregationsToModules = async (
 ): Promise<string[]> => {
   const uniqueFields = Object.values(aggregations)
     .reduce<Array<string | undefined>>((fields, agg) => {
-      if (ESBasicMetricAggRT.is(agg)) {
+      if (isBasicMetricAgg(agg)) {
         return uniq(fields.concat(Object.values(agg).map((a) => a?.field)));
       }
       return fields;

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
@@ -29,10 +29,10 @@ export {
   ItemTypeRT,
   SnapshotMetricTypeRT,
   ESSumBucketAggRT,
-  ESDerivativeAggRT,
-  ESBasicMetricAggRT,
   SnapshotMetricTypeKeys,
   ESTermsWithAggregationRT,
+  isDerivativeAgg,
+  isBasicMetricAgg,
 } from './inventory_models/types';
 
 export type {

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
@@ -28,11 +28,11 @@ export {
   InventoryVisTypeRT,
   ItemTypeRT,
   SnapshotMetricTypeRT,
-  ESSumBucketAggRT,
   SnapshotMetricTypeKeys,
   ESTermsWithAggregationRT,
   isDerivativeAgg,
   isBasicMetricAgg,
+  isSumBucketAgg,
 } from './inventory_models/types';
 
 export type {

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
@@ -15,6 +15,7 @@ export {
   isBasicMetricAgg,
   isDerivativeAgg,
   isSumBucketAgg,
+  isTermsWithAggregation,
 } from './inventory_models';
 
 export { podSnapshotMetricTypes } from './inventory_models/kubernetes/pod';
@@ -32,7 +33,6 @@ export {
   ItemTypeRT,
   SnapshotMetricTypeRT,
   SnapshotMetricTypeKeys,
-  ESTermsWithAggregationRT,
 } from './inventory_models/types';
 
 export type {

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/index.ts
@@ -12,6 +12,9 @@ export {
   findInventoryFields,
   metrics,
   type InventoryModels,
+  isBasicMetricAgg,
+  isDerivativeAgg,
+  isSumBucketAgg,
 } from './inventory_models';
 
 export { podSnapshotMetricTypes } from './inventory_models/kubernetes/pod';
@@ -30,9 +33,6 @@ export {
   SnapshotMetricTypeRT,
   SnapshotMetricTypeKeys,
   ESTermsWithAggregationRT,
-  isDerivativeAgg,
-  isBasicMetricAgg,
-  isSumBucketAgg,
 } from './inventory_models/types';
 
 export type {

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { estypes } from '@elastic/elasticsearch';
 import { POD_FIELD, HOST_FIELD, CONTAINER_FIELD } from '../constants';
 import { host } from './host';
 import { pod } from './kubernetes/pod';
@@ -68,4 +69,27 @@ export const findInventoryFields = (type: InventoryItemType) => {
   } else {
     return inventoryModel.fields;
   }
+};
+
+export const isBasicMetricAgg = (
+  agg: unknown
+): agg is Record<string, undefined | Pick<estypes.AggregationsMetricAggregationBase, 'field'>> => {
+  if (agg === null || typeof agg !== 'object') return false;
+
+  return Object.values(agg).some(
+    (value) =>
+      value === undefined || 'field' in (value as estypes.AggregationsMetricAggregationBase)
+  );
+};
+
+export const isDerivativeAgg = (
+  agg: unknown
+): agg is Pick<estypes.AggregationsAggregationContainer, 'derivative'> => {
+  return !!(agg as estypes.AggregationsAggregationContainer).derivative;
+};
+
+export const isSumBucketAgg = (
+  agg: unknown
+): agg is Pick<estypes.AggregationsAggregationContainer, 'sum_bucket'> => {
+  return !!(agg as estypes.AggregationsAggregationContainer).sum_bucket;
 };

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
@@ -78,7 +78,8 @@ export const isBasicMetricAgg = (
 
   return Object.values(agg).some(
     (value) =>
-      value === undefined || 'field' in (value as estypes.AggregationsMetricAggregationBase)
+      value === undefined ||
+      (value && 'field' in (value as estypes.AggregationsMetricAggregationBase))
   );
 };
 

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
@@ -97,8 +97,6 @@ export const isSumBucketAgg = (
 export const isTermsWithAggregation = (
   agg: unknown
 ): agg is Pick<estypes.AggregationsAggregationContainer, 'terms' | 'aggregations'> => {
-  return !!(
-    (agg as estypes.AggregationsAggregationContainer).aggregations &&
-    (agg as estypes.AggregationsAggregationContainer).terms
-  );
+  const aggContainer = agg as estypes.AggregationsAggregationContainer;
+  return !!(aggContainer.aggregations && aggContainer.terms);
 };

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/index.ts
@@ -93,3 +93,12 @@ export const isSumBucketAgg = (
 ): agg is Pick<estypes.AggregationsAggregationContainer, 'sum_bucket'> => {
   return !!(agg as estypes.AggregationsAggregationContainer).sum_bucket;
 };
+
+export const isTermsWithAggregation = (
+  agg: unknown
+): agg is Pick<estypes.AggregationsAggregationContainer, 'terms' | 'aggregations'> => {
+  return !!(
+    (agg as estypes.AggregationsAggregationContainer).aggregations &&
+    (agg as estypes.AggregationsAggregationContainer).terms
+  );
+};

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
@@ -237,11 +237,6 @@ export type TSVBMetricModelCreator = (
 
 export type MetricsUIAggregation = Record<string, estypes.AggregationsAggregate>;
 
-export const ESTermsWithAggregationRT = rt.type({
-  terms: rt.type({ field: rt.string }),
-  aggregations: rt.UnknownRecord,
-});
-
 export const SnapshotMetricTypeKeys = {
   count: null,
   cpuV2: null,

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
@@ -238,18 +238,12 @@ export type TSVBMetricModelCreator = (
 export const isBasicMetricAgg = (
   agg: unknown
 ): agg is Record<string, undefined | Pick<estypes.AggregationsMetricAggregationBase, 'field'>> => {
-  if (agg && typeof agg === 'object' && Object.keys(agg).length !== 0) {
-    for (const key in agg) {
-      if (Object.hasOwn(agg, key)) {
-        return !!(
-          agg[key as keyof typeof agg] === undefined ||
-          (agg[key as keyof typeof agg] as estypes.AggregationsMetricAggregationBase).field
-        );
-      }
-    }
-  }
+  if (agg === null || typeof agg !== 'object') return false;
 
-  return false;
+  return Object.values(agg).some(
+    (value) =>
+      value === undefined || 'field' in (value as estypes.AggregationsMetricAggregationBase)
+  );
 };
 
 export const isDerivativeAgg = (

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
@@ -235,29 +235,6 @@ export type TSVBMetricModelCreator = (
   interval: string
 ) => TSVBMetricModel;
 
-export const isBasicMetricAgg = (
-  agg: unknown
-): agg is Record<string, undefined | Pick<estypes.AggregationsMetricAggregationBase, 'field'>> => {
-  if (agg === null || typeof agg !== 'object') return false;
-
-  return Object.values(agg).some(
-    (value) =>
-      value === undefined || 'field' in (value as estypes.AggregationsMetricAggregationBase)
-  );
-};
-
-export const isDerivativeAgg = (
-  agg: unknown
-): agg is Pick<estypes.AggregationsAggregationContainer, 'derivative'> => {
-  return !!(agg as estypes.AggregationsAggregationContainer).derivative;
-};
-
-export const isSumBucketAgg = (
-  agg: unknown
-): agg is Pick<estypes.AggregationsAggregationContainer, 'sum_bucket'> => {
-  return !!(agg as estypes.AggregationsAggregationContainer).sum_bucket;
-};
-
 export type MetricsUIAggregation = Record<string, estypes.AggregationsAggregate>;
 
 export const ESTermsWithAggregationRT = rt.type({

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
@@ -235,23 +235,28 @@ export type TSVBMetricModelCreator = (
   interval: string
 ) => TSVBMetricModel;
 
-export const ESBasicMetricAggRT = rt.record(
-  rt.string,
-  rt.union([
-    rt.undefined,
-    rt.type({
-      field: rt.string,
-    }),
-  ])
-);
+export const isBasicMetricAgg = (
+  agg: unknown
+): agg is Record<string, undefined | Pick<estypes.AggregationsMetricAggregationBase, 'field'>> => {
+  if (agg && typeof agg === 'object' && Object.keys(agg).length !== 0) {
+    for (const key in agg) {
+      if (Object.hasOwn(agg, key)) {
+        return !!(
+          agg[key as keyof typeof agg] === undefined ||
+          (agg[key as keyof typeof agg] as estypes.AggregationsMetricAggregationBase).field
+        );
+      }
+    }
+  }
 
-export const ESDerivativeAggRT = rt.type({
-  derivative: rt.type({
-    buckets_path: rt.string,
-    gap_policy: rt.keyof({ skip: null, insert_zeros: null }),
-    unit: rt.string,
-  }),
-});
+  return false;
+};
+
+export const isDerivativeAgg = (
+  agg: unknown
+): agg is Pick<estypes.AggregationsAggregationContainer, 'derivative'> => {
+  return !!(agg as estypes.AggregationsAggregationContainer).derivative;
+};
 
 export const ESSumBucketAggRT = rt.type({
   sum_bucket: rt.type({

--- a/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
+++ b/x-pack/plugins/observability_solution/metrics_data_access/common/inventory_models/types.ts
@@ -258,11 +258,11 @@ export const isDerivativeAgg = (
   return !!(agg as estypes.AggregationsAggregationContainer).derivative;
 };
 
-export const ESSumBucketAggRT = rt.type({
-  sum_bucket: rt.type({
-    buckets_path: rt.string,
-  }),
-});
+export const isSumBucketAgg = (
+  agg: unknown
+): agg is Pick<estypes.AggregationsAggregationContainer, 'sum_bucket'> => {
+  return !!(agg as estypes.AggregationsAggregationContainer).sum_bucket;
+};
 
 export type MetricsUIAggregation = Record<string, estypes.AggregationsAggregate>;
 


### PR DESCRIPTION
Closes #190497 

## Summary

This PR replaces infra aggregation types with types provided by the [Elasticsearch client](https://github.com/elastic/elasticsearch-js/pull/1358).

### Testing

Alerting tested manually.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

