### PR TITLE
[ML] Anomaly explorer: Fix the order of the coordinates displayed on the map tooltip

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/map_config.ts
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/map_config.ts
@@ -22,17 +22,14 @@ function getAnomalyFeatures(
     const geoResults = anomaly.geo_results || (anomaly?.causes && anomaly?.causes[0]?.geo_results);
     const coordinateStr = geoResults && geoResults[type];
     if (coordinateStr !== undefined) {
-      // Must reverse coordinates here. Map expects [lon, lat] - anomalies are stored as [lat, lon] for lat_lon jobs
-      const coordinates = coordinateStr
-        .split(',')
-        .map((point: string) => Number(point))
-        .reverse();
+      const coordinates = coordinateStr.split(',').map((point: string) => Number(point));
 
       anomalyFeatures.push({
         type: FEATURE,
         geometry: {
           type: POINT,
-          coordinates,
+          // Must reverse coordinates here. Map expects [lon, lat] - anomalies are stored as [lat, lon] for lat_lon jobs
+          coordinates: coordinates.toReversed(),
         },
         properties: {
           record_score: Math.floor(anomaly.record_score),


### PR DESCRIPTION
## Summary

Fix for [#190123](https://github.com/elastic/kibana/issues/190123)
Sync the order of the coordinates displayed in the table with those shown in the tooltip in the anomaly explorer map.
![Zrzut ekranu 2024-09-4 o 14 12 19](https://github.com/user-attachments/assets/da304be3-a756-444e-ae42-04e307194042)