### PR TITLE
Optimize ES Query's use of dataViews and searchSourceClient by only loading when it's a search source query

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.test.ts
@@ -189,7 +189,8 @@ describe('es_query executor', () => {
         params: { ...defaultProps, searchType: 'searchSource' },
         latestTimestamp: undefined,
         services: {
-          searchSourceClient: searchSourceClientMock,
+          getSearchSourceClient: expect.any(Function),
+          getDataViews: expect.any(Function),
           logger,
           share: undefined,
         },

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/executor.ts
@@ -54,8 +54,6 @@ export async function executor(core: CoreSetup, options: ExecutorOptions<EsQuery
     getTimeRange,
   } = options;
   const { alertsClient, scopedClusterClient, share } = services;
-  const searchSourceClient = await services.getSearchSourceClient();
-  const dataViews = await services.getDataViews();
 
   if (!alertsClient) {
     throw new AlertsClientError();
@@ -88,9 +86,9 @@ export async function executor(core: CoreSetup, options: ExecutorOptions<EsQuery
         spacePrefix,
         services: {
           share,
-          searchSourceClient,
+          getSearchSourceClient: services.getSearchSourceClient,
           logger,
-          dataViews,
+          getDataViews: services.getDataViews,
         },
         dateStart,
         dateEnd,

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.test.ts
@@ -443,7 +443,7 @@ describe('fetchSearchSourceQuery', () => {
           // @ts-expect-error
           services: {
             logger,
-            searchSourceClient: searchSourceCommonMock,
+            getSearchSourceClient: async () => searchSourceCommonMock,
           },
           spacePrefix: '',
           dateStart: new Date().toISOString(),
@@ -467,7 +467,7 @@ describe('fetchSearchSourceQuery', () => {
           // @ts-expect-error
           services: {
             logger,
-            searchSourceClient: searchSourceCommonMock,
+            getSearchSourceClient: async () => searchSourceCommonMock,
           },
           spacePrefix: '',
           dateStart: new Date().toISOString(),
@@ -528,7 +528,7 @@ describe('fetchSearchSourceQuery', () => {
       const linkWithoutExcludedRuns = await generateLink(
         searchSourceInstance,
         locatorMock,
-        dataViews,
+        async () => dataViews,
         dataViewMock,
         dateStart,
         dateEnd,
@@ -546,7 +546,7 @@ describe('fetchSearchSourceQuery', () => {
       const linkWithExcludedRuns = await generateLink(
         searchSourceInstance,
         locatorMock,
-        dataViews,
+        async () => dataViews,
         dataViewMock,
         dateStart,
         dateEnd,
@@ -590,7 +590,7 @@ describe('fetchSearchSourceQuery', () => {
       await generateLink(
         searchSourceInstance,
         locatorMock,
-        dataViews,
+        async () => dataViews,
         dataViewMock,
         dateStart,
         dateEnd,

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
@@ -36,9 +36,9 @@ export interface FetchSearchSourceQueryOpts {
   spacePrefix: string;
   services: {
     logger: Logger;
-    searchSourceClient: ISearchStartSearchSource;
+    getSearchSourceClient: () => Promise<ISearchStartSearchSource>;
     share: SharePluginStart;
-    dataViews: DataViewsContract;
+    getDataViews: () => Promise<DataViewsContract>;
   };
   dateStart: string;
   dateEnd: string;
@@ -54,7 +54,8 @@ export async function fetchSearchSourceQuery({
   dateStart,
   dateEnd,
 }: FetchSearchSourceQueryOpts) {
-  const { logger, searchSourceClient } = services;
+  const { logger, getSearchSourceClient } = services;
+  const searchSourceClient = await getSearchSourceClient();
   const isGroupAgg = isGroupAggregation(params.termField);
   const isCountAgg = isCountAggregation(params.aggType);
 
@@ -90,7 +91,7 @@ export async function fetchSearchSourceQuery({
   const link = await generateLink(
     initialSearchSource,
     services.share.url.locators.get<DiscoverAppLocatorParams>('DISCOVER_APP_LOCATOR')!,
-    services.dataViews,
+    services.getDataViews,
     index,
     dateStart,
     dateEnd,
@@ -196,13 +197,14 @@ export async function updateSearchSource(
 export async function generateLink(
   searchSource: ISearchSource,
   discoverLocator: LocatorPublic<DiscoverAppLocatorParams>,
-  dataViews: DataViewsContract,
+  getDataViews: () => Promise<DataViewsContract>,
   dataViewToUpdate: DataView,
   dateStart: string,
   dateEnd: string,
   spacePrefix: string,
   filterToExcludeHitsFromPreviousRun: Filter | null
 ) {
+  const dataViews = await getDataViews();
   const prevFilters = [...((searchSource.getField('filter') as Filter[]) || [])];
 
   if (filterToExcludeHitsFromPreviousRun) {


### PR DESCRIPTION
In this PR, I'm optimizing the use of dataViews and searchSourceClient within the ES Query rule by only loading those services whenever the rule uses a search source query and skip loading when it's ES DSL or KQL.