### PR TITLE
[ML] Transforms: Adds confirmation dialog when deleting a transform from warning banner

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/dangling_task_warning/dangling_task_warning.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/dangling_task_warning/dangling_task_warning.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useState } from 'react';
+import { EuiCallOut, EuiButton, EuiConfirmModal, EUI_MODAL_CONFIRM_BUTTON } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useDeleteTransforms } from '../../../../hooks';
+import { TRANSFORM_STATE } from '../../../../../../common/constants';
+
+export const DanglingTasksWarning: FC<{
+  transformIdsWithoutConfig?: string[];
+}> = ({ transformIdsWithoutConfig }) => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const deleteTransforms = useDeleteTransforms();
+
+  const closeModal = () => setIsModalVisible(false);
+  const openModal = () => setIsModalVisible(true);
+
+  const confirmDelete = () => {
+    if (transformIdsWithoutConfig) {
+      deleteTransforms(
+        // If transform task doesn't have any corresponding config
+        // we won't know what the destination index or data view would be
+        // and should be force deleted
+        {
+          transformsInfo: transformIdsWithoutConfig.map((id) => ({
+            id,
+            state: TRANSFORM_STATE.FAILED,
+          })),
+          deleteDestIndex: false,
+          deleteDestDataView: false,
+          forceDelete: true,
+        }
+      );
+    }
+    closeModal();
+  };
+
+  if (!transformIdsWithoutConfig || transformIdsWithoutConfig.length === 0) {
+    return null;
+  }
+
+  const isBulkAction = transformIdsWithoutConfig.length > 1;
+
+  const bulkDeleteModalTitle = i18n.translate(
+    'xpack.transform.transformList.bulkDeleteModalTitle',
+    {
+      defaultMessage: 'Delete {count} {count, plural, one {transform} other {transforms}}?',
+      values: { count: transformIdsWithoutConfig.length },
+    }
+  );
+  const deleteModalTitle = i18n.translate('xpack.transform.transformList.deleteModalTitle', {
+    defaultMessage: 'Delete {transformId}?',
+    values: { transformId: transformIdsWithoutConfig[0] },
+  });
+
+  return (
+    <>
+      <EuiCallOut color="warning">
+        <p>
+          <FormattedMessage
+            id="xpack.transform.danglingTasksError"
+            defaultMessage="{count} {count, plural, one {transform is} other {transforms are}} missing configuration details: [{transformIds}] {count, plural, one {It} other {They}} cannot be recovered and should be deleted."
+            values={{
+              count: transformIdsWithoutConfig.length,
+              transformIds: transformIdsWithoutConfig.join(', '),
+            }}
+          />
+        </p>
+        <EuiButton color="warning" size="s" onClick={openModal}>
+          <FormattedMessage
+            id="xpack.transform.forceDeleteTransformMessage"
+            defaultMessage="Delete {count} {count, plural, one {transform} other {transforms}}"
+            values={{
+              count: transformIdsWithoutConfig.length,
+            }}
+          />
+        </EuiButton>
+      </EuiCallOut>
+
+      {isModalVisible && (
+        <EuiConfirmModal
+          title={isBulkAction ? bulkDeleteModalTitle : deleteModalTitle}
+          onCancel={closeModal}
+          onConfirm={confirmDelete}
+          cancelButtonText={i18n.translate(
+            'xpack.transform.transformList.deleteModalCancelButton',
+            {
+              defaultMessage: 'Cancel',
+            }
+          )}
+          confirmButtonText={i18n.translate(
+            'xpack.transform.transformList.deleteModalDeleteButton',
+            {
+              defaultMessage: 'Delete',
+            }
+          )}
+          defaultFocusedButton={EUI_MODAL_CONFIRM_BUTTON}
+          buttonColor="danger"
+        />
+      )}
+    </>
+  );
+};

--- a/x-pack/plugins/transform/public/app/sections/transform_management/components/dangling_task_warning/dangling_task_warning.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/components/dangling_task_warning/dangling_task_warning.tsx
@@ -7,7 +7,13 @@
 
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import { EuiCallOut, EuiButton, EuiConfirmModal, EUI_MODAL_CONFIRM_BUTTON } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiButton,
+  EuiConfirmModal,
+  EUI_MODAL_CONFIRM_BUTTON,
+  EuiSpacer,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useDeleteTransforms } from '../../../../hooks';
@@ -83,7 +89,7 @@ export const DanglingTasksWarning: FC<{
           />
         </EuiButton>
       </EuiCallOut>
-
+      <EuiSpacer />
       {isModalVisible && (
         <EuiConfirmModal
           title={isBulkAction ? bulkDeleteModalTitle : deleteModalTitle}

--- a/x-pack/plugins/transform/public/app/sections/transform_management/transform_management_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/transform_management_section.tsx
@@ -309,7 +309,6 @@ export const TransformManagement: FC = () => {
 
             <AlertRulesManageContext.Provider value={getAlertRuleManageContext()}>
               <DanglingTasksWarning transformIdsWithoutConfig={transformIdsWithoutConfig} />
-              <EuiSpacer size="s" />
               {(transformNodes > 0 || transforms.length > 0) && (
                 <TransformList
                   isLoading={transformsWithoutStatsLoading}

--- a/x-pack/plugins/transform/public/app/sections/transform_management/transform_management_section.tsx
+++ b/x-pack/plugins/transform/public/app/sections/transform_management/transform_management_section.tsx
@@ -8,7 +8,6 @@
 import React, { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
-  EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiModal,
@@ -33,12 +32,10 @@ import { isTransformStats } from '../../../../common/types/transform_stats';
 import { useGetTransformsStats } from '../../hooks/use_get_transform_stats';
 import { useEnabledFeatures } from '../../serverless_context';
 import { needsReauthorization } from '../../common/reauthorization_utils';
-import { TRANSFORM_STATE } from '../../../../common/constants';
 import { TRANSFORM_LIST_COLUMN } from '../../common';
 
 import {
   useDocumentationLinks,
-  useDeleteTransforms,
   useTransformCapabilities,
   useGetTransforms,
   useGetTransformNodes,
@@ -56,6 +53,7 @@ import {
   getAlertRuleManageContext,
   TransformAlertFlyoutWrapper,
 } from '../../../alerting/transform_alerting_flyout';
+import { DanglingTasksWarning } from './components/dangling_task_warning/dangling_task_warning';
 
 const getDefaultTransformListState = (): ListingPageUrlState => ({
   pageIndex: 0,
@@ -97,8 +95,6 @@ export const TransformManagement: FC = () => {
     'transform',
     getDefaultTransformListState()
   );
-
-  const deleteTransforms = useDeleteTransforms();
 
   const {
     isInitialLoading: transformNodesInitialLoading,
@@ -312,51 +308,8 @@ export const TransformManagement: FC = () => {
             <EuiSpacer size="s" />
 
             <AlertRulesManageContext.Provider value={getAlertRuleManageContext()}>
-              {transformIdsWithoutConfig ? (
-                <>
-                  <EuiCallOut color="warning">
-                    <p>
-                      <FormattedMessage
-                        id="xpack.transform.danglingTasksError"
-                        defaultMessage="{count} {count, plural, one {transform is} other {transforms are}} missing configuration details: [{transformIds}] {count, plural, one {It} other {They}} cannot be recovered and should be deleted."
-                        values={{
-                          count: transformIdsWithoutConfig.length,
-                          transformIds: transformIdsWithoutConfig.join(', '),
-                        }}
-                      />
-                    </p>
-                    <EuiButton
-                      color="warning"
-                      size="s"
-                      onClick={() =>
-                        deleteTransforms(
-                          // If transform task doesn't have any corresponding config
-                          // we won't know what the destination index or data view would be
-                          // and should be force deleted
-                          {
-                            transformsInfo: transformIdsWithoutConfig.map((id) => ({
-                              id,
-                              state: TRANSFORM_STATE.FAILED,
-                            })),
-                            deleteDestIndex: false,
-                            deleteDestDataView: false,
-                            forceDelete: true,
-                          }
-                        )
-                      }
-                    >
-                      <FormattedMessage
-                        id="xpack.transform.forceDeleteTransformMessage"
-                        defaultMessage="Delete {count} {count, plural, one {transform} other {transforms}}"
-                        values={{
-                          count: transformIdsWithoutConfig.length,
-                        }}
-                      />
-                    </EuiButton>
-                  </EuiCallOut>
-                  <EuiSpacer />
-                </>
-              ) : null}
+              <DanglingTasksWarning transformIdsWithoutConfig={transformIdsWithoutConfig} />
+              <EuiSpacer size="s" />
               {(transformNodes > 0 || transforms.length > 0) && (
                 <TransformList
                   isLoading={transformsWithoutStatsLoading}


### PR DESCRIPTION
## Summary

Changes for [#178972](https://github.com/elastic/kibana/issues/178972), adding in a confirmation dialog when deleting a transform from the warning banner in the management list, shown for example when the configuration for a transform has been deleted.

Multiple transforms deletion:

https://github.com/user-attachments/assets/554bf52d-c477-4fc2-94ec-473fb708edc8


Single transform deletion:
![image](https://github.com/user-attachments/assets/3f5a8c58-f520-4280-9205-0485e2b79866)
