### PR TITLE
avoid waiting for filters for control group to be ready

### DIFF
--- a/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/plugins/controls/public/react_controls/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -362,9 +362,9 @@ export const getOptionsListControlFactory = (
         },
       };
 
-      if (selections.hasInitialSelections) {
+      /*if (selections.hasInitialSelections) {
         await dataControl.api.untilFiltersReady();
-      }
+      }*/
 
       return {
         api,

--- a/src/plugins/controls/public/react_controls/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/src/plugins/controls/public/react_controls/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -206,9 +206,9 @@ export const getRangesliderControlFactory = (
         selectionHasNoResults$.next(hasNoResults);
       });
 
-      if (selections.hasInitialSelections) {
+      /*if (selections.hasInitialSelections) {
         await dataControl.api.untilFiltersReady();
-      }
+      }*/
 
       return {
         api,


### PR DESCRIPTION
Test another theory for control group performance degradation - Having control factories wait for control filters to be ready before returning API.