### PR TITLE
[Discover][UnifiedDataTable] Fix Display settings popover when sample size is not a multiple of 10

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
@@ -53,6 +53,7 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
       );
       const input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
       expect(input.prop('value')).toBe(10);
+      expect(input.prop('step')).toBe(10);
 
       await act(async () => {
         input.simulate('change', {
@@ -175,6 +176,45 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
       expect(
         findTestSubject(component, 'unifiedDataTableSampleSizeInput').last().prop('value')
       ).toBe(validIntegerValue);
+    });
+
+    it('should not fail if sample size is not step of 10', async () => {
+      const onChangeSampleSizeMock = jest.fn();
+
+      const customSampleSize = 9995;
+      const newSampleSize = 9992;
+
+      const component = mountWithIntl(
+        <UnifiedDataTableAdditionalDisplaySettings
+          sampleSize={customSampleSize}
+          maxAllowedSampleSize={customSampleSize}
+          onChangeSampleSize={onChangeSampleSizeMock}
+          rowHeight={RowHeightMode.custom}
+          rowHeightLines={10}
+          headerRowHeight={RowHeightMode.custom}
+          headerRowHeightLines={5}
+        />
+      );
+      const input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
+      expect(input.prop('value')).toBe(customSampleSize);
+      expect(input.prop('step')).toBe(1);
+
+      await act(async () => {
+        input.simulate('change', {
+          target: {
+            value: newSampleSize,
+          },
+        });
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      component.update();
+
+      expect(
+        findTestSubject(component, 'unifiedDataTableSampleSizeInput').last().prop('value')
+      ).toBe(newSampleSize);
+
+      expect(onChangeSampleSizeMock).toHaveBeenCalledWith(newSampleSize);
     });
   });
 

--- a/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.test.tsx
@@ -182,7 +182,7 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
       const onChangeSampleSizeMock = jest.fn();
 
       const customSampleSize = 9995;
-      const newSampleSize = 9992;
+      const newSampleSize = 9990;
 
       const component = mountWithIntl(
         <UnifiedDataTableAdditionalDisplaySettings
@@ -195,7 +195,8 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
           headerRowHeightLines={5}
         />
       );
-      const input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
+
+      let input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
       expect(input.prop('value')).toBe(customSampleSize);
       expect(input.prop('step')).toBe(1);
 
@@ -210,9 +211,47 @@ describe('UnifiedDataTableAdditionalDisplaySettings', function () {
       await new Promise((resolve) => setTimeout(resolve, 0));
       component.update();
 
-      expect(
-        findTestSubject(component, 'unifiedDataTableSampleSizeInput').last().prop('value')
-      ).toBe(newSampleSize);
+      input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
+      expect(input.prop('value')).toBe(newSampleSize);
+      expect(input.prop('step')).toBe(1);
+
+      expect(onChangeSampleSizeMock).toHaveBeenCalledWith(newSampleSize);
+    });
+
+    it('should not fail if sample size is less than 10', async () => {
+      const onChangeSampleSizeMock = jest.fn();
+
+      const customSampleSize = 5;
+      const newSampleSize = 10;
+
+      const component = mountWithIntl(
+        <UnifiedDataTableAdditionalDisplaySettings
+          sampleSize={customSampleSize}
+          onChangeSampleSize={onChangeSampleSizeMock}
+          rowHeight={RowHeightMode.custom}
+          rowHeightLines={10}
+          headerRowHeight={RowHeightMode.custom}
+          headerRowHeightLines={5}
+        />
+      );
+      let input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
+      expect(input.prop('value')).toBe(customSampleSize);
+      expect(input.prop('step')).toBe(1);
+
+      await act(async () => {
+        input.simulate('change', {
+          target: {
+            value: newSampleSize,
+          },
+        });
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      component.update();
+
+      input = findTestSubject(component, 'unifiedDataTableSampleSizeInput').last();
+      expect(input.prop('value')).toBe(newSampleSize);
+      expect(input.prop('step')).toBe(1);
 
       expect(onChangeSampleSizeMock).toHaveBeenCalledWith(newSampleSize);
     });

--- a/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_additional_display_settings.tsx
@@ -124,6 +124,17 @@ export const UnifiedDataTableAdditionalDisplaySettings: React.FC<
   }
 
   if (onChangeSampleSize) {
+    let step = minRangeSampleSize === RANGE_MIN_SAMPLE_SIZE ? RANGE_STEP_SAMPLE_SIZE : 1;
+
+    if (
+      step > 1 &&
+      ((activeSampleSize && !checkIfValueIsMultipleOfStep(activeSampleSize, step)) ||
+        !checkIfValueIsMultipleOfStep(minRangeSampleSize, step) ||
+        !checkIfValueIsMultipleOfStep(maxAllowedSampleSize, step))
+    ) {
+      step = 1; // Eui is very strict about step, so we need to switch to 1 if the value is not a multiple of the step
+    }
+
     settings.push(
       <EuiFormRow label={sampleSizeLabel} display="columnCompressed">
         <EuiRange
@@ -131,7 +142,7 @@ export const UnifiedDataTableAdditionalDisplaySettings: React.FC<
           fullWidth
           min={minRangeSampleSize}
           max={maxAllowedSampleSize}
-          step={minRangeSampleSize === RANGE_MIN_SAMPLE_SIZE ? RANGE_STEP_SAMPLE_SIZE : 1}
+          step={step}
           showInput
           value={activeSampleSize}
           onChange={onChangeActiveSampleSize}
@@ -152,3 +163,7 @@ export const UnifiedDataTableAdditionalDisplaySettings: React.FC<
     </>
   );
 };
+
+function checkIfValueIsMultipleOfStep(value: number, step: number) {
+  return value % step === 0;
+}


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/192147

## Summary

This PR fixes the bug with `EuiRange` usage in Display settings popover.

### Testing

Set a random value to `discover:sampleSize` like `9995`. Reload the page and navigate to Discover. Now it should not crash when user presses Display settings button.

<img width="1222" alt="Screenshot 2024-09-05 at 08 40 46" src="https://github.com/user-attachments/assets/07145546-0220-4599-b02b-9ade1ab08eee">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->