### PR TITLE
fix: [Obs Synthetics > Monitor Detail][KEYBOARD]: Tabs have a chart metric that takes keyboard focus but does not change the UI

### DIFF
--- a/src/plugins/chart_expressions/expression_legacy_metric/public/components/metric_component.tsx
+++ b/src/plugins/chart_expressions/expression_legacy_metric/public/components/metric_component.tsx
@@ -156,7 +156,7 @@ class MetricVisComponent extends Component<MetricVisComponentProps> {
         metric={metric}
         style={this.props.visParams.metric.style}
         onFilter={
-          hasBuckets || this.props.filterable[index]
+          hasBuckets && this.props.filterable[index]
             ? () => this.filterColumn(metric.rowIndex, metric.colIndex)
             : undefined
         }


### PR DESCRIPTION
**NOT FOR MERGE! JUST FOR DISCUSSION WITH THE VIS TEAM**

Closes: https://github.com/elastic/kibana/issues/195009

## Description

The `Obs Synthetics` > Monitor Detail `Overview` tab has a "Median duration" metric button that doesn't do anything when clicked. This should be refactored to a non-interactive element. Screenshot attached below.

This issue is related to https://github.com/elastic/kibana/pull/132043. It's necessary to ensure that the new condition doesn't break the existing logic.

### Steps to recreate
1. Open the [Obs Synthetics](https://keepserverless-qa-oblt-b4ba07.kb.eu-west-1.aws.qa.elastic.cloud/app/synthetics) view
2. Click the `Create Monitor` button
3. Create a simple monitor. I added a simple journey for "https://example.com"
4. Click the `Management` tab
5. Click the Monitor name in the table
6. Press `Tab` to navigate through the view by keyboard
7. Verify the Median duration number takes keyboard focus but doesn't do anything on click or keypress

### What was changed:
1. `onFilter` attribute value was updated for `MetricComponent`.  

### Screen: 

<img width="993" alt="image" src="https://github.com/user-attachments/assets/70960e60-e5c0-41bd-96f2-adbf38349664">

 