### PR TITLE
[ML] Fixes display of assignees when attaching ML panels to a new case

### DIFF
--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -83,6 +83,7 @@ const App: FC<AppProps> = ({
       fieldFormats: deps.fieldFormats,
       kibanaVersion: deps.kibanaVersion,
       lens: deps.lens,
+      licensing: deps.licensing,
       licenseManagement: deps.licenseManagement,
       maps: deps.maps,
       observabilityAIAssistant: deps.observabilityAIAssistant,

--- a/x-pack/plugins/ml/public/application/contexts/kibana/kibana_context.ts
+++ b/x-pack/plugins/ml/public/application/contexts/kibana/kibana_context.ts
@@ -32,6 +32,7 @@ import type { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { MlServicesContext } from '../../app';
 
 interface StartPlugins {
@@ -46,6 +47,7 @@ interface StartPlugins {
   embeddable: EmbeddableStart;
   fieldFormats: FieldFormatsRegistry;
   lens: LensPublicStart;
+  licensing: LicensingPluginStart;
   licenseManagement?: LicenseManagementUIPluginSetup;
   maps?: MapsStartApi;
   observabilityAIAssistant?: ObservabilityAIAssistantPublicStart;


### PR DESCRIPTION
## Summary

Adds licensing service to the ML app. 
Fix for: [#188800](https://github.com/elastic/kibana/issues/188800)

Assignees field is now available when attaching embeddables to a new case:
![image](https://github.com/user-attachments/assets/f72a10c8-7684-4d11-87e9-126f2a0a9c6a)
