### PR TITLE
[Fleet] allow +build agent upgrade versions

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.test.ts
@@ -221,7 +221,7 @@ describe('getAvailableVersions', () => {
     expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
   });
 
-  it('should not include duplicate', async () => {
+  it('should include build version', async () => {
     mockKibanaVersion = '300.0.0';
     mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
     mockedFetch.mockResolvedValueOnce({
@@ -245,6 +245,10 @@ describe('getAvailableVersions', () => {
               title: 'Elastic Agent 8.9.2',
               version_number: '8.9.2',
             },
+            {
+              title: 'Elastic Agent 8.9.2',
+              version_number: '8.9.2',
+            },
             ,
           ],
         ])
@@ -254,7 +258,14 @@ describe('getAvailableVersions', () => {
     const res = await getAvailableVersions({ ignoreCache: true });
 
     // Should sort, uniquify and filter out versions < 7.17
-    expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
+    expect(res).toEqual([
+      '8.10.0',
+      '8.10.0+build202407291657',
+      '8.9.2',
+      '8.1.0',
+      '8.0.0',
+      '7.17.0',
+    ]);
   });
 
   it('should cache results', async () => {

--- a/x-pack/plugins/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.test.ts
@@ -221,6 +221,33 @@ describe('getAvailableVersions', () => {
     expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
   });
 
+  it('should filter out rc and beta versions', async () => {
+    mockKibanaVersion = '300.0.0';
+    mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
+    mockedFetch.mockResolvedValueOnce({
+      status: 200,
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify([
+          [
+            {
+              title: 'Elastic Agent 8.0.0',
+              version_number: '8.0.0-rc1',
+            },
+            {
+              title: 'Elastic Agent 8.0.0',
+              version_number: '8.0.0-beta1',
+            },
+          ],
+        ])
+      ),
+    } as any);
+
+    const res = await getAvailableVersions({ ignoreCache: true });
+
+    // Should sort, uniquify and filter out versions < 7.17
+    expect(res).toEqual(['8.1.0', '8.0.0', '7.17.0']);
+  });
+
   it('should include build version', async () => {
     mockKibanaVersion = '300.0.0';
     mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);

--- a/x-pack/plugins/fleet/server/services/agents/versions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.ts
@@ -15,6 +15,7 @@ import semverGte from 'semver/functions/gte';
 import semverGt from 'semver/functions/gt';
 import semverRcompare from 'semver/functions/rcompare';
 import semverLt from 'semver/functions/lt';
+import semverCoerce from 'semver/functions/coerce';
 
 import { REPO_ROOT } from '@kbn/repo-info';
 
@@ -112,6 +113,7 @@ export const getAvailableVersions = async ({
   // only want support versions in the final result. We'll also sort by newest version first.
   availableVersions = uniq(
     [...availableVersions, ...apiVersions]
+      .map((item: any) => (item.includes('+build') ? item : semverCoerce(item)?.version || ''))
       .filter((v: any) => semverGte(v, MINIMUM_SUPPORTED_VERSION))
       .sort((a: any, b: any) => (semverGt(a, b) ? -1 : 1))
   );

--- a/x-pack/plugins/fleet/server/services/agents/versions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.ts
@@ -15,7 +15,6 @@ import semverGte from 'semver/functions/gte';
 import semverGt from 'semver/functions/gt';
 import semverRcompare from 'semver/functions/rcompare';
 import semverLt from 'semver/functions/lt';
-import semverCoerce from 'semver/functions/coerce';
 
 import { REPO_ROOT } from '@kbn/repo-info';
 
@@ -109,11 +108,10 @@ export const getAvailableVersions = async ({
   // fetch from the live API more than `TIME_BETWEEN_FETCHES` milliseconds.
   const apiVersions = await fetchAgentVersionsFromApi();
 
-  // Coerce each version to a semver object and compare to our `MINIMUM_SUPPORTED_VERSION` - we
+  // Take each version and compare to our `MINIMUM_SUPPORTED_VERSION` - we
   // only want support versions in the final result. We'll also sort by newest version first.
   availableVersions = uniq(
     [...availableVersions, ...apiVersions]
-      .map((item: any) => semverCoerce(item)?.version || '')
       .filter((v: any) => semverGte(v, MINIMUM_SUPPORTED_VERSION))
       .sort((a: any, b: any) => (semverGt(a, b) ? -1 : 1))
   );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/191099

Show `+build` versions when upgrade agents

To verify:
- enroll agent before version 8.14.3, latest fleet server
- go to upgrade agent
- check that `+build` versions are available
- verify that the upgrade succeeds

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/c3c10481-8993-4162-8ae6-e3310acb7cd1">
<img width="1525" alt="image" src="https://github.com/user-attachments/assets/2092e98e-58a0-439d-9b1b-253504584c7b">

After 10m monitoring passed, the agent can be upgraded again to newer versions:
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/6cb69dbb-729b-43dc-bf0e-b575c2adb6fa">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->