### PR TITLE
[Lens][Telemetry] track ES time

### DIFF
--- a/packages/kbn-search-types/src/kibana_search_types.ts
+++ b/packages/kbn-search-types/src/kibana_search_types.ts
@@ -68,4 +68,13 @@ export interface IKibanaSearchResponse<RawResponse = any> {
    * HTTP request parameters from elasticsearch transport client t
    */
   requestParams?: SanitizedConnectionRequestParams;
+
+  /**
+   * HTTP Elasticsearch time, query took time and ESClient response time
+   */
+  stats?: {
+    esTime: number;
+    clientTime: number;
+    took: number;
+  };
 }

--- a/src/plugins/data/server/search/strategies/ese_search/response_utils.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/response_utils.ts
@@ -35,7 +35,12 @@ export function toAsyncKibanaSearchStatusResponse(
 export function toAsyncKibanaSearchResponse(
   response: AsyncSearchResponse,
   warning?: string,
-  requestParams?: ConnectionRequestParams
+  requestParams?: ConnectionRequestParams,
+  stats?: {
+    esTime: number;
+    clientTime: number;
+    took: number;
+  }
 ): IKibanaSearchResponse {
   return {
     id: response.id,
@@ -45,5 +50,6 @@ export function toAsyncKibanaSearchResponse(
     ...(warning ? { warning } : {}),
     ...(requestParams ? { requestParams: sanitizeRequestParams(requestParams) } : {}),
     ...getTotalLoaded(response.response),
+    stats,
   };
 }

--- a/src/plugins/inspector/common/adapters/request/types.ts
+++ b/src/plugins/inspector/common/adapters/request/types.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
+import type { IKibanaSearchResponse } from '@kbn/search-types';
 import type { ConnectionRequestParams } from '@elastic/transport';
 
 /**
@@ -54,8 +54,7 @@ export interface RequestStatistic {
 }
 
 export interface Response {
-  // TODO replace object with IKibanaSearchResponse once IKibanaSearchResponse is seperated from data plugin.
-  json?: object;
+  json?: IKibanaSearchResponse;
   requestParams?: ConnectionRequestParams;
   time?: number;
 }


### PR DESCRIPTION
## Summary

This PR add 3 more tracking metrics to the current EBT metric around Lens.
I'm adding:
`esTime`: the time after the `request` and before `deserialization` happening in the elasticsearch client. This time covers the network + all time spent by ES to received the request, parse it, execute the query, collect the results, serialize the response, send it back to the client. It doesn't contain any time spent by the es client.
`took`: the time of the query execution in ES. It doesn't contain the response serialization and the request parsing
`clientTime`: the total amount of time spent by the ES client to send a request and receive and parse a response. This doesn't involve any other Kibana server operation.
 