### PR TITLE
[ci] Increase build artifacts timeout

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -6,7 +6,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c2-standard-16
-    timeout_in_minutes: 75
+    timeout_in_minutes: 120
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
This is a side effect of adding more builds.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->