### PR TITLE
[Entity Manager] Exposing stop and start transforms actions in the EntityClient

### DIFF
--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/delete_transforms.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/delete_transforms.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { EntityDefinition } from '@kbn/entities-schema';
+
+import {
+  generateHistoryTransformId,
+  generateHistoryBackfillTransformId,
+  generateLatestTransformId,
+} from './helpers/generate_component_id';
+import { retryTransientEsErrors } from './helpers/retry';
+
+export async function deleteHistoryTransform(
+  esClient: ElasticsearchClient,
+  definition: EntityDefinition,
+  logger: Logger
+) {
+  try {
+    const historyTransformId = generateHistoryTransformId(definition);
+    await retryTransientEsErrors(
+      () =>
+        esClient.transform.deleteTransform(
+          { transform_id: historyTransformId, force: true },
+          { ignore: [404] }
+        ),
+      { logger }
+    );
+  } catch (e) {
+    logger.error(`Cannot delete history transform [${definition.id}]: ${e}`);
+    throw e;
+  }
+}
+
+export async function deleteHistoryBackfillTransform(
+  esClient: ElasticsearchClient,
+  definition: EntityDefinition,
+  logger: Logger
+) {
+  try {
+    const historyBackfillTransformId = generateHistoryBackfillTransformId(definition);
+    await retryTransientEsErrors(
+      () =>
+        esClient.transform.deleteTransform(
+          { transform_id: historyBackfillTransformId, force: true },
+          { ignore: [404] }
+        ),
+      { logger }
+    );
+  } catch (e) {
+    logger.error(`Cannot delete history backfill transform [${definition.id}]: ${e}`);
+    throw e;
+  }
+}
+
+export async function deleteLatestTransform(
+  esClient: ElasticsearchClient,
+  definition: EntityDefinition,
+  logger: Logger
+) {
+  try {
+    const latestTransformId = generateLatestTransformId(definition);
+    await retryTransientEsErrors(
+      () =>
+        esClient.transform.deleteTransform(
+          { transform_id: latestTransformId, force: true },
+          { ignore: [404] }
+        ),
+      { logger }
+    );
+  } catch (e) {
+    logger.error(`Cannot delete latest transform [${definition.id}]`);
+    throw e;
+  }
+}

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
@@ -32,11 +32,7 @@ import {
   saveEntityDefinition,
   updateEntityDefinition,
 } from './save_entity_definition';
-import {
-  stopAndDeleteHistoryBackfillTransform,
-  stopAndDeleteHistoryTransform,
-  stopAndDeleteLatestTransform,
-} from './stop_and_delete_transform';
+
 import { isBackfillEnabled } from './helpers/is_backfill_enabled';
 import { deleteTemplate, upsertTemplate } from '../manage_index_templates';
 import { generateEntitiesLatestIndexTemplateConfig } from './templates/entities_latest_template';
@@ -45,6 +41,16 @@ import { EntityIdConflict } from './errors/entity_id_conflict_error';
 import { EntityDefinitionNotFound } from './errors/entity_not_found';
 import { EntityDefinitionWithState } from './types';
 import { mergeEntityDefinitionUpdate } from './helpers/merge_definition_update';
+import {
+  stopHistoryBackfillTransform,
+  stopHistoryTransform,
+  stopLatestTransform,
+} from './stop_transforms';
+import {
+  deleteHistoryBackfillTransform,
+  deleteHistoryTransform,
+  deleteLatestTransform,
+} from './delete_transforms';
 
 export interface InstallDefinitionParams {
   esClient: ElasticsearchClient;
@@ -91,14 +97,7 @@ export async function installEntityDefinition({
     return await install({ esClient, soClient, logger, definition: entityDefinition });
   } catch (e) {
     logger.error(`Failed to install entity definition ${definition.id}: ${e}`);
-
-    await Promise.all([
-      stopAndDeleteHistoryTransform(esClient, definition, logger),
-      isBackfillEnabled(definition)
-        ? stopAndDeleteHistoryBackfillTransform(esClient, definition, logger)
-        : Promise.resolve(),
-      stopAndDeleteLatestTransform(esClient, definition, logger),
-    ]);
+    await stopAndDeleteTransforms(esClient, definition, logger);
 
     await Promise.all([
       deleteHistoryIngestPipeline(esClient, definition, logger),
@@ -253,13 +252,7 @@ export async function reinstallEntityDefinition({
     });
 
     logger.debug(`Deleting transforms for definition ${definition.id} v${definition.version}`);
-    await Promise.all([
-      stopAndDeleteHistoryTransform(esClient, definition, logger),
-      isBackfillEnabled(definition)
-        ? stopAndDeleteHistoryBackfillTransform(esClient, definition, logger)
-        : Promise.resolve(),
-      stopAndDeleteLatestTransform(esClient, definition, logger),
-    ]);
+    await stopAndDeleteTransforms(esClient, definition, logger);
 
     return await install({
       esClient,
@@ -307,4 +300,26 @@ const shouldReinstallBuiltinDefinition = (
   const partial = installStatus === 'installed' && !state.installed;
 
   return timedOut || outdated || failed || partial;
+};
+
+const stopAndDeleteTransforms = async (
+  esClient: ElasticsearchClient,
+  definition: EntityDefinition,
+  logger: Logger
+) => {
+  await Promise.all([
+    stopHistoryTransform(esClient, definition, logger),
+    isBackfillEnabled(definition)
+      ? stopHistoryBackfillTransform(esClient, definition, logger)
+      : Promise.resolve(),
+    stopLatestTransform(esClient, definition, logger),
+  ]);
+
+  await Promise.all([
+    deleteHistoryTransform(esClient, definition, logger),
+    isBackfillEnabled(definition)
+      ? deleteHistoryBackfillTransform(esClient, definition, logger)
+      : Promise.resolve(),
+    deleteLatestTransform(esClient, definition, logger),
+  ]);
 };

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/install_entity_definition.ts
@@ -41,16 +41,8 @@ import { EntityIdConflict } from './errors/entity_id_conflict_error';
 import { EntityDefinitionNotFound } from './errors/entity_not_found';
 import { EntityDefinitionWithState } from './types';
 import { mergeEntityDefinitionUpdate } from './helpers/merge_definition_update';
-import {
-  stopHistoryBackfillTransform,
-  stopHistoryTransform,
-  stopLatestTransform,
-} from './stop_transforms';
-import {
-  deleteHistoryBackfillTransform,
-  deleteHistoryTransform,
-  deleteLatestTransform,
-} from './delete_transforms';
+import { stopTransforms } from './stop_transforms';
+import { deleteTransforms } from './delete_transforms';
 
 export interface InstallDefinitionParams {
   esClient: ElasticsearchClient;
@@ -307,19 +299,6 @@ const stopAndDeleteTransforms = async (
   definition: EntityDefinition,
   logger: Logger
 ) => {
-  await Promise.all([
-    stopHistoryTransform(esClient, definition, logger),
-    isBackfillEnabled(definition)
-      ? stopHistoryBackfillTransform(esClient, definition, logger)
-      : Promise.resolve(),
-    stopLatestTransform(esClient, definition, logger),
-  ]);
-
-  await Promise.all([
-    deleteHistoryTransform(esClient, definition, logger),
-    isBackfillEnabled(definition)
-      ? deleteHistoryBackfillTransform(esClient, definition, logger)
-      : Promise.resolve(),
-    deleteLatestTransform(esClient, definition, logger),
-  ]);
+  await stopTransforms(esClient, definition, logger);
+  await deleteTransforms(esClient, definition, logger);
 };

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/start_transforms.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/start_transforms.ts
@@ -15,7 +15,7 @@ import {
 import { retryTransientEsErrors } from './helpers/retry';
 import { isBackfillEnabled } from './helpers/is_backfill_enabled';
 
-export async function startTransform(
+export async function startTransforms(
   esClient: ElasticsearchClient,
   definition: EntityDefinition,
   logger: Logger

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/stop_transforms.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/stop_transforms.ts
@@ -7,14 +7,15 @@
 
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { EntityDefinition } from '@kbn/entities-schema';
+
 import {
-  generateHistoryBackfillTransformId,
   generateHistoryTransformId,
+  generateHistoryBackfillTransformId,
   generateLatestTransformId,
 } from './helpers/generate_component_id';
 import { retryTransientEsErrors } from './helpers/retry';
 
-export async function stopAndDeleteHistoryTransform(
+export async function stopHistoryTransform(
   esClient: ElasticsearchClient,
   definition: EntityDefinition,
   logger: Logger
@@ -29,21 +30,13 @@ export async function stopAndDeleteHistoryTransform(
         ),
       { logger }
     );
-    await retryTransientEsErrors(
-      () =>
-        esClient.transform.deleteTransform(
-          { transform_id: historyTransformId, force: true },
-          { ignore: [404] }
-        ),
-      { logger }
-    );
   } catch (e) {
-    logger.error(`Cannot stop or delete history transform [${definition.id}]: ${e}`);
+    logger.error(`Cannot stop history transform [${definition.id}]: ${e}`);
     throw e;
   }
 }
 
-export async function stopAndDeleteHistoryBackfillTransform(
+export async function stopHistoryBackfillTransform(
   esClient: ElasticsearchClient,
   definition: EntityDefinition,
   logger: Logger
@@ -58,21 +51,13 @@ export async function stopAndDeleteHistoryBackfillTransform(
         ),
       { logger }
     );
-    await retryTransientEsErrors(
-      () =>
-        esClient.transform.deleteTransform(
-          { transform_id: historyBackfillTransformId, force: true },
-          { ignore: [404] }
-        ),
-      { logger }
-    );
   } catch (e) {
-    logger.error(`Cannot stop or delete history backfill transform [${definition.id}]: ${e}`);
+    logger.error(`Cannot stop history backfill transform [${definition.id}]: ${e}`);
     throw e;
   }
 }
 
-export async function stopAndDeleteLatestTransform(
+export async function stopLatestTransform(
   esClient: ElasticsearchClient,
   definition: EntityDefinition,
   logger: Logger
@@ -87,16 +72,8 @@ export async function stopAndDeleteLatestTransform(
         ),
       { logger }
     );
-    await retryTransientEsErrors(
-      () =>
-        esClient.transform.deleteTransform(
-          { transform_id: latestTransformId, force: true },
-          { ignore: [404] }
-        ),
-      { logger }
-    );
   } catch (e) {
-    logger.error(`Cannot stop or delete latest transform [${definition.id}]`);
+    logger.error(`Cannot stop latest transform [${definition.id}]`);
     throw e;
   }
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/uninstall_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/uninstall_entity_definition.ts
@@ -14,24 +14,15 @@ import { deleteIndices } from './delete_index';
 import { deleteHistoryIngestPipeline, deleteLatestIngestPipeline } from './delete_ingest_pipeline';
 import { findEntityDefinitions } from './find_entity_definition';
 
-import { isBackfillEnabled } from './helpers/is_backfill_enabled';
 import {
   generateHistoryIndexTemplateId,
   generateLatestIndexTemplateId,
 } from './helpers/generate_component_id';
 import { deleteTemplate } from '../manage_index_templates';
 
-import {
-  stopHistoryTransform,
-  stopLatestTransform,
-  stopHistoryBackfillTransform,
-} from './stop_transforms';
+import { stopTransforms } from './stop_transforms';
 
-import {
-  deleteHistoryTransform,
-  deleteLatestTransform,
-  deleteHistoryBackfillTransform,
-} from './delete_transforms';
+import { deleteTransforms } from './delete_transforms';
 
 export async function uninstallEntityDefinition({
   definition,
@@ -46,20 +37,8 @@ export async function uninstallEntityDefinition({
   logger: Logger;
   deleteData?: boolean;
 }) {
-  await Promise.all([
-    stopHistoryTransform(esClient, definition, logger),
-    stopLatestTransform(esClient, definition, logger),
-    isBackfillEnabled(definition)
-      ? stopHistoryBackfillTransform(esClient, definition, logger)
-      : Promise.resolve(),
-  ]);
-  await Promise.all([
-    deleteHistoryTransform(esClient, definition, logger),
-    deleteLatestTransform(esClient, definition, logger),
-    isBackfillEnabled(definition)
-      ? deleteHistoryBackfillTransform(esClient, definition, logger)
-      : Promise.resolve(),
-  ]);
+  await stopTransforms(esClient, definition, logger);
+  await deleteTransforms(esClient, definition, logger);
 
   await Promise.all([
     deleteHistoryIngestPipeline(esClient, definition, logger),

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/uninstall_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/uninstall_entity_definition.ts
@@ -13,17 +13,25 @@ import { deleteEntityDefinition } from './delete_entity_definition';
 import { deleteIndices } from './delete_index';
 import { deleteHistoryIngestPipeline, deleteLatestIngestPipeline } from './delete_ingest_pipeline';
 import { findEntityDefinitions } from './find_entity_definition';
-import {
-  stopAndDeleteHistoryBackfillTransform,
-  stopAndDeleteHistoryTransform,
-  stopAndDeleteLatestTransform,
-} from './stop_and_delete_transform';
+
 import { isBackfillEnabled } from './helpers/is_backfill_enabled';
 import {
   generateHistoryIndexTemplateId,
   generateLatestIndexTemplateId,
 } from './helpers/generate_component_id';
 import { deleteTemplate } from '../manage_index_templates';
+
+import {
+  stopHistoryTransform,
+  stopLatestTransform,
+  stopHistoryBackfillTransform,
+} from './stop_transforms';
+
+import {
+  deleteHistoryTransform,
+  deleteLatestTransform,
+  deleteHistoryBackfillTransform,
+} from './delete_transforms';
 
 export async function uninstallEntityDefinition({
   definition,
@@ -39,10 +47,17 @@ export async function uninstallEntityDefinition({
   deleteData?: boolean;
 }) {
   await Promise.all([
-    stopAndDeleteHistoryTransform(esClient, definition, logger),
-    stopAndDeleteLatestTransform(esClient, definition, logger),
+    stopHistoryTransform(esClient, definition, logger),
+    stopLatestTransform(esClient, definition, logger),
     isBackfillEnabled(definition)
-      ? stopAndDeleteHistoryBackfillTransform(esClient, definition, logger)
+      ? stopHistoryBackfillTransform(esClient, definition, logger)
+      : Promise.resolve(),
+  ]);
+  await Promise.all([
+    deleteHistoryTransform(esClient, definition, logger),
+    deleteLatestTransform(esClient, definition, logger),
+    isBackfillEnabled(definition)
+      ? deleteHistoryBackfillTransform(esClient, definition, logger)
       : Promise.resolve(),
   ]);
 

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/upgrade_entity_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/upgrade_entity_definition.ts
@@ -7,7 +7,7 @@
 
 import { EntityDefinition } from '@kbn/entities-schema';
 import { installBuiltInEntityDefinitions } from './install_entity_definition';
-import { startTransform } from './start_transform';
+import { startTransforms } from './start_transforms';
 import { EntityManagerServerSetup } from '../../types';
 import { checkIfEntityDiscoveryAPIKeyIsValid, readEntityDiscoveryAPIKey } from '../auth';
 import { getClientsFromAPIKey } from '../utils';
@@ -46,7 +46,7 @@ export async function upgradeBuiltInEntityDefinitions({
   });
 
   await Promise.all(
-    upgradedDefinitions.map((definition) => startTransform(esClient, definition, logger))
+    upgradedDefinitions.map((definition) => startTransforms(esClient, definition, logger))
   );
 
   return { success: true, definitions: upgradedDefinitions };

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entity_client.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entity_client.ts
@@ -10,18 +10,12 @@ import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { Logger } from '@kbn/logging';
 import { installEntityDefinition } from './entities/install_entity_definition';
-import { startTransform } from './entities/start_transform';
+import { startTransforms } from './entities/start_transforms';
 import { findEntityDefinitions } from './entities/find_entity_definition';
 import { uninstallEntityDefinition } from './entities/uninstall_entity_definition';
 import { EntityDefinitionNotFound } from './entities/errors/entity_not_found';
 
-import {
-  stopHistoryTransform,
-  stopLatestTransform,
-  stopHistoryBackfillTransform,
-} from './entities/stop_transforms';
-
-import { isBackfillEnabled } from './entities/helpers/is_backfill_enabled';
+import { stopTransforms } from './entities/stop_transforms';
 
 export class EntityClient {
   constructor(
@@ -47,7 +41,7 @@ export class EntityClient {
     });
 
     if (!installOnly) {
-      await startTransform(this.options.esClient, definition, this.options.logger);
+      await startTransforms(this.options.esClient, definition, this.options.logger);
     }
 
     return installedDefinition;
@@ -87,17 +81,11 @@ export class EntityClient {
     return { definitions };
   }
 
-  async startTransforms(definition: EntityDefinition) {
-    return startTransform(this.options.esClient, definition, this.options.logger);
+  async startEntityDefinition(definition: EntityDefinition) {
+    return startTransforms(this.options.esClient, definition, this.options.logger);
   }
 
-  async stopTransforms(definition: EntityDefinition) {
-    return Promise.all([
-      stopHistoryTransform(this.options.esClient, definition, this.options.logger),
-      stopLatestTransform(this.options.esClient, definition, this.options.logger),
-      isBackfillEnabled(definition)
-        ? stopHistoryBackfillTransform(this.options.esClient, definition, this.options.logger)
-        : Promise.resolve(),
-    ]);
+  async stopEntityDefinition(definition: EntityDefinition) {
+    return stopTransforms(this.options.esClient, definition, this.options.logger);
   }
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/routes/enablement/enable.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/routes/enablement/enable.ts
@@ -19,9 +19,11 @@ import {
 } from '../../lib/auth';
 import { builtInDefinitions } from '../../lib/entities/built_in';
 import { installBuiltInEntityDefinitions } from '../../lib/entities/install_entity_definition';
-import { startTransform } from '../../lib/entities/start_transform';
+
 import { EntityDiscoveryApiKeyType } from '../../saved_objects';
 import { createEntityManagerServerRoute } from '../create_entity_manager_server_route';
+
+import { startTransforms } from '../../lib/entities/start_transforms';
 
 /**
  * @openapi
@@ -125,7 +127,7 @@ export const enableEntityDiscoveryRoute = createEntityManagerServerRoute({
       if (!params.query.installOnly) {
         await Promise.all(
           installedDefinitions.map((installedDefinition) =>
-            startTransform(esClient, installedDefinition, logger)
+            startTransforms(esClient, installedDefinition, logger)
           )
         );
       }

--- a/x-pack/plugins/observability_solution/entity_manager/server/routes/entities/update.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/routes/entities/update.ts
@@ -13,11 +13,12 @@ import { z } from '@kbn/zod';
 import { EntitySecurityException } from '../../lib/entities/errors/entity_security_exception';
 import { InvalidTransformError } from '../../lib/entities/errors/invalid_transform_error';
 import { findEntityDefinitionById } from '../../lib/entities/find_entity_definition';
+import { startTransforms } from '../../lib/entities/start_transforms';
 import {
   installationInProgress,
   reinstallEntityDefinition,
 } from '../../lib/entities/install_entity_definition';
-import { startTransform } from '../../lib/entities/start_transform';
+
 import { createEntityManagerServerRoute } from '../create_entity_manager_server_route';
 
 /**
@@ -104,7 +105,7 @@ export const updateEntityDefinitionRoute = createEntityManagerServerRoute({
       });
 
       if (!params.query.installOnly) {
-        await startTransform(esClient, updatedDefinition, logger);
+        await startTransforms(esClient, updatedDefinition, logger);
       }
 
       return response.ok({ body: updatedDefinition });


### PR DESCRIPTION
This PR exposes two new methods (`startTransforms` and `stopTransforms`) in the EntityClient as proposed [here](https://github.com/elastic/elastic-entity-model/issues/160)
This work is also required by the Entity Analytics team: https://github.com/elastic/security-team/issues/10230

In addition, it splits up `stop_and_delete_transforms` into more granular actions, one for stopping and another for deleting. The uninstall function is now responsible for appropriately calling those actions in sequence.
