### PR TITLE
[CodeQL] Added max-old-space-size for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3
-      # env:
-      #   NODE_OPTIONS: "--max-old-space-size=6144"
+      env:
+        NODE_OPTIONS: "--max-old-space-size=6144"
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

Added `--max-old-space-size=6144` to increase the maximum heap memory size for the workflow run.

__Fixes: https://github.com/elastic/kibana/issues/192190__