### PR TITLE
[Embeddable Rebuild] [Controls] Stop multiple requests on first Dashboard load

### DIFF
--- a/src/plugins/controls/public/react_controls/control_group/control_fetch/chaining.ts
+++ b/src/plugins/controls/public/react_controls/control_group/control_fetch/chaining.ts
@@ -36,9 +36,6 @@ export function chaining$(
 ) {
   return combineLatest([chainingSystem$, controlsInOrder$, children$]).pipe(
     skipWhile(([chainingSystem, controlsInOrder, children]) => {
-      // wait until all children are available before you start chaining
-      if (controlsInOrder.length !== Object.keys(children).length) return true;
-
       if (chainingSystem === 'HIERARCHICAL') {
         for (let i = 0; i < controlsInOrder.length; i++) {
           if (controlsInOrder[i].id === uuid) {

--- a/src/plugins/controls/public/react_controls/control_group/control_fetch/chaining.ts
+++ b/src/plugins/controls/public/react_controls/control_group/control_fetch/chaining.ts
@@ -36,6 +36,9 @@ export function chaining$(
 ) {
   return combineLatest([chainingSystem$, controlsInOrder$, children$]).pipe(
     skipWhile(([chainingSystem, controlsInOrder, children]) => {
+      // wait until all children are available before you start chaining
+      if (controlsInOrder.length !== Object.keys(children).length) return true;
+
       if (chainingSystem === 'HIERARCHICAL') {
         for (let i = 0; i < controlsInOrder.length; i++) {
           if (controlsInOrder[i].id === uuid) {

--- a/src/plugins/controls/public/react_controls/control_group/get_control_group_factory.tsx
+++ b/src/plugins/controls/public/react_controls/control_group/get_control_group_factory.tsx
@@ -7,7 +7,8 @@
  */
 
 import React, { useEffect } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import deepEqual from 'fast-deep-equal';
+import { BehaviorSubject, distinctUntilChanged } from 'rxjs';
 import fastIsEqual from 'fast-deep-equal';
 import { CoreStart } from '@kbn/core/public';
 import { DataView } from '@kbn/data-views-plugin/common';
@@ -133,7 +134,7 @@ export const getControlGroupEmbeddableFactory = (services: {
               controlsManager.api.children$
             ),
             controlGroupFetch$(ignoreParentSettings$, parentApi ? parentApi : {})
-          ),
+          ).pipe(distinctUntilChanged((a, b) => deepEqual(a, b))),
         ignoreParentSettings$,
         autoApplySelections$,
         allowExpensiveQueries$,

--- a/src/plugins/controls/public/react_controls/control_group/get_control_group_factory.tsx
+++ b/src/plugins/controls/public/react_controls/control_group/get_control_group_factory.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, { useEffect } from 'react';
-import deepEqual from 'fast-deep-equal';
 import { BehaviorSubject, distinctUntilChanged } from 'rxjs';
 import fastIsEqual from 'fast-deep-equal';
 import { CoreStart } from '@kbn/core/public';
@@ -134,7 +133,7 @@ export const getControlGroupEmbeddableFactory = (services: {
               controlsManager.api.children$
             ),
             controlGroupFetch$(ignoreParentSettings$, parentApi ? parentApi : {})
-          ).pipe(distinctUntilChanged((a, b) => deepEqual(a, b))),
+          ).pipe(distinctUntilChanged((a, b) => fastIsEqual(a, b))),
         ignoreParentSettings$,
         autoApplySelections$,
         allowExpensiveQueries$,


### PR DESCRIPTION
## Summary

This PR introduces a small improvement to the `controlFetch$` logic so that it only outputs when the context **changes** - this prevents each control from fetching **twice** on load.

To test the impact of this, I added 8 options lists controls to the sample logs dashboard - before this change, loading this dashboard would trigger **15** requests on the first dashboard load; now, with this change, only 8 fetch requests are fired as expected. Note that this also impacts resetting dashboards and reduces fetching there, but it's less reliable to reproduce than the loading - before this change, I sometimes saw a **flood** of fetch requests on reset (?) whereas this seems to fix that.

Then, to test whether this impacted timing, I compared the dashboard overhead value both before and after this change - before, the average overhead was `1440.93ms` over 10 tests; after, the average dropped a bit to `1395.29ms` over 10 tests. While this is a small improvement (most likely because the first round of server calls should **ideally** be cancelled, assuming our `abortFetchController`s are working as expected), I still think it's worth avoiding unnecessary server calls and not relying on this cancellation.

I also tested reset timing using a similar method by making a selection in the **first** control and recording how long `time2data` takes on reset - before this change, I saw an average of `1273.32ms` over 5 tests, which was reduced to an average of `1200ms` over 5 tests in this PR. This is consistent with the timing improvements seen on load for dashboard overhead.

If we decide this small improvement isn't worth merging, that's fine - but I figured I would open this PR as an option since I went down a bit of a rabbit hole on why we were making so many server requests in my attempts to dig into the timing issues caused by https://github.com/elastic/kibana/pull/190273 🤷 

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
