### PR TITLE
[Screenshotting] Remove pdfjs-dist library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1163,7 +1163,6 @@
     "p-settle": "4.1.1",
     "papaparse": "^5.2.0",
     "pbf": "3.2.1",
-    "pdfjs-dist": "^2.13.216",
     "pdfmake": "^0.2.7",
     "peggy": "^1.2.0",
     "polished": "^3.7.2",

--- a/x-pack/plugins/screenshotting/server/formats/pdf/index.ts
+++ b/x-pack/plugins/screenshotting/server/formats/pdf/index.ts
@@ -5,10 +5,6 @@
  * 2.0.
  */
 
-// FIXME: Once/if we have the ability to get page count directly from Chrome/puppeteer
-// we should get rid of this lib.
-import * as PDFJS from 'pdfjs-dist/legacy/build/pdf.js';
-
 import type { PackageInfo } from '@kbn/core/server';
 import { groupBy } from 'lodash';
 import type { LayoutParams, LayoutType } from '../../../common';
@@ -50,12 +46,7 @@ export interface PdfScreenshotOptions extends CaptureOptions {
   layout?: PdfLayoutParams;
 }
 
-export interface PdfScreenshotMetrics extends Partial<CaptureMetrics> {
-  /**
-   * A number of emitted pages in the generated PDF report.
-   */
-  pages: number;
-}
+export type PdfScreenshotMetrics = Partial<CaptureMetrics>; // TODO: add page count metric, if it becomes possible
 
 /**
  * Final, formatted PDF result
@@ -100,12 +91,11 @@ export async function toPdf(
   { metrics, results }: CaptureResult
 ): Promise<PdfScreenshotResult> {
   let buffer: Buffer;
-  let pages: number;
   const shouldConvertPngsToPdf = layout.id !== 'print';
   if (shouldConvertPngsToPdf) {
     const timeRange = getTimeRange(results);
     try {
-      ({ buffer, pages } = await pngsToPdf({
+      ({ buffer } = await pngsToPdf({
         title: title ? `${title}${timeRange ? ` - ${timeRange}` : ''}` : undefined,
         results,
         layout,
@@ -115,10 +105,7 @@ export async function toPdf(
       }));
 
       return {
-        metrics: {
-          ...(metrics ?? {}),
-          pages,
-        },
+        metrics: metrics ?? {},
         data: buffer,
         errors: results.flatMap(({ error }) => (error ? [error] : [])),
         renderErrors: results.flatMap(({ renderErrors }) => renderErrors ?? []),
@@ -130,18 +117,10 @@ export async function toPdf(
     }
   } else {
     buffer = results[0].screenshots[0].data; // This buffer is already the PDF
-    pages = await PDFJS.getDocument({ data: buffer }).promise.then(async (doc) => {
-      const numPages = doc.numPages;
-      await doc.destroy();
-      return numPages;
-    });
   }
 
   return {
-    metrics: {
-      ...(metrics ?? {}),
-      pages,
-    },
+    metrics: metrics ?? {},
     data: buffer,
     errors: results.flatMap(({ error }) => (error ? [error] : [])),
     renderErrors: results.flatMap(({ renderErrors }) => renderErrors ?? []),

--- a/yarn.lock
+++ b/yarn.lock
@@ -25153,13 +25153,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfjs-dist@^2.13.216:
-  version "2.13.216"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.13.216.tgz#251a11c9c8c6db19baacd833a4e6986c517d1ab3"
-  integrity sha512-qn/9a/3IHIKZarTK6ajeeFXBkG15Lg1Fx99PxU09PAU2i874X8mTcHJYyDJxu7WDfNhV6hM7bRQBZU384anoqQ==
-  dependencies:
-    web-streams-polyfill "^3.2.0"
-
 pdfmake@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/pdfmake/-/pdfmake-0.2.7.tgz#a7a46532ffde032674929988393c20b075cf65e3"
@@ -31954,7 +31947,7 @@ web-streams-polyfill@4.0.0-beta.3:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
   integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
 
-web-streams-polyfill@^3.0.3, web-streams-polyfill@^3.2.0, web-streams-polyfill@^3.2.1:
+web-streams-polyfill@^3.0.3, web-streams-polyfill@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/192006

This PR removes the pdfjs-dist library from Kibana, which was only used to collect the number of pages for PDFs that were generated with the "print layout" feature of dashboard reports.