### PR TITLE
[UII] Fix `unifiedSearch` mock in `SearchBar` jest test

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/search_bar.test.tsx
@@ -114,6 +114,7 @@ jest.mock('../hooks', () => {
               },
             },
           ]),
+          hasQuerySuggestions: jest.fn().mockReturnValue(true),
         },
         ui: {
           IndexPatternSelect: jest.fn(),


### PR DESCRIPTION
## Summary

Resolves #181510. Fixes missing method in the mocked `unifiedSearch` dependency that was causing flaky test failures.


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->