### PR TITLE
Bump micromatch to version 4.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1734,7 +1734,7 @@
     "lmdb": "^2.9.2",
     "loader-utils": "^2.0.4",
     "marge": "^1.0.1",
-    "micromatch": "^4.0.7",
+    "micromatch": "^4.0.8",
     "mini-css-extract-plugin": "1.1.0",
     "minimist": "^1.2.6",
     "mocha": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23123,10 +23123,10 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.7.tgz#33e8190d9fe474a9895525f5618eee136d46c2e5"
-  integrity sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"


### PR DESCRIPTION
## Summary

Bump `micromatch` to `4.0.8`

<!--ONMERGE {"backportTargets":["7.17","8.15"]} ONMERGE-->