### PR TITLE
[Security solution] AI Assistant Evals - `maxConcurrency: 5`

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -332,6 +332,7 @@ export const postEvaluateRoute = (
               evaluators: [], // Evals to be managed in LangSmith for now
               experimentPrefix: name,
               client: new Client({ apiKey: langSmithApiKey }),
+              // prevent rate limiting and unexpected multiple experiment runs
               maxConcurrency: 5,
             });
             logger.debug(`runResp:\n ${JSON.stringify(evalOutput, null, 2)}`);

--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -332,6 +332,7 @@ export const postEvaluateRoute = (
               evaluators: [], // Evals to be managed in LangSmith for now
               experimentPrefix: name,
               client: new Client({ apiKey: langSmithApiKey }),
+              maxConcurrency: 5,
             });
             logger.debug(`runResp:\n ${JSON.stringify(evalOutput, null, 2)}`);
           });


### PR DESCRIPTION
## Summary

Set `maxConcurrency: 5` on the LangSmith `evaluate` call to prevent rate limiting and timeouts.