### PR TITLE
Task Partitioner improvements

### DIFF
--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -317,6 +317,7 @@ export class TaskManagerPlugin
       });
 
       const taskPartitioner = new TaskPartitioner({
+        logger: this.logger,
         podName: this.taskManagerId!,
         kibanaDiscoveryService: this.kibanaDiscoveryService,
         kibanasPerPartition: this.config.kibanas_per_partition,

--- a/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/plugins/task_manager/server/polling_lifecycle.test.ts
@@ -102,6 +102,7 @@ describe('TaskPollingLifecycle', () => {
     pollIntervalConfiguration$: of(100),
     executionContext,
     taskPartitioner: new TaskPartitioner({
+      logger: taskManagerLogger,
       podName: 'test',
       kibanaDiscoveryService: {} as KibanaDiscoveryService,
       kibanasPerPartition: DEFAULT_KIBANAS_PER_PARTITION,

--- a/x-pack/plugins/task_manager/server/queries/query_clauses.test.ts
+++ b/x-pack/plugins/task_manager/server/queries/query_clauses.test.ts
@@ -28,6 +28,7 @@ describe('matchesClauses', () => {
     expect(
       matchesClauses(
         mustBeAllOf(TaskWithSchedule),
+        undefined,
         shouldBeOneOf(RunningTask, IdleTaskWithExpiredRunAt)
       )
     ).toMatchObject({

--- a/x-pack/plugins/task_manager/server/queries/query_clauses.ts
+++ b/x-pack/plugins/task_manager/server/queries/query_clauses.ts
@@ -38,9 +38,12 @@ export interface ScriptClause {
 export type PinnedQuery = Pick<estypes.QueryDslQueryContainer, 'pinned'>;
 
 type BoolClause = Pick<estypes.QueryDslQueryContainer, 'bool'>;
-export function matchesClauses(...clauses: BoolClause[]): BoolClause {
+export function matchesClauses(...clauses: Array<BoolClause | undefined>): BoolClause {
   return {
-    bool: Object.assign({}, ...clauses.map((clause) => clause.bool)),
+    bool: Object.assign(
+      {},
+      ...clauses.filter((clause): clause is BoolClause => !!clause).map((clause) => clause.bool)
+    ),
   };
 }
 

--- a/x-pack/plugins/task_manager/server/queries/task_claiming.test.ts
+++ b/x-pack/plugins/task_manager/server/queries/task_claiming.test.ts
@@ -27,6 +27,7 @@ jest.mock('../constants', () => ({
 
 const taskManagerLogger = mockLogger();
 const taskPartitioner = new TaskPartitioner({
+  logger: taskManagerLogger,
   podName: 'test',
   kibanaDiscoveryService: {} as KibanaDiscoveryService,
   kibanasPerPartition: DEFAULT_KIBANAS_PER_PARTITION,

--- a/x-pack/plugins/task_manager/server/task_claimers/strategy_update_by_query.test.ts
+++ b/x-pack/plugins/task_manager/server/task_claimers/strategy_update_by_query.test.ts
@@ -45,6 +45,7 @@ jest.mock('../constants', () => ({
 
 const taskManagerLogger = mockLogger();
 const taskPartitioner = new TaskPartitioner({
+  logger: taskManagerLogger,
   podName: 'test',
   kibanaDiscoveryService: {} as KibanaDiscoveryService,
   kibanasPerPartition: DEFAULT_KIBANAS_PER_PARTITION,


### PR DESCRIPTION
In this PR, I'm making a few small improvements to the task manager task partitioner.

The improvements include:
- Making a Kibana node claim against all the partitions when its node has no assigned partitions (and log a warning)
- Making the task partitioner skip the cache whenever the previous fetch did not find any partitions
- Log an error message whenever the kibana discover service fails the search for active nodes

## To verify

**Claiming against all partitions:**
1. Set `xpack.task_manager.claim_strategy: mget`
2. Apply the following diff to your code
```
diff --git a/x-pack/plugins/task_manager/server/lib/assign_pod_partitions.ts b/x-pack/plugins/task_manager/server/lib/assign_pod_partitions.ts
index 8639edd0483..d8d2277dbc1 100644
--- a/x-pack/plugins/task_manager/server/lib/assign_pod_partitions.ts
+++ b/x-pack/plugins/task_manager/server/lib/assign_pod_partitions.ts
@@ -42,10 +42,10 @@ export function assignPodPartitions({
 }: AssignPodPartitionsOpts): number[] {
   const map = getPartitionMap({ kibanasPerPartition, podNames, partitions });
   const podPartitions: number[] = [];
-  for (const partition of Object.keys(map)) {
-    if (map[Number(partition)].indexOf(podName) !== -1) {
-      podPartitions.push(Number(partition));
-    }
-  }
+  // for (const partition of Object.keys(map)) {
+  //   if (map[Number(partition)].indexOf(podName) !== -1) {
+  //     podPartitions.push(Number(partition));
+  //   }
+  // }
   return podPartitions;
 }
diff --git a/x-pack/plugins/task_manager/server/task_claimers/strategy_mget.ts b/x-pack/plugins/task_manager/server/task_claimers/strategy_mget.ts
index c0193917f08..fac229d41fb 100644
--- a/x-pack/plugins/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/plugins/task_manager/server/task_claimers/strategy_mget.ts
@@ -367,6 +367,7 @@ async function searchAvailableTasks({
       filterDownBy(InactiveTasks),
       partitions.length ? tasksWithPartitions(partitions) : undefined
     );
+    console.log('queryUnlimitedTasks', JSON.stringify(queryUnlimitedTasks, null, 2));
     searches.push({
       query: queryUnlimitedTasks,
       sort, // note: we could optimize this to not sort on priority, for this case
@@ -394,6 +395,7 @@ async function searchAvailableTasks({
       filterDownBy(InactiveTasks),
       partitions.length ? tasksWithPartitions(partitions) : undefined
     );
+    console.log('queryLimitedTasks', JSON.stringify(query, null, 2));
     searches.push({
       query,
       sort,
```
3. Startup Elasticsearch and Kibana
4. Notice something like the following logged as a warning
```
Background task node "5b2de169-2785-441b-ae8c-186a1936b17d" has no assigned partitions, claiming against all partitions
````
5. Observe the queries logged and ensure no filter exists for partitions

**Skipping the cache:**
1. Set `xpack.task_manager.claim_strategy: mget`
2. Apply the following diff to your code
```
diff --git a/x-pack/plugins/task_manager/server/lib/task_partitioner.ts b/x-pack/plugins/task_manager/server/lib/task_partitioner.ts
index 9e90d459663..8f1d7b312aa 100644
--- a/x-pack/plugins/task_manager/server/lib/task_partitioner.ts
+++ b/x-pack/plugins/task_manager/server/lib/task_partitioner.ts
@@ -64,20 +64,18 @@ export class TaskPartitioner {
     // update the pod partitions cache after 10 seconds or when no partitions were previously found
     if (now - lastUpdated >= CACHE_INTERVAL || this.podPartitions.length === 0) {
       try {
-        const allPodNames = await this.getAllPodNames();
-        this.podPartitions = assignPodPartitions({
-          kibanasPerPartition: this.kibanasPerPartition,
-          podName: this.podName,
-          podNames: allPodNames,
-          partitions: this.allPartitions,
-        });
+        console.log('Loading partitions from Elasticsearch');
+        // const allPodNames = await this.getAllPodNames();
+        this.podPartitions = [];
         this.podPartitionsLastUpdated = now;
+        return this.podPartitions;
       } catch (error) {
         this.logger.error(`Failed to load list of active kibana nodes: ${error.message}`);
         // return the cached value
         return this.podPartitions;
       }
     }
+    console.log('Loading partitions from cache');
     return this.podPartitions;
   }

```
3. Startup Elasticsearch and Kibana
4. Notice we only observe `Loading partitions from Elasticsearch` logs and no `Loading partitions from cache` regardless of the 10s cache threshold.

**Error logging:**
1. Set `xpack.task_manager.claim_strategy: mget`
2. Apply the following diff to your code
```
diff --git a/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts b/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
index c532cb755f7..a9314aae88c 100644
--- a/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
+++ b/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
@@ -91,6 +91,7 @@ export class KibanaDiscoveryService {
   }

   public async getActiveKibanaNodes() {
+    throw new Error('no');
     const { saved_objects: activeNodes } =
       await this.savedObjectsRepository.find<BackgroundTaskNode>({
         type: BACKGROUND_TASK_NODE_SO_NAME,
```
3. Observe the following error messages logged
```
Failed to load list of active kibana nodes: no
```