### PR TITLE
[Fleet] add additional columns to Agent Logs UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/agent_logs.tsx
@@ -50,6 +50,14 @@ const LOG_VIEW_SETTINGS: LogStreamProps['logView'] = {
   logViewId: 'default',
 };
 
+const LOG_VIEW_COLUMNS: LogStreamProps['columns'] = [
+  { type: 'timestamp' },
+  { field: 'event.dataset', type: 'field' },
+  { field: 'component.id', type: 'field' },
+  { type: 'message' },
+  { field: 'error.message', type: 'field' },
+];
+
 export interface AgentLogsProps {
   agent: Agent;
   agentPolicy?: AgentPolicy;
@@ -336,6 +344,7 @@ export const AgentLogsUI: React.FunctionComponent<AgentLogsProps> = memo(
               startTimestamp={dateRangeTimestamps.start}
               endTimestamp={dateRangeTimestamps.end}
               query={logStreamQuery}
+              columns={LOG_VIEW_COLUMNS}
             />
           </EuiPanel>
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/188662

Added `component.id` and `error.message` columns to Agent Details / Logs UI.

<img width="1609" alt="image" src="https://github.com/user-attachments/assets/d3ee03f7-7753-4acd-b8e5-e8e027bd7e5a">

