### PR TITLE
[Automatic Import] Assorted improvements to chains

### DIFF
--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.ts
@@ -212,6 +212,6 @@ export async function getCategorizationGraph({ client, model }: CategorizationGr
       }
     );
 
-  const compiledCategorizationGraph = workflow.compile();
+  const compiledCategorizationGraph = workflow.compile().withConfig({ runName: 'Categorization' });
   return compiledCategorizationGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/chunk.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/chunk.test.ts
@@ -13,7 +13,7 @@ describe('test chunks', () => {
     const chunkSize = 2;
     const result = mergeAndChunkSamples(objects, chunkSize);
     expect(result).toStrictEqual([
-      JSON.stringify({ a: 1, b: 2 }, null, 2),
+      JSON.stringify({ a: [1, 2], b: [2, 3] }, null, 2),
       JSON.stringify({ c: { d: 3 }, e: 4 }, null, 2),
     ]);
   });

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/chunk.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/chunk.ts
@@ -6,7 +6,7 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { merge } from '../../util/samples';
+import { mergeDictionaries } from '../../util/samples';
 
 interface NestedObject {
   [key: string]: any;
@@ -21,7 +21,7 @@ export function mergeAndChunkSamples(objects: string[], chunkSize: number): stri
 
   for (const obj of objects) {
     const sample: NestedObject = JSON.parse(obj);
-    result = merge(result, sample);
+    result = mergeDictionaries(result, sample);
   }
 
   const chunks = generateChunks(result, chunkSize);

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
@@ -118,7 +118,7 @@ export async function getEcsGraph({ model }: EcsGraphParams) {
     })
     .addEdge('modelOutput', END);
 
-  const compiledEcsGraph = workflow.compile();
+  const compiledEcsGraph = workflow.compile().withConfig({ runName: 'ECS Mapping' });
 
   return compiledEcsGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/state.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/state.ts
@@ -7,7 +7,7 @@
 
 import type { StateGraphArgs } from '@langchain/langgraph';
 import type { EcsMappingState } from '../../types';
-import { merge } from '../../util/samples';
+import { mergeDictionaries } from '../../util/samples';
 
 export const graphState: StateGraphArgs<EcsMappingState>['channels'] = {
   ecs: {
@@ -16,7 +16,7 @@ export const graphState: StateGraphArgs<EcsMappingState>['channels'] = {
   },
   chunkSize: {
     value: (x: number, y?: number) => y ?? x,
-    default: () => 25,
+    default: () => 30,
   },
   lastExecutedChain: {
     value: (x: string, y?: string) => y ?? x,
@@ -59,7 +59,7 @@ export const graphState: StateGraphArgs<EcsMappingState>['channels'] = {
     default: () => ({}),
   },
   chunkMapping: {
-    reducer: merge,
+    reducer: mergeDictionaries,
     default: () => ({}),
   },
   finalMapping: {

--- a/x-pack/plugins/integration_assistant/server/graphs/log_type_detection/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/log_type_detection/graph.ts
@@ -103,7 +103,7 @@ export async function getLogFormatDetectionGraph({ model }: LogDetectionGraphPar
       }
     );
 
-  const compiledLogFormatDetectionGraph = workflow.compile();
+  const compiledLogFormatDetectionGraph = workflow.compile().withConfig({ runName: 'Log Format' });
 
   return compiledLogFormatDetectionGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/related/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/graph.ts
@@ -174,6 +174,6 @@ export async function getRelatedGraph({ client, model }: RelatedGraphParams) {
       }
     );
 
-  const compiledRelatedGraph = workflow.compile();
+  const compiledRelatedGraph = workflow.compile().withConfig({ runName: 'Related' });
   return compiledRelatedGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/util/samples.test.ts
+++ b/x-pack/plugins/integration_assistant/server/util/samples.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeDictionaries, mergeArrays } from './samples';
+
+describe('merge', () => {
+  test('merges two objects', () => {
+    const target = {
+      name: 'John',
+      age: 30,
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+      },
+    };
+
+    const source = {
+      age: 35,
+      address: {
+        city: 'San Francisco',
+        state: 'CA',
+      },
+      hobbies: ['reading', 'painting'],
+    };
+
+    const expected = {
+      name: 'John',
+      age: [30, 35],
+      address: {
+        street: '123 Main St',
+        city: ['New York', 'San Francisco'],
+        state: 'CA',
+      },
+      hobbies: ['reading', 'painting'],
+    };
+
+    const result = mergeDictionaries(target, source);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('handles empty values', () => {
+    const target = {
+      name: 'John',
+      age: 30,
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+      },
+    };
+
+    const source = {
+      age: null,
+      address: {},
+      hobbies: [],
+    };
+
+    const expected = {
+      name: 'John',
+      age: 30,
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+      },
+    };
+
+    const result = mergeDictionaries(target, source);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('truncates arrays', () => {
+    const target = {
+      hobbies: ['reading', 'painting'],
+    };
+
+    const source = {
+      hobbies: ['swimming', 'cooking'],
+    };
+
+    const expected = {
+      hobbies: ['cooking', 'painting', 'reading'],
+    };
+
+    const result = mergeDictionaries(target, source);
+
+    expect(result).toEqual(expected);
+  });
+
+  test('merges nested arrays', () => {
+    const target = {
+      name: 'John',
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+      },
+      hobbies: ['reading', 'painting'],
+    };
+
+    const source = {
+      address: {
+        city: 'San Francisco',
+        state: 'CA',
+      },
+      hobbies: ['swimming', 'cooking'],
+    };
+
+    const expected = {
+      name: 'John',
+      address: {
+        street: '123 Main St',
+        city: ['New York', 'San Francisco'],
+        state: 'CA',
+      },
+      hobbies: ['cooking', 'painting', 'reading'],
+    };
+
+    const result = mergeDictionaries(target, source);
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('mergeArrays', () => {
+  test('combines and sorts two arrays', () => {
+    const target = [1, 3, 5];
+    const source = [2, 4, 6];
+    const expected = [1, 2, 3];
+    const result = mergeArrays(target, source);
+    expect(result).toEqual(expected);
+  });
+
+  test('removes duplicates from arrays', () => {
+    const target = [1, 2, 3];
+    const source = [2, 3, 4];
+    const expected = [1, 2, 3];
+    const result = mergeArrays(target, source);
+    expect(result).toEqual(expected);
+  });
+
+  test('truncates array to maxArrayLength elements', () => {
+    const target = [1, 2, 3];
+    const source = [4, 5, 6];
+    const expected = [1, 2, 3];
+    const result = mergeArrays(target, source);
+    expect(result).toEqual(expected);
+  });
+
+  test('handles empty arrays', () => {
+    const target = [];
+    const source = [];
+    const expected = [];
+    const result = mergeArrays(target, source);
+    expect(result).toEqual(expected);
+  });
+
+  test('handles arrays with different types', () => {
+    const target = [1, 'two', true];
+    const source = [false, 'three', 4];
+    const expected = [1, 4, false];
+    const result = mergeArrays(target, source);
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

1. Adds chain names when viewing in LangGraph.
2. ECS mapping chain will send three values for each key instead of one.

Here are examples of what it sends now:

```
<combined_samples>
{
  "ai_teleport_cf0cd058": {
    "audit": {
      "ei": [
        0,
        144,
        38
      ],
      "event": [
        "cert.create",
        "db.session.start",
        "session.end"
      ],
      "uid": [
        "21c82c73-19c3-4024-aa41-abb1abf0850f",
        "2942c7a6-315e-4cec-a024-3bab8a3397c8",
        "373ad109-851b-4126-ac61-2819c328b0ae"
      ],
      "code": [
        "T1000I",
        "T2003I",
        "T2004I"
      ],
      "time": [
        "2024-02-23T18:56:50.628Z",
        "2024-02-23T18:56:50.653Z",
        "2024-02-23T18:57:26.308Z"
      ],
      "cluster_name": [
        "teleport.ericbeahan.com"
      ],
      "user": [
        "teleport-admin"
      ],
      "required_private_key_policy": "none",
      "success": [
        false,
        true
      ],
      "method": "local",
      "mfa_device": {
        "mfa_device_name": "otp-device",
        "mfa_device_uuid": "d07bf388-af49-4ec2-b8a4-c8a9e785b70b",
        "mfa_device_type": "TOTP"
      },
      "user_agent": [
        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
        "tsh/15.0.2 grpc-go/1.60.1"
      ],
      "addr.remote": [
        "175.16.199.196:50332",
        "175.16.199.196:50339"
      ],
      "cert_type": [
        "user"
      ],
      "identity": {
        "user": [
          "teleport-admin"
        ],
        "roles": [
          "access",
          "editor"
        ],
        "logins": [
          "-teleport-internal-join",
          "ec2-user",
          "root"
        ],
        "expires": [
          "2024-02-24T06:56:50.63704628Z",
          "2024-02-24T06:56:50.648137154Z",
          "2024-02-24T07:00:41.004476337Z"
        ],
        "route_to_cluster": [
          "teleport.ericbeahan.com"
        ],
        "traits": {
          "aws_role_arns": null,
          "azure_identities": null,
          "db_names": null,
          "db_roles": null,
          "db_users": null,
          "gcp_service_accounts": null,
          "host_user_gid": [
            ""
          ],
          "host_user_uid": [
            ""
          ],
          "kubernetes_groups": null
        }
      }
    }
  }
}
</combined_samples>

<combined_samples>
{
  "ai_teleport_cf0cd058": {
    "audit": {
      "identity": {
        "traits": {
          "kubernetes_users": null,
          "logins": [
            "ec2-user",
            "root",
            "ubuntu"
          ],
          "windows_logins": null
        },
        "teleport_cluster": [
          "teleport.ericbeahan.com"
        ],
        "client_ip": [
          "175.16.199.196",
          "175.16.199.23"
        ],
        "prev_identity_expires": [
          "0001-01-01T00:00:00Z"
        ],
        "private_key_policy": [
          "none"
        ],
        "usage": [
          "usage:db"
        ],
        "route_to_database": {
          "service_name": "example-dynamodb",
          "protocol": "dynamodb",
          "username": "ExampleTeleportDynamoDBRole"
        }
      },
      "user_kind": [
        1
      ],
      "sid": [
        "033a40d5-f5f0-49e1-9d12-93c9d90a4aa8",
        "0f9b4848-b0a5-411e-bcd1-bc3d04eb8cbf",
        "293fda2d-2266-4d4d-b9d1-bd5ea9dd9fc3"
      ],
      "private_key_policy": [
        "none"
      ],
      "namespace": [
        "default"
      ],
      "server_id": [
        "b321c207-fd08-46c8-b248-0c20436feb62",
        "face0091-2bf1-43fd-a16a-f1514b4119f4"
      ],
      "error": [
        "access to db denied. User does not have permissions. Confirm database user and name."
      ],
      "message": [
        "access to db denied. User does not have permissions. Confirm database user and name."
      ],
      "db_service": [
        "example-dynamodb"
      ],
      "db_protocol": [
        "dynamodb"
      ],
      "db_uri": [
        "aws://dynamodb.us-east-2.amazonaws.com"
      ],
      "db_user": [
        "ExampleTeleportDynamoDBRole"
      ],
      "db_type": [
        "dynamodb"
      ],
      "db_origin": [
        "config-file"
      ],
      "login": [
        "ec2-user"
      ],
      "server_hostname": [
        "ip-175.16.199.163.us-east-2.compute.internal",
        "ip-175.16.199.98.us-east-2.compute.internal"
      ],
      "server_addr": "[::]:3022",
      "server_labels": {
        "hostname": [
          "ip-175.16.199.163.us-east-2.compute.internal",
          "ip-175.16.199.98.us-east-2.compute.internal"
        ],
        "teleport.internal/resource-id": "dccb2999-9fb8-4169-aded-ec7a1c0a26de"
      },
      "proto": "ssh"
    }
  }
}
</combined_samples>
```

Currently the test is failing in the following way:

```
            Object {
    -         "rename": Object {
    +         "convert": Object {
                "field": "mysql_enterprise.audit.cpu_usage",
    +           "ignore_failure": true,
                "ignore_missing": true,
                "target_field": "host.cpu.usage",
    +           "type": "float",
              },
```
that is, the chain tries to convert the array into a scalar down the line, this still needs to be tweaked.


### Checklist

- [ ] Test whether ECS mapping is better with various examples.
- [ ] Make sure the array values are not _converted_ but simply assigned to scalar values.
