### PR TITLE
[Discover] Improve data grid render performance (`flattenHit` and `formatHit`)

### DIFF
--- a/packages/kbn-data-service/index.ts
+++ b/packages/kbn-data-service/index.ts
@@ -10,4 +10,9 @@
 export type { GetConfigFn } from './src/types';
 export { UI_SETTINGS } from './src/constants';
 export { getEsQueryConfig } from './src/es_query';
-export { tabifyDocs, flattenHit } from './src/search/tabify';
+export {
+  tabifyDocs,
+  flattenHit,
+  getFlattenedFieldsComparator,
+  type FlattenedFieldsComparator,
+} from './src/search/tabify';

--- a/packages/kbn-data-service/src/search/tabify/index.ts
+++ b/packages/kbn-data-service/src/search/tabify/index.ts
@@ -7,4 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { tabifyDocs, flattenHit } from './tabify_docs';
+export {
+  tabifyDocs,
+  flattenHit,
+  getFlattenedFieldsComparator,
+  type FlattenedFieldsComparator,
+} from './tabify_docs';

--- a/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
+++ b/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
@@ -171,19 +171,15 @@ function makeProxy(flat: Record<string, any>, indexPattern?: DataView) {
   return new Proxy(flat, {
     defineProperty: (...args) => {
       cachedKeys = undefined;
-      console.log('defineProperty');
       return Reflect.defineProperty(...args);
     },
     deleteProperty: (...args) => {
       cachedKeys = undefined;
-      console.log('deleteProperty');
       return Reflect.deleteProperty(...args);
     },
     ownKeys: (target) => {
       if (!cachedKeys) {
         cachedKeys = Reflect.ownKeys(target).sort(comparator);
-      } else {
-        console.log('cached');
       }
       return cachedKeys;
     },

--- a/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
+++ b/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
@@ -98,7 +98,11 @@ function flattenAccum(
  * @param indexPattern The index pattern for the requested index if available.
  * @param params Parameters how to flatten the hit
  */
-export function flattenHit(hit: Hit, indexPattern?: DataView, params?: TabifyDocsOptions) {
+export function flattenHit(
+  hit: Hit,
+  indexPattern?: DataView,
+  params?: TabifyDocsOptions & { flattenedFieldsComparator?: FlattenedFieldsComparator }
+) {
   const flat = {} as Record<string, any>;
 
   flattenAccum(flat, hit.fields || {}, '', indexPattern, params);
@@ -147,49 +151,55 @@ export function flattenHit(hit: Hit, indexPattern?: DataView, params?: TabifyDoc
 
   // Use a proxy to make sure that keys are always returned in a specific order,
   // so we have a guarantee on the flattened order of keys.
-  return makeProxy(flat, indexPattern);
+  return makeProxy(flat, indexPattern, params?.flattenedFieldsComparator);
 }
 
-function makeProxy(flat: Record<string, any>, indexPattern?: DataView) {
-  const getComparator = () => {
-    const metaFields = new Set(indexPattern?.metaFields);
-    const lowerMap = new Map<string, string>();
-    let aLower: string | undefined;
-    let bLower: string | undefined;
+export const getFlattenedFieldsComparator = (indexPattern?: DataView) => {
+  const metaFields = new Set(indexPattern?.metaFields);
+  const lowerMap = new Map<string, string>();
+  let aLower: string | undefined;
+  let bLower: string | undefined;
 
-    const compareLower = (a: string, b: string) => {
-      aLower = lowerMap.get(a);
-      if (aLower === undefined) {
-        aLower = a.toLowerCase();
-        lowerMap.set(a, aLower);
-      }
-      bLower = lowerMap.get(b);
-      if (bLower === undefined) {
-        bLower = b.toLowerCase();
-        lowerMap.set(b, bLower);
-      }
-      return aLower < bLower ? -1 : aLower > bLower ? 1 : 0;
-    };
-
-    return (a: string | symbol, b: string | symbol) => {
-      if (typeof a === 'symbol' || typeof b === 'symbol') {
-        return 0;
-      }
-      const aIsMeta = metaFields.has(a);
-      const bIsMeta = metaFields.has(b);
-      if (aIsMeta && bIsMeta) {
-        return compareLower(a, b);
-      }
-      if (aIsMeta) {
-        return 1;
-      }
-      if (bIsMeta) {
-        return -1;
-      }
-      return compareLower(a, b);
-    };
+  const compareLower = (a: string, b: string) => {
+    aLower = lowerMap.get(a);
+    if (aLower === undefined) {
+      aLower = a.toLowerCase();
+      lowerMap.set(a, aLower);
+    }
+    bLower = lowerMap.get(b);
+    if (bLower === undefined) {
+      bLower = b.toLowerCase();
+      lowerMap.set(b, bLower);
+    }
+    return aLower < bLower ? -1 : aLower > bLower ? 1 : 0;
   };
 
+  return (a: string | symbol, b: string | symbol) => {
+    if (typeof a === 'symbol' || typeof b === 'symbol') {
+      return 0;
+    }
+    const aIsMeta = metaFields.has(a);
+    const bIsMeta = metaFields.has(b);
+    if (aIsMeta && bIsMeta) {
+      return compareLower(a, b);
+    }
+    if (aIsMeta) {
+      return 1;
+    }
+    if (bIsMeta) {
+      return -1;
+    }
+    return compareLower(a, b);
+  };
+};
+
+export type FlattenedFieldsComparator = ReturnType<typeof getFlattenedFieldsComparator>;
+
+function makeProxy(
+  flat: Record<string, any>,
+  indexPattern?: DataView,
+  flattenedFieldsComparator?: FlattenedFieldsComparator
+) {
   let cachedKeys: Array<string | symbol> | undefined;
 
   return new Proxy(flat, {
@@ -203,7 +213,9 @@ function makeProxy(flat: Record<string, any>, indexPattern?: DataView) {
     },
     ownKeys: (target) => {
       if (!cachedKeys) {
-        cachedKeys = Reflect.ownKeys(target).sort(getComparator());
+        cachedKeys = Reflect.ownKeys(target).sort(
+          flattenedFieldsComparator ?? getFlattenedFieldsComparator(indexPattern)
+        );
       }
       return cachedKeys;
     },

--- a/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
+++ b/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
@@ -166,9 +166,26 @@ function makeProxy(flat: Record<string, any>, indexPattern?: DataView) {
     return String(a).localeCompare(String(b));
   }
 
+  let cachedKeys: Array<string | symbol> | undefined;
+
   return new Proxy(flat, {
+    defineProperty: (...args) => {
+      cachedKeys = undefined;
+      console.log('defineProperty');
+      return Reflect.defineProperty(...args);
+    },
+    deleteProperty: (...args) => {
+      cachedKeys = undefined;
+      console.log('deleteProperty');
+      return Reflect.deleteProperty(...args);
+    },
     ownKeys: (target) => {
-      return Reflect.ownKeys(target).sort(comparator);
+      if (!cachedKeys) {
+        cachedKeys = Reflect.ownKeys(target).sort(comparator);
+      } else {
+        console.log('cached');
+      }
+      return cachedKeys;
     },
   });
 }

--- a/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
+++ b/packages/kbn-data-service/src/search/tabify/tabify_docs.ts
@@ -151,11 +151,16 @@ export function flattenHit(hit: Hit, indexPattern?: DataView, params?: TabifyDoc
 }
 
 function makeProxy(flat: Record<string, any>, indexPattern?: DataView) {
+  const metaFields = new Set(indexPattern?.metaFields);
+
   function comparator(a: string | symbol, b: string | symbol) {
-    const aIsMeta = indexPattern?.metaFields?.includes(String(a));
-    const bIsMeta = indexPattern?.metaFields?.includes(String(b));
+    if (typeof a === 'symbol' || typeof b === 'symbol') {
+      return 0;
+    }
+    const aIsMeta = metaFields.has(a);
+    const bIsMeta = metaFields.has(b);
     if (aIsMeta && bIsMeta) {
-      return String(a).localeCompare(String(b));
+      return a < b ? -1 : a > b ? 1 : 0;
     }
     if (aIsMeta) {
       return 1;
@@ -163,7 +168,7 @@ function makeProxy(flat: Record<string, any>, indexPattern?: DataView) {
     if (bIsMeta) {
       return -1;
     }
-    return String(a).localeCompare(String(b));
+    return a < b ? -1 : a > b ? 1 : 0;
   }
 
   let cachedKeys: Array<string | symbol> | undefined;

--- a/packages/kbn-discover-utils/src/utils/build_data_record.ts
+++ b/packages/kbn-discover-utils/src/utils/build_data_record.ts
@@ -8,7 +8,11 @@
  */
 
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { flattenHit } from '@kbn/data-service';
+import {
+  type FlattenedFieldsComparator,
+  flattenHit,
+  getFlattenedFieldsComparator,
+} from '@kbn/data-service';
 import type { DataTableRecord, EsHitRecord } from '../types';
 import { getDocId } from './get_doc_id';
 
@@ -21,12 +25,16 @@ import { getDocId } from './get_doc_id';
 export function buildDataTableRecord(
   doc: EsHitRecord,
   dataView?: DataView,
-  isAnchor?: boolean
+  isAnchor?: boolean,
+  options?: { flattenedFieldsComparator?: FlattenedFieldsComparator }
 ): DataTableRecord {
   return {
     id: getDocId(doc),
     raw: doc,
-    flattened: flattenHit(doc, dataView, { includeIgnoredValues: true }),
+    flattened: flattenHit(doc, dataView, {
+      includeIgnoredValues: true,
+      flattenedFieldsComparator: options?.flattenedFieldsComparator,
+    }),
     isAnchor,
   };
 }
@@ -45,8 +53,9 @@ export function buildDataTableRecordList<T extends DataTableRecord = DataTableRe
   dataView?: DataView;
   processRecord?: (record: DataTableRecord) => T;
 }): DataTableRecord[] {
+  const buildRecordOption = { flattenedFieldsComparator: getFlattenedFieldsComparator(dataView) };
   return records.map((doc) => {
-    const record = buildDataTableRecord(doc, dataView);
+    const record = buildDataTableRecord(doc, dataView, undefined, buildRecordOption);
     return processRecord ? processRecord(record) : record;
   });
 }

--- a/packages/kbn-discover-utils/src/utils/build_data_record.ts
+++ b/packages/kbn-discover-utils/src/utils/build_data_record.ts
@@ -53,9 +53,9 @@ export function buildDataTableRecordList<T extends DataTableRecord = DataTableRe
   dataView?: DataView;
   processRecord?: (record: DataTableRecord) => T;
 }): DataTableRecord[] {
-  const buildRecordOption = { flattenedFieldsComparator: getFlattenedFieldsComparator(dataView) };
+  const buildRecordOptions = { flattenedFieldsComparator: getFlattenedFieldsComparator(dataView) };
   return records.map((doc) => {
-    const record = buildDataTableRecord(doc, dataView, undefined, buildRecordOption);
+    const record = buildDataTableRecord(doc, dataView, undefined, buildRecordOptions);
     return processRecord ? processRecord(record) : record;
   });
 }

--- a/packages/kbn-unified-data-table/src/components/source_document.tsx
+++ b/packages/kbn-unified-data-table/src/components/source_document.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { Fragment, useEffect, useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import type {
   DataTableRecord,
   EsHitRecord,
@@ -26,7 +26,7 @@ import classnames from 'classnames';
 import { getInnerColumns } from '../utils/columns';
 
 const CELL_CLASS = 'unifiedDataTable__cellValue';
-let i = 0;
+
 export function SourceDocument({
   useTopLevelObjectColumns,
   row,
@@ -52,9 +52,6 @@ export function SourceDocument({
   className?: string;
   isCompressed?: boolean;
 }) {
-  // useEffect(() => {
-  //   console.log('rendered', ++i);
-  // }, []);
   const pairs: FormattedHit = useMemo(
     () =>
       useTopLevelObjectColumns

--- a/packages/kbn-unified-data-table/src/components/source_document.tsx
+++ b/packages/kbn-unified-data-table/src/components/source_document.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { Fragment, useMemo } from 'react';
+import React, { Fragment } from 'react';
 import type {
   DataTableRecord,
   EsHitRecord,
@@ -52,24 +52,12 @@ export function SourceDocument({
   className?: string;
   isCompressed?: boolean;
 }) {
-  const pairs: FormattedHit = useMemo(
-    () =>
-      useTopLevelObjectColumns
-        ? getTopLevelObjectPairs(row.raw, columnId, dataView, shouldShowFieldHandler).slice(
-            0,
-            maxEntries
-          )
-        : formatHit(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats),
-    [
-      columnId,
-      dataView,
-      fieldFormats,
-      maxEntries,
-      row,
-      shouldShowFieldHandler,
-      useTopLevelObjectColumns,
-    ]
-  );
+  const pairs: FormattedHit = useTopLevelObjectColumns
+    ? getTopLevelObjectPairs(row.raw, columnId, dataView, shouldShowFieldHandler).slice(
+        0,
+        maxEntries
+      )
+    : formatHit(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats);
 
   return (
     <EuiDescriptionList

--- a/packages/kbn-unified-data-table/src/components/source_document.tsx
+++ b/packages/kbn-unified-data-table/src/components/source_document.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useMemo } from 'react';
 import type {
   DataTableRecord,
   EsHitRecord,
@@ -26,7 +26,7 @@ import classnames from 'classnames';
 import { getInnerColumns } from '../utils/columns';
 
 const CELL_CLASS = 'unifiedDataTable__cellValue';
-
+let i = 0;
 export function SourceDocument({
   useTopLevelObjectColumns,
   row,
@@ -52,12 +52,27 @@ export function SourceDocument({
   className?: string;
   isCompressed?: boolean;
 }) {
-  const pairs: FormattedHit = useTopLevelObjectColumns
-    ? getTopLevelObjectPairs(row.raw, columnId, dataView, shouldShowFieldHandler).slice(
-        0,
-        maxEntries
-      )
-    : formatHit(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats);
+  // useEffect(() => {
+  //   console.log('rendered', ++i);
+  // }, []);
+  const pairs: FormattedHit = useMemo(
+    () =>
+      useTopLevelObjectColumns
+        ? getTopLevelObjectPairs(row.raw, columnId, dataView, shouldShowFieldHandler).slice(
+            0,
+            maxEntries
+          )
+        : formatHit(row, dataView, shouldShowFieldHandler, maxEntries, fieldFormats),
+    [
+      columnId,
+      dataView,
+      fieldFormats,
+      maxEntries,
+      row,
+      shouldShowFieldHandler,
+      useTopLevelObjectColumns,
+    ]
+  );
 
   return (
     <EuiDescriptionList

--- a/src/plugins/discover/public/application/context/utils/fetch_hits_in_interval.ts
+++ b/src/plugins/discover/public/application/context/utils/fetch_hits_in_interval.ts
@@ -10,7 +10,7 @@
 import { estypes } from '@elastic/elasticsearch';
 import { lastValueFrom } from 'rxjs';
 import { ISearchSource, EsQuerySortValue, SortDirection } from '@kbn/data-plugin/public';
-import { buildDataTableRecord } from '@kbn/discover-utils';
+import { buildDataTableRecordList } from '@kbn/discover-utils';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { SearchResponseWarning } from '@kbn/search-response-warnings';
 import { RequestAdapter } from '@kbn/inspector-plugin/common';
@@ -99,11 +99,11 @@ export async function fetchHitsInInterval(
 
   const { rawResponse } = await lastValueFrom(fetch$);
   const dataView = searchSource.getField('index');
-  const rows = rawResponse.hits?.hits.map((hit) =>
-    profilesManager.resolveDocumentProfile({
-      record: buildDataTableRecord(hit, dataView!),
-    })
-  );
+  const rows = buildDataTableRecordList({
+    records: rawResponse.hits?.hits,
+    dataView,
+    processRecord: (record) => profilesManager.resolveDocumentProfile({ record }),
+  });
   const interceptedWarnings: SearchResponseWarning[] = [];
   services.data.search.showWarnings(adapter, (warning) => {
     interceptedWarnings.push(warning);

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -140,6 +140,9 @@ export interface DiscoverSidebarResponsiveProps {
  * Desktop: Sidebar view, all elements are visible
  * Mobile: Data view selector is visible and a button to trigger a flyout with all elements
  */
+
+let i = 0;
+
 export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps) {
   const [unifiedFieldListSidebarContainerApi, setUnifiedFieldListSidebarContainerApi] =
     useState<UnifiedFieldListSidebarContainerApi | null>(null);
@@ -187,6 +190,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
           });
           break;
         case FetchStatus.COMPLETE:
+          console.log('complete', ++i);
           dispatchSidebarStateAction({
             type: DiscoverSidebarReducerActionType.DOCUMENTS_LOADED,
             payload: {

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -141,8 +141,6 @@ export interface DiscoverSidebarResponsiveProps {
  * Mobile: Data view selector is visible and a button to trigger a flyout with all elements
  */
 
-let i = 0;
-
 export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps) {
   const [unifiedFieldListSidebarContainerApi, setUnifiedFieldListSidebarContainerApi] =
     useState<UnifiedFieldListSidebarContainerApi | null>(null);
@@ -190,7 +188,6 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
           });
           break;
         case FetchStatus.COMPLETE:
-          console.log('complete', ++i);
           dispatchSidebarStateAction({
             type: DiscoverSidebarReducerActionType.DOCUMENTS_LOADED,
             payload: {

--- a/src/plugins/discover/public/embeddable/initialize_fetch.ts
+++ b/src/plugins/discover/public/embeddable/initialize_fetch.ts
@@ -11,12 +11,11 @@ import { BehaviorSubject, combineLatest, lastValueFrom, switchMap, tap } from 'r
 
 import { KibanaExecutionContext } from '@kbn/core/types';
 import {
-  buildDataTableRecord,
+  buildDataTableRecordList,
   SEARCH_EMBEDDABLE_TYPE,
   SEARCH_FIELDS_FROM_SOURCE,
   SORT_DEFAULT_ORDER_SETTING,
 } from '@kbn/discover-utils';
-import { EsHitRecord } from '@kbn/discover-utils/types';
 import { isOfAggregateQueryType, isOfQueryType } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { RequestAdapter } from '@kbn/inspector-plugin/common';
@@ -207,7 +206,12 @@ export function initializeFetch({
 
           return {
             warnings: interceptedWarnings,
-            rows: resp.hits.hits.map((hit) => buildDataTableRecord(hit as EsHitRecord, dataView)),
+            rows: buildDataTableRecordList({
+              records: resp.hits.hits,
+              dataView,
+              processRecord: (record) =>
+                discoverServices.profilesManager.resolveDocumentProfile({ record }),
+            }),
             hitCount: resp.hits.total as number,
             fetchContext,
           };


### PR DESCRIPTION
## Summary

This PR improves the performance of two important utilities used by Discover: `flattenHit` and `formatHit`. It may not have a big impact on typical Discover use cases, but these two functions can account for a significant portion of the Discover data grid render time when viewing documents with many fields (e.g. our `many_fields` performance journey)

### Improvements
- `formatHit` - Used for formatting document column cell values
  - Previously we would call `formatFieldValue` on every field value in every document even though we only show up to a specific number of field values in each cell (configurable, but 200 by default), which can be very expensive in some cases. In this PR we only call `formatFieldValue` on field values that will be shown to the user, reducing the total calls from 343,850 to 10,000 for the `many_fields` dataset.
  - There are also some optimizations to the looping logic and much fewer allocations than before.
- `ownKeys` (`flattenHit`) - Used to ensure document keys are consistently ordered when looping over them
  - We currently use a proxy around the `DataTableRecord.flattened` object to override the `ownKeys` function and ensure document keys are always consistently ordered when looping over them. The issue is that the sorting logic gets called every time `DataTableRecord.flattened` keys are looped over or accessed via `Object.keys`, `Object.entries`, etc., which happens often. In this PR the sorted keys are cached for each `DataTableRecord.flattened` instance until one of its properties are either set or deleted.
  - The actual sorting logic has also been optimized with less casting, removing calls to `localeCompare`, and caching.

### Tests
3 runs each, navigating to Discover with `many_fields` data. There's some overlap between `formatHit` and `ownKeys` since `formatHit` loops over `DataTableRecord.flattened` keys and triggers `ownKeys`, which is why the total render difference doesn't match the sum of differences for both methods.

#### Main

||Total render|`formatHit`|`ownKeys` (`flattenHit`)|
|---|---|---|---|
||4748 ms|1117 ms|1728 ms|
||4804 ms|1111 ms|1757 ms|
||4722 ms|1117 ms|1744 ms|
|**AVG**|4758 ms|1115 ms|1743 ms|

<img width="2168" alt="main" src="https://github.com/user-attachments/assets/dcd718fc-9da7-460d-a045-b88b23db5e1b">

#### This PR

||Total render|`formatHit`|`ownKeys` (`flattenHit`)|
|---|---|---|---|
||3060 ms|159 ms|578 ms|
||3203 ms|154 ms|626 ms|
||3358 ms|160 ms| 623 ms|
|**AVG**|3207 ms|158 ms|609 ms|

<img width="2168" alt="pr" src="https://github.com/user-attachments/assets/c2c9df43-6b0b-426a-826d-231160e3f6ef">

#### Average differences

|Total render|`formatHit`|`ownKeys` (`flattenHit`)|
|---|---|---|
|1551 ms|957 ms|1134 ms|

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)