### PR TITLE
[Lens] fix telemetry on save names

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -42,7 +42,7 @@ import {
 } from '../data_views_service/service';
 import { replaceIndexpattern } from '../state_management/lens_slice';
 import { useApplicationUserMessages } from './get_application_user_messages';
-import { trackUiCounterEvents } from '../lens_ui_telemetry';
+import { trackSaveUiCounterEvents } from '../lens_ui_telemetry';
 
 export type SaveProps = Omit<OnSaveProps, 'onTitleDuplicate' | 'newDescription'> & {
   returnToOrigin: boolean;
@@ -325,7 +325,7 @@ export function App({
         prevVisState
       );
       if (telemetryEvents && telemetryEvents.length) {
-        trackUiCounterEvents(telemetryEvents);
+        trackSaveUiCounterEvents(telemetryEvents);
       }
       return runSaveLensVisualization(
         {

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -48,7 +48,7 @@ import { FlyoutWrapper } from './flyout_wrapper';
 import { getSuggestions, getGridAttrs, type ESQLDataGridAttrs } from './helpers';
 import { SuggestionPanel } from '../../../editor_frame_service/editor_frame/suggestion_panel';
 import { useApplicationUserMessages } from '../../get_application_user_messages';
-import { trackUiCounterEvents } from '../../../lens_ui_telemetry';
+import { trackSaveUiCounterEvents } from '../../../lens_ui_telemetry';
 import { ESQLDataGridAccordion } from './esql_data_grid_accordion';
 
 export function LensEditConfigurationFlyout({
@@ -288,7 +288,7 @@ export function LensEditConfigurationFlyout({
       prevVisState
     );
     if (telemetryEvents && telemetryEvents.length) {
-      trackUiCounterEvents(telemetryEvents);
+      trackSaveUiCounterEvents(telemetryEvents);
     }
 
     onApplyCb?.(attrs as TypedLensByValueInput['attributes']);

--- a/x-pack/plugins/lens/public/lens_ui_telemetry/color_telemetry_helpers.test.ts
+++ b/x-pack/plugins/lens/public/lens_ui_telemetry/color_telemetry_helpers.test.ts
@@ -112,8 +112,8 @@ describe('color_telemetry_helpers', () => {
   });
   it('settings (default): unassigned terms loop, default palette returns correct events', () => {
     expect(getColorMappingTelemetryEvents(DEFAULT_COLOR_MAPPING_CONFIG)).toEqual([
-      'lens_color_mapping_palette_eui_amsterdam_color_blind',
-      'lens_color_mapping_unassigned_terms_loop',
+      'color_mapping_palette_eui_amsterdam_color_blind',
+      'color_mapping_unassigned_terms_loop',
     ]);
   });
   it('gradient event when user changed colorMode to gradient', () => {
@@ -136,33 +136,33 @@ describe('color_telemetry_helpers', () => {
         },
         DEFAULT_COLOR_MAPPING_CONFIG
       )
-    ).toEqual(['lens_color_mapping_gradient']);
+    ).toEqual(['color_mapping_gradient']);
   });
   it('settings: custom palette, unassigned terms from palette, 2 colors with 5 terms in total', () => {
     expect(getColorMappingTelemetryEvents(MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-      'lens_color_mapping_palette_elastic_brand_2023',
-      'lens_color_mapping_unassigned_terms_palette',
-      'lens_color_mapping_colors_2_to_4',
-      'lens_color_mapping_custom_colors_2',
-      'lens_color_mapping_avg_count_terms_per_color_2_to_4',
+      'color_mapping_palette_elastic_brand_2023',
+      'color_mapping_unassigned_terms_palette',
+      'color_mapping_colors_2_to_4',
+      'color_mapping_custom_colors_2',
+      'color_mapping_avg_count_terms_per_color_2_to_4',
     ]);
     expect(
       getColorMappingTelemetryEvents(MANUAL_COLOR_MAPPING_CONFIG, DEFAULT_COLOR_MAPPING_CONFIG)
     ).toEqual([
-      'lens_color_mapping_palette_elastic_brand_2023',
-      'lens_color_mapping_unassigned_terms_palette',
-      'lens_color_mapping_colors_2_to_4',
-      'lens_color_mapping_custom_colors_2',
-      'lens_color_mapping_avg_count_terms_per_color_2_to_4',
+      'color_mapping_palette_elastic_brand_2023',
+      'color_mapping_unassigned_terms_palette',
+      'color_mapping_colors_2_to_4',
+      'color_mapping_custom_colors_2',
+      'color_mapping_avg_count_terms_per_color_2_to_4',
     ]);
   });
   it('color, custom color and count of terms changed (even if the same event would be returned)', () => {
     const config = { ...MANUAL_COLOR_MAPPING_CONFIG };
     config.assignments = config.assignments.slice(0, 3);
     expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-      'lens_color_mapping_colors_2_to_4',
-      'lens_color_mapping_custom_colors_1',
-      'lens_color_mapping_avg_count_terms_per_color_2_to_4',
+      'color_mapping_colors_2_to_4',
+      'color_mapping_custom_colors_1',
+      'color_mapping_avg_count_terms_per_color_2_to_4',
     ]);
   });
 
@@ -177,9 +177,9 @@ describe('color_telemetry_helpers', () => {
 
       config.assignments = [exampleAssignment(4, 'custom')];
       expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-        'lens_color_mapping_colors_up_to_2',
-        'lens_color_mapping_custom_colors_1',
-        'lens_color_mapping_avg_count_terms_per_color_2_to_4',
+        'color_mapping_colors_up_to_2',
+        'color_mapping_custom_colors_1',
+        'color_mapping_avg_count_terms_per_color_2_to_4',
       ]);
     });
     it('2 colors', () => {
@@ -187,8 +187,8 @@ describe('color_telemetry_helpers', () => {
 
       config.assignments = [exampleAssignment(1), exampleAssignment(1)];
       expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-        'lens_color_mapping_colors_2',
-        'lens_color_mapping_avg_count_terms_per_color_1',
+        'color_mapping_colors_2',
+        'color_mapping_avg_count_terms_per_color_1',
       ]);
     });
     it('3 colors, 10 terms per assignment', () => {
@@ -196,8 +196,8 @@ describe('color_telemetry_helpers', () => {
 
       config.assignments = Array.from({ length: 3 }, () => exampleAssignment(10));
       expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-        'lens_color_mapping_colors_2_to_4',
-        'lens_color_mapping_avg_count_terms_per_color_above_4',
+        'color_mapping_colors_2_to_4',
+        'color_mapping_avg_count_terms_per_color_above_4',
       ]);
     });
     it('7 colors, 2 terms per assignment, all custom', () => {
@@ -205,9 +205,9 @@ describe('color_telemetry_helpers', () => {
 
       config.assignments = Array.from({ length: 7 }, () => exampleAssignment(2, 'custom'));
       expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-        'lens_color_mapping_colors_4_to_8',
-        'lens_color_mapping_custom_colors_4_to_8',
-        'lens_color_mapping_avg_count_terms_per_color_2',
+        'color_mapping_colors_4_to_8',
+        'color_mapping_custom_colors_4_to_8',
+        'color_mapping_avg_count_terms_per_color_2',
       ]);
     });
     it('12 colors', () => {
@@ -215,18 +215,18 @@ describe('color_telemetry_helpers', () => {
 
       config.assignments = Array.from({ length: 12 }, () => exampleAssignment(3, 'custom'));
       expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-        'lens_color_mapping_colors_8_to_16',
-        'lens_color_mapping_custom_colors_8_to_16',
-        'lens_color_mapping_avg_count_terms_per_color_2_to_4',
+        'color_mapping_colors_8_to_16',
+        'color_mapping_custom_colors_8_to_16',
+        'color_mapping_avg_count_terms_per_color_2_to_4',
       ]);
     });
     it('27 colors', () => {
       const config = { ...MANUAL_COLOR_MAPPING_CONFIG };
       config.assignments = Array.from({ length: 27 }, () => exampleAssignment(3, 'custom'));
       expect(getColorMappingTelemetryEvents(config, MANUAL_COLOR_MAPPING_CONFIG)).toEqual([
-        'lens_color_mapping_colors_above_16',
-        'lens_color_mapping_custom_colors_above_16',
-        'lens_color_mapping_avg_count_terms_per_color_2_to_4',
+        'color_mapping_colors_above_16',
+        'color_mapping_custom_colors_above_16',
+        'color_mapping_avg_count_terms_per_color_2_to_4',
       ]);
     });
   });
@@ -241,7 +241,7 @@ describe('color_telemetry_helpers', () => {
           },
           DEFAULT_COLOR_MAPPING_CONFIG
         )
-      ).toEqual(['lens_color_mapping_unassigned_terms_palette']);
+      ).toEqual(['color_mapping_unassigned_terms_palette']);
     });
     it('unassigned terms changed from palette to loop', () => {
       expect(
@@ -249,7 +249,7 @@ describe('color_telemetry_helpers', () => {
           ...DEFAULT_COLOR_MAPPING_CONFIG,
           specialAssignments: specialAssignmentsPalette,
         })
-      ).toEqual(['lens_color_mapping_unassigned_terms_loop']);
+      ).toEqual(['color_mapping_unassigned_terms_loop']);
     });
     it('unassigned terms changed from loop to another custom color', () => {
       expect(
@@ -260,7 +260,7 @@ describe('color_telemetry_helpers', () => {
           },
           DEFAULT_COLOR_MAPPING_CONFIG
         )
-      ).toEqual(['lens_color_mapping_unassigned_terms_custom']);
+      ).toEqual(['color_mapping_unassigned_terms_custom']);
     });
     it('unassigned terms changed from custom color to another custom color', () => {
       expect(
@@ -271,7 +271,7 @@ describe('color_telemetry_helpers', () => {
             specialAssignments: specialAssignmentsCustom2,
           }
         )
-      ).toEqual(['lens_color_mapping_unassigned_terms_custom']);
+      ).toEqual(['color_mapping_unassigned_terms_custom']);
     });
   });
 });

--- a/x-pack/plugins/lens/public/lens_ui_telemetry/color_telemetry_helpers.ts
+++ b/x-pack/plugins/lens/public/lens_ui_telemetry/color_telemetry_helpers.ts
@@ -9,7 +9,7 @@ import { ColorMapping, NeutralPalette, DEFAULT_OTHER_ASSIGNMENT_INDEX } from '@k
 import { isEqual } from 'lodash';
 import { nonNullable } from '../utils';
 
-const COLOR_MAPPING_PREFIX = 'lens_color_mapping_';
+const COLOR_MAPPING_PREFIX = 'color_mapping_';
 
 export const getColorMappingTelemetryEvents = (
   colorMapping: ColorMapping.Config | undefined,

--- a/x-pack/plugins/lens/public/lens_ui_telemetry/index.ts
+++ b/x-pack/plugins/lens/public/lens_ui_telemetry/index.ts
@@ -9,5 +9,6 @@ export {
   setUsageCollectionStart,
   getUsageCollectionStart,
   trackUiCounterEvents,
+  trackSaveUiCounterEvents,
   getExecutionContextEvents,
 } from './track_counter_events';

--- a/x-pack/plugins/lens/public/lens_ui_telemetry/track_counter_events.ts
+++ b/x-pack/plugins/lens/public/lens_ui_telemetry/track_counter_events.ts
@@ -27,10 +27,21 @@ const extractContainerType = (context?: KibanaExecutionContext): string | undefi
   }
 };
 
+const RENDER_EVENT_PREFIX = `render_lens_`;
+
+const SAVE_EVENT_PREFIX = `save_lens_`;
+
+/** @internal **/
+export const trackSaveUiCounterEvents = (
+  events: string | string[],
+  context?: KibanaExecutionContext
+) => trackUiCounterEvents(events, context, SAVE_EVENT_PREFIX);
+
 /** @internal **/
 export const trackUiCounterEvents = (
   events: string | string[],
-  context?: KibanaExecutionContext
+  context?: KibanaExecutionContext,
+  eventPrefix = RENDER_EVENT_PREFIX
 ) => {
   const usageCollection = getUsageCollectionStart();
   const containerType = extractContainerType(context) ?? 'application';
@@ -39,7 +50,7 @@ export const trackUiCounterEvents = (
     usageCollection?.reportUiCounter(
       containerType,
       METRIC_TYPE.COUNT,
-      `render_lens_${key}`,
+      `${eventPrefix}${key}`,
       counter.length
     );
   });

--- a/x-pack/plugins/lens/public/visualizations/xy/legend_stats_telemetry_helpers.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/legend_stats_telemetry_helpers.test.ts
@@ -17,10 +17,10 @@ describe('legend_stats_telemetry_helpers', () => {
     expect(
       getLegendStatsTelemetryEvents([LegendValue.CurrentAndLastValue, LegendValue.Average])
     ).toEqual([
-      'lens_legend_stats',
-      'lens_legend_stats_currentAndLastValue',
-      'lens_legend_stats_average',
-      'lens_legend_stats_amount_2',
+      'legend_stats',
+      'legend_stats_currentAndLastValue',
+      'legend_stats_average',
+      'legend_stats_amount_2',
     ]);
   });
 
@@ -36,17 +36,17 @@ describe('legend_stats_telemetry_helpers', () => {
   describe('calculates counter events properly', () => {
     it('returns single count event', () => {
       expect(getLegendStatsTelemetryEvents([LegendValue.Average])).toEqual([
-        'lens_legend_stats',
-        'lens_legend_stats_average',
-        'lens_legend_stats_amount_1',
+        'legend_stats',
+        'legend_stats_average',
+        'legend_stats_amount_1',
       ]);
     });
     it('returns 2 count event', () => {
       expect(getLegendStatsTelemetryEvents([LegendValue.Average, LegendValue.Count])).toEqual([
-        'lens_legend_stats',
-        'lens_legend_stats_average',
-        'lens_legend_stats_count',
-        'lens_legend_stats_amount_2',
+        'legend_stats',
+        'legend_stats_average',
+        'legend_stats_count',
+        'legend_stats_amount_2',
       ]);
     });
     it('returns 3 count event', () => {
@@ -57,11 +57,11 @@ describe('legend_stats_telemetry_helpers', () => {
           LegendValue.CurrentAndLastValue,
         ])
       ).toEqual([
-        'lens_legend_stats',
-        'lens_legend_stats_average',
-        'lens_legend_stats_count',
-        'lens_legend_stats_currentAndLastValue',
-        'lens_legend_stats_amount_3',
+        'legend_stats',
+        'legend_stats_average',
+        'legend_stats_count',
+        'legend_stats_currentAndLastValue',
+        'legend_stats_amount_3',
       ]);
     });
     it('returns 4 count event', () => {
@@ -73,12 +73,12 @@ describe('legend_stats_telemetry_helpers', () => {
           LegendValue.Average,
         ])
       ).toEqual([
-        'lens_legend_stats',
-        'lens_legend_stats_currentAndLastValue',
-        'lens_legend_stats_max',
-        'lens_legend_stats_min',
-        'lens_legend_stats_average',
-        'lens_legend_stats_amount_4_to_7',
+        'legend_stats',
+        'legend_stats_currentAndLastValue',
+        'legend_stats_max',
+        'legend_stats_min',
+        'legend_stats_average',
+        'legend_stats_amount_4_to_7',
       ]);
     });
 
@@ -96,17 +96,17 @@ describe('legend_stats_telemetry_helpers', () => {
           LegendValue.Median,
         ])
       ).toEqual([
-        'lens_legend_stats',
-        'lens_legend_stats_currentAndLastValue',
-        'lens_legend_stats_max',
-        'lens_legend_stats_min',
-        'lens_legend_stats_average',
-        'lens_legend_stats_count',
-        'lens_legend_stats_total',
-        'lens_legend_stats_lastValue',
-        'lens_legend_stats_firstValue',
-        'lens_legend_stats_median',
-        'lens_legend_stats_amount_above_8',
+        'legend_stats',
+        'legend_stats_currentAndLastValue',
+        'legend_stats_max',
+        'legend_stats_min',
+        'legend_stats_average',
+        'legend_stats_count',
+        'legend_stats_total',
+        'legend_stats_lastValue',
+        'legend_stats_firstValue',
+        'legend_stats_median',
+        'legend_stats_amount_above_8',
       ]);
     });
   });

--- a/x-pack/plugins/lens/public/visualizations/xy/legend_stats_telemetry_helpers.ts
+++ b/x-pack/plugins/lens/public/visualizations/xy/legend_stats_telemetry_helpers.ts
@@ -10,7 +10,7 @@ import { XYLegendValue } from '@kbn/visualizations-plugin/common';
 import { nonNullable } from '../../utils';
 import { shouldDisplayTable } from '../../shared_components/legend/legend_settings_popover';
 
-const LEGEND_STATS_PREFIX = 'lens_legend_stats';
+const LEGEND_STATS_PREFIX = 'legend_stats';
 const constructName = (eventName: string) => `${LEGEND_STATS_PREFIX}${eventName}`;
 
 export const getLegendStatsTelemetryEvents = (

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -1113,7 +1113,6 @@ export const getXyVisualization = ({
   },
 
   getRenderEventCounters(state) {
-    console.log(shouldDisplayTable(state.legend.legendStats ?? []));
     if (shouldDisplayTable(state.legend.legendStats ?? [])) {
       return [`legend_stats`];
     }

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -1113,6 +1113,7 @@ export const getXyVisualization = ({
   },
 
   getRenderEventCounters(state) {
+    console.log(shouldDisplayTable(state.legend.legendStats ?? []));
     if (shouldDisplayTable(state.legend.legendStats ?? [])) {
       return [`legend_stats`];
     }


### PR DESCRIPTION
## Summary

corrects the names for the on save telemetry events from `render_lens_lens_*` to `save_lens_*`

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->