### PR TITLE
[Discover][DataViews] Fix "View conflicts" button when data view id has special characters

### DIFF
--- a/src/plugins/data_view_management/public/components/edit_index_pattern/edit_index_pattern_container.tsx
+++ b/src/plugins/data_view_management/public/components/edit_index_pattern/edit_index_pattern_container.tsx
@@ -24,7 +24,7 @@ const EditIndexPatternCont: React.FC<RouteComponentProps<{ id: string }>> = ({ .
 
   useEffect(() => {
     dataViews
-      .get(props.match.params.id)
+      .get(decodeURIComponent(props.match.params.id))
       .then((ip: DataView) => {
         setIndexPattern(ip);
         setBreadcrumbs(getEditBreadcrumbs(ip));


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/192148

## Summary

This bug appears when a custom data view ID (like `logging-*:logs-*`) is used. The PR adds decoding for the `id` param for Data view edit page.

### For testing

Create indices with different field types but with the same field names.

```
PUT my-index-1
{
  "mappings": {
    "dynamic": false,
    "properties": {
      "a": {
        "type": "float"
      }
    }
  }
}

PUT my-index-2
{
  "mappings": {
    "dynamic": false,
    "properties": {
      "a": {
        "type": "keyword"
      }
    }
  }
}

PUT my-index-1/_doc
{
  "a": 500.4
}

PUT my-index-2/_doc
{
  "a": "hi there"
}
```

Then create a data view with `my-index-*` as index pattern  and a custom id `logging-*:logs-*`. Navigate to Data Views Management page and check the button.



<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->