### PR TITLE
[Fleet] Attempt to fix step_select_agent_policy_test again

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
@@ -64,7 +64,7 @@ const useMultipleAgentPoliciesMock = useMultipleAgentPolicies as jest.MockedFunc
   typeof useMultipleAgentPolicies
 >;
 
-describe('step select agent policy', () => {
+describe('stepStepSelectAgentPolicy', () => {
   let testRenderer: TestRenderer;
   let renderResult: ReturnType<typeof testRenderer.render>;
   const mockSetHasAgentPolicyError = jest.fn();
@@ -80,53 +80,56 @@ describe('step select agent policy', () => {
       />
     ));
 
-  beforeEach(() => {
-    testRenderer = createFleetTestRendererMock();
-    useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: false });
-  });
-  afterEach(() => {
-    updateAgentPoliciesMock.mockReset();
-  });
-
-  test('should not select agent policy by default if multiple exists', async () => {
-    useGetAgentPoliciesMock.mockReturnValue({
-      data: {
-        items: [
-          { id: 'policy-1', name: 'Policy 1' },
-          { id: 'policy-2', name: 'Policy 2' },
-        ],
-      },
-      error: undefined,
-      isLoading: false,
-      resendRequest: jest.fn(),
-    } as any);
-
-    render();
-    await act(async () => {}); // Needed as updateAgentPolicies is called after multiple useEffect
-    await act(async () => {
-      const select = renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]');
-      expect((select as any)?.value).toEqual('');
-    });
-  });
-
-  test('should select agent policy by default if one exists', async () => {
-    useGetAgentPoliciesMock.mockReturnValue({
-      data: { items: [{ id: 'policy-1', name: 'Policy 1' }] },
-      error: undefined,
-      isLoading: false,
-      resendRequest: jest.fn(),
-    } as any);
-
-    render();
-    await act(async () => {}); // Needed as updateAgentPolicies is called after multiple useEffect
-    await act(async () => {
-      expect(updateAgentPoliciesMock).toBeCalledTimes(1);
-      expect(updateAgentPoliciesMock).toBeCalledWith([{ id: 'policy-1', package_policies: [] }]);
-    });
-  });
-
-  describe('multiple agent policies', () => {
+  describe('with single agent policy', () => {
     beforeEach(() => {
+      testRenderer = createFleetTestRendererMock();
+      useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: false });
+    });
+    afterEach(() => {
+      updateAgentPoliciesMock.mockReset();
+      useGetAgentPoliciesMock.mockReset();
+    });
+
+    test('should not select agent policy by default if multiple exists', async () => {
+      useGetAgentPoliciesMock.mockReturnValue({
+        data: {
+          items: [
+            { id: 'policy-1', name: 'Policy 1' },
+            { id: 'policy-2', name: 'Policy 2' },
+          ],
+        },
+        error: undefined,
+        isLoading: false,
+        resendRequest: jest.fn(),
+      } as any);
+
+      render();
+      await act(async () => {
+        const select = renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]');
+        expect((select as any)?.value).toEqual('');
+      });
+    });
+
+    test('should select agent policy by default if one exists', async () => {
+      useGetAgentPoliciesMock.mockReturnValue({
+        data: { items: [{ id: 'policy-1', name: 'Policy 1' }] },
+        error: undefined,
+        isLoading: false,
+        resendRequest: jest.fn(),
+      } as any);
+
+      render();
+      await act(async () => {}); // Needed as updateAgentPolicies is called after multiple useEffect
+      await act(async () => {
+        expect(updateAgentPoliciesMock).toBeCalledTimes(1);
+        expect(updateAgentPoliciesMock).toBeCalledWith([{ id: 'policy-1', package_policies: [] }]);
+      });
+    });
+  });
+
+  describe('with multiple agent policies', () => {
+    beforeEach(() => {
+      testRenderer = createFleetTestRendererMock();
       useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: true });
 
       useGetAgentPoliciesMock.mockReturnValue({
@@ -140,6 +143,10 @@ describe('step select agent policy', () => {
         isLoading: false,
         resendRequest: jest.fn(),
       } as any);
+    });
+    afterEach(() => {
+      updateAgentPoliciesMock.mockReset();
+      useGetAgentPoliciesMock.mockReset();
     });
 
     test('should select agent policy by default if one exists', async () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx
@@ -102,7 +102,7 @@ describe('step select agent policy', () => {
     } as any);
 
     render();
-
+    await act(async () => {}); // Needed as updateAgentPolicies is called after multiple useEffect
     await act(async () => {
       const select = renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]');
       expect((select as any)?.value).toEqual('');
@@ -120,7 +120,7 @@ describe('step select agent policy', () => {
     render();
     await act(async () => {}); // Needed as updateAgentPolicies is called after multiple useEffect
     await act(async () => {
-      expect(updateAgentPoliciesMock).toBeCalled();
+      expect(updateAgentPoliciesMock).toBeCalledTimes(1);
       expect(updateAgentPoliciesMock).toBeCalledWith([{ id: 'policy-1', package_policies: [] }]);
     });
   });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/189869
Fixes https://github.com/elastic/kibana/issues/189868

## Summary
Attempt to stabilize flaky test `x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_agent_policy.test.tsx`. 
I previously merged https://github.com/elastic/kibana/pull/190778 but it failed again because of flakyness. 

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
