### PR TITLE
[8.15] [Security Solution] Fixes `enable` field not being respected on rule import (#192302)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.import_rule.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.import_rule.test.ts
@@ -150,6 +150,74 @@ describe('DetectionRulesClient.importRule', () => {
       );
     });
 
+    it('enables the rule if the imported rule has enabled: true', async () => {
+      const disabledExistingRule = {
+        ...existingRule,
+        enabled: false,
+      };
+      (getRuleByRuleId as jest.Mock).mockResolvedValueOnce(disabledExistingRule);
+
+      const rule = await detectionRulesClient.importRule({
+        ruleToImport: {
+          ...ruleToImport,
+          enabled: true,
+        },
+        overwriteRules: true,
+        allowMissingConnectorSecrets,
+      });
+
+      expect(rulesClient.create).not.toHaveBeenCalled();
+      expect(rulesClient.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: existingRule.id,
+          data: expect.not.objectContaining({
+            enabled: expect.anything(),
+          }),
+        })
+      );
+
+      expect(rule.enabled).toBe(true);
+      expect(rulesClient.enableRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: existingRule.id,
+        })
+      );
+    });
+
+    it('disables the rule if the imported rule has enabled: false', async () => {
+      const enabledExistingRule = {
+        ...existingRule,
+        enabled: true,
+      };
+      (getRuleByRuleId as jest.Mock).mockResolvedValueOnce(enabledExistingRule);
+
+      const rule = await detectionRulesClient.importRule({
+        ruleToImport: {
+          ...ruleToImport,
+          enabled: false,
+        },
+        overwriteRules: true,
+        allowMissingConnectorSecrets,
+      });
+
+      expect(rulesClient.create).not.toHaveBeenCalled();
+      expect(rulesClient.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: existingRule.id,
+          data: expect.not.objectContaining({
+            enabled: expect.anything(),
+          }),
+        })
+      );
+
+      expect(rule.enabled).toBe(false);
+      expect(rulesClient.disableRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: existingRule.id,
+        })
+      );
+    });
+
     it('rejects when overwriteRules is false', async () => {
       (readRules as jest.Mock).mockResolvedValue(existingRule);
       await expect(

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.import_rule.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client.import_rule.test.ts
@@ -155,7 +155,7 @@ describe('DetectionRulesClient.importRule', () => {
         ...existingRule,
         enabled: false,
       };
-      (getRuleByRuleId as jest.Mock).mockResolvedValueOnce(disabledExistingRule);
+      (readRules as jest.Mock).mockResolvedValueOnce(disabledExistingRule);
 
       const rule = await detectionRulesClient.importRule({
         ruleToImport: {
@@ -177,7 +177,7 @@ describe('DetectionRulesClient.importRule', () => {
       );
 
       expect(rule.enabled).toBe(true);
-      expect(rulesClient.enableRule).toHaveBeenCalledWith(
+      expect(rulesClient.enable).toHaveBeenCalledWith(
         expect.objectContaining({
           id: existingRule.id,
         })
@@ -189,7 +189,7 @@ describe('DetectionRulesClient.importRule', () => {
         ...existingRule,
         enabled: true,
       };
-      (getRuleByRuleId as jest.Mock).mockResolvedValueOnce(enabledExistingRule);
+      (readRules as jest.Mock).mockResolvedValueOnce(enabledExistingRule);
 
       const rule = await detectionRulesClient.importRule({
         ruleToImport: {
@@ -211,7 +211,7 @@ describe('DetectionRulesClient.importRule', () => {
       );
 
       expect(rule.enabled).toBe(false);
-      expect(rulesClient.disableRule).toHaveBeenCalledWith(
+      expect(rulesClient.disable).toHaveBeenCalledWith(
         expect.objectContaining({
           id: existingRule.id,
         })

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/import_rule.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/import_rule.ts
@@ -58,9 +58,13 @@ export const importRule = async (
       data: ruleUpdateParams,
     });
 
-     // We strip `enabled` from the rule object to use in the rules client and need to enable it separately if user has enabled the updated rule
-     const { enabled: isNowEnabled } = await toggleRuleEnabledOnUpdate(rulesClient, existingRule, ruleToImport.enabled);
-     enabled = isNowEnabled;
+    // We strip `enabled` from the rule object to use in the rules client and need to enable it separately if user has enabled the updated rule
+    const { enabled: isNowEnabled } = await toggleRuleEnabledOnUpdate(
+      rulesClient,
+      existingRule,
+      ruleToImport.enabled
+    );
+    enabled = isNowEnabled;
   } else {
     /* Rule does not exist, so we'll create it */
     const ruleCreateParams = convertCreateAPIToInternalSchema(ruleToImport, {
@@ -74,7 +78,9 @@ export const importRule = async (
   }
 
   /* Trying to convert an internal rule to a RuleResponse object */
-  const parseResult = RuleResponse.safeParse(internalRuleToAPIResponse({...importedInternalRule, enabled}));
+  const parseResult = RuleResponse.safeParse(
+    internalRuleToAPIResponse({ ...importedInternalRule, enabled })
+  );
 
   if (!parseResult.success) {
     throw new RuleResponseValidationError({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/import_rule.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/detection_rules_client/methods/import_rule.ts
@@ -45,7 +45,7 @@ export const importRule = async (
   }
 
   let importedInternalRule: RuleAlertType;
-  let enabled: boolean = ruleToImport.enabled;
+  let enabled: boolean;
 
   if (existingRule && overwriteRules) {
     const ruleUpdateParams = convertUpdateAPIToInternalSchema({
@@ -75,6 +75,7 @@ export const importRule = async (
       data: ruleCreateParams,
       allowMissingConnectorSecrets,
     });
+    enabled = importedInternalRule.enabled;
   }
 
   /* Trying to convert an internal rule to a RuleResponse object */


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Security Solution] Fixes `enable` field not being respected on rule import (#192302)](https://github.com/elastic/kibana/pull/192302)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis Plumlee","email":"56367316+dplumlee@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-09-09T15:59:21Z","message":"[Security Solution] Fixes `enable` field not being respected on rule import (#192302)\n\n**Fixes https://github.com/elastic/kibana/issues/192272**\r\n\r\n## Summary\r\n\r\nFixes a bug where `enabled` field was not respected on rule import\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7149a869e4a8c5621daf394227532792b27d9da1","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","impact:medium","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","v8.16.0","v8.15.2"],"number":192302,"url":"https://github.com/elastic/kibana/pull/192302","mergeCommit":{"message":"[Security Solution] Fixes `enable` field not being respected on rule import (#192302)\n\n**Fixes https://github.com/elastic/kibana/issues/192272**\r\n\r\n## Summary\r\n\r\nFixes a bug where `enabled` field was not respected on rule import\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7149a869e4a8c5621daf394227532792b27d9da1"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192302","number":192302,"mergeCommit":{"message":"[Security Solution] Fixes `enable` field not being respected on rule import (#192302)\n\n**Fixes https://github.com/elastic/kibana/issues/192272**\r\n\r\n## Summary\r\n\r\nFixes a bug where `enabled` field was not respected on rule import\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7149a869e4a8c5621daf394227532792b27d9da1"}},{"branch":"8.15","label":"v8.15.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->