### PR TITLE
[Response Ops][Alerting] Removing second call to load rule at end of rule execution

### DIFF
--- a/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.test.ts
@@ -1947,28 +1947,6 @@ describe('Task Runner', () => {
     expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
   });
 
-  test('rescheduled the rule if the schedule has update during a task run', async () => {
-    const taskRunner = new TaskRunner({
-      ruleType,
-      internalSavedObjectsRepository,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-    });
-    expect(AlertingEventLogger).toHaveBeenCalled();
-    rulesClient.getAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
-    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue({
-      ...mockedRawRuleSO,
-      attributes: { ...mockedRawRuleSO.attributes, schedule: { interval: '30s' } },
-    });
-
-    const runnerResult = await taskRunner.run();
-    expect(runnerResult).toEqual(
-      generateRunnerResult({ state: true, interval: '30s', history: [true] })
-    );
-    expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
-  });
-
   test('should set unexpected errors as framework-error', async () => {
     jest.spyOn(getExecutorServicesModule, 'getExecutorServices').mockImplementation(() => {
       throw new Error('test');
@@ -2874,7 +2852,7 @@ describe('Task Runner', () => {
     await taskRunner.run();
     expect(internalSavedObjectsRepository.update).toHaveBeenCalledWith(
       ...generateSavedObjectParams({
-        nextRun: '1970-01-01T00:00:50.000Z',
+        nextRun: '1970-01-01T00:00:10.000Z',
       })
     );
   });

--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -678,10 +678,7 @@ export class TaskRunner<
         await withAlertingSpan('alerting:run', () => this.runRule(validatedRuleData))
       );
 
-      // fetch the rule again to ensure we return the correct schedule as it may have
-      // changed during the task execution
-      const data = await getDecryptedRule(this.context, ruleId, spaceId);
-      schedule = asOk(data.rawRule.schedule);
+      schedule = asOk(validatedRuleData.rule.schedule);
     } catch (err) {
       stateWithMetrics = asErr(err);
       schedule = asErr(err);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/192396

## Summary

Removes second call to load rule at the end of the rule execution. This call was meant to get any changes to the rule schedule that users may have initiated during rule execution but there is a lot of overhead in loading a rule and any changes to the schedule would be captured during the next execution anyway.

## To Verify

1. Add some logging and a delay to rule execution after the initial rule load:

```
--- a/x-pack/plugins/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner.ts
@@ -684,6 +684,10 @@ export class TaskRunner<
       schedule = asErr(err);
     }

+    this.logger.info(`STARTING RULE EXECUTION`);
+
+    await new Promise((r) => setTimeout(r, 30000));
+
     await withAlertingSpan('alerting:process-run-results-and-update-rule', () =>
```

2. Start Kibana and create a rule with a schedule of 3 minutes.
3. Wait for the rule to run and log, then change the schedule interval to something else.
4. The next execution of the rule should still occur 3 minutes later, and then further executions should occur on the new schedule.