### PR TITLE
[8.14] [Reporting/Docs] Add CSV Download breaking changes to release notes. (#192310)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -282,6 +282,18 @@ The visualization type, region map, comes out of technical preview and is genera
 UI improvements for managed tags. For more information, refer to ({kibana-pull}177089[#177089]).
 ====
 
+[discrete]
+[[breaking-178159]]
+.Downloading a CSV file from a saved search panel in a dashboard has become deprecated in favor of generating a CSV report.
+[%collapsible]
+====
+*Details* +
+The mechanism of exporting CSV data from a saved search panel in a dashboard has been changed to generate a CSV report, rather than allowing the CSV data to be downloaded
+without creating a report. To preserve the original behavior, it is necessary to update `kibana.yml` with the setting of `xpack.reporting.csv.enablePanelActionDownload:
+true`. The scope of this breaking change is limited to downloading CSV files from saved search panels only; downloading CSV files from other types of dashboard panels is
+unchanged. For more information, refer to {kibana-pull}178159[#178159].
+====
+
 [float]
 [[features-8.14.0]]
 === Features
@@ -1945,6 +1957,16 @@ For the full list, refer to {kib-issue}146945[#146945].
 ====
 *Details* +
 The function `addProcessorDefinition` is removed from the Console plugin start contract (server side). For more information, refer to ({kibana-pull}159041[#159041]).
+====
+
+[discrete]
+[[breaking-162288]]
+.The Download CSV endpoint has changed.
+[%collapsible]
+====
+*Details* +
+The API endpoint for downloading a CSV file from a saved search in the Dashboard application has changed to reflect the fact that this is an internal API. The previous API path of
+`/api/reporting/v1/generate/immediate/csv_searchsource` has been changed to `/internal/reporting/generate/immediate/csv_searchsource`. For more information, refer to {kibana-pull}162288[#162288].
 ====
 
 [float]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Reporting/Docs] Add CSV Download breaking changes to release notes. (#192310)](https://github.com/elastic/kibana/pull/192310)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-09-09T16:20:18Z","message":"[Reporting/Docs] Add CSV Download breaking changes to release notes. (#192310)\n\nThis PR retrospectively adds breaking change items to the release notes:\r\n\r\n* 8.10: path change for Download CSV from saved search panel. \r\n* 8.14: requirement to add a yml setting to enable the deprecated\r\nDownload CSV functionality, rather than generating a CSV report\r\n\r\n---------\r\n\r\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"10292a427ab2cec14367f970d672cdd95a64c2bc","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","v8.10.0","v8.14.0","v8.16.0","Feature:Reporting:CSV","backport:version"],"number":192310,"url":"https://github.com/elastic/kibana/pull/192310","mergeCommit":{"message":"[Reporting/Docs] Add CSV Download breaking changes to release notes. (#192310)\n\nThis PR retrospectively adds breaking change items to the release notes:\r\n\r\n* 8.10: path change for Download CSV from saved search panel. \r\n* 8.14: requirement to add a yml setting to enable the deprecated\r\nDownload CSV functionality, rather than generating a CSV report\r\n\r\n---------\r\n\r\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"10292a427ab2cec14367f970d672cdd95a64c2bc"}},"sourceBranch":"main","suggestedTargetBranches":["8.10","8.14"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.14","label":"v8.14.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192310","number":192310,"mergeCommit":{"message":"[Reporting/Docs] Add CSV Download breaking changes to release notes. (#192310)\n\nThis PR retrospectively adds breaking change items to the release notes:\r\n\r\n* 8.10: path change for Download CSV from saved search panel. \r\n* 8.14: requirement to add a yml setting to enable the deprecated\r\nDownload CSV functionality, rather than generating a CSV report\r\n\r\n---------\r\n\r\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"10292a427ab2cec14367f970d672cdd95a64c2bc"}}]}] BACKPORT-->