### PR TITLE
[Console] Small fix to last tour step

### DIFF
--- a/src/plugins/console/public/application/containers/main/get_console_tour_step_props.tsx
+++ b/src/plugins/console/public/application/containers/main/get_console_tour_step_props.tsx
@@ -41,7 +41,7 @@ export const getConsoleTourStepProps = (
       css: step.css,
       onFinish: () => actions.finishTour(false),
       footerAction:
-        tourState.currentTourStep === stateTourStepProps.length ? (
+        step.step === step.stepsTotal ? (
           <EuiButton
             color="success"
             size="s"


### PR DESCRIPTION
## Summary

This PR adds a small fix to the last tour step, where before there was a brief flash after ending the tour where the "Complete" button changes back to Skip tour/Next buttons due to change in state.

Before:

https://github.com/user-attachments/assets/664620b3-a7ff-471c-8b4e-71b0a5a4b689


Now:


https://github.com/user-attachments/assets/ba81eb7e-4b15-47a9-815c-cf079c16657b





