### PR TITLE
[FTR] Fixup code owners check script

### DIFF
--- a/packages/kbn-test/src/functional_test_runner/run_check_ftr_code_owners.ts
+++ b/packages/kbn-test/src/functional_test_runner/run_check_ftr_code_owners.ts
@@ -37,7 +37,7 @@ export async function runCheckFtrCodeOwnersCli() {
       const testFiles = await getRepoFiles(TEST_DIRECTORIES);
       for (const { repoRel } of testFiles) {
         const owners = getCodeOwnersForFile(repoRel, reversedCodeowners);
-        if (owners === undefined) {
+        if (owners === undefined || owners === '') {
           missingOwners.add(repoRel);
         }
       }


### PR DESCRIPTION
## Summary

Ensure paths with empty owner annotations are included in the scripts output for missing code owners

## Notes

With this change, the output of the script goes from this:
```
succ All test files have a code owner (checked 8243 test files in 6.78 s)
```
to this:
```
...
       - x-pack/test_serverless/functional/test_suites/security/cypress/tasks/navigation.ts
       - x-pack/test_serverless/functional/test_suites/security/index.feature_flags.ts
       - x-pack/test_serverless/functional/test_suites/security/index.ts
       - x-pack/test_serverless/functional/test_suites/security/screenshot_creation/index.ts
       - x-pack/test_serverless/kibana.jsonc
       - x-pack/test_serverless/tsconfig.json
ERROR Found 2594 test files without code owner (checked 8243 test files in 7.48 s)
```

Eventually, this script will be included in checks on ci, such that when it returns an error, the checks will fail and report back to a given PR owner.