### PR TITLE
[Inline editor] correct the icon alignment, tooltip design and font size for the button

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -18,6 +18,7 @@ import {
   EuiButton,
   EuiLink,
   EuiBetaBadge,
+  EuiText,
 } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
@@ -87,11 +88,13 @@ export const FlyoutWrapper = ({
             </EuiFlexItem>
             {navigateToLensEditor && (
               <EuiFlexItem grow={false}>
-                <EuiLink onClick={navigateToLensEditor} data-test-subj="navigateToLensEditorLink">
-                  {i18n.translate('xpack.lens.config.editLinkLabel', {
-                    defaultMessage: 'Edit in Lens',
-                  })}
-                </EuiLink>
+                <EuiText size="xs">
+                  <EuiLink onClick={navigateToLensEditor} data-test-subj="navigateToLensEditorLink">
+                    {i18n.translate('xpack.lens.config.editLinkLabel', {
+                      defaultMessage: 'Edit in Lens',
+                    })}
+                  </EuiLink>
+                </EuiText>
               </EuiFlexItem>
             )}
           </EuiFlexGroup>

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -52,30 +52,36 @@ export const FlyoutWrapper = ({
             <EuiFlexItem grow={false}>
               <EuiTitle size="xs" data-test-subj="inlineEditingFlyoutLabel">
                 <h2>
-                  {isNewPanel
-                    ? i18n.translate('xpack.lens.config.createVisualizationLabel', {
-                        defaultMessage: 'Create {lang} visualization',
-                        values: { lang: language },
-                      })
-                    : i18n.translate('xpack.lens.config.editVisualizationLabel', {
-                        defaultMessage: 'Edit {lang} visualization',
-                        values: { lang: language },
-                      })}
-                  <EuiToolTip
-                    content={i18n.translate('xpack.lens.config.experimentalLabelDataview', {
-                      defaultMessage:
-                        'Technical preview, inline editing currently offers limited configuration options',
-                    })}
-                  >
-                    <EuiBetaBadge
-                      label="Lab"
-                      iconType="beaker"
-                      size="s"
-                      css={css`
-                        margin-left: ${euiThemeVars.euiSizeXS};
-                      `}
-                    />
-                  </EuiToolTip>
+                  <EuiFlexGroup alignItems="center" responsive={false} gutterSize="xs">
+                    <EuiFlexItem grow={false}>
+                      {isNewPanel
+                        ? i18n.translate('xpack.lens.config.createVisualizationLabel', {
+                            defaultMessage: 'Create {lang} visualization',
+                            values: { lang: language },
+                          })
+                        : i18n.translate('xpack.lens.config.editVisualizationLabel', {
+                            defaultMessage: 'Edit {lang} visualization',
+                            values: { lang: language },
+                          })}
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiToolTip
+                        content={i18n.translate('xpack.lens.config.experimentalLabelDataview', {
+                          defaultMessage:
+                            'Technical preview, inline editing currently offers limited configuration options',
+                        })}
+                      >
+                        <EuiBetaBadge
+                          label="Lab"
+                          iconType="beaker"
+                          size="s"
+                          css={css`
+                            vertical-align: middle;
+                          `}
+                        />
+                      </EuiToolTip>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
                 </h2>
               </EuiTitle>
             </EuiFlexItem>

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/flyout_wrapper.tsx
@@ -67,13 +67,19 @@ export const FlyoutWrapper = ({
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiToolTip
-                        content={i18n.translate('xpack.lens.config.experimentalLabelDataview', {
-                          defaultMessage:
-                            'Technical preview, inline editing currently offers limited configuration options',
+                        title={i18n.translate('xpack.lens.config.experimentalLabelDataview.title', {
+                          defaultMessage: 'Technical preview',
                         })}
+                        content={i18n.translate(
+                          'xpack.lens.config.experimentalLabelDataview.content',
+                          {
+                            defaultMessage:
+                              'Inline editing currently offers limited configuration options.',
+                          }
+                        )}
                       >
                         <EuiBetaBadge
-                          label="Lab"
+                          label=""
                           iconType="beaker"
                           size="s"
                           css={css`


### PR DESCRIPTION
## Summary

Aligns the technical preview badge with the Create visualization title  and reduce the Edit in Lens link text size to xs. (extracted from https://github.com/elastic/kibana/issues/192073)

Before:
<img width="289" alt="Screenshot 2024-09-10 at 12 52 16" src="https://github.com/user-attachments/assets/d0fffc8e-f4ea-49a8-885d-b8bd2beafbda">

<img width="287" alt="Screenshot 2024-09-10 at 13 09 25" src="https://github.com/user-attachments/assets/16b3bcef-0ab8-4360-b77f-d1f79a32ec87">


After:

<img width="378" alt="Screenshot 2024-09-10 at 12 59 33" src="https://github.com/user-attachments/assets/e5835a52-a9fe-4c07-809a-4c3fa6842581">

<img width="311" alt="Screenshot 2024-09-10 at 13 09 14" src="https://github.com/user-attachments/assets/e2abc06b-c736-450b-bd18-059205ff807e">

