### PR TITLE
[8.15] [Automatic Import] Error handling when uploading a file (#191310)

### DIFF
--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/sample_logs_input.test.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/sample_logs_input.test.tsx
@@ -305,4 +305,80 @@ describe('SampleLogsInput', () => {
       });
     });
   });
+
+  describe('when the file is too large', () => {
+    const type = 'text/plain';
+    let jsonParseSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      // Simulate large log content that would cause a RangeError
+      jsonParseSpy = jest.spyOn(JSON, 'parse').mockImplementation(() => {
+        throw new RangeError();
+      });
+
+      await changeFile(input, new File(['...'], 'test.json', { type }));
+    });
+
+    afterAll(() => {
+      // Restore the original implementation after all tests
+      jsonParseSpy.mockRestore();
+    });
+
+    it('should raise an appropriate error', () => {
+      expect(result.queryByText('This logs sample file is too large to parse')).toBeInTheDocument();
+    });
+  });
+
+  describe('when the file is neither a valid json nor ndjson', () => {
+    const plainTextFile = 'test message 1\ntest message 2';
+    const type = 'text/plain';
+
+    beforeEach(async () => {
+      await changeFile(input, new File([plainTextFile], 'test.txt', { type }));
+    });
+
+    it('should set the integrationSetting correctly', () => {
+      expect(mockActions.setIntegrationSettings).toBeCalledWith({
+        logSamples: plainTextFile.split('\n'),
+        samplesFormat: undefined,
+      });
+    });
+  });
+
+  describe('when the file reader fails', () => {
+    const mockedMessage = 'Mocked error';
+    let myFileReader: FileReader;
+    let fileReaderSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      myFileReader = new FileReader();
+      fileReaderSpy = jest.spyOn(global, 'FileReader').mockImplementation(() => myFileReader);
+
+      // We need to mock the error property
+      Object.defineProperty(myFileReader, 'error', {
+        value: new Error(mockedMessage),
+        writable: false,
+      });
+
+      jest.spyOn(myFileReader, 'readAsText').mockImplementation(() => {
+        const errorEvent = new ProgressEvent('error');
+        myFileReader.dispatchEvent(errorEvent);
+      });
+
+      const file = new File([`...`], 'test.json', { type: 'application/json' });
+      act(() => {
+        fireEvent.change(input, { target: { files: [file] } });
+      });
+    });
+
+    afterEach(() => {
+      fileReaderSpy.mockRestore();
+    });
+
+    it('should set the error message accordingly', () => {
+      expect(
+        result.queryByText(`An error occurred when reading logs sample: ${mockedMessage}`)
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
@@ -126,10 +126,24 @@ export const LOGS_SAMPLE_ERROR = {
       defaultMessage: 'Failed to read the logs sample file',
     }
   ),
+  CAN_NOT_READ_WITH_REASON: (reason: string) =>
+    i18n.translate(
+      'xpack.integrationAssistant.step.dataStream.logsSample.errorCanNotReadWithReason',
+      {
+        values: { reason },
+        defaultMessage: 'An error occurred when reading logs sample: {reason}',
+      }
+    ),
   CAN_NOT_PARSE: i18n.translate(
     'xpack.integrationAssistant.step.dataStream.logsSample.errorCanNotParse',
     {
       defaultMessage: 'Cannot parse the logs sample file as either a JSON or NDJSON file',
+    }
+  ),
+  TOO_LARGE_TO_PARSE: i18n.translate(
+    'xpack.integrationAssistant.step.dataStream.logsSample.errorTooLargeToParse',
+    {
+      defaultMessage: 'This logs sample file is too large to parse',
     }
   ),
   NOT_ARRAY: i18n.translate('xpack.integrationAssistant.step.dataStream.logsSample.errorNotArray', {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Automatic Import] Error handling when uploading a file (#191310)](https://github.com/elastic/kibana/pull/191310)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ilya Nikokoshev","email":"ilya.nikokoshev@elastic.co"},"sourceCommit":{"committedDate":"2024-09-03T11:39:05Z","message":"[Automatic Import] Error handling when uploading a file (#191310)\n\n### Release note\r\n\r\nDisplay better error messages for issues with logs sample file upload in\r\nAutomatic Import.\r\n\r\n## Summary\r\n\r\nPreviously the user would be told about parse issues that occur after\r\nthe file is successfully uploaded. However in the following scenarios\r\nthe operation would silently fail without displaying a user-visible\r\nerror:\r\n\r\n1. When the file fails to upload (e.g. when it is too big).\r\n2. When the upload operation is aborted, e.g. programmatically.\r\n\r\nAdditionally in the following scenario the generic `CAN_NOT_PARSE`\r\nmessage was displayed:\r\n\r\n3. When the file is uploaded but the browser runs out of memory when\r\ntrying to parse it.\r\n\r\nAdditionally, in the following scenario the `EMPTY` message was\r\ndisplayed:\r\n\r\n4. When the file is too big for the V8 engine (e.g. Chrome) to create a\r\nstring so upload process returns an empty string.\r\n\r\nAdditionally:\r\n\r\n5. When the user switches from the invalid file (with an error\r\ndisplayed) to the valid file, the error from the invalid file was\r\ndisplayed during the analysis of the new file.\r\n\r\nAfter the changes in this PR, the following error types would be\r\ndisplayed in these cases, respectively:\r\n\r\n1. `CAN_NOT_READ_WITH_REASON`: _An error occurred when reading logs\r\nsample: {reason}_\r\n2. `CAN_NOT_READ_WITH_REASON`: _An error occurred when reading logs\r\nsample: An ongoing operation was aborted, typically with a call to\r\nabort()._ (reason is provided by the browser)\r\n3. `TOO_LARGE_TO_PARSE`: _This logs sample file is too large to parse_\r\n4. `TOO_LARGE_TO_PARSE`: _This logs sample file is too large to parse_\r\n5. No error would be displayed during the analysis.\r\n\r\nThis covers part of https://github.com/elastic/security-team/issues/9844\r\nthough the issues were discovered separately.\r\n\r\nNote that the fix in item 3 does not work in Firefox as it throws an\r\n`InternalError` rather than `RangeError`. A generic `CAN_NOT_PARSE`\r\nmessage will continue to be displayed in that case. The fix in item 4 is\r\nonly relevant for Chrome.\r\n\r\nOn a slightly different note, we provide the following improvements to\r\nthe log sampling functionality introduced in\r\nhttps://github.com/elastic/kibana/pull/190407:\r\n\r\n- Add documentation for the `parseLogsContents` and its special cases\r\n- Refactor the `parseLogsContent` output fields into protocols that\r\nclearly define their optionality\r\n- Add tests for the functionality of sampling when the format cannot be\r\ndetermined\r\n- Fix so that the error message is displayed for the case where\r\n`fileContent == null` in `onChangeLogsSample`\r\n\r\n### Risk Matrix\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Due to the complexity of browser engines, some of them might produce\r\nunexpected events, or events in unexpected order and we will confuse the\r\nuser with an incorrect error message. | Low | Low | Testing. |\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"16c2bfe41e585fdcdd3e796166ac3e2a6367f1a7","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","enhancement","backport:prev-minor","v8.16.0","Team:Security-Scalability"],"number":191310,"url":"https://github.com/elastic/kibana/pull/191310","mergeCommit":{"message":"[Automatic Import] Error handling when uploading a file (#191310)\n\n### Release note\r\n\r\nDisplay better error messages for issues with logs sample file upload in\r\nAutomatic Import.\r\n\r\n## Summary\r\n\r\nPreviously the user would be told about parse issues that occur after\r\nthe file is successfully uploaded. However in the following scenarios\r\nthe operation would silently fail without displaying a user-visible\r\nerror:\r\n\r\n1. When the file fails to upload (e.g. when it is too big).\r\n2. When the upload operation is aborted, e.g. programmatically.\r\n\r\nAdditionally in the following scenario the generic `CAN_NOT_PARSE`\r\nmessage was displayed:\r\n\r\n3. When the file is uploaded but the browser runs out of memory when\r\ntrying to parse it.\r\n\r\nAdditionally, in the following scenario the `EMPTY` message was\r\ndisplayed:\r\n\r\n4. When the file is too big for the V8 engine (e.g. Chrome) to create a\r\nstring so upload process returns an empty string.\r\n\r\nAdditionally:\r\n\r\n5. When the user switches from the invalid file (with an error\r\ndisplayed) to the valid file, the error from the invalid file was\r\ndisplayed during the analysis of the new file.\r\n\r\nAfter the changes in this PR, the following error types would be\r\ndisplayed in these cases, respectively:\r\n\r\n1. `CAN_NOT_READ_WITH_REASON`: _An error occurred when reading logs\r\nsample: {reason}_\r\n2. `CAN_NOT_READ_WITH_REASON`: _An error occurred when reading logs\r\nsample: An ongoing operation was aborted, typically with a call to\r\nabort()._ (reason is provided by the browser)\r\n3. `TOO_LARGE_TO_PARSE`: _This logs sample file is too large to parse_\r\n4. `TOO_LARGE_TO_PARSE`: _This logs sample file is too large to parse_\r\n5. No error would be displayed during the analysis.\r\n\r\nThis covers part of https://github.com/elastic/security-team/issues/9844\r\nthough the issues were discovered separately.\r\n\r\nNote that the fix in item 3 does not work in Firefox as it throws an\r\n`InternalError` rather than `RangeError`. A generic `CAN_NOT_PARSE`\r\nmessage will continue to be displayed in that case. The fix in item 4 is\r\nonly relevant for Chrome.\r\n\r\nOn a slightly different note, we provide the following improvements to\r\nthe log sampling functionality introduced in\r\nhttps://github.com/elastic/kibana/pull/190407:\r\n\r\n- Add documentation for the `parseLogsContents` and its special cases\r\n- Refactor the `parseLogsContent` output fields into protocols that\r\nclearly define their optionality\r\n- Add tests for the functionality of sampling when the format cannot be\r\ndetermined\r\n- Fix so that the error message is displayed for the case where\r\n`fileContent == null` in `onChangeLogsSample`\r\n\r\n### Risk Matrix\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Due to the complexity of browser engines, some of them might produce\r\nunexpected events, or events in unexpected order and we will confuse the\r\nuser with an incorrect error message. | Low | Low | Testing. |\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"16c2bfe41e585fdcdd3e796166ac3e2a6367f1a7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/191310","number":191310,"mergeCommit":{"message":"[Automatic Import] Error handling when uploading a file (#191310)\n\n### Release note\r\n\r\nDisplay better error messages for issues with logs sample file upload in\r\nAutomatic Import.\r\n\r\n## Summary\r\n\r\nPreviously the user would be told about parse issues that occur after\r\nthe file is successfully uploaded. However in the following scenarios\r\nthe operation would silently fail without displaying a user-visible\r\nerror:\r\n\r\n1. When the file fails to upload (e.g. when it is too big).\r\n2. When the upload operation is aborted, e.g. programmatically.\r\n\r\nAdditionally in the following scenario the generic `CAN_NOT_PARSE`\r\nmessage was displayed:\r\n\r\n3. When the file is uploaded but the browser runs out of memory when\r\ntrying to parse it.\r\n\r\nAdditionally, in the following scenario the `EMPTY` message was\r\ndisplayed:\r\n\r\n4. When the file is too big for the V8 engine (e.g. Chrome) to create a\r\nstring so upload process returns an empty string.\r\n\r\nAdditionally:\r\n\r\n5. When the user switches from the invalid file (with an error\r\ndisplayed) to the valid file, the error from the invalid file was\r\ndisplayed during the analysis of the new file.\r\n\r\nAfter the changes in this PR, the following error types would be\r\ndisplayed in these cases, respectively:\r\n\r\n1. `CAN_NOT_READ_WITH_REASON`: _An error occurred when reading logs\r\nsample: {reason}_\r\n2. `CAN_NOT_READ_WITH_REASON`: _An error occurred when reading logs\r\nsample: An ongoing operation was aborted, typically with a call to\r\nabort()._ (reason is provided by the browser)\r\n3. `TOO_LARGE_TO_PARSE`: _This logs sample file is too large to parse_\r\n4. `TOO_LARGE_TO_PARSE`: _This logs sample file is too large to parse_\r\n5. No error would be displayed during the analysis.\r\n\r\nThis covers part of https://github.com/elastic/security-team/issues/9844\r\nthough the issues were discovered separately.\r\n\r\nNote that the fix in item 3 does not work in Firefox as it throws an\r\n`InternalError` rather than `RangeError`. A generic `CAN_NOT_PARSE`\r\nmessage will continue to be displayed in that case. The fix in item 4 is\r\nonly relevant for Chrome.\r\n\r\nOn a slightly different note, we provide the following improvements to\r\nthe log sampling functionality introduced in\r\nhttps://github.com/elastic/kibana/pull/190407:\r\n\r\n- Add documentation for the `parseLogsContents` and its special cases\r\n- Refactor the `parseLogsContent` output fields into protocols that\r\nclearly define their optionality\r\n- Add tests for the functionality of sampling when the format cannot be\r\ndetermined\r\n- Fix so that the error message is displayed for the case where\r\n`fileContent == null` in `onChangeLogsSample`\r\n\r\n### Risk Matrix\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Due to the complexity of browser engines, some of them might produce\r\nunexpected events, or events in unexpected order and we will confuse the\r\nuser with an incorrect error message. | Low | Low | Testing. |\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"16c2bfe41e585fdcdd3e796166ac3e2a6367f1a7"}}]}] BACKPORT-->