### PR TITLE
Unskip failing unit test (#192475)

### DIFF
--- a/x-pack/plugins/cases/public/components/connectors/thehive/case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/thehive/case_fields.test.tsx
@@ -15,8 +15,7 @@ import type { AppMockRenderer } from '../../../common/mock';
 import { createAppMockRenderer } from '../../../common/mock';
 import { TheHiveTLP } from './types';
 
-// Failing: See https://github.com/elastic/kibana/issues/192475
-describe.skip('TheHive Cases Fields', () => {
+describe('TheHive Cases Fields', () => {
   const fields = {
     TLP: 1,
   };
@@ -45,7 +44,7 @@ describe.skip('TheHive Cases Fields', () => {
       </MockFormWrapperComponent>
     );
 
-    userEvent.selectOptions(screen.getByTestId('tlp-field'), '4');
+    await userEvent.selectOptions(screen.getByTestId('tlp-field'), '4');
     expect(await screen.findByTestId('tlp-field')).toHaveValue(TheHiveTLP.RED.toString());
   });
 });

--- a/x-pack/plugins/cases/public/components/connectors/thehive/case_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/connectors/thehive/case_fields.test.tsx
@@ -44,7 +44,7 @@ describe('TheHive Cases Fields', () => {
       </MockFormWrapperComponent>
     );
 
-    await userEvent.selectOptions(screen.getByTestId('tlp-field'), '4');
+    await userEvent.selectOptions(await screen.findByTestId('tlp-field'), '4');
     expect(await screen.findByTestId('tlp-field')).toHaveValue(TheHiveTLP.RED.toString());
   });
 });


### PR DESCRIPTION
## Summary
 This test (https://github.com/elastic/kibana/pull/180931) was introduced right before the version bump of user-events (https://github.com/elastic/kibana/pull/189949). 

This PR updates the one async call to be awaited, fixing the test.

Solves: https://github.com/elastic/kibana/issues/192475
Unskipped tests are passing now: https://buildkite.com/elastic/kibana-pull-request/builds/233177
