### PR TITLE
Remove reference to deprecated Functionbeat

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -281,9 +281,6 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       base: `${ELASTIC_WEBSITE_URL}guide/en/logstash/${DOC_LINK_VERSION}`,
       inputElasticAgent: `${ELASTIC_WEBSITE_URL}guide/en/logstash/${DOC_LINK_VERSION}/plugins-inputs-elastic_agent.html`,
     },
-    functionbeat: {
-      base: `${ELASTIC_WEBSITE_URL}guide/en/beats/functionbeat/${DOC_LINK_VERSION}`,
-    },
     winlogbeat: {
       base: `${ELASTIC_WEBSITE_URL}guide/en/beats/winlogbeat/${DOC_LINK_VERSION}`,
     },


### PR DESCRIPTION
## Summary

I'm trying to freeze the Functionbeat docs. This PR removes an entry for Functionbeat in Kibana's link checking script. I believe that entry is causing the associated docs PR to fail CI checks. See https://github.com/elastic/docs/pull/2895#issuecomment-2341214476

I'm not sure how to test this PR other than letting the CI checks run.


