### PR TITLE
[ResponseOps][Alerting] fix alert conflict resolution to support create

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
@@ -175,33 +175,9 @@ export class AlertsClient<
       return;
     }
 
-    const queryByUuid = async (uuids: string[]) => {
-      const result = await this.search({
-        size: uuids.length,
-        seq_no_primary_term: true,
-        query: {
-          bool: {
-            filter: [
-              {
-                term: {
-                  [ALERT_RULE_UUID]: this.options.rule.id,
-                },
-              },
-              {
-                terms: {
-                  [ALERT_UUID]: uuids,
-                },
-              },
-            ],
-          },
-        },
-      });
-      return result.hits;
-    };
-
     try {
       const results = await Promise.all(
-        chunk(uuidsToFetch, CHUNK_SIZE).map((uuidChunk: string[]) => queryByUuid(uuidChunk))
+        chunk(uuidsToFetch, CHUNK_SIZE).map((uuidChunk: string[]) => this.queryByUuid(uuidChunk))
       );
 
       for (const hit of results.flat()) {
@@ -223,6 +199,30 @@ export class AlertsClient<
         this.logTags
       );
     }
+  }
+
+  public async queryByUuid(uuids: string[]) {
+    const result = await this.search({
+      size: uuids.length,
+      seq_no_primary_term: true,
+      query: {
+        bool: {
+          filter: [
+            {
+              term: {
+                [ALERT_RULE_UUID]: this.options.rule.id,
+              },
+            },
+            {
+              terms: {
+                [ALERT_UUID]: uuids,
+              },
+            },
+          ],
+        },
+      },
+    });
+    return result.hits;
   }
 
   public async search<Aggregation = unknown>(

--- a/x-pack/plugins/alerting/server/alerts_client/lib/alert_conflict_resolver.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/lib/alert_conflict_resolver.ts
@@ -10,6 +10,12 @@ import {
   BulkResponse,
   BulkOperationContainer,
   MgetResponseItem,
+  BulkCreateOperation,
+  BulkIndexOperation,
+  BulkUpdateOperation,
+  BulkDeleteOperation,
+  BulkOperationType,
+  BulkResponseItem,
 } from '@elastic/elasticsearch/lib/api/types';
 
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
@@ -40,6 +46,13 @@ export interface ResolveAlertConflictsParams {
   ruleType: string;
 }
 
+type BulkOperation =
+  | BulkCreateOperation
+  | BulkIndexOperation
+  | BulkUpdateOperation
+  | BulkDeleteOperation;
+
+type BulkItem = Partial<Record<BulkOperationType, BulkResponseItem>>;
 interface NormalizedBulkRequest {
   op: BulkOperationContainer;
   doc: unknown;
@@ -61,11 +74,11 @@ export async function resolveAlertConflicts(params: ResolveAlertConflictsParams)
 }
 
 async function resolveAlertConflicts_(params: ResolveAlertConflictsParams): Promise<void> {
-  const { logger, esClient, bulkRequest, bulkResponse, ruleId, ruleType, ruleName } = params;
+  const { logger, esClient, bulkRequest, bulkResponse, ruleId, ruleType } = params;
   if (bulkRequest.operations && bulkRequest.operations?.length === 0) return;
   if (bulkResponse.items && bulkResponse.items?.length === 0) return;
 
-  const ruleInfoMessage = `for ${ruleType}:${ruleId} '${ruleName}'`;
+  const ruleInfoMessage = `for ${ruleType}:${ruleId}`;
   const logTags = { tags: [ruleType, ruleId, 'resolve-alert-conflicts'] };
 
   // get numbers for a summary log message
@@ -81,6 +94,9 @@ async function resolveAlertConflicts_(params: ResolveAlertConflictsParams): Prom
   // get a new bulk request for just conflicted docs
   const conflictRequest = getConflictRequest(bulkRequest, bulkResponse);
   if (conflictRequest.length === 0) return;
+
+  // conflicts from creates need to be retried as updates
+  convertCreatesToindexes(conflictRequest);
 
   // get the fresh versions of those docs
   const freshDocs = await getFreshDocs(esClient, conflictRequest);
@@ -134,6 +150,28 @@ interface MakeBulkRequestResponse {
   error?: Error;
 }
 
+function getBulkOperation(opContainer?: BulkOperationContainer): BulkOperation | undefined {
+  if (!opContainer) return undefined;
+
+  const operation =
+    opContainer.create || opContainer.index || opContainer.update || opContainer.delete;
+
+  if (!operation) {
+    throw new Error(`Missing bulk op in op container: ${JSON.stringify(opContainer)}`);
+  }
+  return operation;
+}
+
+function getItemInfoFromBulk(item?: BulkItem): BulkResponseItem | undefined {
+  if (!item) return undefined;
+
+  const info = item.create || item.index || item.update || item.delete;
+  if (!info) {
+    throw new Error(`Missing bulk op in bulk request: ${JSON.stringify(item)}`);
+  }
+  return info;
+}
+
 // make the bulk request to fix conflicts
 async function makeBulkRequest(
   esClient: ElasticsearchClient,
@@ -146,7 +184,7 @@ async function makeBulkRequest(
 
   const bulkResponse = await esClient.bulk(updatedBulkRequest);
 
-  const errors = bulkResponse.items.filter((item) => item.index?.error).length;
+  const errors = bulkResponse.items.filter((item) => getItemInfoFromBulk(item)?.error).length;
   return { bulkRequest, bulkResponse, errors };
 }
 
@@ -156,7 +194,7 @@ async function refreshFieldsInDocs(
   freshResponses: MgetResponseItem[]
 ) {
   for (const [conflictRequest, freshResponse] of zip(conflictRequests, freshResponses)) {
-    if (!conflictRequest?.op.index || !freshResponse) continue;
+    if (!conflictRequest || !getBulkOperation(conflictRequest?.op) || !freshResponse) continue;
 
     // @ts-expect-error @elastic/elasticsearch _source is not in the type!
     const freshDoc = freshResponse._source;
@@ -190,7 +228,10 @@ async function refreshFieldsInDocs(
 /** Update the OCC info in the conflict request with the fresh info. */
 async function updateOCC(conflictRequests: NormalizedBulkRequest[], freshDocs: MgetResponseItem[]) {
   for (const [req, freshDoc] of zip(conflictRequests, freshDocs)) {
-    if (!req?.op.index || !freshDoc) continue;
+    if (!req) continue;
+
+    const bulkOperation = getBulkOperation(req?.op);
+    if (!bulkOperation || !freshDoc) continue;
 
     // @ts-expect-error @elastic/elasticsearch _seq_no is not in the type!
     const seqNo: number | undefined = freshDoc._seq_no;
@@ -200,8 +241,8 @@ async function updateOCC(conflictRequests: NormalizedBulkRequest[], freshDocs: M
     if (seqNo === undefined) throw new Error('Unexpected undefined seqNo');
     if (primaryTerm === undefined) throw new Error('Unexpected undefined primaryTerm');
 
-    req.op.index.if_seq_no = seqNo;
-    req.op.index.if_primary_term = primaryTerm;
+    bulkOperation.if_seq_no = seqNo;
+    bulkOperation.if_primary_term = primaryTerm;
   }
 }
 
@@ -213,7 +254,8 @@ async function getFreshDocs(
   const docs: Array<{ _id: string; _index: string }> = [];
 
   conflictRequests.forEach((req) => {
-    const [id, index] = [req.op.index?._id, req.op.index?._index];
+    const bulkOperation = getBulkOperation(req?.op);
+    const [id, index] = [bulkOperation?._id, bulkOperation?._index];
     if (!id || !index) return;
 
     docs.push({ _id: id, _index: index });
@@ -245,9 +287,9 @@ function getConflictRequest(
 
   if (request.length === 0) return [];
 
-  // we only want op: index where the status was 409 / conflict
+  // pick out just the conflicts (409)
   const conflictRequest = zip(request, bulkResponse.items)
-    .filter(([_, res]) => res?.index?.status === 409)
+    .filter(([_, res]) => getItemInfoFromBulk(res)?.status === 409)
     .map(([req, _]) => req!);
 
   return conflictRequest;
@@ -280,6 +322,29 @@ function normalizeRequest(bulkRequest: BulkRequest) {
   return result;
 }
 
+function convertCreatesToindexes(conflictRequest: NormalizedBulkRequest[]): void {
+  for (const req of conflictRequest) {
+    if (!req.op.create) continue;
+  }
+  const uuids = conflictRequest.filter((req) => req.op.create).map((req) => req.op.create?._id);
+
+  // search for alert docs of these uuids
+
+  for (const req of conflictRequest) {
+    if (!req.op.create) continue;
+
+    req.op.index = {
+      _id: req.op.create._id,
+      _index: index,
+      if_seq_no: seqNo,
+      if_primary_term: primaryTerm,
+      require_alias: false,
+    };
+
+    delete req.op.create;
+  }
+}
+
 interface ResponseStatsResult {
   success: number;
   conflicts: number;
@@ -292,9 +357,9 @@ function getResponseStats(bulkResponse: BulkResponse): ResponseStatsResult {
   const sanitizedResponse = sanitizeBulkErrorResponse(bulkResponse) as BulkResponse;
   const stats: ResponseStatsResult = { success: 0, conflicts: 0, errors: 0, messages: [] };
   for (const item of sanitizedResponse.items) {
-    const op = item.create || item.index || item.update || item.delete;
+    const op = getItemInfoFromBulk(item);
     if (op?.error) {
-      if (op?.status === 409 && op === item.index) {
+      if (op?.status === 409) {
         stats.conflicts++;
       } else {
         stats.errors++;

--- a/x-pack/plugins/alerting/server/integration_tests/alert_conflicts.test.ts
+++ b/x-pack/plugins/alerting/server/integration_tests/alert_conflicts.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CoreKibanaRequest, FakeRawRequest } from '@kbn/core/server';
+import {
+  type TestElasticsearchUtils,
+  type TestKibanaUtils,
+} from '@kbn/core-test-helpers-kbn-server';
+
+import { AlertingPlugin, PluginStartContract as AlertingStart } from '../plugin';
+import { IRuleTypeAlerts } from '..';
+import { setupTestServers, retry } from './lib';
+import { RawAlertInstance, RulesClientApi } from '../types';
+
+const AlertingStartSpy = jest.spyOn(AlertingPlugin.prototype, 'start');
+
+jest.mock('../rule_type_registry', () => {
+  const actual = jest.requireActual('../rule_type_registry');
+  return {
+    ...actual,
+    RuleTypeRegistry: jest.fn().mockImplementation((opts) => {
+      return new actual.RuleTypeRegistry(opts);
+    }),
+  };
+});
+
+jest.mock('../lib/determine_alerts_to_return', () => {
+  const actual = jest.requireActual('../lib/determine_alerts_to_return');
+  return {
+    ...actual,
+    determineAlertsToReturn: jest.fn().mockImplementation((...args) => {
+      const result = new actual.determineAlertsToReturn(...args);
+      return determineAlertsToReturnAdapter(result);
+    }),
+  };
+
+  function determineAlertsToReturnAdapter<X, Y, Z, A>({
+    alertsToReturn,
+    recoveredAlertsToReturn,
+  }: {
+    alertsToReturn: Record<string, RawAlertInstance>;
+    recoveredAlertsToReturn: Record<string, RawAlertInstance>;
+  }): {
+    alertsToReturn: Record<string, RawAlertInstance>;
+    recoveredAlertsToReturn: Record<string, RawAlertInstance>;
+  } {
+    // creates copies of alerts, same uuid, but the id is different
+    for (const id of Object.keys(alertsToReturn)) {
+      alertsToReturn[`${id}-conflicted`] = alertsToReturn[id];
+    }
+    return { alertsToReturn, recoveredAlertsToReturn };
+  }
+});
+
+describe('Handle conflicts when writing alert docs', () => {
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+  let alertingStart: AlertingStart;
+  let rulesClient: RulesClientApi;
+
+  beforeAll(async () => {
+    const setupResult = await setupTestServers({
+      xpack: {
+        alerting: {
+          rules: {
+            minimumScheduleInterval: {
+              value: '1s',
+            },
+          },
+        },
+      },
+    });
+    esServer = setupResult.esServer;
+    kibanaServer = setupResult.kibanaServer;
+
+    expect(AlertingStartSpy).toHaveBeenCalledTimes(1);
+    alertingStart = AlertingStartSpy.mock.results[0].value;
+
+    await wait(5000);
+
+    rulesClient = alertingStart.getRulesClientWithRequest(getFakeRequest());
+  });
+
+  afterAll(async () => {
+    if (kibanaServer) {
+      await kibanaServer.stop();
+    }
+    if (esServer) {
+      await esServer.stop();
+    }
+  });
+
+  test('handle conflict when creating alert', async () => {
+    console.log(`Creating rule...`);
+    const rule = await createRule(rulesClient);
+
+    retry(async () => {
+      const currRule = await rulesClient.get({ id: rule.id });
+      expect(currRule.monitoring?.run.last_run.timestamp).not.toBeFalsy();
+    });
+    console.log(`Created rule: ${JSON.stringify(rule.id, null, 4)}`);
+  });
+});
+
+async function createRule(rulesClient: RulesClientApi) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return await rulesClient.create<any>({
+    data: {
+      alertTypeId: '.es-query',
+      name: 'eq',
+      enabled: true,
+      tags: [],
+      actions: [],
+      consumer: 'alerts',
+      schedule: { interval: '1s' },
+      params: {
+        timeField: '@timestamp',
+        index: ['.kibana-event-log-*'],
+        esQuery: '{\n    "query":{\n      "match_all" : {}\n    }\n  }',
+        size: 100,
+        thresholdComparator: '>',
+        timeWindowSize: 1,
+        timeWindowUnit: 's',
+        threshold: [1000],
+        aggType: 'count',
+        groupBy: 'top',
+        termSize: 5,
+        searchType: 'esQuery',
+        excludeHitsFromPreviousRun: false,
+        sourceFields: [],
+        termField: 'event.action',
+      },
+    },
+  });
+}
+
+async function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getFakeRequest(): CoreKibanaRequest {
+  const auth = Buffer.from(`elastic:changeme`).toString('base64');
+  const headers = {
+    authorization: `Basic ${auth}`,
+  };
+
+  const fakeRawRequest: FakeRawRequest = {
+    headers,
+    path: '/',
+  };
+
+  return CoreKibanaRequest.from(fakeRawRequest);
+}
+
+export const STACK_ALERTS_AAD_CONFIG: IRuleTypeAlerts<{}> = {
+  context: 'jest',
+  mappings: {
+    fieldMap: {},
+  },
+  shouldWrite: true,
+  useEcs: true,
+};
+
+export const RULE_TYPE_ID = '...conflicting-alert-docs';
+export const ACTION_GROUP_ID = 'default';

--- a/x-pack/plugins/alerting/server/integration_tests/lib/index.ts
+++ b/x-pack/plugins/alerting/server/integration_tests/lib/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { setupTestServers } from './setup_test_servers';
+export { retry } from './retry';

--- a/x-pack/plugins/alerting/server/integration_tests/lib/retry.ts
+++ b/x-pack/plugins/alerting/server/integration_tests/lib/retry.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+interface RetryOpts {
+  times: number;
+  intervalMs: number;
+}
+
+export async function retry<T>(
+  cb: () => Promise<T>,
+  options: RetryOpts = { times: 60, intervalMs: 500 }
+) {
+  let attempt = 1;
+  while (true) {
+    try {
+      return await cb();
+    } catch (e) {
+      if (attempt >= options.times) {
+        throw e;
+      }
+    }
+    attempt++;
+    await new Promise((resolve) => setTimeout(resolve, options.intervalMs));
+  }
+}

--- a/x-pack/plugins/alerting/server/integration_tests/lib/setup_test_servers.ts
+++ b/x-pack/plugins/alerting/server/integration_tests/lib/setup_test_servers.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import supertest from 'supertest';
 import { createTestServers, createRootWithCorePlugins } from '@kbn/core-test-helpers-kbn-server';
 
 export async function setupTestServers(settings = {}) {
@@ -32,6 +33,7 @@ export async function setupTestServers(settings = {}) {
       coreSetup,
       coreStart,
       stop: async () => await root.shutdown(),
+      getSupertest: () => supertest(coreSetup.http.server.listener),
     },
   };
 }


### PR DESCRIPTION
resolves: https://github.com/elastic/kibana/issues/190376

In PR https://github.com/elastic/kibana/pull/160572, we changed from using just the bulk op `index` to using `create` when new alerts are being created.

Unfortunately, the code to handle the bulk responses didn't take into account that the bulk responses for `create`s need different handling than `index`s.  Specifically, conflicts for `create` were being treated as errors.

This PR changes the processing to consider additional ops besides just `index`.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
