### PR TITLE
[Fleet] prevent extra agent_status call with empty policyId

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/hooks/use_package_policy.tsx
@@ -74,7 +74,7 @@ export function usePackagePolicyWithRelatedData(
     description: '',
     namespace: '',
     policy_id: '',
-    policy_ids: [''],
+    policy_ids: [],
     enabled: true,
     inputs: [],
     version: '',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
@@ -564,6 +564,7 @@ describe('edit package policy page', () => {
           policy_ids: ['agent-policy-1', 'agent-policy-2'],
         })
       );
+      expect(sendGetAgentStatus).toHaveBeenCalledTimes(1);
     });
 
     it('should not remove managed policy when policies are modified', async () => {


### PR DESCRIPTION
## Summary

UI bug reported by users, there was an extra `/api/fleet/agent_status?policyId=` call when opening Edit integration page, which sometimes causes an incorrect agent count being displayed on the confirmation modal.
Fixing that by starting with an empty `policy_ids` placeholder until the package policy is loaded. The agent status API is only called if there is at least one policy id in `policy_ids` here: https://github.com/elastic/kibana/blob/325dba37ec1b6872bffc21413c1b060f868eb3f8/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx#L163

To verify:
- Create an agent policy with system integration
- Edit the system integration
- Check Chrome Network tab
- Verify that there is no `/api/fleet/agent_status?policyId=` call, only one with an `policyId`

<img width="1924" alt="image" src="https://github.com/user-attachments/assets/4bb60425-da78-4485-83b7-d465ed8abfc0">



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->