### PR TITLE
[Automatic Import] Add validation and error graphs for structured logs header(KVGraph)

### DIFF
--- a/x-pack/plugins/integration_assistant/__jest__/fixtures/kv.ts
+++ b/x-pack/plugins/integration_assistant/__jest__/fixtures/kv.ts
@@ -21,4 +21,5 @@ export const kvState = {
   ecsVersion: 'testVersion',
   errors: { test: 'testerror' },
   additionalProcessors: [{ kv: { field: 'test', target_field: 'newtest' } }],
+  grokPattern: 'testPattern',
 };

--- a/x-pack/plugins/integration_assistant/scripts/draw_graphs_script.ts
+++ b/x-pack/plugins/integration_assistant/scripts/draw_graphs_script.ts
@@ -19,6 +19,7 @@ import { getCategorizationGraph } from '../server/graphs/categorization/graph';
 import { getEcsGraph, getEcsSubGraph } from '../server/graphs/ecs/graph';
 import { getLogFormatDetectionGraph } from '../server/graphs/log_type_detection/graph';
 import { getRelatedGraph } from '../server/graphs/related/graph';
+import { getKVGraph } from '../server/graphs/kv/graph';
 
 // Some mock elements just to get the graph to compile
 const model = new FakeLLM({
@@ -50,9 +51,11 @@ export async function drawGraphs() {
   const categorizationGraph = (await getCategorizationGraph({ client, model })).getGraph();
   const ecsSubGraph = (await getEcsSubGraph({ model })).getGraph();
   const ecsGraph = (await getEcsGraph({ model })).getGraph();
+  const kvGraph = (await getKVGraph({ client, model })).getGraph();
   drawGraph(relatedGraph, 'related_graph');
   drawGraph(logFormatDetectionGraph, 'log_detection_graph');
   drawGraph(categorizationGraph, 'categorization_graph');
   drawGraph(ecsSubGraph, 'ecs_subgraph');
   drawGraph(ecsGraph, 'ecs_graph');
+  drawGraph(kvGraph, 'kv_graph');
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/constants.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/constants.ts
@@ -20,6 +20,11 @@ export const KV_HEADER_EXAMPLE_ANSWER = {
   grok_pattern: '%{WORD:key1}:%{WORD:value1};%{WORD:key2}:%{WORD:value2}:%{GREEDYDATA:message}',
 };
 
+export const KV_HEADER_ERROR_EXAMPLE_ANSWER = {
+  grok_pattern:
+    '%{TIMESTAMP:timestamp}:%{WORD:value1};%{WORD:key2}:%{WORD:value2}:%{GREEDYDATA:message}',
+};
+
 export const onFailure = {
   append: {
     field: 'error.message',

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/error.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/error.ts
@@ -53,6 +53,6 @@ export async function handleHeaderError({
 
   return {
     grokPattern: pattern.grok_pattern,
-    lastExecutedChain: 'kv_error',
+    lastExecutedChain: 'kv_header_error',
   };
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/error.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/error.ts
@@ -42,10 +42,10 @@ export async function handleHeaderError({
   model,
 }: HandleKVNodeParams): Promise<Partial<KVState>> {
   const outputParser = new JsonOutputParser();
-  const grokErrorGraph = KV_HEADER_ERROR_PROMPT.pipe(model).pipe(outputParser);
+  const kvHeaderErrorGraph = KV_HEADER_ERROR_PROMPT.pipe(model).pipe(outputParser);
   const currentPattern = state.grokPattern;
 
-  const pattern = await grokErrorGraph.invoke({
+  const pattern = await kvHeaderErrorGraph.invoke({
     current_pattern: JSON.stringify(currentPattern, null, 2),
     errors: JSON.stringify(state.errors, null, 2),
     ex_answer: JSON.stringify(KV_HEADER_ERROR_EXAMPLE_ANSWER, null, 2),

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/error.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/error.ts
@@ -8,8 +8,8 @@
 import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { KVState } from '../../types';
 import type { HandleKVNodeParams } from './types';
-import { KV_ERROR_PROMPT } from './prompts';
-import { COMMON_ERRORS, KV_EXAMPLE_ANSWER } from './constants';
+import { KV_ERROR_PROMPT, KV_HEADER_ERROR_PROMPT } from './prompts';
+import { COMMON_ERRORS, KV_EXAMPLE_ANSWER, KV_HEADER_ERROR_EXAMPLE_ANSWER } from './constants';
 import { createKVProcessor } from '../../util/processors';
 import { KVProcessor } from '../../processor_types';
 
@@ -33,6 +33,26 @@ export async function handleKVError({
 
   return {
     kvProcessor,
+    lastExecutedChain: 'kv_error',
+  };
+}
+
+export async function handleHeaderError({
+  state,
+  model,
+}: HandleKVNodeParams): Promise<Partial<KVState>> {
+  const outputParser = new JsonOutputParser();
+  const grokErrorGraph = KV_HEADER_ERROR_PROMPT.pipe(model).pipe(outputParser);
+  const currentPattern = state.grokPattern;
+
+  const pattern = await grokErrorGraph.invoke({
+    current_pattern: JSON.stringify(currentPattern, null, 2),
+    errors: JSON.stringify(state.errors, null, 2),
+    ex_answer: JSON.stringify(KV_HEADER_ERROR_EXAMPLE_ANSWER, null, 2),
+  });
+
+  return {
+    grokPattern: pattern.grok_pattern,
     lastExecutedChain: 'kv_error',
   };
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/header.test.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/header.test.ts
@@ -40,7 +40,9 @@ describe('Testing kv header', () => {
   } as unknown as IScopedClusterClient;
   it('handleHeader()', async () => {
     const response = await handleHeader({ state, model, client });
-    expect(response.kvLogMessages).toStrictEqual(['dummy=data']);
+    expect(response.grokPattern).toStrictEqual(
+      '<%{NUMBER:priority}>%{NUMBER:version} %{GREEDYDATA:message}'
+    );
     expect(response.lastExecutedChain).toBe('kv_header');
   });
 });

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/header.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/header.ts
@@ -9,14 +9,7 @@ import { JsonOutputParser } from '@langchain/core/output_parsers';
 import type { KVState } from '../../types';
 import type { HandleKVNodeParams } from './types';
 import { KV_HEADER_PROMPT } from './prompts';
-import { KV_HEADER_EXAMPLE_ANSWER, onFailure } from './constants';
-import { createGrokProcessor } from '../../util/processors';
-import { testPipeline } from '../../util';
-
-interface GrokResult {
-  [key: string]: unknown;
-  message: string;
-}
+import { KV_HEADER_EXAMPLE_ANSWER } from './constants';
 
 export async function handleHeader({
   state,
@@ -31,22 +24,8 @@ export async function handleHeader({
     ex_answer: JSON.stringify(KV_HEADER_EXAMPLE_ANSWER, null, 2),
   });
 
-  const grokProcessors = createGrokProcessor(pattern.grok_pattern);
-  const pipeline = { processors: grokProcessors, on_failure: [onFailure] };
-
-  const { pipelineResults } = (await testPipeline(state.logSamples, pipeline, client)) as {
-    pipelineResults: GrokResult[];
-    errors: object[];
-  };
-
-  const additionalProcessors = state.additionalProcessors;
-  additionalProcessors.push(grokProcessors[0]);
-
-  const kvLogMessages: string[] = pipelineResults.map((entry) => entry.message);
-
   return {
-    kvLogMessages,
-    additionalProcessors,
+    grokPattern: pattern.grok_pattern,
     lastExecutedChain: 'kv_header',
   };
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/kv.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/kv.ts
@@ -27,7 +27,7 @@ export async function handleKV({
   const kvMainGraph = KV_MAIN_PROMPT.pipe(model).pipe(new JsonOutputParser());
 
   // Pick logSamples if there was no header detected.
-  const samples = state.kvLogMessages.length > 0 ? state.kvLogMessages : state.logSamples;
+  const samples = state.header ? state.kvLogMessages : state.logSamples;
 
   const kvInput = (await kvMainGraph.invoke({
     samples: samples[0],

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/prompts.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/prompts.ts
@@ -38,6 +38,7 @@ export const KV_MAIN_PROMPT = ChatPromptTemplate.fromMessages([
  - Do not create any other processors.
  - Do not add any prefix to the processor.
  - Do not use the special characters like \`\s\` or \`\\s+\` in the \`field_split\` or \`value_split\` regular expressions.
+ - Always use single backslash (\\) for escaping special characters in \`field_split\` or \`value_split\` regular expressions.
  - Do not add brackets (), <>, [] as well as single or double quotes in \`trim_value\`.
  - Make sure to trim whitespaces in \`trim_key\`. 
  - Do not respond with anything except the processor as a JSON object enclosed with 3 backticks (\`), see example response below. Use strict JSON response format.
@@ -91,6 +92,45 @@ You then have to create a grok pattern using the regex pattern.
   ['ai', 'Please find the JSON object below:'],
 ]);
 
+export const KV_HEADER_ERROR_PROMPT = ChatPromptTemplate.fromMessages([
+  [
+    'system',
+    `You are an expert in Syslogs and identifying the headers and structured body in syslog messages. Here is some context for you to reference for your task, read it carefully as you will get questions about it later:
+<context>
+<current_pattern>
+{current_pattern}
+</current_pattern>
+</context>`,
+  ],
+  [
+    'human',
+    `Please go through each error below, carefully review the provided current grok pattern, and resolve the most likely cause to the supplied error by returning an updated version of the current_pattern.
+
+<errors>
+{errors}
+</errors>
+
+ You ALWAYS follow these guidelines when writing your response:
+ <guidelines>
+ - Identify any mismatches, incorrect syntax, or logical errors in the pattern.
+ - If the message part contains any unstructured data , make sure to add this in grok pattern.
+ - Do not parse the message part in the regex. Just the header part should be in regex nad grok_pattern.
+ - Make sure to map the remaining message part to \'message\' in grok pattern.
+ - Do not respond with anything except the processor as a JSON object enclosed with 3 backticks (\`), see example response above. Use strict JSON response format.
+ </guidelines>
+
+ You are required to provide the output in the following example response format:
+
+ <example_response>
+ A: Please find the JSON object below:
+ \`\`\`json
+ {ex_answer}
+ \`\`\`
+ </example_response>`,
+  ],
+  ['ai', 'Please find the JSON object below:'],
+]);
+
 export const KV_ERROR_PROMPT = ChatPromptTemplate.fromMessages([
   [
     'system',
@@ -126,6 +166,7 @@ Follow these steps to help resolve the current ingest pipeline issues:
 You ALWAYS follow these guidelines when writing your response:
 <guidelines>
 - Do not use the special characters like \`\s\` or \`\\s+\` in the \`field_split\` or \`value_split\` regular expressions.
+- Always use single backslash (\\) for escaping characters in \`field_split\` or \`value_split\` regular expressions.
 - Do not add brackets (), <>, [] as well as single or double quotes in \`trim_value\`.
 - Do not add multiple delimeters in the \`value_split\` regular expression.
 - Make sure to trim whitespaces in \`trim_key\`. 

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/validate.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/validate.ts
@@ -11,9 +11,15 @@ import type { KVState } from '../../types';
 import type { HandleKVNodeParams } from './types';
 import { testPipeline } from '../../util';
 import { onFailure } from './constants';
+import { createGrokProcessor } from '../../util/processors';
 
 interface KVResult {
   [packageName: string]: { [dataStreamName: string]: unknown };
+}
+
+interface GrokResult {
+  [key: string]: unknown;
+  message: string;
 }
 
 export async function handleKVValidate({
@@ -25,7 +31,7 @@ export async function handleKVValidate({
   const dataStreamName = state.dataStreamName;
 
   // Pick logSamples if there was no header detected.
-  const samples = state.kvLogMessages.length > 0 ? state.kvLogMessages : state.logSamples;
+  const samples = state.header ? state.kvLogMessages : state.logSamples;
 
   const { pipelineResults: kvOutputSamples, errors } = (await createJSONInput(
     kvProcessor,
@@ -51,6 +57,35 @@ export async function handleKVValidate({
     additionalProcessors,
     errors: [],
     lastExecutedChain: 'kv_validate',
+  };
+}
+
+export async function handleHeaderValidate({
+  state,
+  client,
+}: HandleKVNodeParams): Promise<Partial<KVState>> {
+  const grokPattern = state.grokPattern;
+  const grokProcessor = createGrokProcessor(grokPattern);
+  const pipeline = { processors: grokProcessor, on_failure: [onFailure] };
+
+  const { pipelineResults, errors } = (await testPipeline(state.logSamples, pipeline, client)) as {
+    pipelineResults: GrokResult[];
+    errors: object[];
+  };
+
+  if (errors.length > 0) {
+    return { errors, lastExecutedChain: 'kv_header_validate' };
+  }
+
+  const kvLogMessages: string[] = pipelineResults.map((entry) => entry.message);
+  const additionalProcessors = state.additionalProcessors;
+  additionalProcessors.push(grokProcessor[0]);
+
+  return {
+    kvLogMessages,
+    additionalProcessors,
+    errors: [],
+    lastExecutedChain: 'kv_header_validate',
   };
 }
 

--- a/x-pack/plugins/integration_assistant/server/graphs/log_type_detection/prompts.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/log_type_detection/prompts.ts
@@ -22,6 +22,7 @@ Here is some context for you to reference for your task, read it carefully as yo
     `Looking at the log samples , our goal is to identify the syslog type based on the guidelines below.
 <guidelines>
 - Go through each log sample and identify the log format type.
+- If the samples have a timestamp , loglevel in the beginning information then set "header: true".
 - If the samples have a syslog header then set "header: true" , else set "header: false". If you are unable to determine the syslog header presence then set "header: false".
 - If the syslog samples have structured body then classify it as "log_type: structured".
 - If the syslog samples have unstructured body then classify it as "log_type: unstructured".

--- a/x-pack/plugins/integration_assistant/server/types.ts
+++ b/x-pack/plugins/integration_assistant/server/types.ts
@@ -111,6 +111,7 @@ export interface KVState {
   packageName: string;
   dataStreamName: string;
   kvProcessor: ESProcessorItem;
+  grokPattern: string;
   logSamples: string[];
   kvLogMessages: string[];
   jsonSamples: string[];

--- a/x-pack/plugins/integration_assistant/server/util/processors.ts
+++ b/x-pack/plugins/integration_assistant/server/util/processors.ts
@@ -61,8 +61,8 @@ export function createGrokProcessor(grokPattern: string): ESProcessorItem {
   return grokProcessor;
 }
 
-// The kv graph returns a simplified grok processor for header
-// This function takes in the grok pattern string and creates the grok processor
+// The kv graph returns a simplified kv processor for structured body
+// This function takes in the kvInput string and creates the kv processor
 export function createKVProcessor(kvInput: KVProcessor, state: KVState): ESProcessorItem {
   const templatesPath = joinPath(__dirname, '../templates/processors');
   const env = new Environment(new FileSystemLoader(templatesPath), {


### PR DESCRIPTION
## Summary

Currently KVGraph has a 
Header Graph - Creates a Grok processor to separate header and message body and a 
KV Message Body graph - Creates a KV processor to handle KV pairs in the message body

This PR adds a validation and error prompt to the KV Header Graph. This allows extra iteration cycle for errors made by LLM for the header parsing.


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->