### PR TITLE
[eem] prevent customization of builtin definitions

### DIFF
--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/helpers/is_builtin_definition.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/helpers/is_builtin_definition.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../built_in';
+
+export function isBuiltinDefinition(definition: EntityDefinition) {
+  return definition.id.startsWith(BUILT_IN_ID_PREFIX);
+}

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_history_processors.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_history_processors.test.ts.snap
@@ -1,6 +1,157 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateHistoryProcessors(definition) should genearte a valid pipeline 1`] = `
+exports[`generateHistoryProcessors(definition) should generate a valid pipeline for builtin definition 1`] = `
+Array [
+  Object {
+    "set": Object {
+      "field": "event.ingested",
+      "value": "{{{_ingest.timestamp}}}",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.type",
+      "value": "service",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.definitionId",
+      "value": "builtin_mock_entity_definition",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.definitionVersion",
+      "value": "1.0.0",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.schemaVersion",
+      "value": "v1",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.identityFields",
+      "value": Array [
+        "log.logger",
+        "event.category",
+      ],
+    },
+  },
+  Object {
+    "script": Object {
+      "description": "Generated the entity.id field",
+      "source": "// This function will recursively collect all the values of a HashMap of HashMaps
+Collection collectValues(HashMap subject) {
+  Collection values = new ArrayList();
+  // Iterate through the values
+  for(Object value: subject.values()) {
+    // If the value is a HashMap, recurse
+    if (value instanceof HashMap) {
+      values.addAll(collectValues((HashMap) value));
+    } else {
+      values.add(String.valueOf(value));
+    }
+  }
+  return values;
+}
+// Create the string builder
+StringBuilder entityId = new StringBuilder();
+if (ctx[\\"entity\\"][\\"identity\\"] != null) {
+  // Get the values as a collection
+  Collection values = collectValues(ctx[\\"entity\\"][\\"identity\\"]);
+  // Convert to a list and sort
+  List sortedValues = new ArrayList(values);
+  Collections.sort(sortedValues);
+  // Create comma delimited string
+  for(String instanceValue: sortedValues) {
+    entityId.append(instanceValue);
+    entityId.append(\\":\\");
+  }
+  // Assign the entity.id
+  ctx[\\"entity\\"][\\"id\\"] = entityId.length() > 0 ? entityId.substring(0, entityId.length() - 1) : \\"unknown\\";
+}",
+    },
+  },
+  Object {
+    "fingerprint": Object {
+      "fields": Array [
+        "entity.id",
+      ],
+      "method": "MurmurHash3",
+      "target_field": "entity.id",
+    },
+  },
+  Object {
+    "script": Object {
+      "source": "if (ctx.entity?.metadata?.tags != null) {
+  ctx.tags = ctx.entity.metadata.tags.keySet();
+}
+if (ctx.entity?.metadata?.host?.name != null) {
+  if (ctx.host == null) {
+    ctx.host = new HashMap();
+  }
+  ctx.host.name = ctx.entity.metadata.host.name.keySet();
+}
+if (ctx.entity?.metadata?.host?.os?.name != null) {
+  if (ctx.host == null) {
+    ctx.host = new HashMap();
+  }
+  if (ctx.host.os == null) {
+    ctx.host.os = new HashMap();
+  }
+  ctx.host.os.name = ctx.entity.metadata.host.os.name.keySet();
+}
+if (ctx.entity?.metadata?.sourceIndex != null) {
+  ctx.sourceIndex = ctx.entity.metadata.sourceIndex.keySet();
+}",
+    },
+  },
+  Object {
+    "remove": Object {
+      "field": "entity.metadata",
+      "ignore_missing": true,
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "log.logger",
+      "if": "ctx.entity?.identity?.log?.logger != null",
+      "value": "{{entity.identity.log.logger}}",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "event.category",
+      "if": "ctx.entity?.identity?.event?.category != null",
+      "value": "{{entity.identity.event.category}}",
+    },
+  },
+  Object {
+    "remove": Object {
+      "field": "entity.identity",
+      "ignore_missing": true,
+    },
+  },
+  Object {
+    "date_index_name": Object {
+      "date_formats": Array [
+        "UNIX_MS",
+        "ISO8601",
+        "yyyy-MM-dd'T'HH:mm:ss.SSSXX",
+      ],
+      "date_rounding": "M",
+      "field": "@timestamp",
+      "index_name_prefix": ".entities.v1.history.builtin_mock_entity_definition.",
+    },
+  },
+]
+`;
+
+exports[`generateHistoryProcessors(definition) should generate a valid pipeline for custom definition 1`] = `
 Array [
   Object {
     "set": Object {

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
@@ -1,6 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateLatestProcessors(definition) should genearte a valid pipeline 1`] = `
+exports[`generateLatestProcessors(definition) should generate a valid pipeline for builtin definition 1`] = `
+Array [
+  Object {
+    "set": Object {
+      "field": "event.ingested",
+      "value": "{{{_ingest.timestamp}}}",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.type",
+      "value": "service",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.definitionId",
+      "value": "builtin_mock_entity_definition",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.definitionVersion",
+      "value": "1.0.0",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.schemaVersion",
+      "value": "v1",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.identityFields",
+      "value": Array [
+        "log.logger",
+        "event.category",
+      ],
+    },
+  },
+  Object {
+    "script": Object {
+      "source": "if (ctx.entity?.metadata?.tags.data != null) {
+  ctx.tags = ctx.entity.metadata.tags.data.keySet();
+}
+if (ctx.entity?.metadata?.host?.name.data != null) {
+  if (ctx.host == null) {
+    ctx.host = new HashMap();
+  }
+  ctx.host.name = ctx.entity.metadata.host.name.data.keySet();
+}
+if (ctx.entity?.metadata?.host?.os?.name.data != null) {
+  if (ctx.host == null) {
+    ctx.host = new HashMap();
+  }
+  if (ctx.host.os == null) {
+    ctx.host.os = new HashMap();
+  }
+  ctx.host.os.name = ctx.entity.metadata.host.os.name.data.keySet();
+}
+if (ctx.entity?.metadata?.sourceIndex.data != null) {
+  ctx.sourceIndex = ctx.entity.metadata.sourceIndex.data.keySet();
+}",
+    },
+  },
+  Object {
+    "remove": Object {
+      "field": "entity.metadata",
+      "ignore_missing": true,
+    },
+  },
+  Object {
+    "dot_expander": Object {
+      "field": "log.logger",
+      "path": "entity.identity.log.logger.top_metric",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "log.logger",
+      "value": "{{entity.identity.log.logger.top_metric.log.logger}}",
+    },
+  },
+  Object {
+    "dot_expander": Object {
+      "field": "event.category",
+      "path": "entity.identity.event.category.top_metric",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "event.category",
+      "value": "{{entity.identity.event.category.top_metric.event.category}}",
+    },
+  },
+  Object {
+    "remove": Object {
+      "field": "entity.identity",
+      "ignore_missing": true,
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "entity.displayName",
+      "value": "{{log.logger}}{{#event.category}}:{{.}}{{/event.category}}",
+    },
+  },
+  Object {
+    "set": Object {
+      "field": "_index",
+      "value": ".entities.v1.latest.builtin_mock_entity_definition",
+    },
+  },
+]
+`;
+
+exports[`generateLatestProcessors(definition) should generate a valid pipeline for custom definition 1`] = `
 Array [
   Object {
     "set": Object {

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.test.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { entityDefinition } from '../helpers/fixtures/entity_definition';
+import { entityDefinition, builtInEntityDefinition } from '../helpers/fixtures';
 import { generateHistoryProcessors } from './generate_history_processors';
 
 describe('generateHistoryProcessors(definition)', () => {
-  it('should genearte a valid pipeline', () => {
+  it('should generate a valid pipeline for custom definition', () => {
     const processors = generateHistoryProcessors(entityDefinition);
+    expect(processors).toMatchSnapshot();
+  });
+
+  it('should generate a valid pipeline for builtin definition', () => {
+    const processors = generateHistoryProcessors(builtInEntityDefinition);
     expect(processors).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_history_processors.ts
@@ -11,6 +11,7 @@ import {
   cleanScript,
 } from '../helpers/ingest_pipeline_script_processor_helpers';
 import { generateHistoryIndexName } from '../helpers/generate_component_id';
+import { isBuiltinDefinition } from '../helpers/is_builtin_definition';
 
 function mapDestinationToPainless(field: string) {
   return `
@@ -44,6 +45,39 @@ function liftIdentityFieldsToDocumentRoot(definition: EntityDefinition) {
       value: `{{entity.identity.${key.field}}}`,
     },
   }));
+}
+
+function getCustomIngestPipelines(definition: EntityDefinition) {
+  if (isBuiltinDefinition(definition)) {
+    return [];
+  }
+
+  return [
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}@platform`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}-history@platform`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}@custom`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}-history@custom`,
+      },
+    },
+  ];
 }
 
 export function generateHistoryProcessors(definition: EntityDefinition) {
@@ -162,30 +196,6 @@ export function generateHistoryProcessors(definition: EntityDefinition) {
         date_formats: ['UNIX_MS', 'ISO8601', "yyyy-MM-dd'T'HH:mm:ss.SSSXX"],
       },
     },
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}@platform`,
-      },
-    },
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}-history@platform`,
-      },
-    },
-
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}@custom`,
-      },
-    },
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}-history@custom`,
-      },
-    },
+    ...getCustomIngestPipelines(definition),
   ];
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.test.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { entityDefinition } from '../helpers/fixtures/entity_definition';
+import { entityDefinition, builtInEntityDefinition } from '../helpers/fixtures';
 import { generateLatestProcessors } from './generate_latest_processors';
 
 describe('generateLatestProcessors(definition)', () => {
-  it('should genearte a valid pipeline', () => {
+  it('should generate a valid pipeline for custom definition', () => {
     const processors = generateLatestProcessors(entityDefinition);
+    expect(processors).toMatchSnapshot();
+  });
+
+  it('should generate a valid pipeline for builtin definition', () => {
+    const processors = generateLatestProcessors(builtInEntityDefinition);
     expect(processors).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
@@ -11,6 +11,7 @@ import {
   cleanScript,
 } from '../helpers/ingest_pipeline_script_processor_helpers';
 import { generateLatestIndexName } from '../helpers/generate_component_id';
+import { isBuiltinDefinition } from '../helpers/is_builtin_definition';
 
 function mapDestinationToPainless(field: string) {
   return `
@@ -61,6 +62,39 @@ function liftIdentityFieldsToDocumentRoot(definition: EntityDefinition) {
       ];
     })
     .flat();
+}
+
+function getCustomIngestPipelines(definition: EntityDefinition) {
+  if (isBuiltinDefinition(definition)) {
+    return [];
+  }
+
+  return [
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}@platform`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}-latest@platform`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}@custom`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        name: `${definition.id}-latest@custom`,
+      },
+    },
+  ];
 }
 
 export function generateLatestProcessors(definition: EntityDefinition) {
@@ -135,30 +169,6 @@ export function generateLatestProcessors(definition: EntityDefinition) {
         value: `${generateLatestIndexName(definition)}`,
       },
     },
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}@platform`,
-      },
-    },
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}-latest@platform`,
-      },
-    },
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}@custom`,
-      },
-    },
-
-    {
-      pipeline: {
-        ignore_missing_pipeline: true,
-        name: `${definition.id}-latest@custom`,
-      },
-    },
+    ...getCustomIngestPipelines(definition),
   ];
 }

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/__snapshots__/entities_history_template.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/__snapshots__/entities_history_template.test.ts.snap
@@ -1,6 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateEntitiesHistoryIndexTemplateConfig(definition) should generate a valid index template 1`] = `
+exports[`generateEntitiesHistoryIndexTemplateConfig(definition) should generate a valid index template for builtin definition 1`] = `
+Object {
+  "_meta": Object {
+    "description": "Index template for indices managed by the Elastic Entity Model's entity discovery framework for the history dataset",
+    "ecs_version": "8.0.0",
+    "managed": true,
+    "managed_by": "elastic_entity_model",
+  },
+  "composed_of": Array [
+    "entities_v1_history_base",
+    "entities_v1_entity",
+    "entities_v1_event",
+  ],
+  "ignore_missing_component_templates": Array [],
+  "index_patterns": Array [
+    ".entities.v1.history.builtin_mock_entity_definition.*",
+  ],
+  "name": "entities_v1_history_builtin_mock_entity_definition_index_template",
+  "priority": 200,
+  "template": Object {
+    "aliases": Object {
+      "entities-service-history": Object {},
+    },
+    "mappings": Object {
+      "_meta": Object {
+        "version": "1.6.0",
+      },
+      "date_detection": false,
+      "dynamic_templates": Array [
+        Object {
+          "strings_as_keyword": Object {
+            "mapping": Object {
+              "fields": Object {
+                "text": Object {
+                  "type": "text",
+                },
+              },
+              "ignore_above": 1024,
+              "type": "keyword",
+            },
+            "match_mapping_type": "string",
+          },
+        },
+        Object {
+          "entity_metrics": Object {
+            "mapping": Object {
+              "type": "{dynamic_type}",
+            },
+            "match_mapping_type": Array [
+              "long",
+              "double",
+            ],
+            "path_match": "entity.metrics.*",
+          },
+        },
+      ],
+    },
+    "settings": Object {
+      "index": Object {
+        "codec": "best_compression",
+        "mapping": Object {
+          "total_fields": Object {
+            "limit": 2000,
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEntitiesHistoryIndexTemplateConfig(definition) should generate a valid index template for custom definition 1`] = `
 Object {
   "_meta": Object {
     "description": "Index template for indices managed by the Elastic Entity Model's entity discovery framework for the history dataset",

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/__snapshots__/entities_latest_template.test.ts.snap
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/__snapshots__/entities_latest_template.test.ts.snap
@@ -1,6 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateEntitiesLatestIndexTemplateConfig(definition) should generate a valid index template 1`] = `
+exports[`generateEntitiesLatestIndexTemplateConfig(definition) should generate a valid index template for builtin definition 1`] = `
+Object {
+  "_meta": Object {
+    "description": "Index template for indices managed by the Elastic Entity Model's entity discovery framework for the latest dataset",
+    "ecs_version": "8.0.0",
+    "managed": true,
+    "managed_by": "elastic_entity_model",
+  },
+  "composed_of": Array [
+    "entities_v1_latest_base",
+    "entities_v1_entity",
+    "entities_v1_event",
+  ],
+  "ignore_missing_component_templates": Array [],
+  "index_patterns": Array [
+    ".entities.v1.latest.builtin_mock_entity_definition",
+  ],
+  "name": "entities_v1_latest_builtin_mock_entity_definition_index_template",
+  "priority": 200,
+  "template": Object {
+    "aliases": Object {
+      "entities-service-latest": Object {},
+    },
+    "mappings": Object {
+      "_meta": Object {
+        "version": "1.6.0",
+      },
+      "date_detection": false,
+      "dynamic_templates": Array [
+        Object {
+          "strings_as_keyword": Object {
+            "mapping": Object {
+              "fields": Object {
+                "text": Object {
+                  "type": "text",
+                },
+              },
+              "ignore_above": 1024,
+              "type": "keyword",
+            },
+            "match_mapping_type": "string",
+          },
+        },
+        Object {
+          "entity_metrics": Object {
+            "mapping": Object {
+              "type": "{dynamic_type}",
+            },
+            "match_mapping_type": Array [
+              "long",
+              "double",
+            ],
+            "path_match": "entity.metrics.*",
+          },
+        },
+      ],
+    },
+    "settings": Object {
+      "index": Object {
+        "codec": "best_compression",
+        "mapping": Object {
+          "total_fields": Object {
+            "limit": 2000,
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEntitiesLatestIndexTemplateConfig(definition) should generate a valid index template for custom definition 1`] = `
 Object {
   "_meta": Object {
     "description": "Index template for indices managed by the Elastic Entity Model's entity discovery framework for the latest dataset",

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_history_template.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_history_template.test.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { entityDefinition } from '../helpers/fixtures/entity_definition';
+import { entityDefinition, builtInEntityDefinition } from '../helpers/fixtures';
 import { generateEntitiesHistoryIndexTemplateConfig } from './entities_history_template';
 
 describe('generateEntitiesHistoryIndexTemplateConfig(definition)', () => {
-  it('should generate a valid index template', () => {
+  it('should generate a valid index template for custom definition', () => {
     const template = generateEntitiesHistoryIndexTemplateConfig(entityDefinition);
+    expect(template).toMatchSnapshot();
+  });
+
+  it('should generate a valid index template for builtin definition', () => {
+    const template = generateEntitiesHistoryIndexTemplateConfig(builtInEntityDefinition);
     expect(template).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_history_template.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_history_template.ts
@@ -32,12 +32,12 @@ export const generateEntitiesHistoryIndexTemplateConfig = (
     managed: true,
     managed_by: 'elastic_entity_model',
   },
-  ignore_missing_component_templates: getCustomHistoryTemplateComponents(definition.id),
+  ignore_missing_component_templates: getCustomHistoryTemplateComponents(definition),
   composed_of: [
     ENTITY_HISTORY_BASE_COMPONENT_TEMPLATE_V1,
     ENTITY_ENTITY_COMPONENT_TEMPLATE_V1,
     ENTITY_EVENT_COMPONENT_TEMPLATE_V1,
-    ...getCustomHistoryTemplateComponents(definition.id),
+    ...getCustomHistoryTemplateComponents(definition),
   ],
   index_patterns: [
     `${entitiesIndexPattern({

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_latest_template.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_latest_template.test.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { entityDefinition } from '../helpers/fixtures/entity_definition';
+import { entityDefinition, builtInEntityDefinition } from '../helpers/fixtures';
 import { generateEntitiesLatestIndexTemplateConfig } from './entities_latest_template';
 
 describe('generateEntitiesLatestIndexTemplateConfig(definition)', () => {
-  it('should generate a valid index template', () => {
+  it('should generate a valid index template for custom definition', () => {
     const template = generateEntitiesLatestIndexTemplateConfig(entityDefinition);
+    expect(template).toMatchSnapshot();
+  });
+
+  it('should generate a valid index template for builtin definition', () => {
+    const template = generateEntitiesLatestIndexTemplateConfig(builtInEntityDefinition);
     expect(template).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_latest_template.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/lib/entities/templates/entities_latest_template.ts
@@ -32,12 +32,12 @@ export const generateEntitiesLatestIndexTemplateConfig = (
     managed: true,
     managed_by: 'elastic_entity_model',
   },
-  ignore_missing_component_templates: getCustomLatestTemplateComponents(definition.id),
+  ignore_missing_component_templates: getCustomLatestTemplateComponents(definition),
   composed_of: [
     ENTITY_LATEST_BASE_COMPONENT_TEMPLATE_V1,
     ENTITY_ENTITY_COMPONENT_TEMPLATE_V1,
     ENTITY_EVENT_COMPONENT_TEMPLATE_V1,
-    ...getCustomLatestTemplateComponents(definition.id),
+    ...getCustomLatestTemplateComponents(definition),
   ],
   index_patterns: [
     entitiesIndexPattern({

--- a/x-pack/plugins/observability_solution/entity_manager/server/templates/components/helpers.test.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/templates/components/helpers.test.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import { EntityDefinition } from '@kbn/entities-schema';
 import { getCustomHistoryTemplateComponents, getCustomLatestTemplateComponents } from './helpers';
 
 describe('helpers', () => {
   it('getCustomLatestTemplateComponents should return template component in the right sort order', () => {
-    const definitionId = 'test';
-    const result = getCustomLatestTemplateComponents(definitionId);
+    const result = getCustomLatestTemplateComponents({ id: 'test' } as EntityDefinition);
     expect(result).toEqual([
       'test@platform',
       'test-latest@platform',
@@ -20,8 +20,7 @@ describe('helpers', () => {
   });
 
   it('getCustomHistoryTemplateComponents should return template component in the right sort order', () => {
-    const definitionId = 'test';
-    const result = getCustomHistoryTemplateComponents(definitionId);
+    const result = getCustomHistoryTemplateComponents({ id: 'test' } as EntityDefinition);
     expect(result).toEqual([
       'test@platform',
       'test-history@platform',

--- a/x-pack/plugins/observability_solution/entity_manager/server/templates/components/helpers.ts
+++ b/x-pack/plugins/observability_solution/entity_manager/server/templates/components/helpers.ts
@@ -5,16 +5,31 @@
  * 2.0.
  */
 
-export const getCustomLatestTemplateComponents = (definitionId: string) => [
-  `${definitionId}@platform`, // @platform goes before so it can be overwritten by custom
-  `${definitionId}-latest@platform`,
-  `${definitionId}@custom`,
-  `${definitionId}-latest@custom`,
-];
+import { EntityDefinition } from '@kbn/entities-schema';
+import { isBuiltinDefinition } from '../../lib/entities/helpers/is_builtin_definition';
 
-export const getCustomHistoryTemplateComponents = (definitionId: string) => [
-  `${definitionId}@platform`, // @platform goes before so it can be overwritten by custom
-  `${definitionId}-history@platform`,
-  `${definitionId}@custom`,
-  `${definitionId}-history@custom`,
-];
+export const getCustomLatestTemplateComponents = (definition: EntityDefinition) => {
+  if (isBuiltinDefinition(definition)) {
+    return [];
+  }
+
+  return [
+    `${definition.id}@platform`, // @platform goes before so it can be overwritten by custom
+    `${definition.id}-latest@platform`,
+    `${definition.id}@custom`,
+    `${definition.id}-latest@custom`,
+  ];
+};
+
+export const getCustomHistoryTemplateComponents = (definition: EntityDefinition) => {
+  if (isBuiltinDefinition(definition)) {
+    return [];
+  }
+
+  return [
+    `${definition.id}@platform`, // @platform goes before so it can be overwritten by custom
+    `${definition.id}-history@platform`,
+    `${definition.id}@custom`,
+    `${definition.id}-history@custom`,
+  ];
+};


### PR DESCRIPTION
We allow users to define `@platform` and `@custom` ingest pipelines/index templates to customize entity definitions output. This change prevents builtin definitions from being customized