### PR TITLE
Fix overdue tasks metric to consider retryAt when the task status isn't idle

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
@@ -143,8 +143,15 @@ describe('TaskManagerMetricsCollector', () => {
           type: 'long',
           script: {
             source: `
+                def taskStatus = doc['task.status'];
                 def runAt = doc['task.runAt'];
-                if(!runAt.empty) {
+
+                if (taskStatus.empty) {
+                  emit(0);
+                  return;
+                }
+
+                if(taskStatus == 'idle') {
                   emit((new Date().getTime() - runAt.value.getMillis()) / 1000);
                 } else {
                   def retryAt = doc['task.retryAt'];

--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.ts
@@ -102,8 +102,15 @@ export class TaskManagerMetricsCollector implements ITaskEventEmitter<TaskLifecy
             type: 'long',
             script: {
               source: `
+                def taskStatus = doc['task.status'];
                 def runAt = doc['task.runAt'];
-                if(!runAt.empty) {
+
+                if (taskStatus.empty) {
+                  emit(0);
+                  return;
+                }
+
+                if(taskStatus == 'idle') {
                   emit((new Date().getTime() - runAt.value.getMillis()) / 1000);
                 } else {
                   def retryAt = doc['task.retryAt'];


### PR DESCRIPTION
In this PR, I'm fixing the runtime field used to calculate the number of overdue tasks so it considers `retryAt` field when tasks are in running or claiming status.