### PR TITLE
[ES|QL] Fix suggestions within bucket() so that they don't advance cursor if there is a comma

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -299,6 +299,13 @@ describe('autocomplete.suggest', () => {
             scalar: true,
           }),
         ]);
+        await assertSuggestions('from a | stats avg(b) by BUCKET(  /  , 50, ?t_start, ?t_end)', [
+          // Note there's no space or comma in the suggested field names
+          ...getFieldNamesByType(['date', ...ESQL_COMMON_NUMERIC_TYPES]),
+          ...getFunctionSignaturesByReturnType('eval', ['date', ...ESQL_COMMON_NUMERIC_TYPES], {
+            scalar: true,
+          }),
+        ]);
 
         await assertSuggestions(
           'from a | stats avg(b) by BUCKET(dateField, /50, ?t_start, ?t_end)',

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -12,7 +12,12 @@ import { ESQL_COMMON_NUMERIC_TYPES, ESQL_NUMBER_TYPES } from '../../shared/esql_
 import { allStarConstant } from '../complete_items';
 import { getAddDateHistogramSnippet } from '../factories';
 import { roundParameterTypes } from './constants';
-import { setup, getFunctionSignaturesByReturnType, getFieldNamesByType } from './helpers';
+import {
+  setup,
+  getFunctionSignaturesByReturnType,
+  getFieldNamesByType,
+  getLiteralsByType,
+} from './helpers';
 
 const allAggFunctions = getFunctionSignaturesByReturnType('stats', 'any', {
   agg: true,
@@ -283,6 +288,26 @@ describe('autocomplete.suggest', () => {
         await assertSuggestions(
           'from a | stats var0 = AVG(doubleField) BY var1 = BUCKET(dateField, 1 day)/',
           [',', '| ', '+ $0', '- $0']
+        );
+      });
+      test('on space within bucket()', async () => {
+        const { assertSuggestions } = await setup();
+        await assertSuggestions('from a | stats avg(b) by BUCKET(/, 50, ?t_start, ?t_end)', [
+          // Note there's no space or comma in the suggested field names
+          ...getFieldNamesByType(['date', ...ESQL_COMMON_NUMERIC_TYPES]),
+          ...getFunctionSignaturesByReturnType('eval', ['date', ...ESQL_COMMON_NUMERIC_TYPES], {
+            scalar: true,
+          }),
+        ]);
+
+        await assertSuggestions(
+          'from a | stats avg(b) by BUCKET(dateField, /50, ?t_start, ?t_end)',
+          [
+            ...getLiteralsByType('time_literal'),
+            ...getFunctionSignaturesByReturnType('eval', ['integer', 'date_period'], {
+              scalar: true,
+            }),
+          ]
         );
       });
 

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -1335,7 +1335,9 @@ async function getFunctionArgsSuggestions(
 
   // Whether to prepend comma to suggestion string
   // E.g. if true, "fieldName" -> "fieldName, "
-  const alreadyHasComma = fullText ? fullText[offset] === ',' : false;
+  const isCursorFollowedByComma = fullText
+    ? fullText.slice(offset, fullText.length).trimStart().startsWith(',')
+    : false;
   const canBeBooleanCondition =
     // For `CASE()`, there can be multiple conditions, so keep suggesting fields and functions if possible
     fnDefinition.name === 'case' ||
@@ -1345,10 +1347,10 @@ async function getFunctionArgsSuggestions(
   const shouldAddComma =
     hasMoreMandatoryArgs &&
     fnDefinition.type !== 'builtin' &&
-    !alreadyHasComma &&
+    !isCursorFollowedByComma &&
     !canBeBooleanCondition;
   const shouldAdvanceCursor =
-    hasMoreMandatoryArgs && fnDefinition.type !== 'builtin' && !alreadyHasComma;
+    hasMoreMandatoryArgs && fnDefinition.type !== 'builtin' && !isCursorFollowedByComma;
 
   const suggestedConstants = uniq(
     typesToSuggestNext

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -1347,7 +1347,8 @@ async function getFunctionArgsSuggestions(
     fnDefinition.type !== 'builtin' &&
     !alreadyHasComma &&
     !canBeBooleanCondition;
-  const shouldAdvanceCursor = hasMoreMandatoryArgs && fnDefinition.type !== 'builtin';
+  const shouldAdvanceCursor =
+    hasMoreMandatoryArgs && fnDefinition.type !== 'builtin' && !alreadyHasComma;
 
   const suggestedConstants = uniq(
     typesToSuggestNext


### PR DESCRIPTION
## Summary

Fix suggestions within bucket() so that they don't advance cursor if there are already succeeding comma 

Before:

https://github.com/user-attachments/assets/ed7c1d25-1746-401d-ae02-43d5095b204a


After:

https://github.com/user-attachments/assets/21e71d30-8641-474a-81ea-1b9f02cb654e



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
