### PR TITLE
[8.15] [Security Solution] Identify and exclude 24H2+ hotpatch extension pages from stomp detection (#192490)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -1286,17 +1286,6 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
-    key: 'windows.advanced.events.callstacks.use_hardware',
-    first_supported_version: '8.16',
-    documentation: i18n.translate(
-      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.callstacks.use_hardware',
-      {
-        defaultMessage:
-          'Use hardware callstacks (e.g. Intel CET) if supported by the OS and CPU.  Default: true',
-      }
-    ),
-  },
-  {
     key: 'windows.advanced.events.callstacks.exclude_hotpatch_extension_pages',
     first_supported_version: '8.15.2',
     documentation: i18n.translate(

--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -1286,6 +1286,28 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
+    key: 'windows.advanced.events.callstacks.use_hardware',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.callstacks.use_hardware',
+      {
+        defaultMessage:
+          'Use hardware callstacks (e.g. Intel CET) if supported by the OS and CPU.  Default: true',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.callstacks.exclude_hotpatch_extension_pages',
+    first_supported_version: '8.15.2',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.callstacks.exclude_hotpatch_extension_pages',
+      {
+        defaultMessage:
+          'Exclude Windows 11 24H2 hotpatch extension pages, which resemble injected code, from callstack module stomp scanning.  Default: true',
+      }
+    ),
+  },
+  {
     key: 'windows.advanced.events.process_ancestry_length',
     first_supported_version: '8.15',
     documentation: i18n.translate(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Defend] Identify and exclude 24H2+ hotpatch extension pages from stomp detection (#192490)](https://github.com/elastic/kibana/pull/192490)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gabriel Landau","email":"42078554+gabriellandau@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-09-11T19:25:43Z","message":"[Defend] Identify and exclude 24H2+ hotpatch extension pages from stomp detection (#192490)\n\n## Release Note\r\nDefend 8.15.2 will improve support for [Windows call stack module stomp\r\ndetection](https://www.elastic.co/security-labs/upping-the-ante-detecting-in-memory-threats-with-kernel-call-stacks)\r\nin Windows 11 24H2.\r\n\r\n## Description\r\nWindows 11 24H2 adds hotpatch support, a great feature that enables the\r\ninstallation of many security updates without a system reboot. To\r\nimplement hotpatching, Microsoft is changing the layout of executable\r\nimages in memory, appending new \"extension pages\" to the end of every\r\nhotpatchable mapped image in memory. These pages are\r\n`PAGE_EXECUTE_READ`.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/41bb960e-21ff-4c63-a250-81e303506ad8)\r\n\r\nMicrosoft describes the change in some detail\r\n[here](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/hotpatching-on-windows/ba-p/2959541).\r\nHere's a [third-party analysis of the\r\nchange](https://ynwarcs.github.io/Win11-24H2-CFG) showing how it breaks\r\nx64debug.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/3bea1aa5-8c5a-4c27-bf74-9e92833cdc7a)\r\n\r\nUnfortunately, this change affects our module stomp detection feature,\r\nwhich views these executable pages as patched/stomped. We are fixing\r\nthis in 8.15.2. This PR lets users opt out of the change, reverting to\r\nthe old behavior.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ca0d60cb042c6a46afee2297ac2715092917670f","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Defend Workflows","v8.16.0","v8.15.2"],"number":192490,"url":"https://github.com/elastic/kibana/pull/192490","mergeCommit":{"message":"[Defend] Identify and exclude 24H2+ hotpatch extension pages from stomp detection (#192490)\n\n## Release Note\r\nDefend 8.15.2 will improve support for [Windows call stack module stomp\r\ndetection](https://www.elastic.co/security-labs/upping-the-ante-detecting-in-memory-threats-with-kernel-call-stacks)\r\nin Windows 11 24H2.\r\n\r\n## Description\r\nWindows 11 24H2 adds hotpatch support, a great feature that enables the\r\ninstallation of many security updates without a system reboot. To\r\nimplement hotpatching, Microsoft is changing the layout of executable\r\nimages in memory, appending new \"extension pages\" to the end of every\r\nhotpatchable mapped image in memory. These pages are\r\n`PAGE_EXECUTE_READ`.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/41bb960e-21ff-4c63-a250-81e303506ad8)\r\n\r\nMicrosoft describes the change in some detail\r\n[here](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/hotpatching-on-windows/ba-p/2959541).\r\nHere's a [third-party analysis of the\r\nchange](https://ynwarcs.github.io/Win11-24H2-CFG) showing how it breaks\r\nx64debug.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/3bea1aa5-8c5a-4c27-bf74-9e92833cdc7a)\r\n\r\nUnfortunately, this change affects our module stomp detection feature,\r\nwhich views these executable pages as patched/stomped. We are fixing\r\nthis in 8.15.2. This PR lets users opt out of the change, reverting to\r\nthe old behavior.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ca0d60cb042c6a46afee2297ac2715092917670f"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192490","number":192490,"mergeCommit":{"message":"[Defend] Identify and exclude 24H2+ hotpatch extension pages from stomp detection (#192490)\n\n## Release Note\r\nDefend 8.15.2 will improve support for [Windows call stack module stomp\r\ndetection](https://www.elastic.co/security-labs/upping-the-ante-detecting-in-memory-threats-with-kernel-call-stacks)\r\nin Windows 11 24H2.\r\n\r\n## Description\r\nWindows 11 24H2 adds hotpatch support, a great feature that enables the\r\ninstallation of many security updates without a system reboot. To\r\nimplement hotpatching, Microsoft is changing the layout of executable\r\nimages in memory, appending new \"extension pages\" to the end of every\r\nhotpatchable mapped image in memory. These pages are\r\n`PAGE_EXECUTE_READ`.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/41bb960e-21ff-4c63-a250-81e303506ad8)\r\n\r\nMicrosoft describes the change in some detail\r\n[here](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/hotpatching-on-windows/ba-p/2959541).\r\nHere's a [third-party analysis of the\r\nchange](https://ynwarcs.github.io/Win11-24H2-CFG) showing how it breaks\r\nx64debug.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/3bea1aa5-8c5a-4c27-bf74-9e92833cdc7a)\r\n\r\nUnfortunately, this change affects our module stomp detection feature,\r\nwhich views these executable pages as patched/stomped. We are fixing\r\nthis in 8.15.2. This PR lets users opt out of the change, reverting to\r\nthe old behavior.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ca0d60cb042c6a46afee2297ac2715092917670f"}},{"branch":"8.15","label":"v8.15.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->