### PR TITLE
[Synthetics] Unbreak uptime journey

### DIFF
--- a/x-pack/plugins/observability_solution/uptime/e2e/README.md
+++ b/x-pack/plugins/observability_solution/uptime/e2e/README.md
@@ -10,7 +10,7 @@ with an example run command when it finishes.
 
 ### Run the tests
 
-From the same directory you can now run `node node e2e.js --runner`.
+From the same directory you can now run `node e2e.js --runner`.
 
 In addition to the usual flags like `--grep`, you can also specify `--no-headless` in order to view your tests as you debug/develop.
 
@@ -27,6 +27,6 @@ with an example run command when it finishes.
 
 ### Run the tests
 
-From the same directory you can now run `node node uptime_e2e.js --runner`.
+From the same directory you can now run `node uptime_e2e.js --runner`.
 
 In addition to the usual flags like `--grep`, you can also specify `--no-headless` in order to view your tests as you debug/develop.

--- a/x-pack/plugins/observability_solution/uptime/e2e/README.md
+++ b/x-pack/plugins/observability_solution/uptime/e2e/README.md
@@ -22,7 +22,7 @@ script for standing up the test server.
 
 ### Start the server
 
-From `~/x-pack/plugins/observability_solution/synthetics/scripts`, run `node uptime_e2e.js --server`. Wait for the server to startup. It will provide you
+From `~/x-pack/plugins/observability_solution/uptime/scripts`, run `node uptime_e2e.js --server`. Wait for the server to startup. It will provide you
 with an example run command when it finishes.
 
 ### Run the tests

--- a/x-pack/plugins/observability_solution/uptime/e2e/uptime/journeys/uptime.journey.ts
+++ b/x-pack/plugins/observability_solution/uptime/e2e/uptime/journeys/uptime.journey.ts
@@ -17,7 +17,7 @@ journey('uptime', ({ page, params }) => {
   });
 
   step('Go to Kibana', async () => {
-    await page.goto(`${params.kibanaUrl}/app/uptime?dateRangeStart=now-5y&dateRangeEnd=now`, {
+    await page.goto(`${params.kibanaUrl}/app/uptime?dateRangeStart=2018-01-01&dateRangeEnd=now`, {
       waitUntil: 'networkidle',
     });
   });


### PR DESCRIPTION
## Summary

Previously the uptime e2e journey we rely on to test the uptime overview page was looking back 5 years to query for canned data we load during the standard Kibana test script.

Unfortunately, that data was generated now > 5y ago, so the test started to fail.

This patch hardcodes the date of the filter to ensure we permanently look back to a timeframe that includes the canned data we use for testing the page.