### PR TITLE
Update oas_docs ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1788,15 +1788,9 @@ test/functional/page_objects/solution_navigation.ts @elastic/appex-sharedux
 /x-pack/test_serverless/functional/page_objects/svl_common_navigation.ts @elastic/appex-sharedux
 
 # OpenAPI spec files
-/x-pack/plugins/fleet/common/openapi          @elastic/platform-docs
-/x-pack/plugins/ml/common/openapi             @elastic/platform-docs
-/packages/core/saved-objects/docs/openapi     @elastic/platform-docs
-/plugins/data_views/docs/openapi              @elastic/platform-docs
 oas_docs/.spectral.yaml                       @elastic/platform-docs
 oas_docs/kibana.info.serverless.yaml          @elastic/platform-docs
 oas_docs/kibana.info.yaml                     @elastic/platform-docs
-oas_docs/makefile                             @elastic/platform-docs
-oas_docs/overlays                             @elastic/platform-docs
 
 # Plugin manifests
 /src/plugins/**/kibana.jsonc @elastic/kibana-core


### PR DESCRIPTION
## Summary

Writers were mandatory reviewers of PRs related to some OpenAPI files (relates to https://github.com/elastic/kibana/pull/168055) but I don't think that bottleneck is necessary anymore.
Especially as we move to automated deployment, as long as the documents pass linting checks they do not require additional docs oversight.