### PR TITLE
[Storybook] Mute SASS mixed-decls warnings

### DIFF
--- a/packages/kbn-storybook/src/webpack.config.ts
+++ b/packages/kbn-storybook/src/webpack.config.ts
@@ -120,6 +120,18 @@ export default ({ config: storybookConfig }: { config: Configuration }) => {
                 sassOptions: {
                   includePaths: [resolve(REPO_ROOT, 'node_modules')],
                   quietDeps: true,
+                  logger: {
+                    warn: (message: string, warning: any) => {
+                      // Muted - see https://github.com/elastic/kibana/issues/190345 for tracking remediation
+                      if (warning?.deprecationType?.id === 'mixed-decls') return;
+
+                      if (warning.deprecation)
+                        return process.stderr.write(
+                          `DEPRECATION WARNING: ${message}\n${warning.stack}`
+                        );
+                      process.stderr.write('WARNING: ' + message);
+                    },
+                  },
                 },
               },
             },


### PR DESCRIPTION
## Summary

This extends #190348 to the Storybook build because it is quite noisy there as well. Example:

https://buildkite.com/elastic/kibana-pull-request/builds/233585#0191e2ad-bc90-45f1-b375-959f3fc22b98/268-294

Remediation will be tracked at https://github.com/elastic/kibana/issues/190345

### Testing
The Storybook build step should not have SASS deprecation warnings.