### PR TITLE
[DOCS][API] Add /api/fleet to Fleet API paths

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -79,1520 +79,10 @@ servers:
       kibana_url:
         default: 'localhost:5601'
   - url: /
-  - description: Public and supported Fleet API
-    url: 'http://KIBANA_HOST:5601/api/fleet'
+  - url: 'http://KIBANA_HOST:5601'
   - description: local
     url: 'http://localhost:5601'
 paths:
-  /agent_download_sources:
-    get:
-      operationId: get-download-sources
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_download_sources'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent binary download sources
-      tags:
-        - Elastic Agent binary download sources
-    post:
-      operationId: post-download-sources
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host:
-                  type: string
-                id:
-                  type: string
-                is_default:
-                  type: boolean
-                name:
-                  type: string
-              required:
-                - name
-                - host
-                - is_default
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_download_sources'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create agent binary download source
-      tags:
-        - Elastic Agent binary download sources
-  '/agent_download_sources/{sourceId}':
-    delete:
-      operationId: delete-download-source
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete agent binary download source by ID
-      tags:
-        - Elastic Agent binary download sources
-    get:
-      operationId: get-one-download-source
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_download_sources'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent binary download source by ID
-      tags:
-        - Elastic Agent binary download sources
-    parameters:
-      - in: path
-        name: sourceId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-download-source
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host:
-                  type: string
-                is_default:
-                  type: boolean
-                name:
-                  type: string
-              required:
-                - name
-                - is_default
-                - host
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_download_sources'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update agent binary download source by ID
-      tags:
-        - Elastic Agent binary download sources
-  /agent_policies:
-    get:
-      description: ''
-      operationId: agent-policy-list
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-        - $ref: '#/components/parameters/Fleet_format'
-        - description: >-
-            When set to true, retrieve the related package policies for each
-            agent policy.
-          in: query
-          name: full
-          schema:
-            type: boolean
-        - description: >-
-            When set to true, do not count how many agents are in the agent
-            policy, this can improve performance if you are searching over a
-            large number of agent policies. The "agents" property will always be
-            0 if set to true.
-          in: query
-          name: noAgentCount
-          schema:
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_agent_policy'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - total
-                  - page
-                  - perPage
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent policies
-      tags:
-        - Elastic Agent policies
-    post:
-      operationId: create-agent-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_agent_policy_create_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create agent policy
-      tags:
-        - Elastic Agent policies
-  /agent_policies/_bulk_get:
-    post:
-      operationId: bulk-get-agent-policies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                full:
-                  description: get full policies with package policies populated
-                  type: boolean
-                ids:
-                  description: list of agent policy ids
-                  items:
-                    type: string
-                  type: array
-                ignoreMissing:
-                  type: boolean
-              required:
-                - ids
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_agent_policy'
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk get agent policies
-      tags:
-        - Elastic Agent policies
-  '/agent_policies/{agentPolicyId}':
-    get:
-      description: Get one agent policy
-      operationId: agent-policy-info
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent policy by ID
-      tags:
-        - Elastic Agent policies
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - $ref: '#/components/parameters/Fleet_format'
-    put:
-      operationId: update-agent-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_agent_policy_update_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update agent policy by ID
-      tags:
-        - Elastic Agent policies
-  '/agent_policies/{agentPolicyId}/copy':
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - $ref: '#/components/parameters/Fleet_format'
-    post:
-      operationId: agent-policy-copy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                description:
-                  type: string
-                name:
-                  type: string
-              required:
-                - name
-        description: ''
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Copy agent policy by ID
-      tags:
-        - Elastic Agent policies
-  '/agent_policies/{agentPolicyId}/download':
-    get:
-      operationId: agent-policy-download
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Download agent policy by ID
-      tags:
-        - Elastic Agent policies
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: download
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: standalone
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: kubernetes
-        required: false
-        schema:
-          type: string
-  '/agent_policies/{agentPolicyId}/full':
-    get:
-      operationId: agent-policy-full
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    oneOf:
-                      - type: string
-                      - $ref: '#/components/schemas/Fleet_agent_policy_full'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get full agent policy by ID
-      tags:
-        - Elastic Agent policies
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: download
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: standalone
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: kubernetes
-        required: false
-        schema:
-          type: string
-  /agent_policies/delete:
-    parameters: []
-    post:
-      operationId: delete-agent-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                agentPolicyId:
-                  type: string
-                force:
-                  description: >-
-                    bypass validation checks that can prevent agent policy
-                    deletion
-                  type: boolean
-              required:
-                - agentPolicyId
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  success:
-                    type: boolean
-                required:
-                  - id
-                  - success
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete agent policy by ID
-      tags:
-        - Elastic Agent policies
-  /agent_status:
-    get:
-      operationId: get-agent-status
-      parameters:
-        - in: query
-          name: policyId
-          required: false
-          schema:
-            type: string
-        - deprecated: true
-          in: query
-          name: kuery
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  active:
-                    type: integer
-                  all:
-                    type: integer
-                  error:
-                    type: integer
-                  events:
-                    type: integer
-                  inactive:
-                    type: integer
-                  offline:
-                    type: integer
-                  online:
-                    type: integer
-                  other:
-                    type: integer
-                  total:
-                    deprecated: true
-                    type: integer
-                  unenrolled:
-                    type: integer
-                  updating:
-                    type: integer
-                required:
-                  - active
-                  - all
-                  - error
-                  - events
-                  - inactive
-                  - offline
-                  - online
-                  - other
-                  - total
-                  - updating
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent status summary
-      tags:
-        - Elastic Agent status
-  /agent_status/data:
-    get:
-      operationId: get-agent-data
-      parameters:
-        - in: query
-          name: agentsIds
-          required: true
-          schema:
-            items:
-              type: string
-            type: array
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      additionalProperties:
-                        type: object
-                        properties:
-                          data:
-                            type: boolean
-                      type: object
-                    type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get incoming agent data
-      tags:
-        - Elastic Agent status
-  /agent-status:
-    get:
-      deprecated: true
-      operationId: get-agent-status-deprecated
-      parameters:
-        - in: query
-          name: policyId
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: integer
-                  events:
-                    type: integer
-                  inactive:
-                    type: integer
-                  offline:
-                    type: integer
-                  online:
-                    type: integer
-                  other:
-                    type: integer
-                  total:
-                    type: integer
-                  updating:
-                    type: integer
-                required:
-                  - error
-                  - events
-                  - inactive
-                  - offline
-                  - online
-                  - other
-                  - total
-                  - updating
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent status summary
-      tags:
-        - Elastic Agent status
-  /agents:
-    get:
-      operationId: get-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-        - $ref: '#/components/parameters/Fleet_show_inactive'
-        - $ref: '#/components/parameters/Fleet_show_upgradeable'
-        - $ref: '#/components/parameters/Fleet_sort_field'
-        - $ref: '#/components/parameters/Fleet_sort_order'
-        - $ref: '#/components/parameters/Fleet_with_metrics'
-        - in: query
-          name: getStatusSummary
-          required: false
-          schema:
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_agents_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agents
-      tags:
-        - Elastic Agents
-    post:
-      operationId: get-agents-by-actions
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                actionIds:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - policy_id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_agent_get_by_actions'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agents by action ids
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}':
-    delete:
-      operationId: delete-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - deleted
-                    type: string
-                required:
-                  - action
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete agent by ID
-      tags:
-        - Elastic Agents
-    get:
-      operationId: get-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_with_metrics'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent by ID
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                tags:
-                  items:
-                    type: string
-                  type: array
-                user_provided_metadata:
-                  type: object
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update agent by ID
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/actions':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: new-agent-action
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                action:
-                  $ref: '#/components/schemas/Fleet_agent_action'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    items:
-                      type: number
-                    type: array
-                  headers:
-                    type: string
-                  statusCode:
-                    type: number
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create agent action
-      tags:
-        - Elastic Agent actions
-  '/agents/{agentId}/reassign':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: reassign-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                policy_id:
-                  type: string
-              required:
-                - policy_id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Reassign agent
-      tags:
-        - Elastic Agents
-    put:
-      deprecated: true
-      operationId: reassign-agent-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                policy_id:
-                  type: string
-              required:
-                - policy_id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Reassign agent
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/request_diagnostics':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: request-diagnostics-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                additional_metrics:
-                  items:
-                    oneOf:
-                      - enum:
-                          - CPU
-                        type: string
-                  type: array
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Request agent diagnostics
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/unenroll':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: unenroll-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-                revoke:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-          description: OK
-        '400':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  message:
-                    type: string
-                  statusCode:
-                    enum:
-                      - 400
-                    type: number
-          description: BAD REQUEST
-      summary: Unenroll agent
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/upgrade':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: upgrade-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_upgrade_agent'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_upgrade_agent'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Upgrade agent
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/uploads':
-    get:
-      operationId: list-agent-uploads
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      item:
-                        items:
-                          $ref: '#/components/schemas/Fleet_agent_diagnostics'
-                        type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent uploads
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-  /agents/action_status:
-    get:
-      operationId: agents-action-status
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - in: query
-          name: errorSize
-          schema:
-            default: 5
-            type: integer
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        actionId:
-                          type: string
-                        cancellationTime:
-                          type: string
-                        completionTime:
-                          type: string
-                        creationTime:
-                          description: creation time of action
-                          type: string
-                        expiration:
-                          type: string
-                        latestErrors:
-                          description: >-
-                            latest errors that happened when the agents executed
-                            the action
-                          items:
-                            type: object
-                            properties:
-                              agentId:
-                                type: string
-                              error:
-                                type: string
-                              timestamp:
-                                type: string
-                          type: array
-                        nbAgentsAck:
-                          description: number of agents that acknowledged the action
-                          type: number
-                        nbAgentsActionCreated:
-                          description: number of agents included in action from kibana
-                          type: number
-                        nbAgentsActioned:
-                          description: number of agents actioned
-                          type: number
-                        nbAgentsFailed:
-                          description: number of agents that failed to execute the action
-                          type: number
-                        newPolicyId:
-                          description: new policy id (POLICY_REASSIGN action)
-                          type: string
-                        policyId:
-                          description: policy id (POLICY_CHANGE action)
-                          type: string
-                        revision:
-                          description: new policy revision (POLICY_CHANGE action)
-                          type: string
-                        startTime:
-                          description: start time of action (scheduled actions)
-                          type: string
-                        status:
-                          enum:
-                            - COMPLETE
-                            - EXPIRED
-                            - CANCELLED
-                            - FAILED
-                            - IN_PROGRESS
-                            - ROLLOUT_PASSED
-                          type: string
-                        type:
-                          enum:
-                            - POLICY_REASSIGN
-                            - UPGRADE
-                            - UNENROLL
-                            - FORCE_UNENROLL
-                            - UPDATE_TAGS
-                            - CANCEL
-                            - REQUEST_DIAGNOSTICS
-                            - SETTINGS
-                            - POLICY_CHANGE
-                            - INPUT_ACTION
-                          type: string
-                        version:
-                          description: agent version number (UPGRADE action)
-                          type: string
-                      required:
-                        - actionId
-                        - complete
-                        - nbAgentsActioned
-                        - nbAgentsActionCreated
-                        - nbAgentsAck
-                        - nbAgentsFailed
-                        - status
-                        - creationTime
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent action status
-      tags:
-        - Elastic Agent actions
-  '/agents/actions/{actionId}/cancel':
-    parameters:
-      - in: path
-        name: actionId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: agent-action-cancel
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_action'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Cancel agent action
-      tags:
-        - Elastic Agent actions
-  /agents/bulk_reassign:
-    post:
-      operationId: bulk-reassign-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
-              policy_id: policy_id
-            schema:
-              type: object
-              properties:
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                policy_id:
-                  description: new agent policy id
-                  type: string
-              required:
-                - policy_id
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk reassign agents
-      tags:
-        - Elastic Agents
-  /agents/bulk_request_diagnostics:
-    post:
-      operationId: bulk-request-diagnostics
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
-            schema:
-              type: object
-              properties:
-                additional_metrics:
-                  items:
-                    oneOf:
-                      - enum:
-                          - CPU
-                        type: string
-                  type: array
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                batchSize:
-                  type: number
-              required:
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk request diagnostics from agents
-      tags:
-        - Elastic Agents
-  /agents/bulk_unenroll:
-    post:
-      operationId: bulk-unenroll-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents:
-                - agent1
-                - agent2
-              force: false
-              revoke: true
-            schema:
-              type: object
-              properties:
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                force:
-                  description: Unenrolls hosted agents too
-                  type: boolean
-                includeInactive:
-                  description: >-
-                    When passing agents by KQL query, unenrolls inactive agents
-                    too
-                  type: boolean
-                revoke:
-                  description: Revokes API keys of agents
-                  type: boolean
-              required:
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk unenroll agents
-      tags:
-        - Elastic Agents
-  /agents/bulk_update_agent_tags:
-    post:
-      operationId: bulk-update-agent-tags
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents:
-                - agent1
-                - agent2
-              tagsToAdd:
-                - newTag
-              tagsToRemove:
-                - existingTag
-            schema:
-              type: object
-              properties:
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                batchSize:
-                  type: number
-                tagsToAdd:
-                  items:
-                    type: string
-                  type: array
-                tagsToRemove:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk update agent tags
-      tags:
-        - Elastic Agents
-  /agents/bulk_upgrade:
-    post:
-      operationId: bulk-upgrade-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents:
-                - agent1
-                - agent2
-              rollout_duration_seconds: 3600
-              source_uri: 'https://artifacts.elastic.co/downloads/beats/elastic-agent'
-              start_time: 2022-08-03T14:00:00.000Z
-              version: 8.4.0
-            schema:
-              $ref: '#/components/schemas/Fleet_bulk_upgrade_agents'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk upgrade agents
-      tags:
-        - Elastic Agents
-  '/agents/files/{fileId}':
-    delete:
-      operationId: delete-agent-upload-file
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      deleted:
-                        type: boolean
-                      id:
-                        type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete file uploaded by agent
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: fileId
-        required: true
-        schema:
-          type: string
-  '/agents/files/{fileId}/{fileName}':
-    get:
-      operationId: get-agent-upload-file
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      items:
-                        type: object
-                        properties:
-                          body: {}
-                          headers: {}
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get file uploaded by agent
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: fileId
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: fileName
-        required: true
-        schema:
-          type: string
-  /agents/setup:
-    get:
-      operationId: get-agents-setup-status
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_status_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent setup info
-      tags:
-        - Elastic Agents
-    post:
-      operationId: setup-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                admin_password:
-                  type: string
-                admin_username:
-                  type: string
-              required:
-                - admin_username
-                - admin_password
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_setup_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Initiate agent setup
-      tags:
-        - Elastic Agents
-  /agents/tags:
-    get:
-      operationId: get-agent-tags
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_agent_tags_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent tags
-      tags:
-        - Elastic Agents
   /api/actions:
     get:
       deprecated: true
@@ -7037,6 +5527,3703 @@ paths:
       summary: Preview a saved object reference swap
       tags:
         - data views
+  /api/fleet/agent_download_sources:
+    get:
+      operationId: get-download-sources
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_download_sources'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent binary download sources
+      tags:
+        - Elastic Agent binary download sources
+    post:
+      operationId: post-download-sources
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host:
+                  type: string
+                id:
+                  type: string
+                is_default:
+                  type: boolean
+                name:
+                  type: string
+              required:
+                - name
+                - host
+                - is_default
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_download_sources'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create agent binary download source
+      tags:
+        - Elastic Agent binary download sources
+  '/api/fleet/agent_download_sources/{sourceId}':
+    delete:
+      operationId: delete-download-source
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete agent binary download source by ID
+      tags:
+        - Elastic Agent binary download sources
+    get:
+      operationId: get-one-download-source
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_download_sources'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent binary download source by ID
+      tags:
+        - Elastic Agent binary download sources
+    parameters:
+      - in: path
+        name: sourceId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-download-source
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host:
+                  type: string
+                is_default:
+                  type: boolean
+                name:
+                  type: string
+              required:
+                - name
+                - is_default
+                - host
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_download_sources'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update agent binary download source by ID
+      tags:
+        - Elastic Agent binary download sources
+  /api/fleet/agent_policies:
+    get:
+      description: ''
+      operationId: agent-policy-list
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+        - $ref: '#/components/parameters/Fleet_format'
+        - description: >-
+            When set to true, retrieve the related package policies for each
+            agent policy.
+          in: query
+          name: full
+          schema:
+            type: boolean
+        - description: >-
+            When set to true, do not count how many agents are in the agent
+            policy, this can improve performance if you are searching over a
+            large number of agent policies. The "agents" property will always be
+            0 if set to true.
+          in: query
+          name: noAgentCount
+          schema:
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_agent_policy'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+                  - page
+                  - perPage
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent policies
+      tags:
+        - Elastic Agent policies
+    post:
+      operationId: create-agent-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_agent_policy_create_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create agent policy
+      tags:
+        - Elastic Agent policies
+  /api/fleet/agent_policies/_bulk_get:
+    post:
+      operationId: bulk-get-agent-policies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                full:
+                  description: get full policies with package policies populated
+                  type: boolean
+                ids:
+                  description: list of agent policy ids
+                  items:
+                    type: string
+                  type: array
+                ignoreMissing:
+                  type: boolean
+              required:
+                - ids
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_agent_policy'
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk get agent policies
+      tags:
+        - Elastic Agent policies
+  '/api/fleet/agent_policies/{agentPolicyId}':
+    get:
+      description: Get one agent policy
+      operationId: agent-policy-info
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent policy by ID
+      tags:
+        - Elastic Agent policies
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/Fleet_format'
+    put:
+      operationId: update-agent-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_agent_policy_update_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update agent policy by ID
+      tags:
+        - Elastic Agent policies
+  '/api/fleet/agent_policies/{agentPolicyId}/copy':
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/Fleet_format'
+    post:
+      operationId: agent-policy-copy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                name:
+                  type: string
+              required:
+                - name
+        description: ''
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Copy agent policy by ID
+      tags:
+        - Elastic Agent policies
+  '/api/fleet/agent_policies/{agentPolicyId}/download':
+    get:
+      operationId: agent-policy-download
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Download agent policy by ID
+      tags:
+        - Elastic Agent policies
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: download
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: standalone
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: kubernetes
+        required: false
+        schema:
+          type: string
+  '/api/fleet/agent_policies/{agentPolicyId}/full':
+    get:
+      operationId: agent-policy-full
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    oneOf:
+                      - type: string
+                      - $ref: '#/components/schemas/Fleet_agent_policy_full'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get full agent policy by ID
+      tags:
+        - Elastic Agent policies
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: download
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: standalone
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: kubernetes
+        required: false
+        schema:
+          type: string
+  /api/fleet/agent_policies/delete:
+    parameters: []
+    post:
+      operationId: delete-agent-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                agentPolicyId:
+                  type: string
+                force:
+                  description: >-
+                    bypass validation checks that can prevent agent policy
+                    deletion
+                  type: boolean
+              required:
+                - agentPolicyId
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - id
+                  - success
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete agent policy by ID
+      tags:
+        - Elastic Agent policies
+  /api/fleet/agent_status:
+    get:
+      operationId: get-agent-status
+      parameters:
+        - in: query
+          name: policyId
+          required: false
+          schema:
+            type: string
+        - deprecated: true
+          in: query
+          name: kuery
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  active:
+                    type: integer
+                  all:
+                    type: integer
+                  error:
+                    type: integer
+                  events:
+                    type: integer
+                  inactive:
+                    type: integer
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  other:
+                    type: integer
+                  total:
+                    deprecated: true
+                    type: integer
+                  unenrolled:
+                    type: integer
+                  updating:
+                    type: integer
+                required:
+                  - active
+                  - all
+                  - error
+                  - events
+                  - inactive
+                  - offline
+                  - online
+                  - other
+                  - total
+                  - updating
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent status summary
+      tags:
+        - Elastic Agent status
+  /api/fleet/agent_status/data:
+    get:
+      operationId: get-agent-data
+      parameters:
+        - in: query
+          name: agentsIds
+          required: true
+          schema:
+            items:
+              type: string
+            type: array
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      additionalProperties:
+                        type: object
+                        properties:
+                          data:
+                            type: boolean
+                      type: object
+                    type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get incoming agent data
+      tags:
+        - Elastic Agent status
+  /api/fleet/agent-status:
+    get:
+      deprecated: true
+      operationId: get-agent-status-deprecated
+      parameters:
+        - in: query
+          name: policyId
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: integer
+                  events:
+                    type: integer
+                  inactive:
+                    type: integer
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  other:
+                    type: integer
+                  total:
+                    type: integer
+                  updating:
+                    type: integer
+                required:
+                  - error
+                  - events
+                  - inactive
+                  - offline
+                  - online
+                  - other
+                  - total
+                  - updating
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent status summary
+      tags:
+        - Elastic Agent status
+  /api/fleet/agents:
+    get:
+      operationId: get-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+        - $ref: '#/components/parameters/Fleet_show_inactive'
+        - $ref: '#/components/parameters/Fleet_show_upgradeable'
+        - $ref: '#/components/parameters/Fleet_sort_field'
+        - $ref: '#/components/parameters/Fleet_sort_order'
+        - $ref: '#/components/parameters/Fleet_with_metrics'
+        - in: query
+          name: getStatusSummary
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_agents_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agents
+      tags:
+        - Elastic Agents
+    post:
+      operationId: get-agents-by-actions
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                actionIds:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - policy_id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_agent_get_by_actions'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agents by action ids
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}':
+    delete:
+      operationId: delete-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - deleted
+                    type: string
+                required:
+                  - action
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete agent by ID
+      tags:
+        - Elastic Agents
+    get:
+      operationId: get-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_with_metrics'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent by ID
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                tags:
+                  items:
+                    type: string
+                  type: array
+                user_provided_metadata:
+                  type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update agent by ID
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/actions':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: new-agent-action
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                action:
+                  $ref: '#/components/schemas/Fleet_agent_action'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    items:
+                      type: number
+                    type: array
+                  headers:
+                    type: string
+                  statusCode:
+                    type: number
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create agent action
+      tags:
+        - Elastic Agent actions
+  '/api/fleet/agents/{agentId}/reassign':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: reassign-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+              required:
+                - policy_id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Reassign agent
+      tags:
+        - Elastic Agents
+    put:
+      deprecated: true
+      operationId: reassign-agent-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+              required:
+                - policy_id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Reassign agent
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/request_diagnostics':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: request-diagnostics-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                additional_metrics:
+                  items:
+                    oneOf:
+                      - enum:
+                          - CPU
+                        type: string
+                  type: array
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Request agent diagnostics
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/unenroll':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: unenroll-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                revoke:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+          description: OK
+        '400':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  statusCode:
+                    enum:
+                      - 400
+                    type: number
+          description: BAD REQUEST
+      summary: Unenroll agent
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/upgrade':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: upgrade-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_upgrade_agent'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_upgrade_agent'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Upgrade agent
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/uploads':
+    get:
+      operationId: list-agent-uploads
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      item:
+                        items:
+                          $ref: '#/components/schemas/Fleet_agent_diagnostics'
+                        type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent uploads
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+  /api/fleet/agents/action_status:
+    get:
+      operationId: agents-action-status
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - in: query
+          name: errorSize
+          schema:
+            default: 5
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        actionId:
+                          type: string
+                        cancellationTime:
+                          type: string
+                        completionTime:
+                          type: string
+                        creationTime:
+                          description: creation time of action
+                          type: string
+                        expiration:
+                          type: string
+                        latestErrors:
+                          description: >-
+                            latest errors that happened when the agents executed
+                            the action
+                          items:
+                            type: object
+                            properties:
+                              agentId:
+                                type: string
+                              error:
+                                type: string
+                              timestamp:
+                                type: string
+                          type: array
+                        nbAgentsAck:
+                          description: number of agents that acknowledged the action
+                          type: number
+                        nbAgentsActionCreated:
+                          description: number of agents included in action from kibana
+                          type: number
+                        nbAgentsActioned:
+                          description: number of agents actioned
+                          type: number
+                        nbAgentsFailed:
+                          description: number of agents that failed to execute the action
+                          type: number
+                        newPolicyId:
+                          description: new policy id (POLICY_REASSIGN action)
+                          type: string
+                        policyId:
+                          description: policy id (POLICY_CHANGE action)
+                          type: string
+                        revision:
+                          description: new policy revision (POLICY_CHANGE action)
+                          type: string
+                        startTime:
+                          description: start time of action (scheduled actions)
+                          type: string
+                        status:
+                          enum:
+                            - COMPLETE
+                            - EXPIRED
+                            - CANCELLED
+                            - FAILED
+                            - IN_PROGRESS
+                            - ROLLOUT_PASSED
+                          type: string
+                        type:
+                          enum:
+                            - POLICY_REASSIGN
+                            - UPGRADE
+                            - UNENROLL
+                            - FORCE_UNENROLL
+                            - UPDATE_TAGS
+                            - CANCEL
+                            - REQUEST_DIAGNOSTICS
+                            - SETTINGS
+                            - POLICY_CHANGE
+                            - INPUT_ACTION
+                          type: string
+                        version:
+                          description: agent version number (UPGRADE action)
+                          type: string
+                      required:
+                        - actionId
+                        - complete
+                        - nbAgentsActioned
+                        - nbAgentsActionCreated
+                        - nbAgentsAck
+                        - nbAgentsFailed
+                        - status
+                        - creationTime
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent action status
+      tags:
+        - Elastic Agent actions
+  '/api/fleet/agents/actions/{actionId}/cancel':
+    parameters:
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: agent-action-cancel
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_action'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Cancel agent action
+      tags:
+        - Elastic Agent actions
+  /api/fleet/agents/bulk_reassign:
+    post:
+      operationId: bulk-reassign-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
+              policy_id: policy_id
+            schema:
+              type: object
+              properties:
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                policy_id:
+                  description: new agent policy id
+                  type: string
+              required:
+                - policy_id
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk reassign agents
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_request_diagnostics:
+    post:
+      operationId: bulk-request-diagnostics
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
+            schema:
+              type: object
+              properties:
+                additional_metrics:
+                  items:
+                    oneOf:
+                      - enum:
+                          - CPU
+                        type: string
+                  type: array
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                batchSize:
+                  type: number
+              required:
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk request diagnostics from agents
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_unenroll:
+    post:
+      operationId: bulk-unenroll-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents:
+                - agent1
+                - agent2
+              force: false
+              revoke: true
+            schema:
+              type: object
+              properties:
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                force:
+                  description: Unenrolls hosted agents too
+                  type: boolean
+                includeInactive:
+                  description: >-
+                    When passing agents by KQL query, unenrolls inactive agents
+                    too
+                  type: boolean
+                revoke:
+                  description: Revokes API keys of agents
+                  type: boolean
+              required:
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk unenroll agents
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_update_agent_tags:
+    post:
+      operationId: bulk-update-agent-tags
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents:
+                - agent1
+                - agent2
+              tagsToAdd:
+                - newTag
+              tagsToRemove:
+                - existingTag
+            schema:
+              type: object
+              properties:
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                batchSize:
+                  type: number
+                tagsToAdd:
+                  items:
+                    type: string
+                  type: array
+                tagsToRemove:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk update agent tags
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_upgrade:
+    post:
+      operationId: bulk-upgrade-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents:
+                - agent1
+                - agent2
+              rollout_duration_seconds: 3600
+              source_uri: 'https://artifacts.elastic.co/downloads/beats/elastic-agent'
+              start_time: '2022-08-03T14:00:00.000Z'
+              version: 8.4.0
+            schema:
+              $ref: '#/components/schemas/Fleet_bulk_upgrade_agents'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk upgrade agents
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/files/{fileId}':
+    delete:
+      operationId: delete-agent-upload-file
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      deleted:
+                        type: boolean
+                      id:
+                        type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete file uploaded by agent
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: fileId
+        required: true
+        schema:
+          type: string
+  '/api/fleet/agents/files/{fileId}/{fileName}':
+    get:
+      operationId: get-agent-upload-file
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      items:
+                        type: object
+                        properties:
+                          body: {}
+                          headers: {}
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get file uploaded by agent
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: fileId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fileName
+        required: true
+        schema:
+          type: string
+  /api/fleet/agents/setup:
+    get:
+      operationId: get-agents-setup-status
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_status_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent setup info
+      tags:
+        - Elastic Agents
+    post:
+      operationId: setup-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                admin_password:
+                  type: string
+                admin_username:
+                  type: string
+              required:
+                - admin_username
+                - admin_password
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_setup_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Initiate agent setup
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/tags:
+    get:
+      operationId: get-agent-tags
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_agent_tags_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent tags
+      tags:
+        - Elastic Agents
+  /api/fleet/data_streams:
+    get:
+      operationId: data-streams-list
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  data_streams:
+                    items:
+                      $ref: '#/components/schemas/Fleet_data_stream'
+                    type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List data streams
+      tags:
+        - Data streams
+    parameters: []
+  /api/fleet/enrollment_api_keys:
+    get:
+      operationId: get-enrollment-api-keys
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  list:
+                    deprecated: true
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - page
+                  - perPage
+                  - total
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List enrollment API keys
+      tags:
+        - Fleet enrollment API keys
+    post:
+      operationId: create-enrollment-api-keys
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the enrollment API key. Must be unique.
+                  type: string
+                policy_id:
+                  description: >-
+                    The ID of the agent policy the Elastic Agent will be
+                    enrolled in.
+                  type: string
+              required:
+                - policy_id
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - created
+                    type: string
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create enrollment API key
+      tags:
+        - Fleet enrollment API keys
+  '/api/fleet/enrollment_api_keys/{keyId}':
+    delete:
+      operationId: delete-enrollment-api-key
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - deleted
+                    type: string
+                required:
+                  - action
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Revoke enrollment API key by ID by marking it as inactive
+      tags:
+        - Fleet enrollment API keys
+    get:
+      operationId: get-enrollment-api-key
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get enrollment API key by ID
+      tags:
+        - Fleet enrollment API keys
+    parameters:
+      - in: path
+        name: keyId
+        required: true
+        schema:
+          type: string
+  /api/fleet/enrollment-api-keys:
+    get:
+      deprecated: true
+      operationId: get-enrollment-api-keys-deprecated
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  list:
+                    deprecated: true
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - page
+                  - perPage
+                  - total
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List enrollment API keys
+      tags:
+        - Fleet enrollment API keys
+    post:
+      deprecated: true
+      operationId: create-enrollment-api-keys-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - created
+                    type: string
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create enrollment API key
+      tags:
+        - Fleet enrollment API keys
+  '/api/fleet/enrollment-api-keys/{keyId}':
+    delete:
+      deprecated: true
+      operationId: delete-enrollment-api-key-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - deleted
+                    type: string
+                required:
+                  - action
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete enrollment API key by ID
+      tags:
+        - Fleet enrollment API keys
+    get:
+      deprecated: true
+      operationId: get-enrollment-api-key-deprecated
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get enrollment API key by ID
+      tags:
+        - Fleet enrollment API keys
+    parameters:
+      - in: path
+        name: keyId
+        required: true
+        schema:
+          type: string
+  /api/fleet/epm/bulk_assets:
+    post:
+      operationId: bulk-get-assets
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                assetIds:
+                  description: list of items necessary to fetch assets
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                  type: array
+              required:
+                - assetIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_bulk_assets_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk get assets
+      tags:
+        - Elastic Package Manager (EPM)
+  /api/fleet/epm/categories:
+    get:
+      operationId: get-package-categories
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_categories_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List package categories
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - description: >-
+          Whether to include prerelease packages in categories count (e.g. beta,
+          rc, preview)
+        in: query
+        name: prerelease
+        schema:
+          default: false
+          type: boolean
+      - deprecated: true
+        in: query
+        name: experimental
+        schema:
+          default: false
+          type: boolean
+      - in: query
+        name: include_policy_templates
+        schema:
+          default: false
+          type: boolean
+  /api/fleet/epm/packages:
+    get:
+      operationId: list-all-packages
+      parameters:
+        - description: >-
+            Whether to exclude the install status of each package. Enabling this
+            option will opt in to caching for the response via `cache-control`
+            headers. If you don't need up-to-date installation info for a
+            package, and are querying for a list of available packages,
+            providing this flag can improve performance substantially.
+          in: query
+          name: excludeInstallStatus
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+        - deprecated: true
+          in: query
+          name: experimental
+          schema:
+            default: false
+            type: boolean
+        - in: query
+          name: category
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_packages_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List packages
+      tags:
+        - Elastic Package Manager (EPM)
+    post:
+      description: ''
+      operationId: install-package-by-upload
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - description: avoid erroring out on unexpected mapping update errors
+          in: query
+          name: ignoreMappingUpdateErrors
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
+          in: query
+          name: skipDataStreamRollover
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/gzip; Elastic-Api-Version=2023-10-31:
+            schema:
+              format: binary
+              type: string
+          application/zip; Elastic-Api-Version=2023-10-31:
+            schema:
+              format: binary
+              type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  _meta:
+                    type: object
+                    properties:
+                      install_source:
+                        enum:
+                          - upload
+                          - registry
+                          - bundled
+                        type: string
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '429':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Install by package by direct upload
+      tags:
+        - Elastic Package Manager (EPM)
+  /api/fleet/epm/packages/_bulk:
+    post:
+      operationId: bulk-install-packages
+      parameters:
+        - description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  description: force install to ignore package verification errors
+                  type: boolean
+                packages:
+                  description: list of packages to install
+                  items:
+                    oneOf:
+                      - description: package name
+                        type: string
+                      - type: object
+                        properties:
+                          name:
+                            description: package name
+                            type: string
+                          version:
+                            description: package version
+                            type: string
+                  type: array
+              required:
+                - packages
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_bulk_install_packages_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk install packages
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgkey}':
+    delete:
+      deprecated: true
+      operationId: delete-package-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - in: path
+          name: pkgkey
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  response:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - response
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete ackage
+      tags:
+        - Elastic Package Manager (EPM)
+    get:
+      deprecated: true
+      operationId: get-package-deprecated
+      parameters:
+        - in: path
+          name: pkgkey
+          required: true
+          schema:
+            type: string
+        - description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                allOf:
+                  - properties:
+                      response:
+                        $ref: '#/components/schemas/Fleet_package_info'
+                  - properties:
+                      savedObject:
+                        type: string
+                      status:
+                        enum:
+                          - installed
+                          - installing
+                          - install_failed
+                          - not_installed
+                        type: string
+                    required:
+                      - status
+                      - savedObject
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package
+      tags:
+        - Elastic Package Manager (EPM)
+    post:
+      deprecated: true
+      description: ''
+      operationId: install-package-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - in: path
+          name: pkgkey
+          required: true
+          schema:
+            type: string
+        - description: avoid erroring out on unexpected mapping update errors
+          in: query
+          name: ignoreMappingUpdateErrors
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
+          in: query
+          name: skipDataStreamRollover
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  response:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - response
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Install package
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}':
+    delete:
+      operationId: delete-package
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - description: delete package even if policies used by agents
+          in: query
+          name: force
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              deprecated: true
+              type: object
+              properties:
+                force:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete package
+      tags:
+        - Elastic Package Manager (EPM)
+    get:
+      operationId: get-package
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                allOf:
+                  - properties:
+                      item:
+                        $ref: '#/components/schemas/Fleet_package_info'
+                  - properties:
+                      keepPoliciesUpToDate:
+                        type: boolean
+                      latestVersion:
+                        type: string
+                      licensePath:
+                        type: string
+                      notice:
+                        type: string
+                      savedObject:
+                        deprecated: true
+                        type: object
+                      status:
+                        enum:
+                          - installed
+                          - installing
+                          - install_failed
+                          - not_installed
+                        type: string
+                    required:
+                      - status
+                      - savedObject
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pkgVersion
+        required: true
+        schema:
+          type: string
+      - description: Ignore if the package is fails signature verification
+        in: query
+        name: ignoreUnverified
+        schema:
+          type: boolean
+      - description: >-
+          Return all fields from the package manifest, not just those supported
+          by the Elastic Package Registry
+        in: query
+        name: full
+        schema:
+          type: boolean
+      - description: >-
+          Whether to return prerelease versions of packages (e.g. beta, rc,
+          preview)
+        in: query
+        name: prerelease
+        schema:
+          default: false
+          type: boolean
+    post:
+      description: ''
+      operationId: install-package
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - description: avoid erroring out on unexpected mapping update errors
+          in: query
+          name: ignoreMappingUpdateErrors
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
+          in: query
+          name: skipDataStreamRollover
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                ignore_constraints:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  _meta:
+                    type: object
+                    properties:
+                      install_source:
+                        enum:
+                          - registry
+                          - upload
+                          - bundled
+                        type: string
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Install package
+      tags:
+        - Elastic Package Manager (EPM)
+    put:
+      description: ''
+      operationId: update-package
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                keepPoliciesUpToDate:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update package settings
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
+    get:
+      operationId: packages-get-file
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                  headers:
+                    type: object
+                  statusCode:
+                    type: number
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package file
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pkgVersion
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: filePath
+        required: true
+        schema:
+          type: string
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
+    post:
+      description: ''
+      operationId: reauthorize-transforms
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - in: path
+          name: pkgName
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: pkgVersion
+          required: true
+          schema:
+            type: string
+        - description: >-
+            Whether to include prerelease packages in categories count (e.g.
+            beta, rc, preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                transforms:
+                  items:
+                    type: object
+                    properties:
+                      transformId:
+                        type: string
+                  type: array
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        success:
+                          type: boolean
+                        transformId:
+                          type: string
+                      required:
+                        - transformId
+                        - error
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Authorize transforms
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgName}/stats':
+    get:
+      operationId: get-package-stats
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  response:
+                    $ref: '#/components/schemas/Fleet_package_usage_stats'
+                required:
+                  - response
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package stats
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+  /api/fleet/epm/packages/limited:
+    get:
+      operationId: list-limited-packages
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: string
+                    type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get limited package list
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters: []
+  '/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs':
+    get:
+      operationId: get-inputs-template
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get inputs template
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pkgVersion
+        required: true
+        schema:
+          type: string
+      - description: Format of response - json or yaml
+        in: query
+        name: format
+        schema:
+          enum:
+            - json
+            - yaml
+            - yml
+          type: string
+      - description: Specify if version is prerelease
+        in: query
+        name: prerelease
+        schema:
+          type: boolean
+      - description: Ignore if the package is fails signature verification
+        in: query
+        name: ignoreUnverified
+        schema:
+          type: boolean
+  /api/fleet/epm/verification_key_id:
+    get:
+      operationId: packages-get-verification-key-id
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      id:
+                        description: >-
+                          the key ID of the GPG key used to verify package
+                          signatures
+                        nullable: true
+                        type: string
+                  headers:
+                    type: object
+                  statusCode:
+                    type: number
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package signature verification key ID
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters: []
+  /api/fleet/fleet_server_hosts:
+    get:
+      operationId: get-fleet-server-hosts
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_fleet_server_host'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List Fleet Server hosts
+      tags:
+        - Fleet Server hosts
+    post:
+      operationId: post-fleet-server-hosts
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host_urls:
+                  items:
+                    type: string
+                  type: array
+                id:
+                  type: string
+                is_default:
+                  type: boolean
+                is_internal:
+                  type: boolean
+                name:
+                  type: string
+                proxy_id:
+                  description: >-
+                    The ID of the proxy to use for this fleet server host. See
+                    the proxies API for more information.
+                  type: string
+              required:
+                - name
+                - host_urls
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_fleet_server_host'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create Fleet Server host
+      tags:
+        - Fleet Server hosts
+  '/api/fleet/fleet_server_hosts/{itemId}':
+    delete:
+      operationId: delete-fleet-server-hosts
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete Fleet Server host by ID
+      tags:
+        - Fleet Server hosts
+    get:
+      operationId: get-one-fleet-server-hosts
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_fleet_server_host'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get Fleet Server host by ID
+      tags:
+        - Fleet Server hosts
+    parameters:
+      - in: path
+        name: itemId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-fleet-server-hosts
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host_urls:
+                  items:
+                    type: string
+                  type: array
+                is_default:
+                  type: boolean
+                is_internal:
+                  type: boolean
+                name:
+                  type: string
+                proxy_id:
+                  description: >-
+                    The ID of the proxy to use for this fleet server host. See
+                    the proxies API for more information.
+                  nullable: true
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_fleet_server_host'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update Fleet Server host by ID
+      tags:
+        - Fleet Server hosts
+  /api/fleet/health_check:
+    post:
+      operationId: fleet-server-health-check
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host:
+                  deprecated: true
+                  type: string
+                id:
+                  type: string
+              required:
+                - id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  host:
+                    deprecated: true
+                    type: string
+                  id:
+                    description: Fleet Server host id
+                    type: string
+                  status:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Fleet Server health check
+      tags:
+        - Fleet internals
+  /api/fleet/kubernetes:
+    get:
+      operationId: get-full-k8s-manifest
+      parameters:
+        - in: query
+          name: download
+          required: false
+          schema:
+            type: boolean
+        - in: query
+          name: fleetServer
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: enrolToken
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get full K8s agent manifest
+      tags:
+        - Fleet Kubernetes
+  /api/fleet/logstash_api_keys:
+    post:
+      operationId: generate-logstash-api-key
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  api_key:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Generate Logstash API key
+      tags:
+        - Fleet outputs
+  /api/fleet/outputs:
+    get:
+      operationId: get-outputs
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_output_create_request'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List outputs
+      tags:
+        - Fleet outputs
+    post:
+      operationId: post-outputs
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_output_create_request'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_output_create_request'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create output
+      tags:
+        - Fleet outputs
+  '/api/fleet/outputs/{outputId}':
+    delete:
+      operationId: delete-output
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete output by ID
+      tags:
+        - Fleet outputs
+    get:
+      operationId: get-output
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_output_create_request'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get output by ID
+      tags:
+        - Fleet outputs
+    parameters:
+      - in: path
+        name: outputId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-output
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_output_update_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_output_update_request'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update output by ID
+      tags:
+        - Fleet outputs
+  '/api/fleet/outputs/{outputId}/health':
+    get:
+      operationId: get-output-health
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: long message if unhealthy
+                    type: string
+                  state:
+                    description: 'state of output, HEALTHY or DEGRADED'
+                    type: string
+                  timestamp:
+                    description: timestamp of reported state
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get latest output health
+      tags:
+        - Fleet outputs
+    parameters:
+      - in: path
+        name: outputId
+        required: true
+        schema:
+          type: string
+  /api/fleet/package_policies:
+    get:
+      operationId: get-package-policies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+        - $ref: '#/components/parameters/Fleet_format'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_package_policy'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List package policies
+      tags:
+        - Fleet package policies
+    parameters: []
+    post:
+      operationId: create-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_package_policy_request'
+        description: >-
+          You should use inputs as an object and not use the deprecated inputs
+          array.
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_package_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '409':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create package policy
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/_bulk_get:
+    post:
+      operationId: bulk-get-package-policies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                ids:
+                  description: list of package policy ids
+                  items:
+                    type: string
+                  type: array
+                ignoreMissing:
+                  type: boolean
+              required:
+                - ids
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_package_policy'
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk get package policies
+      tags:
+        - Fleet package policies
+  '/api/fleet/package_policies/{packagePolicyId}':
+    delete:
+      operationId: delete-package-policy
+      parameters:
+        - in: query
+          name: force
+          schema:
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete package policy by ID
+      tags:
+        - Fleet package policies
+    get:
+      operationId: get-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_format'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_package_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package policy by ID
+      tags:
+        - Fleet package policies
+    parameters:
+      - in: path
+        name: packagePolicyId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_package_policy_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_package_policy'
+                  sucess:
+                    type: boolean
+                required:
+                  - item
+                  - sucess
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update package policy by ID
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/delete:
+    post:
+      operationId: post-delete-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                packagePolicyIds:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    success:
+                      type: boolean
+                  required:
+                    - id
+                    - success
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete package policy
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/upgrade:
+    post:
+      operationId: upgrade-package-policy
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                packagePolicyIds:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    success:
+                      type: boolean
+                  required:
+                    - id
+                    - success
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '409':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Upgrade package policy to a newer package version
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/upgrade/dryrun:
+    post:
+      operationId: upgrade-package-policy-dry-run
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                packagePolicyIds:
+                  items:
+                    type: string
+                  type: array
+                packageVersion:
+                  type: string
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                items:
+                  type: object
+                  properties:
+                    agent_diff:
+                      $ref: '#/components/schemas/Fleet_upgrade_agent_diff'
+                    diff:
+                      $ref: '#/components/schemas/Fleet_upgrade_diff'
+                    hasErrors:
+                      type: boolean
+                  required:
+                    - hasErrors
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Dry run package policy upgrade
+      tags:
+        - Fleet package policies
+  /api/fleet/proxies:
+    get:
+      operationId: get-fleet-proxies
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_proxies'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List proxies
+      tags:
+        - Fleet proxies
+    post:
+      operationId: post-fleet-proxies
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                certificate:
+                  type: string
+                certificate_authorities:
+                  type: string
+                certificate_key:
+                  type: string
+                id:
+                  type: string
+                name:
+                  type: string
+                proxy_headers:
+                  type: object
+                url:
+                  type: string
+              required:
+                - name
+                - url
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_proxies'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create proxy
+      tags:
+        - Fleet proxies
+  '/api/fleet/proxies/{itemId}':
+    delete:
+      operationId: delete-fleet-proxies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete proxy by ID
+      tags:
+        - Fleet proxies
+    get:
+      operationId: get-one-fleet-proxies
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_proxies'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get proxy by ID
+      tags:
+        - Fleet proxies
+    parameters:
+      - in: path
+        name: itemId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-fleet-proxies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                certificate:
+                  type: string
+                certificate_authorities:
+                  type: string
+                certificate_key:
+                  type: string
+                name:
+                  type: string
+                proxy_headers:
+                  type: object
+                url:
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_proxies'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update proxy by ID
+      tags:
+        - Fleet proxies
+  /api/fleet/service_tokens:
+    post:
+      operationId: generate-service-token
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create service token
+      tags:
+        - Fleet service tokens
+  /api/fleet/service-tokens:
+    post:
+      deprecated: true
+      operationId: generate-service-token-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create service token
+      tags:
+        - Fleet service tokens
+  /api/fleet/settings:
+    get:
+      operationId: get-settings
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_settings_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get settings
+      tags:
+        - Fleet internals
+    put:
+      operationId: update-settings
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                additional_yaml_config:
+                  type: string
+                fleet_server_hosts:
+                  description: Protocol and path must be the same for each URL
+                  items:
+                    type: string
+                  type: array
+                has_seen_add_data_notice:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_settings_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update settings
+      tags:
+        - Fleet internals
+  /api/fleet/setup:
+    post:
+      operationId: setup
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_setup_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '500':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+          description: Internal Server Error
+      summary: Initiate Fleet setup
+      tags:
+        - Fleet internals
+  /api/fleet/uninstall_tokens:
+    get:
+      operationId: get-uninstall-tokens
+      parameters:
+        - description: The number of items to return
+          in: query
+          name: perPage
+          required: false
+          schema:
+            default: 20
+            minimum: 5
+            type: integer
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - description: Partial match filtering for policy IDs
+          in: query
+          name: policyId
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        created_at:
+                          type: string
+                        id:
+                          type: string
+                        policy_id:
+                          type: string
+                      required:
+                        - id
+                        - policy_id
+                        - created_at
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+                  - page
+                  - perPage
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List metadata for latest uninstall tokens per agent policy
+      tags:
+        - Fleet uninstall tokens
+  '/api/fleet/uninstall_tokens/{uninstallTokenId}':
+    get:
+      operationId: get-uninstall-token
+      parameters:
+        - in: path
+          name: uninstallTokenId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    type: object
+                    properties:
+                      created_at:
+                        type: string
+                      id:
+                        type: string
+                      policy_id:
+                        type: string
+                      token:
+                        type: string
+                    required:
+                      - id
+                      - token
+                      - policy_id
+                      - created_at
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get one decrypted uninstall token by its ID
+      tags:
+        - Fleet uninstall tokens
   /api/ml/saved_objects/sync:
     get:
       description: >
@@ -7331,1981 +9518,6 @@ paths:
       summary: Get Kibana's current status
       tags:
         - system
-  /data_streams:
-    get:
-      operationId: data-streams-list
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  data_streams:
-                    items:
-                      $ref: '#/components/schemas/Fleet_data_stream'
-                    type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List data streams
-      tags:
-        - Data streams
-    parameters: []
-  /enrollment_api_keys:
-    get:
-      operationId: get-enrollment-api-keys
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  list:
-                    deprecated: true
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - page
-                  - perPage
-                  - total
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List enrollment API keys
-      tags:
-        - Fleet enrollment API keys
-    post:
-      operationId: create-enrollment-api-keys
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                name:
-                  description: The name of the enrollment API key. Must be unique.
-                  type: string
-                policy_id:
-                  description: >-
-                    The ID of the agent policy the Elastic Agent will be
-                    enrolled in.
-                  type: string
-              required:
-                - policy_id
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - created
-                    type: string
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create enrollment API key
-      tags:
-        - Fleet enrollment API keys
-  '/enrollment_api_keys/{keyId}':
-    delete:
-      operationId: delete-enrollment-api-key
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - deleted
-                    type: string
-                required:
-                  - action
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Revoke enrollment API key by ID by marking it as inactive
-      tags:
-        - Fleet enrollment API keys
-    get:
-      operationId: get-enrollment-api-key
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get enrollment API key by ID
-      tags:
-        - Fleet enrollment API keys
-    parameters:
-      - in: path
-        name: keyId
-        required: true
-        schema:
-          type: string
-  /enrollment-api-keys:
-    get:
-      deprecated: true
-      operationId: get-enrollment-api-keys-deprecated
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  list:
-                    deprecated: true
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - page
-                  - perPage
-                  - total
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List enrollment API keys
-      tags:
-        - Fleet enrollment API keys
-    post:
-      deprecated: true
-      operationId: create-enrollment-api-keys-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - created
-                    type: string
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create enrollment API key
-      tags:
-        - Fleet enrollment API keys
-  '/enrollment-api-keys/{keyId}':
-    delete:
-      deprecated: true
-      operationId: delete-enrollment-api-key-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - deleted
-                    type: string
-                required:
-                  - action
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete enrollment API key by ID
-      tags:
-        - Fleet enrollment API keys
-    get:
-      deprecated: true
-      operationId: get-enrollment-api-key-deprecated
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get enrollment API key by ID
-      tags:
-        - Fleet enrollment API keys
-    parameters:
-      - in: path
-        name: keyId
-        required: true
-        schema:
-          type: string
-  /epm/bulk_assets:
-    post:
-      operationId: bulk-get-assets
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                assetIds:
-                  description: list of items necessary to fetch assets
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      type:
-                        type: string
-                  type: array
-              required:
-                - assetIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_bulk_assets_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk get assets
-      tags:
-        - Elastic Package Manager (EPM)
-  /epm/categories:
-    get:
-      operationId: get-package-categories
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_categories_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List package categories
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - description: >-
-          Whether to include prerelease packages in categories count (e.g. beta,
-          rc, preview)
-        in: query
-        name: prerelease
-        schema:
-          default: false
-          type: boolean
-      - deprecated: true
-        in: query
-        name: experimental
-        schema:
-          default: false
-          type: boolean
-      - in: query
-        name: include_policy_templates
-        schema:
-          default: false
-          type: boolean
-  /epm/packages:
-    get:
-      operationId: list-all-packages
-      parameters:
-        - description: >-
-            Whether to exclude the install status of each package. Enabling this
-            option will opt in to caching for the response via `cache-control`
-            headers. If you don't need up-to-date installation info for a
-            package, and are querying for a list of available packages,
-            providing this flag can improve performance substantially.
-          in: query
-          name: excludeInstallStatus
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-        - deprecated: true
-          in: query
-          name: experimental
-          schema:
-            default: false
-            type: boolean
-        - in: query
-          name: category
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_packages_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List packages
-      tags:
-        - Elastic Package Manager (EPM)
-    post:
-      description: ''
-      operationId: install-package-by-upload
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - description: avoid erroring out on unexpected mapping update errors
-          in: query
-          name: ignoreMappingUpdateErrors
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
-          in: query
-          name: skipDataStreamRollover
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/gzip; Elastic-Api-Version=2023-10-31:
-            schema:
-              format: binary
-              type: string
-          application/zip; Elastic-Api-Version=2023-10-31:
-            schema:
-              format: binary
-              type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  _meta:
-                    type: object
-                    properties:
-                      install_source:
-                        enum:
-                          - upload
-                          - registry
-                          - bundled
-                        type: string
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '429':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Install by package by direct upload
-      tags:
-        - Elastic Package Manager (EPM)
-  /epm/packages/_bulk:
-    post:
-      operationId: bulk-install-packages
-      parameters:
-        - description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  description: force install to ignore package verification errors
-                  type: boolean
-                packages:
-                  description: list of packages to install
-                  items:
-                    oneOf:
-                      - description: package name
-                        type: string
-                      - type: object
-                        properties:
-                          name:
-                            description: package name
-                            type: string
-                          version:
-                            description: package version
-                            type: string
-                  type: array
-              required:
-                - packages
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_bulk_install_packages_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk install packages
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgkey}':
-    delete:
-      deprecated: true
-      operationId: delete-package-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - in: path
-          name: pkgkey
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  response:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - response
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete ackage
-      tags:
-        - Elastic Package Manager (EPM)
-    get:
-      deprecated: true
-      operationId: get-package-deprecated
-      parameters:
-        - in: path
-          name: pkgkey
-          required: true
-          schema:
-            type: string
-        - description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                allOf:
-                  - properties:
-                      response:
-                        $ref: '#/components/schemas/Fleet_package_info'
-                  - properties:
-                      savedObject:
-                        type: string
-                      status:
-                        enum:
-                          - installed
-                          - installing
-                          - install_failed
-                          - not_installed
-                        type: string
-                    required:
-                      - status
-                      - savedObject
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package
-      tags:
-        - Elastic Package Manager (EPM)
-    post:
-      deprecated: true
-      description: ''
-      operationId: install-package-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - in: path
-          name: pkgkey
-          required: true
-          schema:
-            type: string
-        - description: avoid erroring out on unexpected mapping update errors
-          in: query
-          name: ignoreMappingUpdateErrors
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
-          in: query
-          name: skipDataStreamRollover
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  response:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - response
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Install package
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgName}/{pkgVersion}':
-    delete:
-      operationId: delete-package
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - description: delete package even if policies used by agents
-          in: query
-          name: force
-          schema:
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              deprecated: true
-              type: object
-              properties:
-                force:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete package
-      tags:
-        - Elastic Package Manager (EPM)
-    get:
-      operationId: get-package
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                allOf:
-                  - properties:
-                      item:
-                        $ref: '#/components/schemas/Fleet_package_info'
-                  - properties:
-                      keepPoliciesUpToDate:
-                        type: boolean
-                      latestVersion:
-                        type: string
-                      licensePath:
-                        type: string
-                      notice:
-                        type: string
-                      savedObject:
-                        deprecated: true
-                        type: object
-                      status:
-                        enum:
-                          - installed
-                          - installing
-                          - install_failed
-                          - not_installed
-                        type: string
-                    required:
-                      - status
-                      - savedObject
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: pkgVersion
-        required: true
-        schema:
-          type: string
-      - description: Ignore if the package is fails signature verification
-        in: query
-        name: ignoreUnverified
-        schema:
-          type: boolean
-      - description: >-
-          Return all fields from the package manifest, not just those supported
-          by the Elastic Package Registry
-        in: query
-        name: full
-        schema:
-          type: boolean
-      - description: >-
-          Whether to return prerelease versions of packages (e.g. beta, rc,
-          preview)
-        in: query
-        name: prerelease
-        schema:
-          default: false
-          type: boolean
-    post:
-      description: ''
-      operationId: install-package
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - description: avoid erroring out on unexpected mapping update errors
-          in: query
-          name: ignoreMappingUpdateErrors
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
-          in: query
-          name: skipDataStreamRollover
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-                ignore_constraints:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  _meta:
-                    type: object
-                    properties:
-                      install_source:
-                        enum:
-                          - registry
-                          - upload
-                          - bundled
-                        type: string
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Install package
-      tags:
-        - Elastic Package Manager (EPM)
-    put:
-      description: ''
-      operationId: update-package
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                keepPoliciesUpToDate:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update package settings
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
-    get:
-      operationId: packages-get-file
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                  headers:
-                    type: object
-                  statusCode:
-                    type: number
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package file
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: pkgVersion
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: filePath
-        required: true
-        schema:
-          type: string
-  '/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
-    post:
-      description: ''
-      operationId: reauthorize-transforms
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - in: path
-          name: pkgName
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: pkgVersion
-          required: true
-          schema:
-            type: string
-        - description: >-
-            Whether to include prerelease packages in categories count (e.g.
-            beta, rc, preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                transforms:
-                  items:
-                    type: object
-                    properties:
-                      transformId:
-                        type: string
-                  type: array
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        error:
-                          type: string
-                        success:
-                          type: boolean
-                        transformId:
-                          type: string
-                      required:
-                        - transformId
-                        - error
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Authorize transforms
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgName}/stats':
-    get:
-      operationId: get-package-stats
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  response:
-                    $ref: '#/components/schemas/Fleet_package_usage_stats'
-                required:
-                  - response
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package stats
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-  /epm/packages/limited:
-    get:
-      operationId: list-limited-packages
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: string
-                    type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get limited package list
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters: []
-  '/epm/templates/{pkgName}/{pkgVersion}/inputs':
-    get:
-      operationId: get-inputs-template
-      responses:
-        '200':
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get inputs template
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: pkgVersion
-        required: true
-        schema:
-          type: string
-      - description: Format of response - json or yaml
-        in: query
-        name: format
-        schema:
-          enum:
-            - json
-            - yaml
-            - yml
-          type: string
-      - description: Specify if version is prerelease
-        in: query
-        name: prerelease
-        schema:
-          type: boolean
-      - description: Ignore if the package is fails signature verification
-        in: query
-        name: ignoreUnverified
-        schema:
-          type: boolean
-  /epm/verification_key_id:
-    get:
-      operationId: packages-get-verification-key-id
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      id:
-                        description: >-
-                          the key ID of the GPG key used to verify package
-                          signatures
-                        nullable: true
-                        type: string
-                  headers:
-                    type: object
-                  statusCode:
-                    type: number
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package signature verification key ID
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters: []
-  /fleet_server_hosts:
-    get:
-      operationId: get-fleet-server-hosts
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_fleet_server_host'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List Fleet Server hosts
-      tags:
-        - Fleet Server hosts
-    post:
-      operationId: post-fleet-server-hosts
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host_urls:
-                  items:
-                    type: string
-                  type: array
-                id:
-                  type: string
-                is_default:
-                  type: boolean
-                is_internal:
-                  type: boolean
-                name:
-                  type: string
-                proxy_id:
-                  description: >-
-                    The ID of the proxy to use for this fleet server host. See
-                    the proxies API for more information.
-                  type: string
-              required:
-                - name
-                - host_urls
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_fleet_server_host'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create Fleet Server host
-      tags:
-        - Fleet Server hosts
-  '/fleet_server_hosts/{itemId}':
-    delete:
-      operationId: delete-fleet-server-hosts
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete Fleet Server host by ID
-      tags:
-        - Fleet Server hosts
-    get:
-      operationId: get-one-fleet-server-hosts
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_fleet_server_host'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get Fleet Server host by ID
-      tags:
-        - Fleet Server hosts
-    parameters:
-      - in: path
-        name: itemId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-fleet-server-hosts
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host_urls:
-                  items:
-                    type: string
-                  type: array
-                is_default:
-                  type: boolean
-                is_internal:
-                  type: boolean
-                name:
-                  type: string
-                proxy_id:
-                  description: >-
-                    The ID of the proxy to use for this fleet server host. See
-                    the proxies API for more information.
-                  nullable: true
-                  type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_fleet_server_host'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update Fleet Server host by ID
-      tags:
-        - Fleet Server hosts
-  /health_check:
-    post:
-      operationId: fleet-server-health-check
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host:
-                  deprecated: true
-                  type: string
-                id:
-                  type: string
-              required:
-                - id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  host:
-                    deprecated: true
-                    type: string
-                  id:
-                    description: Fleet Server host id
-                    type: string
-                  status:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Fleet Server health check
-      tags:
-        - Fleet internals
-  /kubernetes:
-    get:
-      operationId: get-full-k8s-manifest
-      parameters:
-        - in: query
-          name: download
-          required: false
-          schema:
-            type: boolean
-        - in: query
-          name: fleetServer
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: enrolToken
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get full K8s agent manifest
-      tags:
-        - Fleet Kubernetes
-  /logstash_api_keys:
-    post:
-      operationId: generate-logstash-api-key
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  api_key:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Generate Logstash API key
-      tags:
-        - Fleet outputs
-  /outputs:
-    get:
-      operationId: get-outputs
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_output_create_request'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List outputs
-      tags:
-        - Fleet outputs
-    post:
-      operationId: post-outputs
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_output_create_request'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_output_create_request'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create output
-      tags:
-        - Fleet outputs
-  '/outputs/{outputId}':
-    delete:
-      operationId: delete-output
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete output by ID
-      tags:
-        - Fleet outputs
-    get:
-      operationId: get-output
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_output_create_request'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get output by ID
-      tags:
-        - Fleet outputs
-    parameters:
-      - in: path
-        name: outputId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-output
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_output_update_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_output_update_request'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update output by ID
-      tags:
-        - Fleet outputs
-  '/outputs/{outputId}/health':
-    get:
-      operationId: get-output-health
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  message:
-                    description: long message if unhealthy
-                    type: string
-                  state:
-                    description: 'state of output, HEALTHY or DEGRADED'
-                    type: string
-                  timestamp:
-                    description: timestamp of reported state
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get latest output health
-      tags:
-        - Fleet outputs
-    parameters:
-      - in: path
-        name: outputId
-        required: true
-        schema:
-          type: string
-  /package_policies:
-    get:
-      operationId: get-package-policies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-        - $ref: '#/components/parameters/Fleet_format'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_package_policy'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List package policies
-      tags:
-        - Fleet package policies
-    parameters: []
-    post:
-      operationId: create-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_package_policy_request'
-        description: >-
-          You should use inputs as an object and not use the deprecated inputs
-          array.
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_package_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '409':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create package policy
-      tags:
-        - Fleet package policies
-  /package_policies/_bulk_get:
-    post:
-      operationId: bulk-get-package-policies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                ids:
-                  description: list of package policy ids
-                  items:
-                    type: string
-                  type: array
-                ignoreMissing:
-                  type: boolean
-              required:
-                - ids
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_package_policy'
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk get package policies
-      tags:
-        - Fleet package policies
-  '/package_policies/{packagePolicyId}':
-    delete:
-      operationId: delete-package-policy
-      parameters:
-        - in: query
-          name: force
-          schema:
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete package policy by ID
-      tags:
-        - Fleet package policies
-    get:
-      operationId: get-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_format'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_package_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package policy by ID
-      tags:
-        - Fleet package policies
-    parameters:
-      - in: path
-        name: packagePolicyId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_package_policy_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_package_policy'
-                  sucess:
-                    type: boolean
-                required:
-                  - item
-                  - sucess
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update package policy by ID
-      tags:
-        - Fleet package policies
-  /package_policies/delete:
-    post:
-      operationId: post-delete-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-                packagePolicyIds:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - packagePolicyIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    success:
-                      type: boolean
-                  required:
-                    - id
-                    - success
-                type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete package policy
-      tags:
-        - Fleet package policies
-  /package_policies/upgrade:
-    post:
-      operationId: upgrade-package-policy
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                packagePolicyIds:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - packagePolicyIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    success:
-                      type: boolean
-                  required:
-                    - id
-                    - success
-                type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '409':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Upgrade package policy to a newer package version
-      tags:
-        - Fleet package policies
-  /package_policies/upgrade/dryrun:
-    post:
-      operationId: upgrade-package-policy-dry-run
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                packagePolicyIds:
-                  items:
-                    type: string
-                  type: array
-                packageVersion:
-                  type: string
-              required:
-                - packagePolicyIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                items:
-                  type: object
-                  properties:
-                    agent_diff:
-                      $ref: '#/components/schemas/Fleet_upgrade_agent_diff'
-                    diff:
-                      $ref: '#/components/schemas/Fleet_upgrade_diff'
-                    hasErrors:
-                      type: boolean
-                  required:
-                    - hasErrors
-                type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Dry run package policy upgrade
-      tags:
-        - Fleet package policies
-  /proxies:
-    get:
-      operationId: get-fleet-proxies
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_proxies'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List proxies
-      tags:
-        - Fleet proxies
-    post:
-      operationId: post-fleet-proxies
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                certificate:
-                  type: string
-                certificate_authorities:
-                  type: string
-                certificate_key:
-                  type: string
-                id:
-                  type: string
-                name:
-                  type: string
-                proxy_headers:
-                  type: object
-                url:
-                  type: string
-              required:
-                - name
-                - url
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_proxies'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create proxy
-      tags:
-        - Fleet proxies
-  '/proxies/{itemId}':
-    delete:
-      operationId: delete-fleet-proxies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete proxy by ID
-      tags:
-        - Fleet proxies
-    get:
-      operationId: get-one-fleet-proxies
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_proxies'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get proxy by ID
-      tags:
-        - Fleet proxies
-    parameters:
-      - in: path
-        name: itemId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-fleet-proxies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                certificate:
-                  type: string
-                certificate_authorities:
-                  type: string
-                certificate_key:
-                  type: string
-                name:
-                  type: string
-                proxy_headers:
-                  type: object
-                url:
-                  type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_proxies'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update proxy by ID
-      tags:
-        - Fleet proxies
   '/s/{spaceId}/api/observability/slos':
     get:
       description: >
@@ -9753,247 +9965,6 @@ paths:
       summary: Enable an SLO
       tags:
         - slo
-  /service_tokens:
-    post:
-      operationId: generate-service-token
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create service token
-      tags:
-        - Fleet service tokens
-  /service-tokens:
-    post:
-      deprecated: true
-      operationId: generate-service-token-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create service token
-      tags:
-        - Fleet service tokens
-  /settings:
-    get:
-      operationId: get-settings
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_settings_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get settings
-      tags:
-        - Fleet internals
-    put:
-      operationId: update-settings
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                additional_yaml_config:
-                  type: string
-                fleet_server_hosts:
-                  description: Protocol and path must be the same for each URL
-                  items:
-                    type: string
-                  type: array
-                has_seen_add_data_notice:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_settings_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update settings
-      tags:
-        - Fleet internals
-  /settings/enrollment:
-    get:
-      operationId: get-enrollment-settings
-      parameters:
-        - description: >-
-            An agent policy ID to scope the enrollment settings to. For example,
-            that policy's Fleet Server host, its proxy, download location, etc.
-            If not provided, the default Fleet Server policy is used (if any).
-          in: query
-          name: agentPolicyId
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_settings_enrollment_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get enrollment settings
-      tags:
-        - Fleet internals
-    servers:
-      - description: Used for Fleet internals and not supported
-        url: 'http://KIBANA_HOST:5601/internal/fleet'
-  /setup:
-    post:
-      operationId: setup
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_setup_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '500':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-          description: Internal Server Error
-      summary: Initiate Fleet setup
-      tags:
-        - Fleet internals
-  /uninstall_tokens:
-    get:
-      operationId: get-uninstall-tokens
-      parameters:
-        - description: The number of items to return
-          in: query
-          name: perPage
-          required: false
-          schema:
-            default: 20
-            minimum: 5
-            type: integer
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - description: Partial match filtering for policy IDs
-          in: query
-          name: policyId
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        created_at:
-                          type: string
-                        id:
-                          type: string
-                        policy_id:
-                          type: string
-                      required:
-                        - id
-                        - policy_id
-                        - created_at
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - total
-                  - page
-                  - perPage
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List metadata for latest uninstall tokens per agent policy
-      tags:
-        - Fleet uninstall tokens
-  '/uninstall_tokens/{uninstallTokenId}':
-    get:
-      operationId: get-uninstall-token
-      parameters:
-        - in: path
-          name: uninstallTokenId
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    type: object
-                    properties:
-                      created_at:
-                        type: string
-                      id:
-                        type: string
-                      policy_id:
-                        type: string
-                      token:
-                        type: string
-                    required:
-                      - id
-                      - token
-                      - policy_id
-                      - created_at
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get one decrypted uninstall token by its ID
-      tags:
-        - Fleet uninstall tokens
 components:
   examples:
     Data_views_create_data_view_request:
@@ -12639,49 +12610,6 @@ components:
         - is_default
         - is_preconfigured
         - host_urls
-    Fleet_fleet_settings_enrollment_response:
-      title: Fleet settings response
-      type: object
-      properties:
-        download_source:
-          $ref: '#/components/schemas/Fleet_download_sources'
-        fleet_server:
-          type: object
-          properties:
-            has_active:
-              type: boolean
-            host:
-              $ref: '#/components/schemas/Fleet_fleet_server_host'
-            host_proxy:
-              $ref: '#/components/schemas/Fleet_proxies'
-            policies:
-              items:
-                type: object
-                properties:
-                  download_source_id:
-                    type: string
-                  fleet_server_host_id:
-                    type: string
-                  has_fleet_server:
-                    type: boolean
-                  id:
-                    type: string
-                  is_default_fleet_server:
-                    type: boolean
-                  is_managed:
-                    type: boolean
-                  name:
-                    type: string
-                required:
-                  - id
-                  - name
-                  - is_managed
-              type: array
-          required:
-            - agent_policies
-            - has_active
-      required:
-        - fleet_server
     Fleet_fleet_settings_response:
       title: Fleet settings response
       type: object

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -75,1515 +75,6 @@ servers:
       kibana_url:
         default: 'localhost:5601'
 paths:
-  /agent_download_sources:
-    get:
-      operationId: get-download-sources
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_download_sources'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent binary download sources
-      tags:
-        - Elastic Agent binary download sources
-    post:
-      operationId: post-download-sources
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host:
-                  type: string
-                id:
-                  type: string
-                is_default:
-                  type: boolean
-                name:
-                  type: string
-              required:
-                - name
-                - host
-                - is_default
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_download_sources'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create agent binary download source
-      tags:
-        - Elastic Agent binary download sources
-  '/agent_download_sources/{sourceId}':
-    delete:
-      operationId: delete-download-source
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete agent binary download source by ID
-      tags:
-        - Elastic Agent binary download sources
-    get:
-      operationId: get-one-download-source
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_download_sources'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent binary download source by ID
-      tags:
-        - Elastic Agent binary download sources
-    parameters:
-      - in: path
-        name: sourceId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-download-source
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host:
-                  type: string
-                is_default:
-                  type: boolean
-                name:
-                  type: string
-              required:
-                - name
-                - is_default
-                - host
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_download_sources'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update agent binary download source by ID
-      tags:
-        - Elastic Agent binary download sources
-  /agent_policies:
-    get:
-      description: ''
-      operationId: agent-policy-list
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-        - $ref: '#/components/parameters/Fleet_format'
-        - description: >-
-            When set to true, retrieve the related package policies for each
-            agent policy.
-          in: query
-          name: full
-          schema:
-            type: boolean
-        - description: >-
-            When set to true, do not count how many agents are in the agent
-            policy, this can improve performance if you are searching over a
-            large number of agent policies. The "agents" property will always be
-            0 if set to true.
-          in: query
-          name: noAgentCount
-          schema:
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_agent_policy'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - total
-                  - page
-                  - perPage
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent policies
-      tags:
-        - Elastic Agent policies
-    post:
-      operationId: create-agent-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_agent_policy_create_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create agent policy
-      tags:
-        - Elastic Agent policies
-  /agent_policies/_bulk_get:
-    post:
-      operationId: bulk-get-agent-policies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                full:
-                  description: get full policies with package policies populated
-                  type: boolean
-                ids:
-                  description: list of agent policy ids
-                  items:
-                    type: string
-                  type: array
-                ignoreMissing:
-                  type: boolean
-              required:
-                - ids
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_agent_policy'
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk get agent policies
-      tags:
-        - Elastic Agent policies
-  '/agent_policies/{agentPolicyId}':
-    get:
-      description: Get one agent policy
-      operationId: agent-policy-info
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent policy by ID
-      tags:
-        - Elastic Agent policies
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - $ref: '#/components/parameters/Fleet_format'
-    put:
-      operationId: update-agent-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_agent_policy_update_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update agent policy by ID
-      tags:
-        - Elastic Agent policies
-  '/agent_policies/{agentPolicyId}/copy':
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - $ref: '#/components/parameters/Fleet_format'
-    post:
-      operationId: agent-policy-copy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                description:
-                  type: string
-                name:
-                  type: string
-              required:
-                - name
-        description: ''
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Copy agent policy by ID
-      tags:
-        - Elastic Agent policies
-  '/agent_policies/{agentPolicyId}/download':
-    get:
-      operationId: agent-policy-download
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Download agent policy by ID
-      tags:
-        - Elastic Agent policies
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: download
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: standalone
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: kubernetes
-        required: false
-        schema:
-          type: string
-  '/agent_policies/{agentPolicyId}/full':
-    get:
-      operationId: agent-policy-full
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    oneOf:
-                      - type: string
-                      - $ref: '#/components/schemas/Fleet_agent_policy_full'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get full agent policy by ID
-      tags:
-        - Elastic Agent policies
-    parameters:
-      - in: path
-        name: agentPolicyId
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: download
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: standalone
-        required: false
-        schema:
-          type: string
-      - in: query
-        name: kubernetes
-        required: false
-        schema:
-          type: string
-  /agent_policies/delete:
-    parameters: []
-    post:
-      operationId: delete-agent-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                agentPolicyId:
-                  type: string
-                force:
-                  description: >-
-                    bypass validation checks that can prevent agent policy
-                    deletion
-                  type: boolean
-              required:
-                - agentPolicyId
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  success:
-                    type: boolean
-                required:
-                  - id
-                  - success
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete agent policy by ID
-      tags:
-        - Elastic Agent policies
-  /agent_status:
-    get:
-      operationId: get-agent-status
-      parameters:
-        - in: query
-          name: policyId
-          required: false
-          schema:
-            type: string
-        - deprecated: true
-          in: query
-          name: kuery
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  active:
-                    type: integer
-                  all:
-                    type: integer
-                  error:
-                    type: integer
-                  events:
-                    type: integer
-                  inactive:
-                    type: integer
-                  offline:
-                    type: integer
-                  online:
-                    type: integer
-                  other:
-                    type: integer
-                  total:
-                    deprecated: true
-                    type: integer
-                  unenrolled:
-                    type: integer
-                  updating:
-                    type: integer
-                required:
-                  - active
-                  - all
-                  - error
-                  - events
-                  - inactive
-                  - offline
-                  - online
-                  - other
-                  - total
-                  - updating
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent status summary
-      tags:
-        - Elastic Agent status
-  /agent_status/data:
-    get:
-      operationId: get-agent-data
-      parameters:
-        - in: query
-          name: agentsIds
-          required: true
-          schema:
-            items:
-              type: string
-            type: array
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      additionalProperties:
-                        type: object
-                        properties:
-                          data:
-                            type: boolean
-                      type: object
-                    type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get incoming agent data
-      tags:
-        - Elastic Agent status
-  /agent-status:
-    get:
-      deprecated: true
-      operationId: get-agent-status-deprecated
-      parameters:
-        - in: query
-          name: policyId
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: integer
-                  events:
-                    type: integer
-                  inactive:
-                    type: integer
-                  offline:
-                    type: integer
-                  online:
-                    type: integer
-                  other:
-                    type: integer
-                  total:
-                    type: integer
-                  updating:
-                    type: integer
-                required:
-                  - error
-                  - events
-                  - inactive
-                  - offline
-                  - online
-                  - other
-                  - total
-                  - updating
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent status summary
-      tags:
-        - Elastic Agent status
-  /agents:
-    get:
-      operationId: get-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-        - $ref: '#/components/parameters/Fleet_show_inactive'
-        - $ref: '#/components/parameters/Fleet_show_upgradeable'
-        - $ref: '#/components/parameters/Fleet_sort_field'
-        - $ref: '#/components/parameters/Fleet_sort_order'
-        - $ref: '#/components/parameters/Fleet_with_metrics'
-        - in: query
-          name: getStatusSummary
-          required: false
-          schema:
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_agents_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agents
-      tags:
-        - Elastic Agents
-    post:
-      operationId: get-agents-by-actions
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                actionIds:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - policy_id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_agent_get_by_actions'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agents by action ids
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}':
-    delete:
-      operationId: delete-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - deleted
-                    type: string
-                required:
-                  - action
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete agent by ID
-      tags:
-        - Elastic Agents
-    get:
-      operationId: get-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_with_metrics'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent by ID
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                tags:
-                  items:
-                    type: string
-                  type: array
-                user_provided_metadata:
-                  type: object
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update agent by ID
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/actions':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: new-agent-action
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                action:
-                  $ref: '#/components/schemas/Fleet_agent_action'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    items:
-                      type: number
-                    type: array
-                  headers:
-                    type: string
-                  statusCode:
-                    type: number
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create agent action
-      tags:
-        - Elastic Agent actions
-  '/agents/{agentId}/reassign':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: reassign-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                policy_id:
-                  type: string
-              required:
-                - policy_id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Reassign agent
-      tags:
-        - Elastic Agents
-    put:
-      deprecated: true
-      operationId: reassign-agent-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                policy_id:
-                  type: string
-              required:
-                - policy_id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Reassign agent
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/request_diagnostics':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: request-diagnostics-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                additional_metrics:
-                  items:
-                    oneOf:
-                      - enum:
-                          - CPU
-                        type: string
-                  type: array
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Request agent diagnostics
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/unenroll':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: unenroll-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-                revoke:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-          description: OK
-        '400':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  message:
-                    type: string
-                  statusCode:
-                    enum:
-                      - 400
-                    type: number
-          description: BAD REQUEST
-      summary: Unenroll agent
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/upgrade':
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: upgrade-agent
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_upgrade_agent'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_upgrade_agent'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Upgrade agent
-      tags:
-        - Elastic Agents
-  '/agents/{agentId}/uploads':
-    get:
-      operationId: list-agent-uploads
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      item:
-                        items:
-                          $ref: '#/components/schemas/Fleet_agent_diagnostics'
-                        type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent uploads
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: agentId
-        required: true
-        schema:
-          type: string
-  /agents/action_status:
-    get:
-      operationId: agents-action-status
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - in: query
-          name: errorSize
-          schema:
-            default: 5
-            type: integer
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        actionId:
-                          type: string
-                        cancellationTime:
-                          type: string
-                        completionTime:
-                          type: string
-                        creationTime:
-                          description: creation time of action
-                          type: string
-                        expiration:
-                          type: string
-                        latestErrors:
-                          description: >-
-                            latest errors that happened when the agents executed
-                            the action
-                          items:
-                            type: object
-                            properties:
-                              agentId:
-                                type: string
-                              error:
-                                type: string
-                              timestamp:
-                                type: string
-                          type: array
-                        nbAgentsAck:
-                          description: number of agents that acknowledged the action
-                          type: number
-                        nbAgentsActionCreated:
-                          description: number of agents included in action from kibana
-                          type: number
-                        nbAgentsActioned:
-                          description: number of agents actioned
-                          type: number
-                        nbAgentsFailed:
-                          description: number of agents that failed to execute the action
-                          type: number
-                        newPolicyId:
-                          description: new policy id (POLICY_REASSIGN action)
-                          type: string
-                        policyId:
-                          description: policy id (POLICY_CHANGE action)
-                          type: string
-                        revision:
-                          description: new policy revision (POLICY_CHANGE action)
-                          type: string
-                        startTime:
-                          description: start time of action (scheduled actions)
-                          type: string
-                        status:
-                          enum:
-                            - COMPLETE
-                            - EXPIRED
-                            - CANCELLED
-                            - FAILED
-                            - IN_PROGRESS
-                            - ROLLOUT_PASSED
-                          type: string
-                        type:
-                          enum:
-                            - POLICY_REASSIGN
-                            - UPGRADE
-                            - UNENROLL
-                            - FORCE_UNENROLL
-                            - UPDATE_TAGS
-                            - CANCEL
-                            - REQUEST_DIAGNOSTICS
-                            - SETTINGS
-                            - POLICY_CHANGE
-                            - INPUT_ACTION
-                          type: string
-                        version:
-                          description: agent version number (UPGRADE action)
-                          type: string
-                      required:
-                        - actionId
-                        - complete
-                        - nbAgentsActioned
-                        - nbAgentsActionCreated
-                        - nbAgentsAck
-                        - nbAgentsFailed
-                        - status
-                        - creationTime
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent action status
-      tags:
-        - Elastic Agent actions
-  '/agents/actions/{actionId}/cancel':
-    parameters:
-      - in: path
-        name: actionId
-        required: true
-        schema:
-          type: string
-    post:
-      operationId: agent-action-cancel
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_agent_action'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Cancel agent action
-      tags:
-        - Elastic Agent actions
-  /agents/bulk_reassign:
-    post:
-      operationId: bulk-reassign-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
-              policy_id: policy_id
-            schema:
-              type: object
-              properties:
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                policy_id:
-                  description: new agent policy id
-                  type: string
-              required:
-                - policy_id
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk reassign agents
-      tags:
-        - Elastic Agents
-  /agents/bulk_request_diagnostics:
-    post:
-      operationId: bulk-request-diagnostics
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
-            schema:
-              type: object
-              properties:
-                additional_metrics:
-                  items:
-                    oneOf:
-                      - enum:
-                          - CPU
-                        type: string
-                  type: array
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                batchSize:
-                  type: number
-              required:
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk request diagnostics from agents
-      tags:
-        - Elastic Agents
-  /agents/bulk_unenroll:
-    post:
-      operationId: bulk-unenroll-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents:
-                - agent1
-                - agent2
-              force: false
-              revoke: true
-            schema:
-              type: object
-              properties:
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                force:
-                  description: Unenrolls hosted agents too
-                  type: boolean
-                includeInactive:
-                  description: >-
-                    When passing agents by KQL query, unenrolls inactive agents
-                    too
-                  type: boolean
-                revoke:
-                  description: Revokes API keys of agents
-                  type: boolean
-              required:
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk unenroll agents
-      tags:
-        - Elastic Agents
-  /agents/bulk_update_agent_tags:
-    post:
-      operationId: bulk-update-agent-tags
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents:
-                - agent1
-                - agent2
-              tagsToAdd:
-                - newTag
-              tagsToRemove:
-                - existingTag
-            schema:
-              type: object
-              properties:
-                agents:
-                  oneOf:
-                    - description: 'KQL query string, leave empty to action all agents'
-                      type: string
-                    - description: list of agent IDs
-                      items:
-                        type: string
-                      type: array
-                batchSize:
-                  type: number
-                tagsToAdd:
-                  items:
-                    type: string
-                  type: array
-                tagsToRemove:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - agents
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk update agent tags
-      tags:
-        - Elastic Agents
-  /agents/bulk_upgrade:
-    post:
-      operationId: bulk-upgrade-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            example:
-              agents:
-                - agent1
-                - agent2
-              rollout_duration_seconds: 3600
-              source_uri: 'https://artifacts.elastic.co/downloads/beats/elastic-agent'
-              start_time: 2022-08-03T14:00:00.000Z
-              version: 8.4.0
-            schema:
-              $ref: '#/components/schemas/Fleet_bulk_upgrade_agents'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  actionId:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk upgrade agents
-      tags:
-        - Elastic Agents
-  '/agents/files/{fileId}':
-    delete:
-      operationId: delete-agent-upload-file
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      deleted:
-                        type: boolean
-                      id:
-                        type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete file uploaded by agent
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: fileId
-        required: true
-        schema:
-          type: string
-  '/agents/files/{fileId}/{fileName}':
-    get:
-      operationId: get-agent-upload-file
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      items:
-                        type: object
-                        properties:
-                          body: {}
-                          headers: {}
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get file uploaded by agent
-      tags:
-        - Elastic Agents
-    parameters:
-      - in: path
-        name: fileId
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: fileName
-        required: true
-        schema:
-          type: string
-  /agents/setup:
-    get:
-      operationId: get-agents-setup-status
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_status_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get agent setup info
-      tags:
-        - Elastic Agents
-    post:
-      operationId: setup-agents
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                admin_password:
-                  type: string
-                admin_username:
-                  type: string
-              required:
-                - admin_username
-                - admin_password
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_setup_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Initiate agent setup
-      tags:
-        - Elastic Agents
-  /agents/tags:
-    get:
-      operationId: get-agent-tags
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_agent_tags_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List agent tags
-      tags:
-        - Elastic Agents
   /api/actions:
     get:
       deprecated: true
@@ -9647,6 +8138,3703 @@ paths:
       summary: Rotate a key for encrypted saved objects
       tags:
         - saved objects
+  /api/fleet/agent_download_sources:
+    get:
+      operationId: get-download-sources
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_download_sources'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent binary download sources
+      tags:
+        - Elastic Agent binary download sources
+    post:
+      operationId: post-download-sources
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host:
+                  type: string
+                id:
+                  type: string
+                is_default:
+                  type: boolean
+                name:
+                  type: string
+              required:
+                - name
+                - host
+                - is_default
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_download_sources'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create agent binary download source
+      tags:
+        - Elastic Agent binary download sources
+  '/api/fleet/agent_download_sources/{sourceId}':
+    delete:
+      operationId: delete-download-source
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete agent binary download source by ID
+      tags:
+        - Elastic Agent binary download sources
+    get:
+      operationId: get-one-download-source
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_download_sources'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent binary download source by ID
+      tags:
+        - Elastic Agent binary download sources
+    parameters:
+      - in: path
+        name: sourceId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-download-source
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host:
+                  type: string
+                is_default:
+                  type: boolean
+                name:
+                  type: string
+              required:
+                - name
+                - is_default
+                - host
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_download_sources'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update agent binary download source by ID
+      tags:
+        - Elastic Agent binary download sources
+  /api/fleet/agent_policies:
+    get:
+      description: ''
+      operationId: agent-policy-list
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+        - $ref: '#/components/parameters/Fleet_format'
+        - description: >-
+            When set to true, retrieve the related package policies for each
+            agent policy.
+          in: query
+          name: full
+          schema:
+            type: boolean
+        - description: >-
+            When set to true, do not count how many agents are in the agent
+            policy, this can improve performance if you are searching over a
+            large number of agent policies. The "agents" property will always be
+            0 if set to true.
+          in: query
+          name: noAgentCount
+          schema:
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_agent_policy'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+                  - page
+                  - perPage
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent policies
+      tags:
+        - Elastic Agent policies
+    post:
+      operationId: create-agent-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_agent_policy_create_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create agent policy
+      tags:
+        - Elastic Agent policies
+  /api/fleet/agent_policies/_bulk_get:
+    post:
+      operationId: bulk-get-agent-policies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                full:
+                  description: get full policies with package policies populated
+                  type: boolean
+                ids:
+                  description: list of agent policy ids
+                  items:
+                    type: string
+                  type: array
+                ignoreMissing:
+                  type: boolean
+              required:
+                - ids
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_agent_policy'
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk get agent policies
+      tags:
+        - Elastic Agent policies
+  '/api/fleet/agent_policies/{agentPolicyId}':
+    get:
+      description: Get one agent policy
+      operationId: agent-policy-info
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent policy by ID
+      tags:
+        - Elastic Agent policies
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/Fleet_format'
+    put:
+      operationId: update-agent-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_agent_policy_update_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update agent policy by ID
+      tags:
+        - Elastic Agent policies
+  '/api/fleet/agent_policies/{agentPolicyId}/copy':
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - $ref: '#/components/parameters/Fleet_format'
+    post:
+      operationId: agent-policy-copy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                name:
+                  type: string
+              required:
+                - name
+        description: ''
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Copy agent policy by ID
+      tags:
+        - Elastic Agent policies
+  '/api/fleet/agent_policies/{agentPolicyId}/download':
+    get:
+      operationId: agent-policy-download
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Download agent policy by ID
+      tags:
+        - Elastic Agent policies
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: download
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: standalone
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: kubernetes
+        required: false
+        schema:
+          type: string
+  '/api/fleet/agent_policies/{agentPolicyId}/full':
+    get:
+      operationId: agent-policy-full
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    oneOf:
+                      - type: string
+                      - $ref: '#/components/schemas/Fleet_agent_policy_full'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get full agent policy by ID
+      tags:
+        - Elastic Agent policies
+    parameters:
+      - in: path
+        name: agentPolicyId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: download
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: standalone
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: kubernetes
+        required: false
+        schema:
+          type: string
+  /api/fleet/agent_policies/delete:
+    parameters: []
+    post:
+      operationId: delete-agent-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                agentPolicyId:
+                  type: string
+                force:
+                  description: >-
+                    bypass validation checks that can prevent agent policy
+                    deletion
+                  type: boolean
+              required:
+                - agentPolicyId
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - id
+                  - success
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete agent policy by ID
+      tags:
+        - Elastic Agent policies
+  /api/fleet/agent_status:
+    get:
+      operationId: get-agent-status
+      parameters:
+        - in: query
+          name: policyId
+          required: false
+          schema:
+            type: string
+        - deprecated: true
+          in: query
+          name: kuery
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  active:
+                    type: integer
+                  all:
+                    type: integer
+                  error:
+                    type: integer
+                  events:
+                    type: integer
+                  inactive:
+                    type: integer
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  other:
+                    type: integer
+                  total:
+                    deprecated: true
+                    type: integer
+                  unenrolled:
+                    type: integer
+                  updating:
+                    type: integer
+                required:
+                  - active
+                  - all
+                  - error
+                  - events
+                  - inactive
+                  - offline
+                  - online
+                  - other
+                  - total
+                  - updating
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent status summary
+      tags:
+        - Elastic Agent status
+  /api/fleet/agent_status/data:
+    get:
+      operationId: get-agent-data
+      parameters:
+        - in: query
+          name: agentsIds
+          required: true
+          schema:
+            items:
+              type: string
+            type: array
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      additionalProperties:
+                        type: object
+                        properties:
+                          data:
+                            type: boolean
+                      type: object
+                    type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get incoming agent data
+      tags:
+        - Elastic Agent status
+  /api/fleet/agent-status:
+    get:
+      deprecated: true
+      operationId: get-agent-status-deprecated
+      parameters:
+        - in: query
+          name: policyId
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: integer
+                  events:
+                    type: integer
+                  inactive:
+                    type: integer
+                  offline:
+                    type: integer
+                  online:
+                    type: integer
+                  other:
+                    type: integer
+                  total:
+                    type: integer
+                  updating:
+                    type: integer
+                required:
+                  - error
+                  - events
+                  - inactive
+                  - offline
+                  - online
+                  - other
+                  - total
+                  - updating
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent status summary
+      tags:
+        - Elastic Agent status
+  /api/fleet/agents:
+    get:
+      operationId: get-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+        - $ref: '#/components/parameters/Fleet_show_inactive'
+        - $ref: '#/components/parameters/Fleet_show_upgradeable'
+        - $ref: '#/components/parameters/Fleet_sort_field'
+        - $ref: '#/components/parameters/Fleet_sort_order'
+        - $ref: '#/components/parameters/Fleet_with_metrics'
+        - in: query
+          name: getStatusSummary
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_agents_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agents
+      tags:
+        - Elastic Agents
+    post:
+      operationId: get-agents-by-actions
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                actionIds:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - policy_id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_agent_get_by_actions'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agents by action ids
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}':
+    delete:
+      operationId: delete-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - deleted
+                    type: string
+                required:
+                  - action
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete agent by ID
+      tags:
+        - Elastic Agents
+    get:
+      operationId: get-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_with_metrics'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent by ID
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                tags:
+                  items:
+                    type: string
+                  type: array
+                user_provided_metadata:
+                  type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update agent by ID
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/actions':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: new-agent-action
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                action:
+                  $ref: '#/components/schemas/Fleet_agent_action'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    items:
+                      type: number
+                    type: array
+                  headers:
+                    type: string
+                  statusCode:
+                    type: number
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create agent action
+      tags:
+        - Elastic Agent actions
+  '/api/fleet/agents/{agentId}/reassign':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: reassign-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+              required:
+                - policy_id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Reassign agent
+      tags:
+        - Elastic Agents
+    put:
+      deprecated: true
+      operationId: reassign-agent-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                policy_id:
+                  type: string
+              required:
+                - policy_id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Reassign agent
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/request_diagnostics':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: request-diagnostics-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                additional_metrics:
+                  items:
+                    oneOf:
+                      - enum:
+                          - CPU
+                        type: string
+                  type: array
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Request agent diagnostics
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/unenroll':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: unenroll-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                revoke:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+          description: OK
+        '400':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+                  statusCode:
+                    enum:
+                      - 400
+                    type: number
+          description: BAD REQUEST
+      summary: Unenroll agent
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/upgrade':
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: upgrade-agent
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_upgrade_agent'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_upgrade_agent'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Upgrade agent
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/{agentId}/uploads':
+    get:
+      operationId: list-agent-uploads
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      item:
+                        items:
+                          $ref: '#/components/schemas/Fleet_agent_diagnostics'
+                        type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent uploads
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+  /api/fleet/agents/action_status:
+    get:
+      operationId: agents-action-status
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - in: query
+          name: errorSize
+          schema:
+            default: 5
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        actionId:
+                          type: string
+                        cancellationTime:
+                          type: string
+                        completionTime:
+                          type: string
+                        creationTime:
+                          description: creation time of action
+                          type: string
+                        expiration:
+                          type: string
+                        latestErrors:
+                          description: >-
+                            latest errors that happened when the agents executed
+                            the action
+                          items:
+                            type: object
+                            properties:
+                              agentId:
+                                type: string
+                              error:
+                                type: string
+                              timestamp:
+                                type: string
+                          type: array
+                        nbAgentsAck:
+                          description: number of agents that acknowledged the action
+                          type: number
+                        nbAgentsActionCreated:
+                          description: number of agents included in action from kibana
+                          type: number
+                        nbAgentsActioned:
+                          description: number of agents actioned
+                          type: number
+                        nbAgentsFailed:
+                          description: number of agents that failed to execute the action
+                          type: number
+                        newPolicyId:
+                          description: new policy id (POLICY_REASSIGN action)
+                          type: string
+                        policyId:
+                          description: policy id (POLICY_CHANGE action)
+                          type: string
+                        revision:
+                          description: new policy revision (POLICY_CHANGE action)
+                          type: string
+                        startTime:
+                          description: start time of action (scheduled actions)
+                          type: string
+                        status:
+                          enum:
+                            - COMPLETE
+                            - EXPIRED
+                            - CANCELLED
+                            - FAILED
+                            - IN_PROGRESS
+                            - ROLLOUT_PASSED
+                          type: string
+                        type:
+                          enum:
+                            - POLICY_REASSIGN
+                            - UPGRADE
+                            - UNENROLL
+                            - FORCE_UNENROLL
+                            - UPDATE_TAGS
+                            - CANCEL
+                            - REQUEST_DIAGNOSTICS
+                            - SETTINGS
+                            - POLICY_CHANGE
+                            - INPUT_ACTION
+                          type: string
+                        version:
+                          description: agent version number (UPGRADE action)
+                          type: string
+                      required:
+                        - actionId
+                        - complete
+                        - nbAgentsActioned
+                        - nbAgentsActionCreated
+                        - nbAgentsAck
+                        - nbAgentsFailed
+                        - status
+                        - creationTime
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent action status
+      tags:
+        - Elastic Agent actions
+  '/api/fleet/agents/actions/{actionId}/cancel':
+    parameters:
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: agent-action-cancel
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_agent_action'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Cancel agent action
+      tags:
+        - Elastic Agent actions
+  /api/fleet/agents/bulk_reassign:
+    post:
+      operationId: bulk-reassign-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
+              policy_id: policy_id
+            schema:
+              type: object
+              properties:
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                policy_id:
+                  description: new agent policy id
+                  type: string
+              required:
+                - policy_id
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk reassign agents
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_request_diagnostics:
+    post:
+      operationId: bulk-request-diagnostics
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
+            schema:
+              type: object
+              properties:
+                additional_metrics:
+                  items:
+                    oneOf:
+                      - enum:
+                          - CPU
+                        type: string
+                  type: array
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                batchSize:
+                  type: number
+              required:
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk request diagnostics from agents
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_unenroll:
+    post:
+      operationId: bulk-unenroll-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents:
+                - agent1
+                - agent2
+              force: false
+              revoke: true
+            schema:
+              type: object
+              properties:
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                force:
+                  description: Unenrolls hosted agents too
+                  type: boolean
+                includeInactive:
+                  description: >-
+                    When passing agents by KQL query, unenrolls inactive agents
+                    too
+                  type: boolean
+                revoke:
+                  description: Revokes API keys of agents
+                  type: boolean
+              required:
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk unenroll agents
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_update_agent_tags:
+    post:
+      operationId: bulk-update-agent-tags
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents:
+                - agent1
+                - agent2
+              tagsToAdd:
+                - newTag
+              tagsToRemove:
+                - existingTag
+            schema:
+              type: object
+              properties:
+                agents:
+                  oneOf:
+                    - description: 'KQL query string, leave empty to action all agents'
+                      type: string
+                    - description: list of agent IDs
+                      items:
+                        type: string
+                      type: array
+                batchSize:
+                  type: number
+                tagsToAdd:
+                  items:
+                    type: string
+                  type: array
+                tagsToRemove:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - agents
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk update agent tags
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/bulk_upgrade:
+    post:
+      operationId: bulk-upgrade-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            example:
+              agents:
+                - agent1
+                - agent2
+              rollout_duration_seconds: 3600
+              source_uri: 'https://artifacts.elastic.co/downloads/beats/elastic-agent'
+              start_time: '2022-08-03T14:00:00.000Z'
+              version: 8.4.0
+            schema:
+              $ref: '#/components/schemas/Fleet_bulk_upgrade_agents'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  actionId:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk upgrade agents
+      tags:
+        - Elastic Agents
+  '/api/fleet/agents/files/{fileId}':
+    delete:
+      operationId: delete-agent-upload-file
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      deleted:
+                        type: boolean
+                      id:
+                        type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete file uploaded by agent
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: fileId
+        required: true
+        schema:
+          type: string
+  '/api/fleet/agents/files/{fileId}/{fileName}':
+    get:
+      operationId: get-agent-upload-file
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      items:
+                        type: object
+                        properties:
+                          body: {}
+                          headers: {}
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get file uploaded by agent
+      tags:
+        - Elastic Agents
+    parameters:
+      - in: path
+        name: fileId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fileName
+        required: true
+        schema:
+          type: string
+  /api/fleet/agents/setup:
+    get:
+      operationId: get-agents-setup-status
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_status_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get agent setup info
+      tags:
+        - Elastic Agents
+    post:
+      operationId: setup-agents
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                admin_password:
+                  type: string
+                admin_username:
+                  type: string
+              required:
+                - admin_username
+                - admin_password
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_setup_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Initiate agent setup
+      tags:
+        - Elastic Agents
+  /api/fleet/agents/tags:
+    get:
+      operationId: get-agent-tags
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_agent_tags_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List agent tags
+      tags:
+        - Elastic Agents
+  /api/fleet/data_streams:
+    get:
+      operationId: data-streams-list
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  data_streams:
+                    items:
+                      $ref: '#/components/schemas/Fleet_data_stream'
+                    type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List data streams
+      tags:
+        - Data streams
+    parameters: []
+  /api/fleet/enrollment_api_keys:
+    get:
+      operationId: get-enrollment-api-keys
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  list:
+                    deprecated: true
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - page
+                  - perPage
+                  - total
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List enrollment API keys
+      tags:
+        - Fleet enrollment API keys
+    post:
+      operationId: create-enrollment-api-keys
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name of the enrollment API key. Must be unique.
+                  type: string
+                policy_id:
+                  description: >-
+                    The ID of the agent policy the Elastic Agent will be
+                    enrolled in.
+                  type: string
+              required:
+                - policy_id
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - created
+                    type: string
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create enrollment API key
+      tags:
+        - Fleet enrollment API keys
+  '/api/fleet/enrollment_api_keys/{keyId}':
+    delete:
+      operationId: delete-enrollment-api-key
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - deleted
+                    type: string
+                required:
+                  - action
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Revoke enrollment API key by ID by marking it as inactive
+      tags:
+        - Fleet enrollment API keys
+    get:
+      operationId: get-enrollment-api-key
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get enrollment API key by ID
+      tags:
+        - Fleet enrollment API keys
+    parameters:
+      - in: path
+        name: keyId
+        required: true
+        schema:
+          type: string
+  /api/fleet/enrollment-api-keys:
+    get:
+      deprecated: true
+      operationId: get-enrollment-api-keys-deprecated
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  list:
+                    deprecated: true
+                    items:
+                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - page
+                  - perPage
+                  - total
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List enrollment API keys
+      tags:
+        - Fleet enrollment API keys
+    post:
+      deprecated: true
+      operationId: create-enrollment-api-keys-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - created
+                    type: string
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create enrollment API key
+      tags:
+        - Fleet enrollment API keys
+  '/api/fleet/enrollment-api-keys/{keyId}':
+    delete:
+      deprecated: true
+      operationId: delete-enrollment-api-key-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  action:
+                    enum:
+                      - deleted
+                    type: string
+                required:
+                  - action
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete enrollment API key by ID
+      tags:
+        - Fleet enrollment API keys
+    get:
+      deprecated: true
+      operationId: get-enrollment-api-key-deprecated
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get enrollment API key by ID
+      tags:
+        - Fleet enrollment API keys
+    parameters:
+      - in: path
+        name: keyId
+        required: true
+        schema:
+          type: string
+  /api/fleet/epm/bulk_assets:
+    post:
+      operationId: bulk-get-assets
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                assetIds:
+                  description: list of items necessary to fetch assets
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                  type: array
+              required:
+                - assetIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_bulk_assets_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk get assets
+      tags:
+        - Elastic Package Manager (EPM)
+  /api/fleet/epm/categories:
+    get:
+      operationId: get-package-categories
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_categories_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List package categories
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - description: >-
+          Whether to include prerelease packages in categories count (e.g. beta,
+          rc, preview)
+        in: query
+        name: prerelease
+        schema:
+          default: false
+          type: boolean
+      - deprecated: true
+        in: query
+        name: experimental
+        schema:
+          default: false
+          type: boolean
+      - in: query
+        name: include_policy_templates
+        schema:
+          default: false
+          type: boolean
+  /api/fleet/epm/packages:
+    get:
+      operationId: list-all-packages
+      parameters:
+        - description: >-
+            Whether to exclude the install status of each package. Enabling this
+            option will opt in to caching for the response via `cache-control`
+            headers. If you don't need up-to-date installation info for a
+            package, and are querying for a list of available packages,
+            providing this flag can improve performance substantially.
+          in: query
+          name: excludeInstallStatus
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+        - deprecated: true
+          in: query
+          name: experimental
+          schema:
+            default: false
+            type: boolean
+        - in: query
+          name: category
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_get_packages_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List packages
+      tags:
+        - Elastic Package Manager (EPM)
+    post:
+      description: ''
+      operationId: install-package-by-upload
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - description: avoid erroring out on unexpected mapping update errors
+          in: query
+          name: ignoreMappingUpdateErrors
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
+          in: query
+          name: skipDataStreamRollover
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/gzip; Elastic-Api-Version=2023-10-31:
+            schema:
+              format: binary
+              type: string
+          application/zip; Elastic-Api-Version=2023-10-31:
+            schema:
+              format: binary
+              type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  _meta:
+                    type: object
+                    properties:
+                      install_source:
+                        enum:
+                          - upload
+                          - registry
+                          - bundled
+                        type: string
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '429':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Install by package by direct upload
+      tags:
+        - Elastic Package Manager (EPM)
+  /api/fleet/epm/packages/_bulk:
+    post:
+      operationId: bulk-install-packages
+      parameters:
+        - description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  description: force install to ignore package verification errors
+                  type: boolean
+                packages:
+                  description: list of packages to install
+                  items:
+                    oneOf:
+                      - description: package name
+                        type: string
+                      - type: object
+                        properties:
+                          name:
+                            description: package name
+                            type: string
+                          version:
+                            description: package version
+                            type: string
+                  type: array
+              required:
+                - packages
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_bulk_install_packages_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk install packages
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgkey}':
+    delete:
+      deprecated: true
+      operationId: delete-package-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - in: path
+          name: pkgkey
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  response:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - response
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete ackage
+      tags:
+        - Elastic Package Manager (EPM)
+    get:
+      deprecated: true
+      operationId: get-package-deprecated
+      parameters:
+        - in: path
+          name: pkgkey
+          required: true
+          schema:
+            type: string
+        - description: >-
+            Whether to return prerelease versions of packages (e.g. beta, rc,
+            preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                allOf:
+                  - properties:
+                      response:
+                        $ref: '#/components/schemas/Fleet_package_info'
+                  - properties:
+                      savedObject:
+                        type: string
+                      status:
+                        enum:
+                          - installed
+                          - installing
+                          - install_failed
+                          - not_installed
+                        type: string
+                    required:
+                      - status
+                      - savedObject
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package
+      tags:
+        - Elastic Package Manager (EPM)
+    post:
+      deprecated: true
+      description: ''
+      operationId: install-package-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - in: path
+          name: pkgkey
+          required: true
+          schema:
+            type: string
+        - description: avoid erroring out on unexpected mapping update errors
+          in: query
+          name: ignoreMappingUpdateErrors
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
+          in: query
+          name: skipDataStreamRollover
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  response:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - response
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Install package
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}':
+    delete:
+      operationId: delete-package
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - description: delete package even if policies used by agents
+          in: query
+          name: force
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              deprecated: true
+              type: object
+              properties:
+                force:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete package
+      tags:
+        - Elastic Package Manager (EPM)
+    get:
+      operationId: get-package
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                allOf:
+                  - properties:
+                      item:
+                        $ref: '#/components/schemas/Fleet_package_info'
+                  - properties:
+                      keepPoliciesUpToDate:
+                        type: boolean
+                      latestVersion:
+                        type: string
+                      licensePath:
+                        type: string
+                      notice:
+                        type: string
+                      savedObject:
+                        deprecated: true
+                        type: object
+                      status:
+                        enum:
+                          - installed
+                          - installing
+                          - install_failed
+                          - not_installed
+                        type: string
+                    required:
+                      - status
+                      - savedObject
+                type: object
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pkgVersion
+        required: true
+        schema:
+          type: string
+      - description: Ignore if the package is fails signature verification
+        in: query
+        name: ignoreUnverified
+        schema:
+          type: boolean
+      - description: >-
+          Return all fields from the package manifest, not just those supported
+          by the Elastic Package Registry
+        in: query
+        name: full
+        schema:
+          type: boolean
+      - description: >-
+          Whether to return prerelease versions of packages (e.g. beta, rc,
+          preview)
+        in: query
+        name: prerelease
+        schema:
+          default: false
+          type: boolean
+    post:
+      description: ''
+      operationId: install-package
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - description: avoid erroring out on unexpected mapping update errors
+          in: query
+          name: ignoreMappingUpdateErrors
+          schema:
+            default: false
+            type: boolean
+        - description: >-
+            Skip data stream rollover during index template mapping or settings
+            update
+          in: query
+          name: skipDataStreamRollover
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                ignore_constraints:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  _meta:
+                    type: object
+                    properties:
+                      install_source:
+                        enum:
+                          - registry
+                          - upload
+                          - bundled
+                        type: string
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Install package
+      tags:
+        - Elastic Package Manager (EPM)
+    put:
+      description: ''
+      operationId: update-package
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                keepPoliciesUpToDate:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          oneOf:
+                            - $ref: >-
+                                #/components/schemas/Fleet_kibana_saved_object_type
+                            - $ref: >-
+                                #/components/schemas/Fleet_elasticsearch_asset_type
+                      required:
+                        - id
+                        - type
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update package settings
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
+    get:
+      operationId: packages-get-file
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                  headers:
+                    type: object
+                  statusCode:
+                    type: number
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package file
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pkgVersion
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: filePath
+        required: true
+        schema:
+          type: string
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
+    post:
+      description: ''
+      operationId: reauthorize-transforms
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - in: path
+          name: pkgName
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: pkgVersion
+          required: true
+          schema:
+            type: string
+        - description: >-
+            Whether to include prerelease packages in categories count (e.g.
+            beta, rc, preview)
+          in: query
+          name: prerelease
+          schema:
+            default: false
+            type: boolean
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                transforms:
+                  items:
+                    type: object
+                    properties:
+                      transformId:
+                        type: string
+                  type: array
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        error:
+                          type: string
+                        success:
+                          type: boolean
+                        transformId:
+                          type: string
+                      required:
+                        - transformId
+                        - error
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Authorize transforms
+      tags:
+        - Elastic Package Manager (EPM)
+  '/api/fleet/epm/packages/{pkgName}/stats':
+    get:
+      operationId: get-package-stats
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  response:
+                    $ref: '#/components/schemas/Fleet_package_usage_stats'
+                required:
+                  - response
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package stats
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+  /api/fleet/epm/packages/limited:
+    get:
+      operationId: list-limited-packages
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: string
+                    type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get limited package list
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters: []
+  '/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs':
+    get:
+      operationId: get-inputs-template
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get inputs template
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters:
+      - in: path
+        name: pkgName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pkgVersion
+        required: true
+        schema:
+          type: string
+      - description: Format of response - json or yaml
+        in: query
+        name: format
+        schema:
+          enum:
+            - json
+            - yaml
+            - yml
+          type: string
+      - description: Specify if version is prerelease
+        in: query
+        name: prerelease
+        schema:
+          type: boolean
+      - description: Ignore if the package is fails signature verification
+        in: query
+        name: ignoreUnverified
+        schema:
+          type: boolean
+  /api/fleet/epm/verification_key_id:
+    get:
+      operationId: packages-get-verification-key-id
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  body:
+                    type: object
+                    properties:
+                      id:
+                        description: >-
+                          the key ID of the GPG key used to verify package
+                          signatures
+                        nullable: true
+                        type: string
+                  headers:
+                    type: object
+                  statusCode:
+                    type: number
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package signature verification key ID
+      tags:
+        - Elastic Package Manager (EPM)
+    parameters: []
+  /api/fleet/fleet_server_hosts:
+    get:
+      operationId: get-fleet-server-hosts
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_fleet_server_host'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List Fleet Server hosts
+      tags:
+        - Fleet Server hosts
+    post:
+      operationId: post-fleet-server-hosts
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host_urls:
+                  items:
+                    type: string
+                  type: array
+                id:
+                  type: string
+                is_default:
+                  type: boolean
+                is_internal:
+                  type: boolean
+                name:
+                  type: string
+                proxy_id:
+                  description: >-
+                    The ID of the proxy to use for this fleet server host. See
+                    the proxies API for more information.
+                  type: string
+              required:
+                - name
+                - host_urls
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_fleet_server_host'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create Fleet Server host
+      tags:
+        - Fleet Server hosts
+  '/api/fleet/fleet_server_hosts/{itemId}':
+    delete:
+      operationId: delete-fleet-server-hosts
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete Fleet Server host by ID
+      tags:
+        - Fleet Server hosts
+    get:
+      operationId: get-one-fleet-server-hosts
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_fleet_server_host'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get Fleet Server host by ID
+      tags:
+        - Fleet Server hosts
+    parameters:
+      - in: path
+        name: itemId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-fleet-server-hosts
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host_urls:
+                  items:
+                    type: string
+                  type: array
+                is_default:
+                  type: boolean
+                is_internal:
+                  type: boolean
+                name:
+                  type: string
+                proxy_id:
+                  description: >-
+                    The ID of the proxy to use for this fleet server host. See
+                    the proxies API for more information.
+                  nullable: true
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_fleet_server_host'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update Fleet Server host by ID
+      tags:
+        - Fleet Server hosts
+  /api/fleet/health_check:
+    post:
+      operationId: fleet-server-health-check
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                host:
+                  deprecated: true
+                  type: string
+                id:
+                  type: string
+              required:
+                - id
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  host:
+                    deprecated: true
+                    type: string
+                  id:
+                    description: Fleet Server host id
+                    type: string
+                  status:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Fleet Server health check
+      tags:
+        - Fleet internals
+  /api/fleet/kubernetes:
+    get:
+      operationId: get-full-k8s-manifest
+      parameters:
+        - in: query
+          name: download
+          required: false
+          schema:
+            type: boolean
+        - in: query
+          name: fleetServer
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: enrolToken
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get full K8s agent manifest
+      tags:
+        - Fleet Kubernetes
+  /api/fleet/logstash_api_keys:
+    post:
+      operationId: generate-logstash-api-key
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  api_key:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Generate Logstash API key
+      tags:
+        - Fleet outputs
+  /api/fleet/outputs:
+    get:
+      operationId: get-outputs
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_output_create_request'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List outputs
+      tags:
+        - Fleet outputs
+    post:
+      operationId: post-outputs
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_output_create_request'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_output_create_request'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create output
+      tags:
+        - Fleet outputs
+  '/api/fleet/outputs/{outputId}':
+    delete:
+      operationId: delete-output
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete output by ID
+      tags:
+        - Fleet outputs
+    get:
+      operationId: get-output
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_output_create_request'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get output by ID
+      tags:
+        - Fleet outputs
+    parameters:
+      - in: path
+        name: outputId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-output
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_output_update_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_output_update_request'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update output by ID
+      tags:
+        - Fleet outputs
+  '/api/fleet/outputs/{outputId}/health':
+    get:
+      operationId: get-output-health
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: long message if unhealthy
+                    type: string
+                  state:
+                    description: 'state of output, HEALTHY or DEGRADED'
+                    type: string
+                  timestamp:
+                    description: timestamp of reported state
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get latest output health
+      tags:
+        - Fleet outputs
+    parameters:
+      - in: path
+        name: outputId
+        required: true
+        schema:
+          type: string
+  /api/fleet/package_policies:
+    get:
+      operationId: get-package-policies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_page_size'
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - $ref: '#/components/parameters/Fleet_kuery'
+        - $ref: '#/components/parameters/Fleet_format'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_package_policy'
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List package policies
+      tags:
+        - Fleet package policies
+    parameters: []
+    post:
+      operationId: create-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_package_policy_request'
+        description: >-
+          You should use inputs as an object and not use the deprecated inputs
+          array.
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_package_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '409':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create package policy
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/_bulk_get:
+    post:
+      operationId: bulk-get-package-policies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                ids:
+                  description: list of package policy ids
+                  items:
+                    type: string
+                  type: array
+                ignoreMissing:
+                  type: boolean
+              required:
+                - ids
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_package_policy'
+                    type: array
+                required:
+                  - items
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Bulk get package policies
+      tags:
+        - Fleet package policies
+  '/api/fleet/package_policies/{packagePolicyId}':
+    delete:
+      operationId: delete-package-policy
+      parameters:
+        - in: query
+          name: force
+          schema:
+            type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete package policy by ID
+      tags:
+        - Fleet package policies
+    get:
+      operationId: get-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_format'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_package_policy'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get package policy by ID
+      tags:
+        - Fleet package policies
+    parameters:
+      - in: path
+        name: packagePolicyId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+        - $ref: '#/components/parameters/Fleet_format'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Fleet_package_policy_request'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_package_policy'
+                  sucess:
+                    type: boolean
+                required:
+                  - item
+                  - sucess
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update package policy by ID
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/delete:
+    post:
+      operationId: post-delete-package-policy
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                force:
+                  type: boolean
+                packagePolicyIds:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    success:
+                      type: boolean
+                  required:
+                    - id
+                    - success
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete package policy
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/upgrade:
+    post:
+      operationId: upgrade-package-policy
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                packagePolicyIds:
+                  items:
+                    type: string
+                  type: array
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    success:
+                      type: boolean
+                  required:
+                    - id
+                    - success
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '409':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Upgrade package policy to a newer package version
+      tags:
+        - Fleet package policies
+  /api/fleet/package_policies/upgrade/dryrun:
+    post:
+      operationId: upgrade-package-policy-dry-run
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                packagePolicyIds:
+                  items:
+                    type: string
+                  type: array
+                packageVersion:
+                  type: string
+              required:
+                - packagePolicyIds
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                items:
+                  type: object
+                  properties:
+                    agent_diff:
+                      $ref: '#/components/schemas/Fleet_upgrade_agent_diff'
+                    diff:
+                      $ref: '#/components/schemas/Fleet_upgrade_diff'
+                    hasErrors:
+                      type: boolean
+                  required:
+                    - hasErrors
+                type: array
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Dry run package policy upgrade
+      tags:
+        - Fleet package policies
+  /api/fleet/proxies:
+    get:
+      operationId: get-fleet-proxies
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      $ref: '#/components/schemas/Fleet_proxies'
+                    type: array
+                  page:
+                    type: integer
+                  perPage:
+                    type: integer
+                  total:
+                    type: integer
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List proxies
+      tags:
+        - Fleet proxies
+    post:
+      operationId: post-fleet-proxies
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                certificate:
+                  type: string
+                certificate_authorities:
+                  type: string
+                certificate_key:
+                  type: string
+                id:
+                  type: string
+                name:
+                  type: string
+                proxy_headers:
+                  type: object
+                url:
+                  type: string
+              required:
+                - name
+                - url
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_proxies'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create proxy
+      tags:
+        - Fleet proxies
+  '/api/fleet/proxies/{itemId}':
+    delete:
+      operationId: delete-fleet-proxies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                required:
+                  - id
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Delete proxy by ID
+      tags:
+        - Fleet proxies
+    get:
+      operationId: get-one-fleet-proxies
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_proxies'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get proxy by ID
+      tags:
+        - Fleet proxies
+    parameters:
+      - in: path
+        name: itemId
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: update-fleet-proxies
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                certificate:
+                  type: string
+                certificate_authorities:
+                  type: string
+                certificate_key:
+                  type: string
+                name:
+                  type: string
+                proxy_headers:
+                  type: object
+                url:
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/Fleet_proxies'
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update proxy by ID
+      tags:
+        - Fleet proxies
+  /api/fleet/service_tokens:
+    post:
+      operationId: generate-service-token
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create service token
+      tags:
+        - Fleet service tokens
+  /api/fleet/service-tokens:
+    post:
+      deprecated: true
+      operationId: generate-service-token-deprecated
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Create service token
+      tags:
+        - Fleet service tokens
+  /api/fleet/settings:
+    get:
+      operationId: get-settings
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_settings_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get settings
+      tags:
+        - Fleet internals
+    put:
+      operationId: update-settings
+      requestBody:
+        content:
+          application/json; Elastic-Api-Version=2023-10-31:
+            schema:
+              type: object
+              properties:
+                additional_yaml_config:
+                  type: string
+                fleet_server_hosts:
+                  description: Protocol and path must be the same for each URL
+                  items:
+                    type: string
+                  type: array
+                has_seen_add_data_notice:
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_settings_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Update settings
+      tags:
+        - Fleet internals
+  /api/fleet/setup:
+    post:
+      operationId: setup
+      parameters:
+        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Fleet_fleet_setup_response'
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+        '500':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+          description: Internal Server Error
+      summary: Initiate Fleet setup
+      tags:
+        - Fleet internals
+  /api/fleet/uninstall_tokens:
+    get:
+      operationId: get-uninstall-tokens
+      parameters:
+        - description: The number of items to return
+          in: query
+          name: perPage
+          required: false
+          schema:
+            default: 20
+            minimum: 5
+            type: integer
+        - $ref: '#/components/parameters/Fleet_page_index'
+        - description: Partial match filtering for policy IDs
+          in: query
+          name: policyId
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  items:
+                    items:
+                      type: object
+                      properties:
+                        created_at:
+                          type: string
+                        id:
+                          type: string
+                        policy_id:
+                          type: string
+                      required:
+                        - id
+                        - policy_id
+                        - created_at
+                    type: array
+                  page:
+                    type: number
+                  perPage:
+                    type: number
+                  total:
+                    type: number
+                required:
+                  - items
+                  - total
+                  - page
+                  - perPage
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: List metadata for latest uninstall tokens per agent policy
+      tags:
+        - Fleet uninstall tokens
+  '/api/fleet/uninstall_tokens/{uninstallTokenId}':
+    get:
+      operationId: get-uninstall-token
+      parameters:
+        - in: path
+          name: uninstallTokenId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                type: object
+                properties:
+                  item:
+                    type: object
+                    properties:
+                      created_at:
+                        type: string
+                      id:
+                        type: string
+                      policy_id:
+                        type: string
+                      token:
+                        type: string
+                    required:
+                      - id
+                      - token
+                      - policy_id
+                      - created_at
+                required:
+                  - item
+          description: OK
+        '400':
+          $ref: '#/components/responses/Fleet_error'
+      summary: Get one decrypted uninstall token by its ID
+      tags:
+        - Fleet uninstall tokens
   /api/ml/saved_objects/sync:
     get:
       description: >
@@ -10602,1981 +12790,6 @@ paths:
       summary: Get Kibana's current status
       tags:
         - system
-  /data_streams:
-    get:
-      operationId: data-streams-list
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  data_streams:
-                    items:
-                      $ref: '#/components/schemas/Fleet_data_stream'
-                    type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List data streams
-      tags:
-        - Data streams
-    parameters: []
-  /enrollment_api_keys:
-    get:
-      operationId: get-enrollment-api-keys
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  list:
-                    deprecated: true
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - page
-                  - perPage
-                  - total
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List enrollment API keys
-      tags:
-        - Fleet enrollment API keys
-    post:
-      operationId: create-enrollment-api-keys
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                name:
-                  description: The name of the enrollment API key. Must be unique.
-                  type: string
-                policy_id:
-                  description: >-
-                    The ID of the agent policy the Elastic Agent will be
-                    enrolled in.
-                  type: string
-              required:
-                - policy_id
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - created
-                    type: string
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create enrollment API key
-      tags:
-        - Fleet enrollment API keys
-  '/enrollment_api_keys/{keyId}':
-    delete:
-      operationId: delete-enrollment-api-key
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - deleted
-                    type: string
-                required:
-                  - action
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Revoke enrollment API key by ID by marking it as inactive
-      tags:
-        - Fleet enrollment API keys
-    get:
-      operationId: get-enrollment-api-key
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get enrollment API key by ID
-      tags:
-        - Fleet enrollment API keys
-    parameters:
-      - in: path
-        name: keyId
-        required: true
-        schema:
-          type: string
-  /enrollment-api-keys:
-    get:
-      deprecated: true
-      operationId: get-enrollment-api-keys-deprecated
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  list:
-                    deprecated: true
-                    items:
-                      $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - page
-                  - perPage
-                  - total
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List enrollment API keys
-      tags:
-        - Fleet enrollment API keys
-    post:
-      deprecated: true
-      operationId: create-enrollment-api-keys-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - created
-                    type: string
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create enrollment API key
-      tags:
-        - Fleet enrollment API keys
-  '/enrollment-api-keys/{keyId}':
-    delete:
-      deprecated: true
-      operationId: delete-enrollment-api-key-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  action:
-                    enum:
-                      - deleted
-                    type: string
-                required:
-                  - action
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete enrollment API key by ID
-      tags:
-        - Fleet enrollment API keys
-    get:
-      deprecated: true
-      operationId: get-enrollment-api-key-deprecated
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_enrollment_api_key'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get enrollment API key by ID
-      tags:
-        - Fleet enrollment API keys
-    parameters:
-      - in: path
-        name: keyId
-        required: true
-        schema:
-          type: string
-  /epm/bulk_assets:
-    post:
-      operationId: bulk-get-assets
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                assetIds:
-                  description: list of items necessary to fetch assets
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      type:
-                        type: string
-                  type: array
-              required:
-                - assetIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_bulk_assets_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk get assets
-      tags:
-        - Elastic Package Manager (EPM)
-  /epm/categories:
-    get:
-      operationId: get-package-categories
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_categories_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List package categories
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - description: >-
-          Whether to include prerelease packages in categories count (e.g. beta,
-          rc, preview)
-        in: query
-        name: prerelease
-        schema:
-          default: false
-          type: boolean
-      - deprecated: true
-        in: query
-        name: experimental
-        schema:
-          default: false
-          type: boolean
-      - in: query
-        name: include_policy_templates
-        schema:
-          default: false
-          type: boolean
-  /epm/packages:
-    get:
-      operationId: list-all-packages
-      parameters:
-        - description: >-
-            Whether to exclude the install status of each package. Enabling this
-            option will opt in to caching for the response via `cache-control`
-            headers. If you don't need up-to-date installation info for a
-            package, and are querying for a list of available packages,
-            providing this flag can improve performance substantially.
-          in: query
-          name: excludeInstallStatus
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-        - deprecated: true
-          in: query
-          name: experimental
-          schema:
-            default: false
-            type: boolean
-        - in: query
-          name: category
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_get_packages_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List packages
-      tags:
-        - Elastic Package Manager (EPM)
-    post:
-      description: ''
-      operationId: install-package-by-upload
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - description: avoid erroring out on unexpected mapping update errors
-          in: query
-          name: ignoreMappingUpdateErrors
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
-          in: query
-          name: skipDataStreamRollover
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/gzip; Elastic-Api-Version=2023-10-31:
-            schema:
-              format: binary
-              type: string
-          application/zip; Elastic-Api-Version=2023-10-31:
-            schema:
-              format: binary
-              type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  _meta:
-                    type: object
-                    properties:
-                      install_source:
-                        enum:
-                          - upload
-                          - registry
-                          - bundled
-                        type: string
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '429':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Install by package by direct upload
-      tags:
-        - Elastic Package Manager (EPM)
-  /epm/packages/_bulk:
-    post:
-      operationId: bulk-install-packages
-      parameters:
-        - description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  description: force install to ignore package verification errors
-                  type: boolean
-                packages:
-                  description: list of packages to install
-                  items:
-                    oneOf:
-                      - description: package name
-                        type: string
-                      - type: object
-                        properties:
-                          name:
-                            description: package name
-                            type: string
-                          version:
-                            description: package version
-                            type: string
-                  type: array
-              required:
-                - packages
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_bulk_install_packages_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk install packages
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgkey}':
-    delete:
-      deprecated: true
-      operationId: delete-package-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - in: path
-          name: pkgkey
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  response:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - response
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete ackage
-      tags:
-        - Elastic Package Manager (EPM)
-    get:
-      deprecated: true
-      operationId: get-package-deprecated
-      parameters:
-        - in: path
-          name: pkgkey
-          required: true
-          schema:
-            type: string
-        - description: >-
-            Whether to return prerelease versions of packages (e.g. beta, rc,
-            preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                allOf:
-                  - properties:
-                      response:
-                        $ref: '#/components/schemas/Fleet_package_info'
-                  - properties:
-                      savedObject:
-                        type: string
-                      status:
-                        enum:
-                          - installed
-                          - installing
-                          - install_failed
-                          - not_installed
-                        type: string
-                    required:
-                      - status
-                      - savedObject
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package
-      tags:
-        - Elastic Package Manager (EPM)
-    post:
-      deprecated: true
-      description: ''
-      operationId: install-package-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - in: path
-          name: pkgkey
-          required: true
-          schema:
-            type: string
-        - description: avoid erroring out on unexpected mapping update errors
-          in: query
-          name: ignoreMappingUpdateErrors
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
-          in: query
-          name: skipDataStreamRollover
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  response:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - response
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Install package
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgName}/{pkgVersion}':
-    delete:
-      operationId: delete-package
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - description: delete package even if policies used by agents
-          in: query
-          name: force
-          schema:
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              deprecated: true
-              type: object
-              properties:
-                force:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete package
-      tags:
-        - Elastic Package Manager (EPM)
-    get:
-      operationId: get-package
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                allOf:
-                  - properties:
-                      item:
-                        $ref: '#/components/schemas/Fleet_package_info'
-                  - properties:
-                      keepPoliciesUpToDate:
-                        type: boolean
-                      latestVersion:
-                        type: string
-                      licensePath:
-                        type: string
-                      notice:
-                        type: string
-                      savedObject:
-                        deprecated: true
-                        type: object
-                      status:
-                        enum:
-                          - installed
-                          - installing
-                          - install_failed
-                          - not_installed
-                        type: string
-                    required:
-                      - status
-                      - savedObject
-                type: object
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: pkgVersion
-        required: true
-        schema:
-          type: string
-      - description: Ignore if the package is fails signature verification
-        in: query
-        name: ignoreUnverified
-        schema:
-          type: boolean
-      - description: >-
-          Return all fields from the package manifest, not just those supported
-          by the Elastic Package Registry
-        in: query
-        name: full
-        schema:
-          type: boolean
-      - description: >-
-          Whether to return prerelease versions of packages (e.g. beta, rc,
-          preview)
-        in: query
-        name: prerelease
-        schema:
-          default: false
-          type: boolean
-    post:
-      description: ''
-      operationId: install-package
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - description: avoid erroring out on unexpected mapping update errors
-          in: query
-          name: ignoreMappingUpdateErrors
-          schema:
-            default: false
-            type: boolean
-        - description: >-
-            Skip data stream rollover during index template mapping or settings
-            update
-          in: query
-          name: skipDataStreamRollover
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-                ignore_constraints:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  _meta:
-                    type: object
-                    properties:
-                      install_source:
-                        enum:
-                          - registry
-                          - upload
-                          - bundled
-                        type: string
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Install package
-      tags:
-        - Elastic Package Manager (EPM)
-    put:
-      description: ''
-      operationId: update-package
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                keepPoliciesUpToDate:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        type:
-                          oneOf:
-                            - $ref: >-
-                                #/components/schemas/Fleet_kibana_saved_object_type
-                            - $ref: >-
-                                #/components/schemas/Fleet_elasticsearch_asset_type
-                      required:
-                        - id
-                        - type
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update package settings
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
-    get:
-      operationId: packages-get-file
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                  headers:
-                    type: object
-                  statusCode:
-                    type: number
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package file
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: pkgVersion
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: filePath
-        required: true
-        schema:
-          type: string
-  '/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
-    post:
-      description: ''
-      operationId: reauthorize-transforms
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - in: path
-          name: pkgName
-          required: true
-          schema:
-            type: string
-        - in: path
-          name: pkgVersion
-          required: true
-          schema:
-            type: string
-        - description: >-
-            Whether to include prerelease packages in categories count (e.g.
-            beta, rc, preview)
-          in: query
-          name: prerelease
-          schema:
-            default: false
-            type: boolean
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                transforms:
-                  items:
-                    type: object
-                    properties:
-                      transformId:
-                        type: string
-                  type: array
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        error:
-                          type: string
-                        success:
-                          type: boolean
-                        transformId:
-                          type: string
-                      required:
-                        - transformId
-                        - error
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Authorize transforms
-      tags:
-        - Elastic Package Manager (EPM)
-  '/epm/packages/{pkgName}/stats':
-    get:
-      operationId: get-package-stats
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  response:
-                    $ref: '#/components/schemas/Fleet_package_usage_stats'
-                required:
-                  - response
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package stats
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-  /epm/packages/limited:
-    get:
-      operationId: list-limited-packages
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: string
-                    type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get limited package list
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters: []
-  '/epm/templates/{pkgName}/{pkgVersion}/inputs':
-    get:
-      operationId: get-inputs-template
-      responses:
-        '200':
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get inputs template
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters:
-      - in: path
-        name: pkgName
-        required: true
-        schema:
-          type: string
-      - in: path
-        name: pkgVersion
-        required: true
-        schema:
-          type: string
-      - description: Format of response - json or yaml
-        in: query
-        name: format
-        schema:
-          enum:
-            - json
-            - yaml
-            - yml
-          type: string
-      - description: Specify if version is prerelease
-        in: query
-        name: prerelease
-        schema:
-          type: boolean
-      - description: Ignore if the package is fails signature verification
-        in: query
-        name: ignoreUnverified
-        schema:
-          type: boolean
-  /epm/verification_key_id:
-    get:
-      operationId: packages-get-verification-key-id
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  body:
-                    type: object
-                    properties:
-                      id:
-                        description: >-
-                          the key ID of the GPG key used to verify package
-                          signatures
-                        nullable: true
-                        type: string
-                  headers:
-                    type: object
-                  statusCode:
-                    type: number
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package signature verification key ID
-      tags:
-        - Elastic Package Manager (EPM)
-    parameters: []
-  /fleet_server_hosts:
-    get:
-      operationId: get-fleet-server-hosts
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_fleet_server_host'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List Fleet Server hosts
-      tags:
-        - Fleet Server hosts
-    post:
-      operationId: post-fleet-server-hosts
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host_urls:
-                  items:
-                    type: string
-                  type: array
-                id:
-                  type: string
-                is_default:
-                  type: boolean
-                is_internal:
-                  type: boolean
-                name:
-                  type: string
-                proxy_id:
-                  description: >-
-                    The ID of the proxy to use for this fleet server host. See
-                    the proxies API for more information.
-                  type: string
-              required:
-                - name
-                - host_urls
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_fleet_server_host'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create Fleet Server host
-      tags:
-        - Fleet Server hosts
-  '/fleet_server_hosts/{itemId}':
-    delete:
-      operationId: delete-fleet-server-hosts
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete Fleet Server host by ID
-      tags:
-        - Fleet Server hosts
-    get:
-      operationId: get-one-fleet-server-hosts
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_fleet_server_host'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get Fleet Server host by ID
-      tags:
-        - Fleet Server hosts
-    parameters:
-      - in: path
-        name: itemId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-fleet-server-hosts
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host_urls:
-                  items:
-                    type: string
-                  type: array
-                is_default:
-                  type: boolean
-                is_internal:
-                  type: boolean
-                name:
-                  type: string
-                proxy_id:
-                  description: >-
-                    The ID of the proxy to use for this fleet server host. See
-                    the proxies API for more information.
-                  nullable: true
-                  type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_fleet_server_host'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update Fleet Server host by ID
-      tags:
-        - Fleet Server hosts
-  /health_check:
-    post:
-      operationId: fleet-server-health-check
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                host:
-                  deprecated: true
-                  type: string
-                id:
-                  type: string
-              required:
-                - id
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  host:
-                    deprecated: true
-                    type: string
-                  id:
-                    description: Fleet Server host id
-                    type: string
-                  status:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Fleet Server health check
-      tags:
-        - Fleet internals
-  /kubernetes:
-    get:
-      operationId: get-full-k8s-manifest
-      parameters:
-        - in: query
-          name: download
-          required: false
-          schema:
-            type: boolean
-        - in: query
-          name: fleetServer
-          required: false
-          schema:
-            type: string
-        - in: query
-          name: enrolToken
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get full K8s agent manifest
-      tags:
-        - Fleet Kubernetes
-  /logstash_api_keys:
-    post:
-      operationId: generate-logstash-api-key
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  api_key:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Generate Logstash API key
-      tags:
-        - Fleet outputs
-  /outputs:
-    get:
-      operationId: get-outputs
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_output_create_request'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List outputs
-      tags:
-        - Fleet outputs
-    post:
-      operationId: post-outputs
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_output_create_request'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_output_create_request'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create output
-      tags:
-        - Fleet outputs
-  '/outputs/{outputId}':
-    delete:
-      operationId: delete-output
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete output by ID
-      tags:
-        - Fleet outputs
-    get:
-      operationId: get-output
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_output_create_request'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get output by ID
-      tags:
-        - Fleet outputs
-    parameters:
-      - in: path
-        name: outputId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-output
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_output_update_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_output_update_request'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update output by ID
-      tags:
-        - Fleet outputs
-  '/outputs/{outputId}/health':
-    get:
-      operationId: get-output-health
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  message:
-                    description: long message if unhealthy
-                    type: string
-                  state:
-                    description: 'state of output, HEALTHY or DEGRADED'
-                    type: string
-                  timestamp:
-                    description: timestamp of reported state
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get latest output health
-      tags:
-        - Fleet outputs
-    parameters:
-      - in: path
-        name: outputId
-        required: true
-        schema:
-          type: string
-  /package_policies:
-    get:
-      operationId: get-package-policies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_page_size'
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - $ref: '#/components/parameters/Fleet_kuery'
-        - $ref: '#/components/parameters/Fleet_format'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_package_policy'
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List package policies
-      tags:
-        - Fleet package policies
-    parameters: []
-    post:
-      operationId: create-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_package_policy_request'
-        description: >-
-          You should use inputs as an object and not use the deprecated inputs
-          array.
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_package_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '409':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create package policy
-      tags:
-        - Fleet package policies
-  /package_policies/_bulk_get:
-    post:
-      operationId: bulk-get-package-policies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                ids:
-                  description: list of package policy ids
-                  items:
-                    type: string
-                  type: array
-                ignoreMissing:
-                  type: boolean
-              required:
-                - ids
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_package_policy'
-                    type: array
-                required:
-                  - items
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Bulk get package policies
-      tags:
-        - Fleet package policies
-  '/package_policies/{packagePolicyId}':
-    delete:
-      operationId: delete-package-policy
-      parameters:
-        - in: query
-          name: force
-          schema:
-            type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete package policy by ID
-      tags:
-        - Fleet package policies
-    get:
-      operationId: get-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_format'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_package_policy'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get package policy by ID
-      tags:
-        - Fleet package policies
-    parameters:
-      - in: path
-        name: packagePolicyId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-        - $ref: '#/components/parameters/Fleet_format'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              $ref: '#/components/schemas/Fleet_package_policy_request'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_package_policy'
-                  sucess:
-                    type: boolean
-                required:
-                  - item
-                  - sucess
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update package policy by ID
-      tags:
-        - Fleet package policies
-  /package_policies/delete:
-    post:
-      operationId: post-delete-package-policy
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                force:
-                  type: boolean
-                packagePolicyIds:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - packagePolicyIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    success:
-                      type: boolean
-                  required:
-                    - id
-                    - success
-                type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete package policy
-      tags:
-        - Fleet package policies
-  /package_policies/upgrade:
-    post:
-      operationId: upgrade-package-policy
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                packagePolicyIds:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - packagePolicyIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    success:
-                      type: boolean
-                  required:
-                    - id
-                    - success
-                type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '409':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Upgrade package policy to a newer package version
-      tags:
-        - Fleet package policies
-  /package_policies/upgrade/dryrun:
-    post:
-      operationId: upgrade-package-policy-dry-run
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                packagePolicyIds:
-                  items:
-                    type: string
-                  type: array
-                packageVersion:
-                  type: string
-              required:
-                - packagePolicyIds
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                items:
-                  type: object
-                  properties:
-                    agent_diff:
-                      $ref: '#/components/schemas/Fleet_upgrade_agent_diff'
-                    diff:
-                      $ref: '#/components/schemas/Fleet_upgrade_diff'
-                    hasErrors:
-                      type: boolean
-                  required:
-                    - hasErrors
-                type: array
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Dry run package policy upgrade
-      tags:
-        - Fleet package policies
-  /proxies:
-    get:
-      operationId: get-fleet-proxies
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      $ref: '#/components/schemas/Fleet_proxies'
-                    type: array
-                  page:
-                    type: integer
-                  perPage:
-                    type: integer
-                  total:
-                    type: integer
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List proxies
-      tags:
-        - Fleet proxies
-    post:
-      operationId: post-fleet-proxies
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                certificate:
-                  type: string
-                certificate_authorities:
-                  type: string
-                certificate_key:
-                  type: string
-                id:
-                  type: string
-                name:
-                  type: string
-                proxy_headers:
-                  type: object
-                url:
-                  type: string
-              required:
-                - name
-                - url
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_proxies'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create proxy
-      tags:
-        - Fleet proxies
-  '/proxies/{itemId}':
-    delete:
-      operationId: delete-fleet-proxies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                required:
-                  - id
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Delete proxy by ID
-      tags:
-        - Fleet proxies
-    get:
-      operationId: get-one-fleet-proxies
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_proxies'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get proxy by ID
-      tags:
-        - Fleet proxies
-    parameters:
-      - in: path
-        name: itemId
-        required: true
-        schema:
-          type: string
-    put:
-      operationId: update-fleet-proxies
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                certificate:
-                  type: string
-                certificate_authorities:
-                  type: string
-                certificate_key:
-                  type: string
-                name:
-                  type: string
-                proxy_headers:
-                  type: object
-                url:
-                  type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    $ref: '#/components/schemas/Fleet_proxies'
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update proxy by ID
-      tags:
-        - Fleet proxies
   '/s/{spaceId}/api/observability/slos':
     get:
       description: >
@@ -13020,244 +13233,6 @@ paths:
       summary: Enable an SLO
       tags:
         - slo
-  /service_tokens:
-    post:
-      operationId: generate-service-token
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create service token
-      tags:
-        - Fleet service tokens
-  /service-tokens:
-    post:
-      deprecated: true
-      operationId: generate-service-token-deprecated
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Create service token
-      tags:
-        - Fleet service tokens
-  /settings:
-    get:
-      operationId: get-settings
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_settings_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get settings
-      tags:
-        - Fleet internals
-    put:
-      operationId: update-settings
-      requestBody:
-        content:
-          application/json; Elastic-Api-Version=2023-10-31:
-            schema:
-              type: object
-              properties:
-                additional_yaml_config:
-                  type: string
-                fleet_server_hosts:
-                  description: Protocol and path must be the same for each URL
-                  items:
-                    type: string
-                  type: array
-                has_seen_add_data_notice:
-                  type: boolean
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_settings_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Update settings
-      tags:
-        - Fleet internals
-  /settings/enrollment:
-    get:
-      operationId: get-enrollment-settings
-      parameters:
-        - description: >-
-            An agent policy ID to scope the enrollment settings to. For example,
-            that policy's Fleet Server host, its proxy, download location, etc.
-            If not provided, the default Fleet Server policy is used (if any).
-          in: query
-          name: agentPolicyId
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_settings_enrollment_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get enrollment settings
-      tags:
-        - Fleet internals
-  /setup:
-    post:
-      operationId: setup
-      parameters:
-        - $ref: '#/components/parameters/Fleet_kbn_xsrf'
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                $ref: '#/components/schemas/Fleet_fleet_setup_response'
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-        '500':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-          description: Internal Server Error
-      summary: Initiate Fleet setup
-      tags:
-        - Fleet internals
-  /uninstall_tokens:
-    get:
-      operationId: get-uninstall-tokens
-      parameters:
-        - description: The number of items to return
-          in: query
-          name: perPage
-          required: false
-          schema:
-            default: 20
-            minimum: 5
-            type: integer
-        - $ref: '#/components/parameters/Fleet_page_index'
-        - description: Partial match filtering for policy IDs
-          in: query
-          name: policyId
-          required: false
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  items:
-                    items:
-                      type: object
-                      properties:
-                        created_at:
-                          type: string
-                        id:
-                          type: string
-                        policy_id:
-                          type: string
-                      required:
-                        - id
-                        - policy_id
-                        - created_at
-                    type: array
-                  page:
-                    type: number
-                  perPage:
-                    type: number
-                  total:
-                    type: number
-                required:
-                  - items
-                  - total
-                  - page
-                  - perPage
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: List metadata for latest uninstall tokens per agent policy
-      tags:
-        - Fleet uninstall tokens
-  '/uninstall_tokens/{uninstallTokenId}':
-    get:
-      operationId: get-uninstall-token
-      parameters:
-        - in: path
-          name: uninstallTokenId
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          content:
-            application/json; Elastic-Api-Version=2023-10-31:
-              schema:
-                type: object
-                properties:
-                  item:
-                    type: object
-                    properties:
-                      created_at:
-                        type: string
-                      id:
-                        type: string
-                      policy_id:
-                        type: string
-                      token:
-                        type: string
-                    required:
-                      - id
-                      - token
-                      - policy_id
-                      - created_at
-                required:
-                  - item
-          description: OK
-        '400':
-          $ref: '#/components/responses/Fleet_error'
-      summary: Get one decrypted uninstall token by its ID
-      tags:
-        - Fleet uninstall tokens
 components:
   examples:
     Alerting_get_health_response:
@@ -19594,49 +19569,6 @@ components:
         - is_default
         - is_preconfigured
         - host_urls
-    Fleet_fleet_settings_enrollment_response:
-      title: Fleet settings response
-      type: object
-      properties:
-        download_source:
-          $ref: '#/components/schemas/Fleet_download_sources'
-        fleet_server:
-          type: object
-          properties:
-            has_active:
-              type: boolean
-            host:
-              $ref: '#/components/schemas/Fleet_fleet_server_host'
-            host_proxy:
-              $ref: '#/components/schemas/Fleet_proxies'
-            policies:
-              items:
-                type: object
-                properties:
-                  download_source_id:
-                    type: string
-                  fleet_server_host_id:
-                    type: string
-                  has_fleet_server:
-                    type: boolean
-                  id:
-                    type: string
-                  is_default_fleet_server:
-                    type: boolean
-                  is_managed:
-                    type: boolean
-                  name:
-                    type: string
-                required:
-                  - id
-                  - name
-                  - is_managed
-              type: array
-          required:
-            - agent_policies
-            - has_active
-      required:
-        - fleet_server
     Fleet_fleet_settings_response:
       title: Fleet settings response
       type: object

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -64,12 +64,11 @@
   },
   "servers": [
     {
-      "url": "http://KIBANA_HOST:5601/api/fleet",
-      "description": "Public and supported Fleet API"
+      "url": "http://KIBANA_HOST:5601"
     }
   ],
   "paths": {
-    "/health_check": {
+    "/api/fleet/health_check": {
       "post": {
         "summary": "Fleet Server health check",
         "tags": [
@@ -133,7 +132,7 @@
         }
       }
     },
-    "/setup": {
+    "/api/fleet/setup": {
       "post": {
         "summary": "Initiate Fleet setup",
         "tags": [
@@ -177,7 +176,7 @@
         ]
       }
     },
-    "/settings": {
+    "/api/fleet/settings": {
       "get": {
         "summary": "Get settings",
         "tags": [
@@ -247,48 +246,7 @@
         "operationId": "update-settings"
       }
     },
-    "/settings/enrollment": {
-      "servers": [
-        {
-          "url": "http://KIBANA_HOST:5601/internal/fleet",
-          "description": "Used for Fleet internals and not supported"
-        }
-      ],
-      "get": {
-        "summary": "Get enrollment settings",
-        "tags": [
-          "Fleet internals"
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "agentPolicyId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "An agent policy ID to scope the enrollment settings to. For example, that policy's Fleet Server host, its proxy, download location, etc. If not provided, the default Fleet Server policy is used (if any)."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/fleet_settings_enrollment_response"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "operationId": "get-enrollment-settings"
-      }
-    },
-    "/service-tokens": {
+    "/api/fleet/service-tokens": {
       "post": {
         "summary": "Create service token",
         "tags": [
@@ -326,7 +284,7 @@
         "deprecated": true
       }
     },
-    "/service_tokens": {
+    "/api/fleet/service_tokens": {
       "post": {
         "summary": "Create service token",
         "tags": [
@@ -363,7 +321,7 @@
         ]
       }
     },
-    "/epm/verification_key_id": {
+    "/api/fleet/epm/verification_key_id": {
       "get": {
         "summary": "Get package signature verification key ID",
         "tags": [
@@ -406,7 +364,7 @@
       },
       "parameters": []
     },
-    "/epm/bulk_assets": {
+    "/api/fleet/epm/bulk_assets": {
       "post": {
         "summary": "Bulk get assets",
         "tags": [
@@ -459,7 +417,7 @@
         }
       }
     },
-    "/epm/categories": {
+    "/api/fleet/epm/categories": {
       "get": {
         "summary": "List package categories",
         "tags": [
@@ -511,7 +469,7 @@
         }
       ]
     },
-    "/epm/packages/limited": {
+    "/api/fleet/epm/packages/limited": {
       "get": {
         "summary": "Get limited package list",
         "tags": [
@@ -544,7 +502,7 @@
       },
       "parameters": []
     },
-    "/epm/packages": {
+    "/api/fleet/epm/packages": {
       "get": {
         "summary": "List packages",
         "tags": [
@@ -712,7 +670,7 @@
         }
       }
     },
-    "/epm/packages/_bulk": {
+    "/api/fleet/epm/packages/_bulk": {
       "post": {
         "summary": "Bulk install packages",
         "tags": [
@@ -790,7 +748,7 @@
         }
       }
     },
-    "/epm/packages/{pkgkey}": {
+    "/api/fleet/epm/packages/{pkgkey}": {
       "get": {
         "summary": "Get package",
         "tags": [
@@ -1047,7 +1005,7 @@
         "deprecated": true
       }
     },
-    "/epm/packages/{pkgName}/{pkgVersion}": {
+    "/api/fleet/epm/packages/{pkgName}/{pkgVersion}": {
       "get": {
         "summary": "Get package",
         "tags": [
@@ -1414,7 +1372,7 @@
         }
       }
     },
-    "/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize": {
+    "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize": {
       "post": {
         "summary": "Authorize transforms",
         "tags": [
@@ -1517,7 +1475,7 @@
         }
       }
     },
-    "/epm/packages/{pkgName}/{pkgVersion}/{filePath}": {
+    "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}": {
       "get": {
         "summary": "Get package file",
         "tags": [
@@ -1578,7 +1536,7 @@
         }
       ]
     },
-    "/epm/packages/{pkgName}/stats": {
+    "/api/fleet/epm/packages/{pkgName}/stats": {
       "get": {
         "summary": "Get package stats",
         "tags": [
@@ -1625,7 +1583,7 @@
         }
       ]
     },
-    "/epm/templates/{pkgName}/{pkgVersion}/inputs": {
+    "/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs": {
       "get": {
         "summary": "Get inputs template",
         "tags": [
@@ -1694,7 +1652,7 @@
         }
       ]
     },
-    "/agents/setup": {
+    "/api/fleet/agents/setup": {
       "get": {
         "summary": "Get agent setup info",
         "tags": [
@@ -1771,7 +1729,7 @@
         ]
       }
     },
-    "/agent-status": {
+    "/api/fleet/agent-status": {
       "get": {
         "summary": "Get agent status summary",
         "tags": [
@@ -1842,7 +1800,7 @@
         "deprecated": true
       }
     },
-    "/agent_status": {
+    "/api/fleet/agent_status": {
       "get": {
         "summary": "Get agent status summary",
         "tags": [
@@ -1933,7 +1891,7 @@
         ]
       }
     },
-    "/agent_status/data": {
+    "/api/fleet/agent_status/data": {
       "get": {
         "summary": "Get incoming agent data",
         "tags": [
@@ -1986,7 +1944,7 @@
         ]
       }
     },
-    "/agents": {
+    "/api/fleet/agents": {
       "get": {
         "summary": "List agents",
         "tags": [
@@ -2097,7 +2055,7 @@
         }
       }
     },
-    "/agents/bulk_upgrade": {
+    "/api/fleet/agents/bulk_upgrade": {
       "post": {
         "summary": "Bulk upgrade agents",
         "tags": [
@@ -2151,7 +2109,7 @@
         }
       }
     },
-    "/agents/action_status": {
+    "/api/fleet/agents/action_status": {
       "get": {
         "summary": "Get agent action status",
         "tags": [
@@ -2311,7 +2269,7 @@
         "operationId": "agents-action-status"
       }
     },
-    "/agents/{agentId}": {
+    "/api/fleet/agents/{agentId}": {
       "parameters": [
         {
           "schema": {
@@ -2452,7 +2410,7 @@
         ]
       }
     },
-    "/agents/{agentId}/actions": {
+    "/api/fleet/agents/{agentId}/actions": {
       "parameters": [
         {
           "schema": {
@@ -2520,7 +2478,7 @@
         }
       }
     },
-    "/agents/actions/{actionId}/cancel": {
+    "/api/fleet/agents/actions/{actionId}/cancel": {
       "parameters": [
         {
           "schema": {
@@ -2564,7 +2522,7 @@
         ]
       }
     },
-    "/agents/files/{fileId}/{fileName}": {
+    "/api/fleet/agents/files/{fileId}/{fileName}": {
       "parameters": [
         {
           "schema": {
@@ -2620,7 +2578,7 @@
         "operationId": "get-agent-upload-file"
       }
     },
-    "/agents/files/{fileId}": {
+    "/api/fleet/agents/files/{fileId}": {
       "parameters": [
         {
           "schema": {
@@ -2667,7 +2625,7 @@
         "operationId": "delete-agent-upload-file"
       }
     },
-    "/agents/{agentId}/reassign": {
+    "/api/fleet/agents/{agentId}/reassign": {
       "parameters": [
         {
           "schema": {
@@ -2770,7 +2728,7 @@
         "deprecated": true
       }
     },
-    "/agents/{agentId}/unenroll": {
+    "/api/fleet/agents/{agentId}/unenroll": {
       "parameters": [
         {
           "schema": {
@@ -2847,7 +2805,7 @@
         }
       }
     },
-    "/agents/{agentId}/upgrade": {
+    "/api/fleet/agents/{agentId}/upgrade": {
       "parameters": [
         {
           "schema": {
@@ -2896,7 +2854,7 @@
         }
       }
     },
-    "/agents/{agentId}/uploads": {
+    "/api/fleet/agents/{agentId}/uploads": {
       "parameters": [
         {
           "schema": {
@@ -2943,7 +2901,7 @@
         "operationId": "list-agent-uploads"
       }
     },
-    "/agents/bulk_reassign": {
+    "/api/fleet/agents/bulk_reassign": {
       "post": {
         "summary": "Bulk reassign agents",
         "tags": [
@@ -3015,7 +2973,7 @@
         }
       }
     },
-    "/agents/bulk_unenroll": {
+    "/api/fleet/agents/bulk_unenroll": {
       "post": {
         "summary": "Bulk unenroll agents",
         "tags": [
@@ -3098,7 +3056,7 @@
         }
       }
     },
-    "/agents/bulk_update_agent_tags": {
+    "/api/fleet/agents/bulk_update_agent_tags": {
       "post": {
         "summary": "Bulk update agent tags",
         "tags": [
@@ -3188,7 +3146,7 @@
         }
       }
     },
-    "/agents/tags": {
+    "/api/fleet/agents/tags": {
       "get": {
         "summary": "List agent tags",
         "tags": [
@@ -3212,7 +3170,7 @@
         "operationId": "get-agent-tags"
       }
     },
-    "/agents/{agentId}/request_diagnostics": {
+    "/api/fleet/agents/{agentId}/request_diagnostics": {
       "parameters": [
         {
           "schema": {
@@ -3280,7 +3238,7 @@
         ]
       }
     },
-    "/agents/bulk_request_diagnostics": {
+    "/api/fleet/agents/bulk_request_diagnostics": {
       "post": {
         "summary": "Bulk request diagnostics from agents",
         "tags": [
@@ -3362,7 +3320,7 @@
         }
       }
     },
-    "/agent_policies": {
+    "/api/fleet/agent_policies": {
       "get": {
         "summary": "List agent policies",
         "tags": [
@@ -3482,7 +3440,7 @@
         ]
       }
     },
-    "/agent_policies/{agentPolicyId}": {
+    "/api/fleet/agent_policies/{agentPolicyId}": {
       "parameters": [
         {
           "schema": {
@@ -3573,7 +3531,7 @@
         ]
       }
     },
-    "/agent_policies/{agentPolicyId}/copy": {
+    "/api/fleet/agent_policies/{agentPolicyId}/copy": {
       "parameters": [
         {
           "schema": {
@@ -3644,7 +3602,7 @@
         }
       }
     },
-    "/agent_policies/{agentPolicyId}/full": {
+    "/api/fleet/agent_policies/{agentPolicyId}/full": {
       "get": {
         "summary": "Get full agent policy by ID",
         "tags": [
@@ -3714,7 +3672,7 @@
         }
       ]
     },
-    "/agent_policies/{agentPolicyId}/download": {
+    "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
         "summary": "Download agent policy by ID",
         "tags": [
@@ -3777,7 +3735,7 @@
         }
       ]
     },
-    "/agent_policies/_bulk_get": {
+    "/api/fleet/agent_policies/_bulk_get": {
       "post": {
         "summary": "Bulk get agent policies",
         "tags": [
@@ -3846,7 +3804,7 @@
         ]
       }
     },
-    "/agent_policies/delete": {
+    "/api/fleet/agent_policies/delete": {
       "post": {
         "summary": "Delete agent policy by ID",
         "tags": [
@@ -3909,7 +3867,7 @@
       },
       "parameters": []
     },
-    "/data_streams": {
+    "/api/fleet/data_streams": {
       "get": {
         "summary": "List data streams",
         "tags": [
@@ -3942,7 +3900,7 @@
       },
       "parameters": []
     },
-    "/enrollment-api-keys": {
+    "/api/fleet/enrollment-api-keys": {
       "get": {
         "summary": "List enrollment API keys",
         "tags": [
@@ -4037,7 +3995,7 @@
         "deprecated": true
       }
     },
-    "/enrollment-api-keys/{keyId}": {
+    "/api/fleet/enrollment-api-keys/{keyId}": {
       "parameters": [
         {
           "schema": {
@@ -4119,7 +4077,7 @@
         "deprecated": true
       }
     },
-    "/enrollment_api_keys": {
+    "/api/fleet/enrollment_api_keys": {
       "get": {
         "summary": "List enrollment API keys",
         "tags": [
@@ -4244,7 +4202,7 @@
         ]
       }
     },
-    "/enrollment_api_keys/{keyId}": {
+    "/api/fleet/enrollment_api_keys/{keyId}": {
       "parameters": [
         {
           "schema": {
@@ -4324,7 +4282,7 @@
         ]
       }
     },
-    "/package_policies": {
+    "/api/fleet/package_policies": {
       "get": {
         "summary": "List package policies",
         "tags": [
@@ -4435,7 +4393,7 @@
         ]
       }
     },
-    "/package_policies/_bulk_get": {
+    "/api/fleet/package_policies/_bulk_get": {
       "post": {
         "summary": "Bulk get package policies",
         "tags": [
@@ -4500,7 +4458,7 @@
         ]
       }
     },
-    "/package_policies/delete": {
+    "/api/fleet/package_policies/delete": {
       "post": {
         "summary": "Delete package policy",
         "tags": [
@@ -4570,7 +4528,7 @@
         ]
       }
     },
-    "/package_policies/upgrade": {
+    "/api/fleet/package_policies/upgrade": {
       "post": {
         "summary": "Upgrade package policy to a newer package version",
         "tags": [
@@ -4635,7 +4593,7 @@
         }
       }
     },
-    "/package_policies/upgrade/dryrun": {
+    "/api/fleet/package_policies/upgrade/dryrun": {
       "post": {
         "summary": "Dry run package policy upgrade",
         "tags": [
@@ -4699,7 +4657,7 @@
         }
       }
     },
-    "/package_policies/{packagePolicyId}": {
+    "/api/fleet/package_policies/{packagePolicyId}": {
       "parameters": [
         {
           "schema": {
@@ -4836,7 +4794,7 @@
         ]
       }
     },
-    "/outputs": {
+    "/api/fleet/outputs": {
       "get": {
         "summary": "List outputs",
         "tags": [
@@ -4914,7 +4872,7 @@
         "operationId": "post-outputs"
       }
     },
-    "/outputs/{outputId}": {
+    "/api/fleet/outputs/{outputId}": {
       "get": {
         "summary": "Get output by ID",
         "tags": [
@@ -5029,7 +4987,7 @@
         ]
       }
     },
-    "/outputs/{outputId}/health": {
+    "/api/fleet/outputs/{outputId}/health": {
       "get": {
         "summary": "Get latest output health",
         "tags": [
@@ -5077,7 +5035,7 @@
         }
       ]
     },
-    "/logstash_api_keys": {
+    "/api/fleet/logstash_api_keys": {
       "post": {
         "summary": "Generate Logstash API key",
         "tags": [
@@ -5111,7 +5069,7 @@
         ]
       }
     },
-    "/agent_download_sources": {
+    "/api/fleet/agent_download_sources": {
       "get": {
         "summary": "List agent binary download sources",
         "tags": [
@@ -5207,7 +5165,7 @@
         "operationId": "post-download-sources"
       }
     },
-    "/agent_download_sources/{sourceId}": {
+    "/api/fleet/agent_download_sources/{sourceId}": {
       "get": {
         "summary": "Get agent binary download source by ID",
         "tags": [
@@ -5344,7 +5302,7 @@
         ]
       }
     },
-    "/fleet_server_hosts": {
+    "/api/fleet/fleet_server_hosts": {
       "get": {
         "summary": "List Fleet Server hosts",
         "tags": [
@@ -5449,7 +5407,7 @@
         "operationId": "post-fleet-server-hosts"
       }
     },
-    "/fleet_server_hosts/{itemId}": {
+    "/api/fleet/fleet_server_hosts/{itemId}": {
       "get": {
         "summary": "Get Fleet Server host by ID",
         "tags": [
@@ -5592,7 +5550,7 @@
         ]
       }
     },
-    "/proxies": {
+    "/api/fleet/proxies": {
       "get": {
         "summary": "List proxies",
         "tags": [
@@ -5696,7 +5654,7 @@
         "operationId": "post-fleet-proxies"
       }
     },
-    "/proxies/{itemId}": {
+    "/api/fleet/proxies/{itemId}": {
       "get": {
         "summary": "Get proxy by ID",
         "tags": [
@@ -5837,7 +5795,7 @@
         ]
       }
     },
-    "/kubernetes": {
+    "/api/fleet/kubernetes": {
       "get": {
         "summary": "Get full K8s agent manifest",
         "tags": [
@@ -5892,7 +5850,7 @@
         ]
       }
     },
-    "/uninstall_tokens": {
+    "/api/fleet/uninstall_tokens": {
       "get": {
         "summary": "List metadata for latest uninstall tokens per agent policy",
         "tags": [
@@ -5980,7 +5938,7 @@
         ]
       }
     },
-    "/uninstall_tokens/{uninstallTokenId}": {
+    "/api/fleet/uninstall_tokens/{uninstallTokenId}": {
       "get": {
         "summary": "Get one decrypted uninstall token by its ID",
         "tags": [
@@ -6250,166 +6208,6 @@
         },
         "required": [
           "item"
-        ]
-      },
-      "fleet_server_host": {
-        "title": "Fleet Server Host",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "is_default": {
-            "type": "boolean"
-          },
-          "is_internal": {
-            "type": "boolean"
-          },
-          "is_preconfigured": {
-            "type": "boolean"
-          },
-          "proxy_id": {
-            "type": "string"
-          },
-          "host_urls": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "fleet_server_hosts",
-          "id",
-          "is_default",
-          "is_preconfigured",
-          "host_urls"
-        ]
-      },
-      "proxies": {
-        "title": "Fleet Proxy",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          },
-          "proxy_headers": {
-            "type": "object"
-          },
-          "certificate_authorities": {
-            "type": "string"
-          },
-          "certificate": {
-            "type": "string"
-          },
-          "certificate_key": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "url"
-        ]
-      },
-      "download_sources": {
-        "title": "Download Source",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "is_default": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": "string"
-          },
-          "host": {
-            "type": "string"
-          },
-          "proxy_id": {
-            "description": "The ID of the proxy to use for this download source. See the proxies API for more information.",
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "is_default",
-          "name",
-          "host"
-        ]
-      },
-      "fleet_settings_enrollment_response": {
-        "title": "Fleet settings response",
-        "type": "object",
-        "properties": {
-          "fleet_server": {
-            "type": "object",
-            "properties": {
-              "policies": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "is_managed": {
-                      "type": "boolean"
-                    },
-                    "is_default_fleet_server": {
-                      "type": "boolean"
-                    },
-                    "has_fleet_server": {
-                      "type": "boolean"
-                    },
-                    "fleet_server_host_id": {
-                      "type": "string"
-                    },
-                    "download_source_id": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "is_managed"
-                  ]
-                }
-              },
-              "has_active": {
-                "type": "boolean"
-              },
-              "host": {
-                "$ref": "#/components/schemas/fleet_server_host"
-              },
-              "host_proxy": {
-                "$ref": "#/components/schemas/proxies"
-              }
-            },
-            "required": [
-              "agent_policies",
-              "has_active"
-            ]
-          },
-          "download_source": {
-            "$ref": "#/components/schemas/download_sources"
-          }
-        },
-        "required": [
-          "fleet_server"
         ]
       },
       "saved_object_type": {
@@ -9528,6 +9326,102 @@
             "logstash": "#/components/schemas/output_update_request_logstash"
           }
         }
+      },
+      "download_sources": {
+        "title": "Download Source",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "proxy_id": {
+            "description": "The ID of the proxy to use for this download source. See the proxies API for more information.",
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "is_default",
+          "name",
+          "host"
+        ]
+      },
+      "fleet_server_host": {
+        "title": "Fleet Server Host",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_internal": {
+            "type": "boolean"
+          },
+          "is_preconfigured": {
+            "type": "boolean"
+          },
+          "proxy_id": {
+            "type": "string"
+          },
+          "host_urls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "fleet_server_hosts",
+          "id",
+          "is_default",
+          "is_preconfigured",
+          "host_urls"
+        ]
+      },
+      "proxies": {
+        "title": "Fleet Proxy",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "proxy_headers": {
+            "type": "object"
+          },
+          "certificate_authorities": {
+            "type": "string"
+          },
+          "certificate": {
+            "type": "string"
+          },
+          "certificate_key": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ]
       }
     }
   },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -24,12 +24,11 @@ info:
     name: Fleet Team
   license:
     name: Elastic License 2.0
-    url: 'https://www.elastic.co/licensing/elastic-license'
+    url: https://www.elastic.co/licensing/elastic-license
 servers:
-  - url: 'http://KIBANA_HOST:5601/api/fleet'
-    description: Public and supported Fleet API
+  - url: http://KIBANA_HOST:5601
 paths:
-  /health_check:
+  /api/fleet/health_check:
     post:
       summary: Fleet Server health check
       tags:
@@ -69,7 +68,7 @@ paths:
                   deprecated: true
               required:
                 - id
-  /setup:
+  /api/fleet/setup:
     post:
       summary: Initiate Fleet setup
       tags:
@@ -95,7 +94,7 @@ paths:
       operationId: setup
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /settings:
+  /api/fleet/settings:
     get:
       summary: Get settings
       tags:
@@ -139,35 +138,7 @@ paths:
         '400':
           $ref: '#/components/responses/error'
       operationId: update-settings
-  /settings/enrollment:
-    servers:
-      - url: 'http://KIBANA_HOST:5601/internal/fleet'
-        description: Used for Fleet internals and not supported
-    get:
-      summary: Get enrollment settings
-      tags:
-        - Fleet internals
-      parameters:
-        - in: query
-          name: agentPolicyId
-          required: false
-          schema:
-            type: string
-          description: >-
-            An agent policy ID to scope the enrollment settings to. For example,
-            that policy's Fleet Server host, its proxy, download location, etc.
-            If not provided, the default Fleet Server policy is used (if any).
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/fleet_settings_enrollment_response'
-        '400':
-          $ref: '#/components/responses/error'
-      operationId: get-enrollment-settings
-  /service-tokens:
+  /api/fleet/service-tokens:
     post:
       summary: Create service token
       tags:
@@ -190,7 +161,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
       deprecated: true
-  /service_tokens:
+  /api/fleet/service_tokens:
     post:
       summary: Create service token
       tags:
@@ -212,7 +183,7 @@ paths:
       operationId: generate-service-token
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /epm/verification_key_id:
+  /api/fleet/epm/verification_key_id:
     get:
       summary: Get package signature verification key ID
       tags:
@@ -242,7 +213,7 @@ paths:
           $ref: '#/components/responses/error'
       operationId: packages-get-verification-key-id
     parameters: []
-  /epm/bulk_assets:
+  /api/fleet/epm/bulk_assets:
     post:
       summary: Bulk get assets
       tags:
@@ -275,7 +246,7 @@ paths:
                   description: list of items necessary to fetch assets
               required:
                 - assetIds
-  /epm/categories:
+  /api/fleet/epm/categories:
     get:
       summary: List package categories
       tags:
@@ -310,7 +281,7 @@ paths:
         schema:
           type: boolean
           default: false
-  /epm/packages/limited:
+  /api/fleet/epm/packages/limited:
     get:
       summary: Get limited package list
       tags:
@@ -331,7 +302,7 @@ paths:
           $ref: '#/components/responses/error'
       operationId: list-limited-packages
     parameters: []
-  /epm/packages:
+  /api/fleet/epm/packages:
     get:
       summary: List packages
       tags:
@@ -445,7 +416,7 @@ paths:
             schema:
               type: string
               format: binary
-  /epm/packages/_bulk:
+  /api/fleet/epm/packages/_bulk:
     post:
       summary: Bulk install packages
       tags:
@@ -495,7 +466,7 @@ paths:
                   description: force install to ignore package verification errors
               required:
                 - packages
-  '/epm/packages/{pkgkey}':
+  /api/fleet/epm/packages/{pkgkey}:
     get:
       summary: Get package
       tags:
@@ -653,7 +624,7 @@ paths:
                 force:
                   type: boolean
       deprecated: true
-  '/epm/packages/{pkgName}/{pkgVersion}':
+  /api/fleet/epm/packages/{pkgName}/{pkgVersion}:
     get:
       summary: Get package
       tags:
@@ -881,7 +852,7 @@ paths:
               properties:
                 force:
                   type: boolean
-  '/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
+  /api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize:
     post:
       summary: Authorize transforms
       tags:
@@ -947,7 +918,7 @@ paths:
                     properties:
                       transformId:
                         type: string
-  '/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
+  /api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}:
     get:
       summary: Get package file
       tags:
@@ -985,7 +956,7 @@ paths:
         name: filePath
         in: path
         required: true
-  '/epm/packages/{pkgName}/stats':
+  /api/fleet/epm/packages/{pkgName}/stats:
     get:
       summary: Get package stats
       tags:
@@ -1013,7 +984,7 @@ paths:
         name: pkgName
         in: path
         required: true
-  '/epm/templates/{pkgName}/{pkgVersion}/inputs':
+  /api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs:
     get:
       summary: Get inputs template
       tags:
@@ -1056,7 +1027,7 @@ paths:
         name: ignoreUnverified
         description: Ignore if the package is fails signature verification
         in: query
-  /agents/setup:
+  /api/fleet/agents/setup:
     get:
       summary: Get agent setup info
       tags:
@@ -1102,7 +1073,7 @@ paths:
                 - admin_password
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /agent-status:
+  /api/fleet/agent-status:
     get:
       summary: Get agent status summary
       tags:
@@ -1150,7 +1121,7 @@ paths:
           in: query
           required: false
       deprecated: true
-  /agent_status:
+  /api/fleet/agent_status:
     get:
       summary: Get agent status summary
       tags:
@@ -1212,7 +1183,7 @@ paths:
           in: query
           required: false
           deprecated: true
-  /agent_status/data:
+  /api/fleet/agent_status/data:
     get:
       summary: Get incoming agent data
       tags:
@@ -1245,7 +1216,7 @@ paths:
           name: agentsIds
           in: query
           required: true
-  /agents:
+  /api/fleet/agents:
     get:
       summary: List agents
       tags:
@@ -1305,7 +1276,7 @@ paths:
                     type: string
               required:
                 - policy_id
-  /agents/bulk_upgrade:
+  /api/fleet/agents/bulk_upgrade:
     post:
       summary: Bulk upgrade agents
       tags:
@@ -1333,13 +1304,13 @@ paths:
               $ref: '#/components/schemas/bulk_upgrade_agents'
             example:
               version: 8.4.0
-              source_uri: 'https://artifacts.elastic.co/downloads/beats/elastic-agent'
+              source_uri: https://artifacts.elastic.co/downloads/beats/elastic-agent
               rollout_duration_seconds: 3600
               agents:
                 - agent1
                 - agent2
-              start_time: 2022-08-03T14:00:00.000Z
-  /agents/action_status:
+              start_time: '2022-08-03T14:00:00.000Z'
+  /api/fleet/agents/action_status:
     get:
       summary: Get agent action status
       tags:
@@ -1454,7 +1425,7 @@ paths:
         '400':
           $ref: '#/components/responses/error'
       operationId: agents-action-status
-  '/agents/{agentId}':
+  /api/fleet/agents/{agentId}:
     parameters:
       - schema:
           type: string
@@ -1539,7 +1510,7 @@ paths:
       operationId: delete-agent
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agents/{agentId}/actions':
+  /api/fleet/agents/{agentId}/actions:
     parameters:
       - schema:
           type: string
@@ -1580,7 +1551,7 @@ paths:
               properties:
                 action:
                   $ref: '#/components/schemas/agent_action'
-  '/agents/actions/{actionId}/cancel':
+  /api/fleet/agents/actions/{actionId}/cancel:
     parameters:
       - schema:
           type: string
@@ -1606,7 +1577,7 @@ paths:
       operationId: agent-action-cancel
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agents/files/{fileId}/{fileName}':
+  /api/fleet/agents/files/{fileId}/{fileName}:
     parameters:
       - schema:
           type: string
@@ -1641,7 +1612,7 @@ paths:
         '400':
           $ref: '#/components/responses/error'
       operationId: get-agent-upload-file
-  '/agents/files/{fileId}':
+  /api/fleet/agents/files/{fileId}:
     parameters:
       - schema:
           type: string
@@ -1670,7 +1641,7 @@ paths:
         '400':
           $ref: '#/components/responses/error'
       operationId: delete-agent-upload-file
-  '/agents/{agentId}/reassign':
+  /api/fleet/agents/{agentId}/reassign:
     parameters:
       - schema:
           type: string
@@ -1732,7 +1703,7 @@ paths:
               required:
                 - policy_id
       deprecated: true
-  '/agents/{agentId}/unenroll':
+  /api/fleet/agents/{agentId}/unenroll:
     parameters:
       - schema:
           type: string
@@ -1778,7 +1749,7 @@ paths:
                   type: boolean
                 force:
                   type: boolean
-  '/agents/{agentId}/upgrade':
+  /api/fleet/agents/{agentId}/upgrade:
     parameters:
       - schema:
           type: string
@@ -1807,7 +1778,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/upgrade_agent'
-  '/agents/{agentId}/uploads':
+  /api/fleet/agents/{agentId}/uploads:
     parameters:
       - schema:
           type: string
@@ -1836,7 +1807,7 @@ paths:
         '400':
           $ref: '#/components/responses/error'
       operationId: list-agent-uploads
-  /agents/bulk_reassign:
+  /api/fleet/agents/bulk_reassign:
     post:
       summary: Bulk reassign agents
       tags:
@@ -1868,7 +1839,7 @@ paths:
                 agents:
                   oneOf:
                     - type: string
-                      description: 'KQL query string, leave empty to action all agents'
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
@@ -1879,7 +1850,7 @@ paths:
             example:
               policy_id: policy_id
               agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
-  /agents/bulk_unenroll:
+  /api/fleet/agents/bulk_unenroll:
     post:
       summary: Bulk unenroll agents
       tags:
@@ -1908,7 +1879,7 @@ paths:
                 agents:
                   oneOf:
                     - type: string
-                      description: 'KQL query string, leave empty to action all agents'
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
@@ -1932,7 +1903,7 @@ paths:
               agents:
                 - agent1
                 - agent2
-  /agents/bulk_update_agent_tags:
+  /api/fleet/agents/bulk_update_agent_tags:
     post:
       summary: Bulk update agent tags
       tags:
@@ -1961,7 +1932,7 @@ paths:
                 agents:
                   oneOf:
                     - type: string
-                      description: 'KQL query string, leave empty to action all agents'
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
@@ -1986,7 +1957,7 @@ paths:
                 - newTag
               tagsToRemove:
                 - existingTag
-  /agents/tags:
+  /api/fleet/agents/tags:
     get:
       summary: List agent tags
       tags:
@@ -2001,7 +1972,7 @@ paths:
         '400':
           $ref: '#/components/responses/error'
       operationId: get-agent-tags
-  '/agents/{agentId}/request_diagnostics':
+  /api/fleet/agents/{agentId}/request_diagnostics:
     parameters:
       - schema:
           type: string
@@ -2040,7 +2011,7 @@ paths:
       operationId: request-diagnostics-agent
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /agents/bulk_request_diagnostics:
+  /api/fleet/agents/bulk_request_diagnostics:
     post:
       summary: Bulk request diagnostics from agents
       tags:
@@ -2071,7 +2042,7 @@ paths:
                 agents:
                   oneOf:
                     - type: string
-                      description: 'KQL query string, leave empty to action all agents'
+                      description: KQL query string, leave empty to action all agents
                     - type: array
                       items:
                         type: string
@@ -2087,7 +2058,7 @@ paths:
                 - agents
             example:
               agents: 'fleet-agents.policy_id : ("policy1" or "policy2")'
-  /agent_policies:
+  /api/fleet/agent_policies:
     get:
       summary: List agent policies
       tags:
@@ -2165,7 +2136,7 @@ paths:
       security: []
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agent_policies/{agentPolicyId}':
+  /api/fleet/agent_policies/{agentPolicyId}:
     parameters:
       - schema:
           type: string
@@ -2220,7 +2191,7 @@ paths:
               $ref: '#/components/schemas/agent_policy_update_request'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/agent_policies/{agentPolicyId}/copy':
+  /api/fleet/agent_policies/{agentPolicyId}/copy:
     parameters:
       - schema:
           type: string
@@ -2262,7 +2233,7 @@ paths:
               required:
                 - name
         description: ''
-  '/agent_policies/{agentPolicyId}/full':
+  /api/fleet/agent_policies/{agentPolicyId}/full:
     get:
       summary: Get full agent policy by ID
       tags:
@@ -2303,7 +2274,7 @@ paths:
         name: kubernetes
         in: query
         required: false
-  '/agent_policies/{agentPolicyId}/download':
+  /api/fleet/agent_policies/{agentPolicyId}/download:
     get:
       summary: Download agent policy by ID
       tags:
@@ -2342,7 +2313,7 @@ paths:
         name: kubernetes
         in: query
         required: false
-  /agent_policies/_bulk_get:
+  /api/fleet/agent_policies/_bulk_get:
     post:
       summary: Bulk get agent policies
       tags:
@@ -2385,7 +2356,7 @@ paths:
       security: []
       parameters:
         - $ref: '#/components/parameters/format'
-  /agent_policies/delete:
+  /api/fleet/agent_policies/delete:
     post:
       summary: Delete agent policy by ID
       tags:
@@ -2426,7 +2397,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
     parameters: []
-  /data_streams:
+  /api/fleet/data_streams:
     get:
       summary: List data streams
       tags:
@@ -2447,7 +2418,7 @@ paths:
           $ref: '#/components/responses/error'
       operationId: data-streams-list
     parameters: []
-  /enrollment-api-keys:
+  /api/fleet/enrollment-api-keys:
     get:
       summary: List enrollment API keys
       tags:
@@ -2509,7 +2480,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
       deprecated: true
-  '/enrollment-api-keys/{keyId}':
+  /api/fleet/enrollment-api-keys/{keyId}:
     parameters:
       - schema:
           type: string
@@ -2560,7 +2531,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
       deprecated: true
-  /enrollment_api_keys:
+  /api/fleet/enrollment_api_keys:
     get:
       summary: List enrollment API keys
       tags:
@@ -2639,7 +2610,7 @@ paths:
       operationId: create-enrollment-api-keys
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/enrollment_api_keys/{keyId}':
+  /api/fleet/enrollment_api_keys/{keyId}:
     parameters:
       - schema:
           type: string
@@ -2688,7 +2659,7 @@ paths:
       operationId: delete-enrollment-api-key
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /package_policies:
+  /api/fleet/package_policies:
     get:
       summary: List package policies
       tags:
@@ -2755,7 +2726,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
         - $ref: '#/components/parameters/format'
-  /package_policies/_bulk_get:
+  /api/fleet/package_policies/_bulk_get:
     post:
       summary: Bulk get package policies
       tags:
@@ -2795,7 +2766,7 @@ paths:
       security: []
       parameters:
         - $ref: '#/components/parameters/format'
-  /package_policies/delete:
+  /api/fleet/package_policies/delete:
     post:
       summary: Delete package policy
       tags:
@@ -2838,7 +2809,7 @@ paths:
           $ref: '#/components/responses/error'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /package_policies/upgrade:
+  /api/fleet/package_policies/upgrade:
     post:
       summary: Upgrade package policy to a newer package version
       tags:
@@ -2879,7 +2850,7 @@ paths:
           $ref: '#/components/responses/error'
         '409':
           $ref: '#/components/responses/error'
-  /package_policies/upgrade/dryrun:
+  /api/fleet/package_policies/upgrade/dryrun:
     post:
       summary: Dry run package policy upgrade
       tags:
@@ -2919,7 +2890,7 @@ paths:
                     - hasErrors
         '400':
           $ref: '#/components/responses/error'
-  '/package_policies/{packagePolicyId}':
+  /api/fleet/package_policies/{packagePolicyId}:
     parameters:
       - schema:
           type: string
@@ -3001,7 +2972,7 @@ paths:
             type: boolean
           name: force
           in: query
-  /outputs:
+  /api/fleet/outputs:
     get:
       summary: List outputs
       tags:
@@ -3050,7 +3021,7 @@ paths:
             schema:
               $ref: '#/components/schemas/output_create_request'
       operationId: post-outputs
-  '/outputs/{outputId}':
+  /api/fleet/outputs/{outputId}:
     get:
       summary: Get output by ID
       tags:
@@ -3119,7 +3090,7 @@ paths:
           $ref: '#/components/responses/error'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  '/outputs/{outputId}/health':
+  /api/fleet/outputs/{outputId}/health:
     get:
       summary: Get latest output health
       tags:
@@ -3134,7 +3105,7 @@ paths:
                 properties:
                   state:
                     type: string
-                    description: 'state of output, HEALTHY or DEGRADED'
+                    description: state of output, HEALTHY or DEGRADED
                   message:
                     type: string
                     description: long message if unhealthy
@@ -3150,7 +3121,7 @@ paths:
         name: outputId
         in: path
         required: true
-  /logstash_api_keys:
+  /api/fleet/logstash_api_keys:
     post:
       summary: Generate Logstash API key
       tags:
@@ -3170,7 +3141,7 @@ paths:
       operationId: generate-logstash-api-key
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /agent_download_sources:
+  /api/fleet/agent_download_sources:
     get:
       summary: List agent binary download sources
       tags:
@@ -3231,7 +3202,7 @@ paths:
                 - host
                 - is_default
       operationId: post-download-sources
-  '/agent_download_sources/{sourceId}':
+  /api/fleet/agent_download_sources/{sourceId}:
     get:
       summary: Get agent binary download source by ID
       tags:
@@ -3315,7 +3286,7 @@ paths:
           $ref: '#/components/responses/error'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /fleet_server_hosts:
+  /api/fleet/fleet_server_hosts:
     get:
       summary: List Fleet Server hosts
       tags:
@@ -3384,7 +3355,7 @@ paths:
                 - name
                 - host_urls
       operationId: post-fleet-server-hosts
-  '/fleet_server_hosts/{itemId}':
+  /api/fleet/fleet_server_hosts/{itemId}:
     get:
       summary: Get Fleet Server host by ID
       tags:
@@ -3474,7 +3445,7 @@ paths:
           $ref: '#/components/responses/error'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /proxies:
+  /api/fleet/proxies:
     get:
       summary: List proxies
       tags:
@@ -3540,7 +3511,7 @@ paths:
                 - name
                 - url
       operationId: post-fleet-proxies
-  '/proxies/{itemId}':
+  /api/fleet/proxies/{itemId}:
     get:
       summary: Get proxy by ID
       tags:
@@ -3626,7 +3597,7 @@ paths:
           $ref: '#/components/responses/error'
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
-  /kubernetes:
+  /api/fleet/kubernetes:
     get:
       summary: Get full K8s agent manifest
       tags:
@@ -3660,7 +3631,7 @@ paths:
           name: enrolToken
           in: query
           required: false
-  /uninstall_tokens:
+  /api/fleet/uninstall_tokens:
     get:
       summary: List metadata for latest uninstall tokens per agent policy
       tags:
@@ -3718,7 +3689,7 @@ paths:
           required: false
           schema:
             type: string
-  '/uninstall_tokens/{uninstallTokenId}':
+  /api/fleet/uninstall_tokens/{uninstallTokenId}:
     get:
       summary: Get one decrypted uninstall token by its ID
       tags:
@@ -3833,7 +3804,7 @@ components:
     with_metrics:
       name: withMetrics
       in: query
-      description: 'Return agent metrics, false by default'
+      description: Return agent metrics, false by default
       required: false
       schema:
         type: boolean
@@ -3909,118 +3880,6 @@ components:
           $ref: '#/components/schemas/settings'
       required:
         - item
-    fleet_server_host:
-      title: Fleet Server Host
-      type: object
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        is_default:
-          type: boolean
-        is_internal:
-          type: boolean
-        is_preconfigured:
-          type: boolean
-        proxy_id:
-          type: string
-        host_urls:
-          type: array
-          items:
-            type: string
-      required:
-        - fleet_server_hosts
-        - id
-        - is_default
-        - is_preconfigured
-        - host_urls
-    proxies:
-      title: Fleet Proxy
-      type: object
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        url:
-          type: string
-        proxy_headers:
-          type: object
-        certificate_authorities:
-          type: string
-        certificate:
-          type: string
-        certificate_key:
-          type: string
-      required:
-        - name
-        - url
-    download_sources:
-      title: Download Source
-      type: object
-      properties:
-        id:
-          type: string
-        is_default:
-          type: boolean
-        name:
-          type: string
-        host:
-          type: string
-        proxy_id:
-          description: >-
-            The ID of the proxy to use for this download source. See the proxies
-            API for more information.
-          type: string
-          nullable: true
-      required:
-        - is_default
-        - name
-        - host
-    fleet_settings_enrollment_response:
-      title: Fleet settings response
-      type: object
-      properties:
-        fleet_server:
-          type: object
-          properties:
-            policies:
-              type: array
-              items:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  is_managed:
-                    type: boolean
-                  is_default_fleet_server:
-                    type: boolean
-                  has_fleet_server:
-                    type: boolean
-                  fleet_server_host_id:
-                    type: string
-                  download_source_id:
-                    type: string
-                required:
-                  - id
-                  - name
-                  - is_managed
-            has_active:
-              type: boolean
-            host:
-              $ref: '#/components/schemas/fleet_server_host'
-            host_proxy:
-              $ref: '#/components/schemas/proxies'
-          required:
-            - agent_policies
-            - has_active
-        download_source:
-          $ref: '#/components/schemas/download_sources'
-      required:
-        - fleet_server
     saved_object_type:
       title: Saved Object type
       oneOf:
@@ -4720,14 +4579,14 @@ components:
         agents:
           oneOf:
             - type: string
-              description: 'KQL query string, leave empty to action all agents'
+              description: KQL query string, leave empty to action all agents
             - type: array
               items:
                 type: string
               description: list of agent IDs
         force:
           type: boolean
-          description: 'Force upgrade, skipping validation (should be used with caution)'
+          description: Force upgrade, skipping validation (should be used with caution)
         skipRateLimitCheck:
           type: boolean
           description: Skip rate limit check for upgrade
@@ -4772,7 +4631,7 @@ components:
           type: string
         force:
           type: boolean
-          description: 'Force upgrade, skipping validation (should be used with caution)'
+          description: Force upgrade, skipping validation (should be used with caution)
         skipRateLimitCheck:
           type: boolean
           description: Skip rate limit check for upgrade
@@ -5407,7 +5266,7 @@ components:
             properties:
               enabled:
                 type: boolean
-                description: 'enable or disable that input, (default to true)'
+                description: enable or disable that input, (default to true)
               vars:
                 type: object
                 description: >-
@@ -5423,7 +5282,7 @@ components:
                   properties:
                     enabled:
                       type: boolean
-                      description: 'enable or disable that stream, (default to true)'
+                      description: enable or disable that stream, (default to true)
                     vars:
                       type: object
                       description: >-
@@ -6180,5 +6039,74 @@ components:
           elasticsearch: '#/components/schemas/output_update_request_elasticsearch'
           kafka: '#/components/schemas/output_update_request_kafka'
           logstash: '#/components/schemas/output_update_request_logstash'
+    download_sources:
+      title: Download Source
+      type: object
+      properties:
+        id:
+          type: string
+        is_default:
+          type: boolean
+        name:
+          type: string
+        host:
+          type: string
+        proxy_id:
+          description: >-
+            The ID of the proxy to use for this download source. See the proxies
+            API for more information.
+          type: string
+          nullable: true
+      required:
+        - is_default
+        - name
+        - host
+    fleet_server_host:
+      title: Fleet Server Host
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        is_default:
+          type: boolean
+        is_internal:
+          type: boolean
+        is_preconfigured:
+          type: boolean
+        proxy_id:
+          type: string
+        host_urls:
+          type: array
+          items:
+            type: string
+      required:
+        - fleet_server_hosts
+        - id
+        - is_default
+        - is_preconfigured
+        - host_urls
+    proxies:
+      title: Fleet Proxy
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        url:
+          type: string
+        proxy_headers:
+          type: object
+        certificate_authorities:
+          type: string
+        certificate:
+          type: string
+        certificate_key:
+          type: string
+      required:
+        - name
+        - url
 security:
   - basicAuth: []

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -164,7 +164,7 @@ paths:
   # Outputs
   /api/fleet/outputs:
     $ref: paths/outputs.yaml
-  '/api/fleet//outputs/{outputId}':
+  '/api/fleet/outputs/{outputId}':
     $ref: paths/outputs@{output_id}.yaml
   '/api/fleet/outputs/{outputId}/health':
     $ref: paths/output_health@{output_id}.yaml

--- a/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
+++ b/x-pack/plugins/fleet/common/openapi/entrypoint.yaml
@@ -26,178 +26,177 @@ info:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
 servers:
-  - url: 'http://KIBANA_HOST:5601/api/fleet'
-    description: Public and supported Fleet API
+  - url: 'http://KIBANA_HOST:5601'
 paths:
   # Fleet internals
-  /health_check:
+  /api/fleet/health_check:
     $ref: paths/health_check.yaml
-  /setup:
+  /api/fleet/setup:
     $ref: paths/setup.yaml
-  /settings:
+  /api/fleet/settings:
     $ref: paths/settings.yaml
-  /settings/enrollment:
-    servers:
-      - url: 'http://KIBANA_HOST:5601/internal/fleet'
-        description: Used for Fleet internals and not supported
-    $ref: paths/settings_enrollment.yaml
-  /service-tokens:
+  # /internal/fleet/settings/enrollment:
+  #   servers:
+  #     - url: 'http://KIBANA_HOST:5601/internal/fleet'
+  #       description: Used for Fleet internals and not supported
+  #   $ref: paths/settings_enrollment.yaml
+  /api/fleet/service-tokens:
     $ref: paths/service_tokens_deprecated.yaml
-  /service_tokens:
+  /api/fleet/service_tokens:
     $ref: paths/service_tokens.yaml
 
   # EPM / integrations endpoints
-  /epm/verification_key_id:
+  /api/fleet/epm/verification_key_id:
     $ref: paths/epm@verification_key_id.yaml
-  /epm/bulk_assets:
+  /api/fleet/epm/bulk_assets:
     $ref: paths/epm@bulk_assets.yaml
-  /epm/categories:
+  /api/fleet/epm/categories:
     $ref: paths/epm@categories.yaml
-  /epm/packages/limited:
+  /api/fleet/epm/packages/limited:
     $ref: paths/epm@limited_list.yaml
-  /epm/packages:
+  /api/fleet/epm/packages:
     $ref: paths/epm@packages.yaml
-  /epm/packages/_bulk:
+  /api/fleet/epm/packages/_bulk:
     $ref: paths/epm@packages_bulk.yaml
-  '/epm/packages/{pkgkey}':
+  '/api/fleet/epm/packages/{pkgkey}':
     $ref: 'paths/epm@packages@{pkgkey}_deprecated.yaml'
-  '/epm/packages/{pkgName}/{pkgVersion}':
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}':
     $ref: 'paths/epm@packages@{pkg_name}@{pkg_version}.yaml'
-  '/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize':
     $ref: 'paths/epm@packages@{pkg_name}@{pkg_version}@transforms@authorize.yaml'
-  '/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
+  '/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}':
     $ref: paths/epm@get_file.yaml
-  '/epm/packages/{pkgName}/stats':
+  '/api/fleet/epm/packages/{pkgName}/stats':
     $ref: 'paths/epm@packages@{pkg_name}@stats.yaml'
-  '/epm/templates/{pkgName}/{pkgVersion}/inputs':
+  '/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs':
     $ref: 'paths/epm@templates@{pkg_name}@{pkg_version}@inputs.yaml'
 
   # Agent endpoints
-  /agents/setup:
+  /api/fleet/agents/setup:
     $ref: paths/agents@setup.yaml
-  /agent-status:
+  /api/fleet/agent-status:
     $ref: paths/agent_status_deprecated.yaml
-  /agent_status:
+  /api/fleet/agent_status:
     $ref: paths/agent_status.yaml
-  /agent_status/data:
+  /api/fleet/agent_status/data:
     $ref: paths/agent_status@data.yaml
-  /agents:
+  /api/fleet/agents:
     $ref: paths/agents.yaml
-  /agents/bulk_upgrade:
+  /api/fleet/agents/bulk_upgrade:
     $ref: paths/agents@bulk_upgrade.yaml
-  /agents/action_status:
+  /api/fleet/agents/action_status:
     $ref: paths/agents@action_status.yaml
-  '/agents/{agentId}':
+  '/api/fleet/agents/{agentId}':
     $ref: 'paths/agents@{agent_id}.yaml'
-  '/agents/{agentId}/actions':
+  '/api/fleet/agents/{agentId}/actions':
     $ref: 'paths/agents@{agent_id}@actions.yaml'
-  '/agents/actions/{actionId}/cancel':
+  '/api/fleet/agents/actions/{actionId}/cancel':
     $ref: 'paths/agents@actions@{action_id}@cancel.yaml'
-  '/agents/files/{fileId}/{fileName}':
+  '/api/fleet/agents/files/{fileId}/{fileName}':
     $ref: 'paths/agents@files@{file_id}@{file_name}.yaml'
-  '/agents/files/{fileId}':
+  '/api/fleet/agents/files/{fileId}':
     $ref: 'paths/agents@files@{file_id}.yaml'
-  '/agents/{agentId}/reassign':
+  '/api/fleet/agents/{agentId}/reassign':
     $ref: 'paths/agents@{agent_id}@reassign.yaml'
-  '/agents/{agentId}/unenroll':
+  '/api/fleet/agents/{agentId}/unenroll':
     $ref: 'paths/agents@{agent_id}@unenroll.yaml'
-  '/agents/{agentId}/upgrade':
+  '/api/fleet/agents/{agentId}/upgrade':
     $ref: 'paths/agents@{agent_id}@upgrade.yaml'
-  '/agents/{agentId}/uploads':
+  '/api/fleet/agents/{agentId}/uploads':
     $ref: 'paths/agents@{agent_id}@uploads.yaml'
-  '/agents/bulk_reassign':
+  '/api/fleet/agents/bulk_reassign':
     $ref: 'paths/agents@bulk_reassign.yaml'
-  '/agents/bulk_unenroll':
+  '/api/fleet/agents/bulk_unenroll':
     $ref: 'paths/agents@bulk_unenroll.yaml'
-  '/agents/bulk_update_agent_tags':
+  '/api/fleet/agents/bulk_update_agent_tags':
     $ref: 'paths/agents@bulk_update_tags.yaml'
-  /agents/tags:
+  /api/fleet/agents/tags:
     $ref: paths/agent_tags.yaml
-  '/agents/{agentId}/request_diagnostics':
+  '/api/fleet/agents/{agentId}/request_diagnostics':
     $ref: 'paths/agents@{agent_id}@request_diagnostics.yaml'
-  /agents/bulk_request_diagnostics:
+  /api/fleet/agents/bulk_request_diagnostics:
     $ref: 'paths/agents@bulk_request_diagnostics.yaml'
 
   #  Agent policies endpoints
-  /agent_policies:
+  /api/fleet/agent_policies:
     $ref: paths/agent_policies.yaml
-  '/agent_policies/{agentPolicyId}':
+  '/api/fleet/agent_policies/{agentPolicyId}':
     $ref: 'paths/agent_policies@{agent_policy_id}.yaml'
-  '/agent_policies/{agentPolicyId}/copy':
+  '/api/fleet/agent_policies/{agentPolicyId}/copy':
     $ref: 'paths/agent_policies@{agent_policy_id}@copy.yaml'
-  '/agent_policies/{agentPolicyId}/full':
+  '/api/fleet/agent_policies/{agentPolicyId}/full':
     $ref: 'paths/agent_policies@{agent_policy_id}@full.yaml'
-  '/agent_policies/{agentPolicyId}/download':
+  '/api/fleet/agent_policies/{agentPolicyId}/download':
     $ref: 'paths/agent_policies@{agent_policy_id}@download.yaml'
-  /agent_policies/_bulk_get:
+  /api/fleet/agent_policies/_bulk_get:
     $ref: paths/agent_policies@_bulk_get.yaml
-  /agent_policies/delete:
+  /api/fleet/agent_policies/delete:
     $ref: paths/agent_policies@delete.yaml
 
   # Data streams endpoints
-  /data_streams:
+  /api/fleet/data_streams:
     $ref: paths/data_streams.yaml
 
   #  Enrollment endpoints
-  /enrollment-api-keys:
+  /api/fleet/enrollment-api-keys:
     $ref: paths/enrollment_api_keys_deprecated.yaml
-  '/enrollment-api-keys/{keyId}':
+  '/api/fleet/enrollment-api-keys/{keyId}':
     $ref: 'paths/enrollment_api_keys@{key_id}_deprecated.yaml'
-  /enrollment_api_keys:
+  /api/fleet/enrollment_api_keys:
     $ref: paths/enrollment_api_keys.yaml
-  '/enrollment_api_keys/{keyId}':
+  '/api/fleet/enrollment_api_keys/{keyId}':
     $ref: 'paths/enrollment_api_keys@{key_id}.yaml'
 
   #  Package policies endpoints
-  /package_policies:
+  /api/fleet/package_policies:
     $ref: paths/package_policies.yaml
-  /package_policies/_bulk_get:
+  /api/fleet/package_policies/_bulk_get:
     $ref: paths/package_policies@_bulk_get.yaml
-  /package_policies/delete:
+  /api/fleet/package_policies/delete:
     $ref: paths/package_policies@delete.yaml
-  /package_policies/upgrade:
+  /api/fleet/package_policies/upgrade:
     $ref: paths/package_policies@upgrade.yaml
-  /package_policies/upgrade/dryrun:
+  /api/fleet/package_policies/upgrade/dryrun:
     $ref: paths/package_policies@upgrade_dryrun.yaml
-  '/package_policies/{packagePolicyId}':
+  '/api/fleet/package_policies/{packagePolicyId}':
     $ref: 'paths/package_policies@{package_policy_id}.yaml'
 
   # Outputs
-  /outputs:
+  /api/fleet/outputs:
     $ref: paths/outputs.yaml
-  /outputs/{outputId}:
+  '/api/fleet//outputs/{outputId}':
     $ref: paths/outputs@{output_id}.yaml
-  /outputs/{outputId}/health:
+  '/api/fleet/outputs/{outputId}/health':
     $ref: paths/output_health@{output_id}.yaml
-  /logstash_api_keys:
+  /api/fleet/logstash_api_keys:
     $ref: paths/logstash_api_keys.yaml
 
   # Agent binary download sources
-  /agent_download_sources:
+  /api/fleet/agent_download_sources:
     $ref: paths/agent_download_sources.yaml
-  /agent_download_sources/{sourceId}:
+  '/api/fleet/agent_download_sources/{sourceId}':
     $ref: paths/agent_download_sources@{source_id}.yaml
 
   # Fleet server hosts
-  /fleet_server_hosts:
+  /api/fleet/fleet_server_hosts:
     $ref: paths/fleet_server_hosts.yaml
-  /fleet_server_hosts/{itemId}:
+  '/api/fleet/fleet_server_hosts/{itemId}':
     $ref: paths/fleet_server_hosts@{item_id}.yaml
 
   # Fleet proxies
-  /proxies:
+  /api/fleet/proxies:
     $ref: paths/proxies.yaml
-  /proxies/{itemId}:
+  '/api/fleet/proxies/{itemId}':
     $ref: paths/proxies@{item_id}.yaml
 
   # K8s
-  /kubernetes:
+  /api/fleet/kubernetes:
     $ref: paths/kubernetes.yaml
 
   # Uninstall tokens
-  /uninstall_tokens:
+  /api/fleet/uninstall_tokens:
     $ref: paths/uninstall_tokens.yaml
-  /uninstall_tokens/{uninstallTokenId}:
+  '/api/fleet/uninstall_tokens/{uninstallTokenId}':
     $ref: paths/uninstall_tokens@{uninstall_token_id}.yaml
 components:
   securitySchemes:


### PR DESCRIPTION
## Summary

This PR moves `api/fleet` from the OpenAPI servers definition into the path definition, since it's being lost when we merge this file into all the rest of the Kibana APIs (for example: https://www.elastic.co/docs/api/doc/kibana/operation/operation-new-agent-action). I've also commented out the `internal/fleet` endpoint since it seemed unlikely we want this published publicly. If that's an incorrect assumption, we can uncomment and re-generate the bundles.

<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->