### PR TITLE
Use the same date for set alert timestmap

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
@@ -65,16 +65,18 @@ const augmentAlerts = <T>({
   intendedTimestamp: Date | undefined;
 }) => {
   const commonRuleFields = getCommonAlertFields(options);
+  const currentDate = new Date();
+  const timestampOverrideOrCurrent = currentTimeOverride ?? currentDate;
   return alerts.map((alert) => {
     return {
       ...alert,
       _source: {
-        [ALERT_RULE_EXECUTION_TIMESTAMP]: new Date(),
-        [ALERT_START]: currentTimeOverride ?? new Date(),
-        [ALERT_LAST_DETECTED]: currentTimeOverride ?? new Date(),
+        [ALERT_RULE_EXECUTION_TIMESTAMP]: currentDate,
+        [ALERT_START]: timestampOverrideOrCurrent,
+        [ALERT_LAST_DETECTED]: timestampOverrideOrCurrent,
         [ALERT_INTENDED_TIMESTAMP]: intendedTimestamp
           ? intendedTimestamp
-          : currentTimeOverride ?? new Date(),
+          : timestampOverrideOrCurrent,
         [VERSION]: kibanaVersion,
         ...(options?.maintenanceWindowIds?.length
           ? { [ALERT_MAINTENANCE_WINDOW_IDS]: options.maintenanceWindowIds }


### PR DESCRIPTION
## Summary

Looks like [there can be](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6918#0191e0e0-8cde-48a7-a47e-d0919db0f220) situation when new Date() can produce slightly different result for those fields

So, I just extract them into 1 variable
