### PR TITLE
[Automatic Import] Move tech preview badge

### DIFF
--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
@@ -6,52 +6,19 @@
  */
 
 import React from 'react';
-import {
-  EuiButton,
-  EuiCard,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiText,
-  EuiTitle,
-  useEuiTheme,
-} from '@elastic/eui';
+import { EuiButton, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
 import { AssistantAvatar } from '@kbn/elastic-assistant';
-import { css } from '@emotion/react';
 import { useAuthorization } from '../../../common/hooks/use_authorization';
 import { MissingPrivilegesTooltip } from '../../../common/components/authorization';
 import { useNavigate, Page } from '../../../common/hooks/use_navigate';
 import * as i18n from './translations';
 
-const useAssistantCardCss = () => {
-  const { euiTheme } = useEuiTheme();
-  return css`
-    /* compensate for EuiCard children margin-block-start */
-    margin-block-start: calc(${euiTheme.size.s} * -2);
-  `;
-};
-
 export const IntegrationAssistantCard = React.memo(() => {
   const { canExecuteConnectors } = useAuthorization();
   const navigate = useNavigate();
-  const assistantCardCss = useAssistantCardCss();
   return (
-    <EuiCard
-      display="plain"
-      hasBorder={true}
-      paddingSize="l"
-      title={''} // title shown inside the child component
-      betaBadgeProps={{
-        label: i18n.TECH_PREVIEW,
-        tooltipContent: i18n.TECH_PREVIEW_TOOLTIP,
-      }}
-    >
-      <EuiFlexGroup
-        direction="row"
-        gutterSize="l"
-        alignItems="center"
-        justifyContent="center"
-        css={assistantCardCss}
-      >
+    <EuiPanel hasBorder={true} paddingSize="l">
+      <EuiFlexGroup direction="row" gutterSize="l" alignItems="center" justifyContent="center">
         <EuiFlexItem grow={false}>
           <AssistantAvatar />
         </EuiFlexItem>
@@ -84,7 +51,7 @@ export const IntegrationAssistantCard = React.memo(() => {
           )}
         </EuiFlexItem>
       </EuiFlexGroup>
-    </EuiCard>
+    </EuiPanel>
   );
 });
 IntegrationAssistantCard.displayName = 'IntegrationAssistantCard';

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
@@ -6,7 +6,15 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTitle,
+  EuiBetaBadge,
+} from '@elastic/eui';
 import { AssistantAvatar } from '@kbn/elastic-assistant';
 import { useAuthorization } from '../../../common/hooks/use_authorization';
 import { MissingPrivilegesTooltip } from '../../../common/components/authorization';
@@ -30,9 +38,27 @@ export const IntegrationAssistantCard = React.memo(() => {
             justifyContent="flexStart"
           >
             <EuiFlexItem>
-              <EuiTitle size="xs">
-                <h3>{i18n.ASSISTANT_TITLE}</h3>
-              </EuiTitle>
+              <EuiFlexGroup
+                direction="row"
+                gutterSize="s"
+                // alignItems="flexStart"
+                // justifyContent="flexStart"
+              >
+                <EuiFlexItem>
+                  <EuiTitle size="xs">
+                    <h3>{i18n.ASSISTANT_TITLE}</h3>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBetaBadge
+                    iconType="beaker"
+                    label={i18n.TECH_PREVIEW}
+                    tooltipContent={i18n.TECH_PREVIEW_TOOLTIP}
+                    size="s"
+                    color="hollow"
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiText size="s" color="subdued" textAlign="left">

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/integration_assistant_card.tsx
@@ -38,12 +38,7 @@ export const IntegrationAssistantCard = React.memo(() => {
             justifyContent="flexStart"
           >
             <EuiFlexItem>
-              <EuiFlexGroup
-                direction="row"
-                gutterSize="s"
-                // alignItems="flexStart"
-                // justifyContent="flexStart"
-              >
+              <EuiFlexGroup direction="row" gutterSize="s">
                 <EuiFlexItem>
                   <EuiTitle size="xs">
                     <h3>{i18n.ASSISTANT_TITLE}</h3>

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/translations.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/translations.ts
@@ -63,18 +63,3 @@ export const ASSISTANT_BUTTON = i18n.translate(
     defaultMessage: 'Create Integration',
   }
 );
-
-export const TECH_PREVIEW = i18n.translate(
-  'xpack.integrationAssistant.createIntegrationLanding.assistant.techPreviewBadge',
-  {
-    defaultMessage: 'Technical preview',
-  }
-);
-
-export const TECH_PREVIEW_TOOLTIP = i18n.translate(
-  'xpack.integrationAssistant.createIntegrationLanding.assistant.techPreviewTooltip',
-  {
-    defaultMessage:
-      'This functionality is in technical preview and is subject to change. Please use with caution in production environments.',
-  }
-);

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/translations.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_landing/translations.ts
@@ -63,3 +63,18 @@ export const ASSISTANT_BUTTON = i18n.translate(
     defaultMessage: 'Create Integration',
   }
 );
+
+export const TECH_PREVIEW = i18n.translate(
+  'xpack.integrationAssistant.createIntegrationLanding.assistant.techPreviewBadge',
+  {
+    defaultMessage: 'Technical preview',
+  }
+);
+
+export const TECH_PREVIEW_TOOLTIP = i18n.translate(
+  'xpack.integrationAssistant.createIntegrationLanding.assistant.techPreviewTooltip',
+  {
+    defaultMessage:
+      'This functionality is in technical preview and is subject to change. Please use with caution in production environments.',
+  }
+);


### PR DESCRIPTION
## Summary

The tech preview top panel badge was removed from the AutoImport landing page and added to the title as an icon.

#### Before

<img width="869" alt="Before with tech preview badge" src="https://github.com/user-attachments/assets/7546b7dc-c0d7-484d-a478-fee73d007474">

#### After

<img width="869" alt="after tech preview icon badge" src="https://github.com/user-attachments/assets/2f2b9afd-4b4f-4921-a76e-8cb2ed1ad16b">

On hover appears the tooltip text:

<img width="869" alt="after tech preview icon badge popover" src="https://github.com/user-attachments/assets/7460c7bf-1fbd-45a6-88ee-a4da25df52cd">


<!--ONMERGE {"backportTargets":["8.15"]} ONMERGE-->