### PR TITLE
[HTTP/OAS] Improve RegEx performance of path variable matcher

### DIFF
--- a/packages/kbn-router-to-openapispec/src/util.test.ts
+++ b/packages/kbn-router-to-openapispec/src/util.test.ts
@@ -14,6 +14,7 @@ import {
   getXsrfHeaderForMethod,
   mergeResponseContent,
   prepareRoutes,
+  getPathParameters,
 } from './util';
 import { assignToPaths, extractTags } from './util';
 
@@ -228,5 +229,25 @@ describe('getXsrfHeaderForMethod', () => {
     },
   ])('$method', ({ method, options, expected }) => {
     expect(getXsrfHeaderForMethod(method as RouteMethod, options)).toEqual(expected);
+  });
+});
+
+describe('getPathParameters', () => {
+  test.each([
+    ['', {}],
+    ['/', {}],
+    ['{}', {}],
+    ['{{}', {}],
+    ['{badinput', {}],
+    ['{ok}', { ok: { optional: false } }],
+    ['{ok?}', { ok: { optional: true } }],
+    ['{ok??}', {}],
+    ['/api/{path}/is/{cool}', { path: { optional: false }, cool: { optional: false } }],
+    [
+      '/{required}/and/{optional?}',
+      { required: { optional: false }, optional: { optional: true } },
+    ],
+  ])('%s', (input, output) => {
+    expect(getPathParameters(input)).toEqual(output);
   });
 });

--- a/packages/kbn-router-to-openapispec/src/util.ts
+++ b/packages/kbn-router-to-openapispec/src/util.ts
@@ -62,7 +62,7 @@ export const buildGlobalTags = (paths: OpenAPIV3.PathsObject, additionalTags: st
 };
 
 export const getPathParameters = (path: string): KnownParameters => {
-  return Array.from(path.matchAll(/\{(.+?)\}/g)).reduce<KnownParameters>((acc, [_, key]) => {
+  return Array.from(path.matchAll(/\{([^{}?]+\??)\}/g)).reduce<KnownParameters>((acc, [_, key]) => {
     const optional = key.endsWith('?');
     acc[optional ? key.slice(0, key.length - 1) : key] = { optional };
     return acc;


### PR DESCRIPTION
## Summary

Minor improvement to the existing regexp and added some test coverage for the utility.

Close https://github.com/elastic/kibana/issues/192586


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->