### PR TITLE
[Fleet] using @kbn/config-schema part 2 (outputs and other apis)

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/output.ts
+++ b/x-pack/plugins/fleet/common/types/models/output.ts
@@ -62,7 +62,7 @@ export interface NewElasticsearchOutput extends NewBaseOutput {
 
 export interface NewRemoteElasticsearchOutput extends NewBaseOutput {
   type: OutputType['RemoteElasticsearch'];
-  service_token?: string;
+  service_token?: string | null;
   secrets?: {
     service_token?: OutputSecret;
   };
@@ -110,11 +110,11 @@ export interface KafkaOutput extends NewBaseOutput {
   compression_level?: number;
   auth_type?: ValueOf<KafkaAuthType>;
   connection_type?: ValueOf<KafkaConnectionTypeType>;
-  username?: string;
-  password?: string;
+  username?: string | null;
+  password?: string | null;
   sasl?: {
     mechanism?: ValueOf<KafkaSaslMechanism>;
-  };
+  } | null;
   partition?: ValueOf<KafkaPartitionType>;
   random?: {
     group_events?: number;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -366,12 +366,12 @@ export function useOutputForm(onSucess: () => void, output?: Output, defaultOupu
   );
 
   const kafkaAuthUsernameInput = useInput(
-    kafkaOutput?.username,
+    kafkaOutput?.username ?? undefined,
     kafkaAuthMethodInput.value === kafkaAuthType.Userpass ? validateKafkaUsername : undefined,
     isDisabled('username')
   );
   const kafkaAuthPasswordInput = useInput(
-    kafkaOutput?.password,
+    kafkaOutput?.password ?? undefined,
     kafkaAuthMethodInput.value === kafkaAuthType.Userpass ? validateKafkaPassword : undefined,
     isDisabled('password')
   );

--- a/x-pack/plugins/fleet/server/routes/data_streams/index.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/index.ts
@@ -4,12 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { schema } from '@kbn/config-schema';
 
 import type { FleetAuthzRouter } from '../../services/security';
 
 import { API_VERSIONS } from '../../../common/constants';
 
 import { DATA_STREAM_API_ROUTES } from '../../constants';
+
+import { genericErrorResponse } from '../schema/errors';
 
 import { getListHandler } from './handlers';
 
@@ -21,11 +24,52 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
+      description: `List data streams`,
+      options: {
+        tags: ['oas_tag:Data streams'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: false,
+        validate: {
+          request: {},
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  data_streams: schema.arrayOf(
+                    schema.object({
+                      index: schema.string(),
+                      dataset: schema.string(),
+                      namespace: schema.string(),
+                      type: schema.string(),
+                      package: schema.string(),
+                      package_version: schema.string(),
+                      last_activity_ms: schema.number(),
+                      size_in_bytes: schema.number(),
+                      size_in_bytes_formatted: schema.oneOf([schema.number(), schema.string()]),
+                      dashboards: schema.arrayOf(
+                        schema.object({
+                          id: schema.string(),
+                          title: schema.string(),
+                        })
+                      ),
+                      serviceDetails: schema.nullable(
+                        schema.object({
+                          environment: schema.string(),
+                          serviceName: schema.string(),
+                        })
+                      ),
+                    })
+                  ),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getListHandler
     );

--- a/x-pack/plugins/fleet/server/routes/fleet_proxies/index.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_proxies/index.ts
@@ -4,15 +4,20 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { schema } from '@kbn/config-schema';
+
 import type { FleetAuthzRouter } from '../../services/security';
 import { API_VERSIONS } from '../../../common/constants';
 
 import { FLEET_PROXY_API_ROUTES } from '../../../common/constants';
 import {
+  FleetProxySchema,
   GetOneFleetProxyRequestSchema,
   PostFleetProxyRequestSchema,
   PutFleetProxyRequestSchema,
 } from '../../types';
+
+import { genericErrorResponse } from '../schema/errors';
 
 import {
   getAllFleetProxyHandler,
@@ -29,11 +34,31 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
+      description: `List proxies`,
+      options: {
+        tags: ['oas_tag:Fleet proxies'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: false,
+        validate: {
+          request: {},
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  items: schema.arrayOf(FleetProxySchema),
+                  total: schema.number(),
+                  page: schema.number(),
+                  perPage: schema.number(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getAllFleetProxyHandler
     );
@@ -44,11 +69,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: `Create proxy`,
+      options: {
+        tags: ['oas_tag:Fleet proxies'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: PostFleetProxyRequestSchema },
+        validate: {
+          request: PostFleetProxyRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: FleetProxySchema,
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       postFleetProxyHandler
     );
@@ -59,11 +101,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: `Update proxy by ID`,
+      options: {
+        tags: ['oas_tag:Fleet proxies'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: PutFleetProxyRequestSchema },
+        validate: {
+          request: PutFleetProxyRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: FleetProxySchema,
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       putFleetProxyHandler
     );
@@ -74,11 +133,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
+      description: `Get proxy by ID`,
+      options: {
+        tags: ['oas_tag:Fleet proxies'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetOneFleetProxyRequestSchema },
+        validate: {
+          request: GetOneFleetProxyRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: FleetProxySchema,
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getFleetProxyHandler
     );
@@ -89,11 +165,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: `Delete proxy by ID`,
+      options: {
+        tags: ['oas_tag:Fleet proxies'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetOneFleetProxyRequestSchema },
+        validate: {
+          request: GetOneFleetProxyRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  id: schema.string(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       deleteFleetProxyHandler
     );

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/index.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/index.ts
@@ -50,11 +50,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
             200: {
               body: () =>
                 schema.object({
-                  items: schema.arrayOf(
-                    FleetServerHostSchema.extends({
-                      id: schema.string(),
-                    })
-                  ),
+                  items: schema.arrayOf(FleetServerHostSchema),
                   total: schema.number(),
                   page: schema.number(),
                   perPage: schema.number(),
@@ -88,9 +84,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
             200: {
               body: () =>
                 schema.object({
-                  item: FleetServerHostSchema.extends({
-                    id: schema.string(),
-                  }),
+                  item: FleetServerHostSchema,
                 }),
             },
             400: {
@@ -121,9 +115,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
             200: {
               body: () =>
                 schema.object({
-                  item: FleetServerHostSchema.extends({
-                    id: schema.string(),
-                  }),
+                  item: FleetServerHostSchema,
                 }),
             },
             400: {
@@ -185,9 +177,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
             200: {
               body: () =>
                 schema.object({
-                  item: FleetServerHostSchema.extends({
-                    id: schema.string(),
-                  }),
+                  item: FleetServerHostSchema,
                 }),
             },
             400: {

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/index.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/index.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { schema } from '@kbn/config-schema';
 
 import type { FleetAuthzRouter } from '../../services/security';
 
@@ -11,11 +12,14 @@ import { API_VERSIONS } from '../../../common/constants';
 
 import { FLEET_SERVER_HOST_API_ROUTES } from '../../../common/constants';
 import {
+  FleetServerHostSchema,
   GetAllFleetServerHostRequestSchema,
   GetOneFleetServerHostRequestSchema,
   PostFleetServerHostRequestSchema,
   PutFleetServerHostRequestSchema,
 } from '../../types';
+
+import { genericErrorResponse } from '../schema/errors';
 
 import {
   deleteFleetServerHostHandler,
@@ -32,11 +36,35 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.addAgents || authz.fleet.addFleetServers || authz.fleet.readSettings;
       },
+      description: `List Fleet Server hosts`,
+      options: {
+        tags: ['oas_tag:Fleet Server hosts'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetAllFleetServerHostRequestSchema },
+        validate: {
+          request: GetAllFleetServerHostRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  items: schema.arrayOf(
+                    FleetServerHostSchema.extends({
+                      id: schema.string(),
+                    })
+                  ),
+                  total: schema.number(),
+                  page: schema.number(),
+                  perPage: schema.number(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getAllFleetServerHostsHandler
     );
@@ -46,11 +74,30 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: `Create Fleet Server host`,
+      options: {
+        tags: ['oas_tag:Fleet Server hosts'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: PostFleetServerHostRequestSchema },
+        validate: {
+          request: PostFleetServerHostRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: FleetServerHostSchema.extends({
+                    id: schema.string(),
+                  }),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       postFleetServerHost
     );
@@ -60,11 +107,30 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
+      description: `Get Fleet Server host by ID`,
+      options: {
+        tags: ['oas_tag:Fleet Server hosts'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetOneFleetServerHostRequestSchema },
+        validate: {
+          request: GetOneFleetServerHostRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: FleetServerHostSchema.extends({
+                    id: schema.string(),
+                  }),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getFleetServerHostHandler
     );
@@ -74,11 +140,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: `Delete Fleet Server host by ID`,
+      options: {
+        tags: ['oas_tag:Fleet Server hosts'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetOneFleetServerHostRequestSchema },
+        validate: {
+          request: GetOneFleetServerHostRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  id: schema.string(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       deleteFleetServerHostHandler
     );
@@ -88,11 +171,30 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: `Update Fleet Server host by ID`,
+      options: {
+        tags: ['oas_tag:Fleet Server hosts'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: PutFleetServerHostRequestSchema },
+        validate: {
+          request: PutFleetServerHostRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: FleetServerHostSchema.extends({
+                    id: schema.string(),
+                  }),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       putFleetServerHostHandler
     );

--- a/x-pack/plugins/fleet/server/routes/message_signing_service/index.ts
+++ b/x-pack/plugins/fleet/server/routes/message_signing_service/index.ts
@@ -4,11 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { schema } from '@kbn/config-schema';
 
 import type { FleetAuthzRouter } from '../../services/security';
 import { API_VERSIONS } from '../../../common/constants';
 import { MESSAGE_SIGNING_SERVICE_API_ROUTES } from '../../constants';
 import { RotateKeyPairSchema } from '../../types';
+
+import { genericErrorResponse } from '../schema/errors';
 
 import { rotateKeyPairHandler } from './handlers';
 
@@ -20,11 +23,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
+      description: 'Rotate fleet message signing key pair',
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: RotateKeyPairSchema },
+        validate: {
+          request: RotateKeyPairSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  message: schema.string(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+            500: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       rotateKeyPairHandler
     );

--- a/x-pack/plugins/fleet/server/routes/output/index.ts
+++ b/x-pack/plugins/fleet/server/routes/output/index.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { schema } from '@kbn/config-schema';
 
 import type { FleetAuthzRouter } from '../../services/security';
 
@@ -15,9 +16,12 @@ import {
   GetLatestOutputHealthRequestSchema,
   GetOneOutputRequestSchema,
   GetOutputsRequestSchema,
+  OutputSchema,
   PostOutputRequestSchema,
   PutOutputRequestSchema,
 } from '../../types';
+
+import { genericErrorResponse } from '../schema/errors';
 
 import {
   deleteOutputHandler,
@@ -36,11 +40,31 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
+      description: 'List outputs',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetOutputsRequestSchema },
+        validate: {
+          request: GetOutputsRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  items: schema.arrayOf(OutputSchema),
+                  total: schema.number(),
+                  page: schema.number(),
+                  perPage: schema.number(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getOutputsHandler
     );
@@ -50,11 +74,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
+      description: 'Get output by ID',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetOneOutputRequestSchema },
+        validate: {
+          request: GetOneOutputRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: OutputSchema,
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getOneOuputHandler
     );
@@ -64,11 +105,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: 'Update output by ID',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: PutOutputRequestSchema },
+        validate: {
+          request: PutOutputRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: OutputSchema,
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       putOutputHandler
     );
@@ -79,11 +137,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: 'Create output',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: PostOutputRequestSchema },
+        validate: {
+          request: PostOutputRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  item: OutputSchema,
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       postOutputHandler
     );
@@ -94,11 +169,31 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: 'Delete output by ID',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: DeleteOutputRequestSchema },
+        validate: {
+          request: DeleteOutputRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  id: schema.string(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+            404: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       deleteOutputHandler
     );
@@ -109,11 +204,28 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
+      description: 'Generate Logstash API keyy',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: false,
+        validate: {
+          request: {},
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  api_key: schema.string(),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       postLogstashApiKeyHandler
     );
@@ -124,11 +236,42 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
+      description: 'Get latest output health',
+      options: {
+        tags: ['oas_tag:Fleet outputs'],
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
-        validate: { request: GetLatestOutputHealthRequestSchema },
+        validate: {
+          request: GetLatestOutputHealthRequestSchema,
+          response: {
+            200: {
+              body: () =>
+                schema.object({
+                  state: schema.string({
+                    meta: {
+                      description: 'state of output, HEALTHY or DEGRADED',
+                    },
+                  }),
+                  message: schema.string({
+                    meta: {
+                      description: 'long message if unhealthy',
+                    },
+                  }),
+                  timestamp: schema.string({
+                    meta: {
+                      description: 'timestamp of reported state',
+                    },
+                  }),
+                }),
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+          },
+        },
       },
       getLatestOutputHealth
     );

--- a/x-pack/plugins/fleet/server/routes/package_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/index.ts
@@ -282,7 +282,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
                       )
                     ),
                     policy_ids: schema.arrayOf(schema.string()),
-                    output_id: schema.nullable(schema.maybe(schema.string())),
+                    output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
                     package: PackagePolicyPackageSchema,
                   })
                 ),

--- a/x-pack/plugins/fleet/server/routes/settings/index.ts
+++ b/x-pack/plugins/fleet/server/routes/settings/index.ts
@@ -204,8 +204,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
                         is_managed: schema.boolean(),
                         is_default_fleet_server: schema.maybe(schema.boolean()),
                         has_fleet_server: schema.maybe(schema.boolean()),
-                        fleet_server_host_id: schema.nullable(schema.maybe(schema.string())),
-                        download_source_id: schema.nullable(schema.maybe(schema.string())),
+                        fleet_server_host_id: schema.maybe(
+                          schema.oneOf([schema.literal(null), schema.string()])
+                        ),
+                        download_source_id: schema.maybe(
+                          schema.oneOf([schema.literal(null), schema.string()])
+                        ),
                         space_ids: schema.maybe(schema.arrayOf(schema.string())),
                       })
                     ),
@@ -218,7 +222,9 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
                         is_default: schema.boolean(),
                         is_preconfigured: schema.boolean(),
                         is_internal: schema.maybe(schema.boolean()),
-                        proxy_id: schema.nullable(schema.maybe(schema.string())),
+                        proxy_id: schema.maybe(
+                          schema.oneOf([schema.literal(null), schema.string()])
+                        ),
                       })
                     ),
                     host_proxy: schema.maybe(
@@ -232,9 +238,15 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
                         ),
                         name: schema.string(),
                         url: schema.string(),
-                        certificate_authorities: schema.nullable(schema.maybe(schema.string())),
-                        certificate: schema.nullable(schema.maybe(schema.string())),
-                        certificate_key: schema.nullable(schema.maybe(schema.string())),
+                        certificate_authorities: schema.maybe(
+                          schema.oneOf([schema.literal(null), schema.string()])
+                        ),
+                        certificate: schema.maybe(
+                          schema.oneOf([schema.literal(null), schema.string()])
+                        ),
+                        certificate_key: schema.maybe(
+                          schema.oneOf([schema.literal(null), schema.string()])
+                        ),
                         is_preconfigured: schema.boolean(),
                       })
                     ),

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -65,10 +65,10 @@ export const AgentPolicyBaseSchema = {
     )
   ),
   keep_monitoring_alive: schema.maybe(schema.boolean({ defaultValue: false })),
-  data_output_id: schema.maybe(schema.nullable(schema.string())),
-  monitoring_output_id: schema.maybe(schema.nullable(schema.string())),
-  download_source_id: schema.maybe(schema.nullable(schema.string())),
-  fleet_server_host_id: schema.maybe(schema.nullable(schema.string())),
+  data_output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  monitoring_output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  download_source_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  fleet_server_host_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   agent_features: schema.maybe(
     schema.arrayOf(
       schema.object({

--- a/x-pack/plugins/fleet/server/types/models/output.ts
+++ b/x-pack/plugins/fleet/server/types/models/output.ts
@@ -67,11 +67,12 @@ const BaseSchema = {
   is_default_monitoring: schema.boolean({ defaultValue: false }),
   is_internal: schema.maybe(schema.boolean()),
   is_preconfigured: schema.maybe(schema.boolean()),
-  ca_sha256: schema.nullable(schema.maybe(schema.string())),
-  ca_trusted_fingerprint: schema.nullable(schema.maybe(schema.string())),
-  config_yaml: schema.nullable(schema.maybe(schema.string())),
-  ssl: schema.nullable(
-    schema.maybe(
+  ca_sha256: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  ca_trusted_fingerprint: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  config_yaml: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  ssl: schema.maybe(
+    schema.oneOf([
+      schema.literal(null),
       schema.object({
         certificate_authorities: schema.maybe(schema.arrayOf(schema.string())),
         certificate: schema.maybe(schema.string()),
@@ -84,12 +85,13 @@ const BaseSchema = {
             schema.literal(kafkaVerificationModes.Strict),
           ])
         ),
-      })
-    )
+      }),
+    ])
   ),
-  proxy_id: schema.nullable(schema.maybe(schema.string())),
-  shipper: schema.nullable(
-    schema.maybe(
+  proxy_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  shipper: schema.maybe(
+    schema.oneOf([
+      schema.literal(null),
       schema.object({
         disk_queue_enabled: schema.nullable(schema.boolean({ defaultValue: false })),
         disk_queue_path: schema.nullable(schema.string()),
@@ -101,8 +103,8 @@ const BaseSchema = {
         mem_queue_events: schema.nullable(schema.number()),
         queue_flush_timeout: schema.nullable(schema.number()),
         max_batch_bytes: schema.nullable(schema.number()),
-      })
-    )
+      }),
+    ])
   ),
   allow_edit: schema.maybe(schema.arrayOf(schema.string())),
 };
@@ -147,7 +149,7 @@ const ElasticSearchUpdateSchema = {
 export const RemoteElasticSearchSchema = {
   ...ElasticSearchSchema,
   type: schema.literal(outputType.RemoteElasticsearch),
-  service_token: schema.nullable(schema.maybe(schema.string())),
+  service_token: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   secrets: schema.maybe(
     schema.object({
       service_token: schema.maybe(secretRefSchema),
@@ -158,7 +160,7 @@ export const RemoteElasticSearchSchema = {
 const RemoteElasticSearchUpdateSchema = {
   ...ElasticSearchUpdateSchema,
   type: schema.maybe(schema.literal(outputType.RemoteElasticsearch)),
-  service_token: schema.nullable(schema.maybe(schema.string())),
+  service_token: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   secrets: schema.maybe(
     schema.object({
       service_token: schema.maybe(secretRefSchema),
@@ -274,8 +276,9 @@ export const KafkaSchema = {
       )
     )
   ),
-  sasl: schema.nullable(
-    schema.maybe(
+  sasl: schema.maybe(
+    schema.oneOf([
+      schema.literal(null),
       schema.object({
         mechanism: schema.maybe(
           schema.oneOf([
@@ -284,8 +287,8 @@ export const KafkaSchema = {
             schema.literal(kafkaSaslMechanism.ScramSha512),
           ])
         ),
-      })
-    )
+      }),
+    ])
   ),
   partition: schema.maybe(
     schema.oneOf([

--- a/x-pack/plugins/fleet/server/types/models/package_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/package_policy.ts
@@ -150,7 +150,7 @@ export const PackagePolicyBaseSchema = {
       })
     )
   ),
-  output_id: schema.nullable(schema.maybe(schema.string())),
+  output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   enabled: schema.boolean(),
   is_managed: schema.maybe(schema.boolean()),
   package: schema.maybe(PackagePolicyPackageSchema),
@@ -296,7 +296,7 @@ export const SimplifiedPackagePolicyBaseSchema = schema.object({
   name: schema.string(),
   description: schema.maybe(schema.string()),
   namespace: schema.maybe(schema.string()),
-  output_id: schema.nullable(schema.maybe(schema.string())),
+  output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   vars: schema.maybe(SimplifiedVarsSchema),
   inputs: SimplifiedPackagePolicyInputsSchema,
 });
@@ -312,7 +312,7 @@ export const SimplifiedPackagePolicyPreconfiguredSchema = SimplifiedPackagePolic
 
 export const SimplifiedCreatePackagePolicyRequestBodySchema =
   SimplifiedPackagePolicyBaseSchema.extends({
-    policy_id: schema.nullable(schema.maybe(schema.string())),
+    policy_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
     policy_ids: schema.maybe(schema.arrayOf(schema.string())),
     force: schema.maybe(schema.boolean()),
     package: PackagePolicyPackageSchema,

--- a/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
@@ -162,7 +162,7 @@ export const PreconfiguredAgentPoliciesSchema = schema.arrayOf(
             }),
             description: schema.maybe(schema.string()),
             namespace: schema.maybe(PackagePolicyNamespaceSchema),
-            output_id: schema.nullable(schema.maybe(schema.string())),
+            output_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
             inputs: schema.maybe(
               schema.arrayOf(
                 schema.object({

--- a/x-pack/plugins/fleet/server/types/rest_spec/fleet_proxies.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/fleet_proxies.ts
@@ -29,9 +29,9 @@ export const FleetProxySchema = schema.object({
       )
     )
   ),
-  certificate_authorities: schema.nullable(schema.maybe(schema.string())),
-  certificate: schema.nullable(schema.maybe(schema.string())),
-  certificate_key: schema.nullable(schema.maybe(schema.string())),
+  certificate_authorities: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  certificate: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  certificate_key: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   is_preconfigured: schema.boolean({ defaultValue: false }),
 });
 

--- a/x-pack/plugins/fleet/server/types/rest_spec/fleet_proxies.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/fleet_proxies.ts
@@ -15,22 +15,29 @@ function validateUrl(value: string) {
   }
 }
 
-export const PostFleetProxyRequestSchema = {
-  body: schema.object({
-    id: schema.maybe(schema.string()),
-    url: schema.string({
-      validate: validateUrl,
-    }),
-    name: schema.string(),
-    proxy_headers: schema.maybe(
+export const FleetProxySchema = schema.object({
+  id: schema.string(),
+  url: schema.string({
+    validate: validateUrl,
+  }),
+  name: schema.string(),
+  proxy_headers: schema.nullable(
+    schema.maybe(
       schema.recordOf(
         schema.string(),
         schema.oneOf([schema.string(), schema.boolean(), schema.number()])
       )
-    ),
-    certificate_authorities: schema.maybe(schema.string()),
-    certificate: schema.maybe(schema.string()),
-    certificate_key: schema.maybe(schema.string()),
+    )
+  ),
+  certificate_authorities: schema.nullable(schema.maybe(schema.string())),
+  certificate: schema.nullable(schema.maybe(schema.string())),
+  certificate_key: schema.nullable(schema.maybe(schema.string())),
+  is_preconfigured: schema.boolean({ defaultValue: false }),
+});
+
+export const PostFleetProxyRequestSchema = {
+  body: FleetProxySchema.extends({
+    id: schema.maybe(schema.string()),
   }),
 };
 

--- a/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
@@ -7,14 +7,18 @@
 
 import { schema } from '@kbn/config-schema';
 
+export const FleetServerHostSchema = schema.object({
+  name: schema.string(),
+  host_urls: schema.arrayOf(schema.string(), { minSize: 1 }),
+  is_default: schema.boolean({ defaultValue: false }),
+  is_internal: schema.maybe(schema.boolean()),
+  is_preconfigured: schema.boolean({ defaultValue: false }),
+  proxy_id: schema.nullable(schema.maybe(schema.string())),
+});
+
 export const PostFleetServerHostRequestSchema = {
-  body: schema.object({
+  body: FleetServerHostSchema.extends({
     id: schema.maybe(schema.string()),
-    name: schema.string(),
-    host_urls: schema.arrayOf(schema.string(), { minSize: 1 }),
-    is_default: schema.boolean({ defaultValue: false }),
-    is_internal: schema.maybe(schema.boolean()),
-    proxy_id: schema.nullable(schema.string()),
   }),
 };
 
@@ -24,13 +28,7 @@ export const GetOneFleetServerHostRequestSchema = {
 
 export const PutFleetServerHostRequestSchema = {
   params: schema.object({ itemId: schema.string() }),
-  body: schema.object({
-    name: schema.maybe(schema.string()),
-    host_urls: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
-    is_default: schema.maybe(schema.boolean({ defaultValue: false })),
-    is_internal: schema.maybe(schema.boolean()),
-    proxy_id: schema.nullable(schema.string()),
-  }),
+  body: FleetServerHostSchema,
 };
 
 export const GetAllFleetServerHostRequestSchema = {};

--- a/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
@@ -28,7 +28,13 @@ export const GetOneFleetServerHostRequestSchema = {
 
 export const PutFleetServerHostRequestSchema = {
   params: schema.object({ itemId: schema.string() }),
-  body: FleetServerHostSchema,
+  body: schema.object({
+    name: schema.maybe(schema.string()),
+    host_urls: schema.maybe(schema.arrayOf(schema.string(), { minSize: 1 })),
+    is_default: schema.maybe(schema.boolean({ defaultValue: false })),
+    is_internal: schema.maybe(schema.boolean()),
+    proxy_id: schema.nullable(schema.string()),
+  }),
 };
 
 export const GetAllFleetServerHostRequestSchema = {};

--- a/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
@@ -8,6 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 export const FleetServerHostSchema = schema.object({
+  id: schema.string(),
   name: schema.string(),
   host_urls: schema.arrayOf(schema.string(), { minSize: 1 }),
   is_default: schema.boolean({ defaultValue: false }),

--- a/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/fleet_server_policy_config.ts
@@ -14,7 +14,7 @@ export const FleetServerHostSchema = schema.object({
   is_default: schema.boolean({ defaultValue: false }),
   is_internal: schema.maybe(schema.boolean()),
   is_preconfigured: schema.boolean({ defaultValue: false }),
-  proxy_id: schema.nullable(schema.maybe(schema.string())),
+  proxy_id: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
 });
 
 export const PostFleetServerHostRequestSchema = {

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/__snapshots__/agent_policy.snap
@@ -30,7 +30,6 @@ Object {
       "enabled": true,
       "name": "system-1",
       "namespace": "default",
-      "output_id": null,
       "package": Object {
         "name": "system",
         "requires_root": true,


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/184685

Follow up after https://github.com/elastic/kibana/pull/192447

To verify, go to Fleet settings and try create/update different output types, fleet server hosts, outputs.
While verifying I got a few errors where some fields were missing `schema.nullable`.

```
GET kbn:/api/oas?pathStartsWith=/api/fleet/outputs
GET kbn:/api/oas?pathStartsWith=/api/fleet/health_check
GET kbn:/api/oas?pathStartsWith=/api/fleet/message_signing_service/rotate_key_pair
GET kbn:/api/oas?pathStartsWith=/api/fleet/fleet_server_hosts
GET kbn:/api/oas?pathStartsWith=/api/fleet/data_streams

# test APIs
POST kbn:/api/fleet/health_check
{
  "id": "default-fleet-server"
}
POST kbn:/api/fleet/message_signing_service/rotate_key_pair
GET kbn:/api/fleet/data_streams
GET kbn:/api/fleet/check-permissions
POST kbn:/api/fleet/service_tokens
``` 
