### PR TITLE
Hook up discovery service to Task Manager health

### DIFF
--- a/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.test.ts
+++ b/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.test.ts
@@ -187,6 +187,7 @@ describe('KibanaDiscoveryService', () => {
     savedObjectsRepository.find.mockResolvedValueOnce(createFindResponse(mockActiveNodes));
 
     it('returns the active kibana nodes', async () => {
+      const onNodesCounted = jest.fn();
       const kibanaDiscoveryService = new KibanaDiscoveryService({
         savedObjectsRepository,
         logger,
@@ -195,6 +196,7 @@ describe('KibanaDiscoveryService', () => {
           active_nodes_lookback: DEFAULT_ACTIVE_NODES_LOOK_BACK_DURATION,
           interval: DEFAULT_DISCOVERY_INTERVAL_MS,
         },
+        onNodesCounted,
       });
 
       const activeNodes = await kibanaDiscoveryService.getActiveKibanaNodes();
@@ -206,6 +208,7 @@ describe('KibanaDiscoveryService', () => {
         type: BACKGROUND_TASK_NODE_SO_NAME,
       });
       expect(activeNodes).toEqual(mockActiveNodes);
+      expect(onNodesCounted).toHaveBeenCalledWith(mockActiveNodes.length);
     });
   });
 

--- a/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
+++ b/x-pack/plugins/task_manager/server/kibana_discovery_service/kibana_discovery_service.ts
@@ -16,6 +16,7 @@ interface DiscoveryServiceParams {
   currentNode: string;
   savedObjectsRepository: ISavedObjectsRepository;
   logger: Logger;
+  onNodesCounted?: (numOfNodes: number) => void;
 }
 
 interface DiscoveryServiceUpsertParams {
@@ -30,13 +31,15 @@ export class KibanaDiscoveryService {
   private started = false;
   private savedObjectsRepository: ISavedObjectsRepository;
   private logger: Logger;
+  private onNodesCounted?: (numOfNodes: number) => void;
 
-  constructor({ config, currentNode, savedObjectsRepository, logger }: DiscoveryServiceParams) {
-    this.activeNodesLookBack = config.active_nodes_lookback;
-    this.discoveryInterval = config.interval;
-    this.savedObjectsRepository = savedObjectsRepository;
-    this.logger = logger;
-    this.currentNode = currentNode;
+  constructor(opts: DiscoveryServiceParams) {
+    this.activeNodesLookBack = opts.config.active_nodes_lookback;
+    this.discoveryInterval = opts.config.interval;
+    this.savedObjectsRepository = opts.savedObjectsRepository;
+    this.logger = opts.logger;
+    this.currentNode = opts.currentNode;
+    this.onNodesCounted = opts.onNodesCounted;
   }
 
   private async upsertCurrentNode({ id, lastSeen }: DiscoveryServiceUpsertParams) {
@@ -98,6 +101,10 @@ export class KibanaDiscoveryService {
         page: 1,
         filter: `${BACKGROUND_TASK_NODE_SO_NAME}.attributes.last_seen > now-${this.activeNodesLookBack}`,
       });
+
+    if (this.onNodesCounted) {
+      this.onNodesCounted(activeNodes.length);
+    }
 
     return activeNodes;
   }

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.test.ts
@@ -63,7 +63,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 1,
@@ -119,7 +120,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 1,
@@ -158,7 +160,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 1,
@@ -214,7 +217,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 1,
@@ -271,7 +275,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 1,
@@ -327,7 +332,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        3
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 3,
@@ -396,7 +402,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        2
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: provisionedKibanaInstances,
@@ -477,7 +484,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        2
       ).value
     ).toMatchObject({
       observed: {
@@ -561,7 +569,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       )
     ).toMatchObject({
       status: 'OK',
@@ -626,7 +635,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       )
     ).toMatchObject({
       status: 'OK',
@@ -691,7 +701,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       )
     ).toMatchObject({
       status: 'OK',
@@ -755,7 +766,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       )
     ).toMatchObject({
       status: 'OK',
@@ -831,7 +843,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       )
     ).toMatchObject({
       status: 'OK',
@@ -905,7 +918,8 @@ describe('estimateCapacity', () => {
               result_frequency_percent_as_number: {},
             },
           }
-        )
+        ),
+        1
       ).value.observed
     ).toMatchObject({
       observed_kibana_instances: 1,

--- a/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/capacity_estimation.ts
@@ -46,11 +46,10 @@ function isCapacityEstimationParams(
 
 export function estimateCapacity(
   logger: Logger,
-  capacityStats: CapacityEstimationParams
+  capacityStats: CapacityEstimationParams,
+  assumedKibanaInstances: number
 ): RawMonitoredStat<CapacityEstimationStat> {
   const workload = capacityStats.workload.value;
-  // if there are no active owners right now, assume there's at least 1
-  const assumedKibanaInstances = Math.max(workload.owner_ids, 1);
 
   const {
     load: { p90: averageLoadPercentage },
@@ -262,12 +261,13 @@ function getHealthStatus(
 
 export function withCapacityEstimate(
   logger: Logger,
-  monitoredStats: RawMonitoringStats['stats']
+  monitoredStats: RawMonitoringStats['stats'],
+  assumedKibanaInstances: number
 ): RawMonitoringStats['stats'] {
   if (isCapacityEstimationParams(monitoredStats)) {
     return {
       ...monitoredStats,
-      capacity_estimation: estimateCapacity(logger, monitoredStats),
+      capacity_estimation: estimateCapacity(logger, monitoredStats, assumedKibanaInstances),
     };
   }
   return monitoredStats;

--- a/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/monitoring_stats_stream.ts
@@ -158,42 +158,47 @@ export function summarizeMonitoringStats(
     last_update,
     stats: { runtime, workload, configuration, ephemeral, utilization },
   }: MonitoringStats,
-  config: TaskManagerConfig
+  config: TaskManagerConfig,
+  assumedKibanaInstances: number
 ): RawMonitoringStats {
-  const summarizedStats = withCapacityEstimate(logger, {
-    ...(configuration
-      ? {
-          configuration: {
-            ...configuration,
-            status: HealthStatus.OK,
-          },
-        }
-      : {}),
-    ...(runtime
-      ? {
-          runtime: {
-            timestamp: runtime.timestamp,
-            ...summarizeTaskRunStat(logger, runtime.value, config),
-          },
-        }
-      : {}),
-    ...(workload
-      ? {
-          workload: {
-            timestamp: workload.timestamp,
-            ...summarizeWorkloadStat(workload.value),
-          },
-        }
-      : {}),
-    ...(ephemeral
-      ? {
-          ephemeral: {
-            timestamp: ephemeral.timestamp,
-            ...summarizeEphemeralStat(ephemeral.value),
-          },
-        }
-      : {}),
-  });
+  const summarizedStats = withCapacityEstimate(
+    logger,
+    {
+      ...(configuration
+        ? {
+            configuration: {
+              ...configuration,
+              status: HealthStatus.OK,
+            },
+          }
+        : {}),
+      ...(runtime
+        ? {
+            runtime: {
+              timestamp: runtime.timestamp,
+              ...summarizeTaskRunStat(logger, runtime.value, config),
+            },
+          }
+        : {}),
+      ...(workload
+        ? {
+            workload: {
+              timestamp: workload.timestamp,
+              ...summarizeWorkloadStat(workload.value),
+            },
+          }
+        : {}),
+      ...(ephemeral
+        ? {
+            ephemeral: {
+              timestamp: ephemeral.timestamp,
+              ...summarizeEphemeralStat(ephemeral.value),
+            },
+          }
+        : {}),
+    },
+    assumedKibanaInstances
+  );
 
   return {
     last_update,

--- a/x-pack/plugins/task_manager/server/monitoring/workload_statistics.test.ts
+++ b/x-pack/plugins/task_manager/server/monitoring/workload_statistics.test.ts
@@ -169,10 +169,6 @@ describe('Workload Statistics Aggregator', () => {
               missing: { field: 'task.schedule.interval' },
               aggs: { taskType: { terms: { size: 3, field: 'task.taskType' } } },
             },
-            ownerIds: {
-              filter: { range: { 'task.startedAt': { gte: 'now-1w/w' } } },
-              aggs: { ownerIds: { cardinality: { field: 'task.ownerId' } } },
-            },
             idleTasks: {
               filter: { term: { 'task.status': 'idle' } },
               aggs: {

--- a/x-pack/plugins/task_manager/server/plugin.ts
+++ b/x-pack/plugins/task_manager/server/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { combineLatest, Observable, Subject } from 'rxjs';
+import { combineLatest, Observable, Subject, BehaviorSubject } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { UsageCollectionSetup, UsageCounter } from '@kbn/usage-collection-plugin/server';
@@ -106,6 +106,7 @@ export class TaskManagerPlugin
   private nodeRoles: PluginInitializerContext['node']['roles'];
   private kibanaDiscoveryService?: KibanaDiscoveryService;
   private heapSizeLimit: number = 0;
+  private numOfKibanaInstances$: Subject<number> = new BehaviorSubject(1);
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.initContext = initContext;
@@ -169,6 +170,7 @@ export class TaskManagerPlugin
         startServicesPromise.then(({ elasticsearch }) => elasticsearch.client),
       shouldRunTasks: this.shouldRunBackgroundTasks,
       docLinks: core.docLinks,
+      numOfKibanaInstances$: this.numOfKibanaInstances$,
     });
     const monitoredUtilization$ = backgroundTaskUtilizationRoute({
       router,
@@ -260,6 +262,7 @@ export class TaskManagerPlugin
       logger: this.logger,
       currentNode: this.taskManagerId!,
       config: this.config.discovery,
+      onNodesCounted: (numOfNodes: number) => this.numOfKibanaInstances$.next(numOfNodes),
     });
 
     if (this.shouldRunBackgroundTasks) {

--- a/x-pack/plugins/task_manager/server/routes/health.test.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { firstValueFrom, of, Subject } from 'rxjs';
+import { firstValueFrom, of, Subject, BehaviorSubject } from 'rxjs';
 import { merge } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { httpServiceMock, docLinksServiceMock } from '@kbn/core/server/mocks';
@@ -87,6 +87,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const [config] = router.get.mock.calls[0];
@@ -111,6 +112,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const [, handler] = router.get.mock.calls[0];
@@ -153,6 +155,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const [, handler] = router.get.mock.calls[0];
@@ -200,6 +203,7 @@ describe('healthRoute', () => {
       getClusterClient: () => Promise.resolve(mockClusterClient),
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const [, handler] = router.get.mock.calls[0];
@@ -242,6 +246,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     stats$.next(mockStat);
@@ -319,6 +324,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const serviceStatus = firstValueFrom(serviceStatus$);
@@ -421,6 +427,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const serviceStatus = firstValueFrom(serviceStatus$);
@@ -509,6 +516,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const serviceStatus = firstValueFrom(serviceStatus$);
@@ -602,6 +610,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
 
     const serviceStatus = firstValueFrom(serviceStatus$);
@@ -683,6 +692,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: true,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
     const serviceStatus = firstValueFrom(serviceStatus$);
     await sleep(0);
@@ -782,6 +792,7 @@ describe('healthRoute', () => {
       usageCounter: mockUsageCounter,
       shouldRunTasks: false,
       docLinks,
+      numOfKibanaInstances$: new BehaviorSubject(1),
     });
     const serviceStatus = firstValueFrom(serviceStatus$);
     await sleep(0);

--- a/x-pack/plugins/task_manager/server/routes/health.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.ts
@@ -86,6 +86,7 @@ export function healthRoute(params: HealthRouteParams): {
 
   let numOfKibanaInstances = 1;
   numOfKibanaInstances$.subscribe((updatedNumber) => {
+    // if there are no active nodes right now, assume there's at least 1
     numOfKibanaInstances = Math.max(updatedNumber, 1);
   });
 

--- a/x-pack/plugins/task_manager/server/routes/health.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.ts
@@ -86,7 +86,7 @@ export function healthRoute(params: HealthRouteParams): {
 
   let numOfKibanaInstances = 1;
   numOfKibanaInstances$.subscribe((updatedNumber) => {
-    numOfKibanaInstances = updatedNumber;
+    numOfKibanaInstances = Math.max(updatedNumber, 1);
   });
 
   // if "hot" health stats are any more stale than monitored_stats_required_freshness (pollInterval +1s buffer by default)

--- a/x-pack/plugins/task_manager/server/routes/health.ts
+++ b/x-pack/plugins/task_manager/server/routes/health.ts
@@ -62,6 +62,7 @@ export interface HealthRouteParams {
   getClusterClient: () => Promise<IClusterClient>;
   usageCounter?: UsageCounter;
   docLinks: DocLinksServiceSetup;
+  numOfKibanaInstances$: Observable<number>;
 }
 
 export function healthRoute(params: HealthRouteParams): {
@@ -80,14 +81,25 @@ export function healthRoute(params: HealthRouteParams): {
     usageCounter,
     shouldRunTasks,
     docLinks,
+    numOfKibanaInstances$,
   } = params;
+
+  let numOfKibanaInstances = 1;
+  numOfKibanaInstances$.subscribe((updatedNumber) => {
+    numOfKibanaInstances = updatedNumber;
+  });
 
   // if "hot" health stats are any more stale than monitored_stats_required_freshness (pollInterval +1s buffer by default)
   // consider the system unhealthy
   const requiredHotStatsFreshness: number = config.monitored_stats_required_freshness;
 
   function getHealthStatus(monitoredStats: MonitoringStats) {
-    const summarizedStats = summarizeMonitoringStats(logger, monitoredStats, config);
+    const summarizedStats = summarizeMonitoringStats(
+      logger,
+      monitoredStats,
+      config,
+      numOfKibanaInstances
+    );
     const { status, reason } = calculateHealthStatus(
       summarizedStats,
       config,

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/health_route.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/health_route.ts
@@ -237,7 +237,6 @@ export default function ({ getService }: FtrProviderContext) {
       expect(typeof workload.overdue).to.eql('number');
 
       expect(typeof workload.non_recurring).to.eql('number');
-      expect(typeof workload.owner_ids).to.eql('number');
 
       expect(typeof workload.capacity_requirements.per_minute).to.eql('number');
       expect(typeof workload.capacity_requirements.per_hour).to.eql('number');

--- a/x-pack/test/task_manager_claimer_mget/test_suites/task_manager/health_route.ts
+++ b/x-pack/test/task_manager_claimer_mget/test_suites/task_manager/health_route.ts
@@ -237,7 +237,6 @@ export default function ({ getService }: FtrProviderContext) {
       expect(typeof workload.overdue).to.eql('number');
 
       expect(typeof workload.non_recurring).to.eql('number');
-      expect(typeof workload.owner_ids).to.eql('number');
 
       expect(typeof workload.capacity_requirements.per_minute).to.eql('number');
       expect(typeof workload.capacity_requirements.per_hour).to.eql('number');


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/192568

In this PR, I'm solving the issue where the task manager health API is unable to determine how many Kibana nodes are running. I'm doing so by leveraging the Kibana discovery service to get a count instead of calculating it based on an aggregation on the `.kibana_task_manager` index where we count the unique number of `ownerId`, which requires tasks to be running and a sufficient distribution across the Kibana nodes to determine the number properly.

## To verify
Play with the cloud deployment created by this PR, scale Kibana up and down and observe the health API's `observed_kibana_instances` number reflect accordingly. You may need to rely on the Kibana logs of the task manager health to get this value.