### PR TITLE
[Synthetics] [Backport] Unbreak uptime journey (#192641)

### DIFF
--- a/x-pack/plugins/observability_solution/uptime/e2e/README.md
+++ b/x-pack/plugins/observability_solution/uptime/e2e/README.md
@@ -10,7 +10,7 @@ with an example run command when it finishes.
 
 ### Run the tests
 
-From the same directory you can now run `node node e2e.js --runner`.
+From the same directory you can now run `node e2e.js --runner`.
 
 In addition to the usual flags like `--grep`, you can also specify `--no-headless` in order to view your tests as you debug/develop.
 
@@ -22,11 +22,11 @@ script for standing up the test server.
 
 ### Start the server
 
-From `~/x-pack/plugins/observability_solution/synthetics/scripts`, run `node uptime_e2e.js --server`. Wait for the server to startup. It will provide you
+From `~/x-pack/plugins/observability_solution/uptime/scripts`, run `node uptime_e2e.js --server`. Wait for the server to startup. It will provide you
 with an example run command when it finishes.
 
 ### Run the tests
 
-From the same directory you can now run `node node uptime_e2e.js --runner`.
+From the same directory you can now run `node uptime_e2e.js --runner`.
 
 In addition to the usual flags like `--grep`, you can also specify `--no-headless` in order to view your tests as you debug/develop.

--- a/x-pack/plugins/observability_solution/uptime/e2e/uptime/journeys/uptime.journey.ts
+++ b/x-pack/plugins/observability_solution/uptime/e2e/uptime/journeys/uptime.journey.ts
@@ -17,7 +17,7 @@ journey('uptime', ({ page, params }) => {
   });
 
   step('Go to Kibana', async () => {
-    await page.goto(`${params.kibanaUrl}/app/uptime?dateRangeStart=now-5y&dateRangeEnd=now`, {
+    await page.goto(`${params.kibanaUrl}/app/uptime?dateRangeStart=2018-01-01&dateRangeEnd=now`, {
       waitUntil: 'networkidle',
     });
   });


### PR DESCRIPTION
## Summary

Previously the uptime e2e journey we rely on to test the uptime overview page was looking back 5 years to query for canned data we load during the standard Kibana test script.

Unfortunately, that data was generated now > 5y ago, so the test started to fail.

This patch hardcodes the date of the filter to ensure we permanently look back to a timeframe that includes the canned data we use for testing the page.

---------

Co-authored-by: shahzad31 <shahzad31comp@gmail.com>
(cherry picked from commit 10c1c2c7acac40edb592ed19a0c36e7ce515cf0d)

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
