### PR TITLE
[Console] Make config panel scrollable

### DIFF
--- a/src/plugins/console/public/application/containers/config/config.tsx
+++ b/src/plugins/console/public/application/containers/config/config.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, useEuiTheme, EuiSpacer } from '@elastic/eui';
 
 import { Settings } from './settings';
 import { Variables } from './variables';
@@ -36,9 +36,11 @@ export function Config({ containerWidth }: Props) {
       >
         <EuiFlexItem>
           <Settings />
+          <EuiSpacer size="m" />
         </EuiFlexItem>
         <EuiFlexItem>
           <Variables />
+          <EuiSpacer size="m" />
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/src/plugins/console/public/application/containers/main/main.tsx
+++ b/src/plugins/console/public/application/containers/main/main.tsx
@@ -19,7 +19,10 @@ import {
   EuiHorizontalRule,
   EuiScreenReaderOnly,
   useResizeObserver,
+  useEuiOverflowScroll,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { downloadFileAs } from '@kbn/share-plugin/public';
 import { getConsoleTourStepProps } from './get_console_tour_step_props';
@@ -70,6 +73,7 @@ export function Main({ isEmbeddable = false }: MainProps) {
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isFullscreenOpen, setIsFullScreen] = useState(false);
+  const { euiTheme } = useEuiTheme();
 
   const [resizeRef, setResizeRef] = useState<HTMLDivElement | null>(null);
   const containerDimensions = useResizeObserver(resizeRef);
@@ -167,6 +171,10 @@ export function Main({ isEmbeddable = false }: MainProps) {
       reader.readAsText(file);
     }
   };
+
+  const scrollablePanelStyle = css`
+    ${useEuiOverflowScroll('y', false)}
+  `;
 
   if (error) {
     return (
@@ -301,7 +309,10 @@ export function Main({ isEmbeddable = false }: MainProps) {
           </EuiFlexGroup>
         </EuiSplitPanel.Inner>
         <EuiHorizontalRule margin="none" />
-        <EuiSplitPanel.Inner paddingSize="none">
+        <EuiSplitPanel.Inner
+          paddingSize="none"
+          css={[scrollablePanelStyle, { backgroundColor: euiTheme.colors.body }]}
+        >
           {currentView === SHELL_TAB_ID && (
             <Editor
               loading={!done}


### PR DESCRIPTION
## Summary

This PR makes the middle Console panel scrollable so that if a component inside doesn't fit, it is scrollable. This fixes the Config component in Embeddable Console where the embeddable console container is smaller than the Config component, so the settings were partially hidden.



https://github.com/user-attachments/assets/52c92a57-016c-4c25-ae9c-41caf065b296




