### PR TITLE
Don't use wait_for_active_shards=all in migration actions

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/bulk_overwrite_transformed_documents.ts
@@ -17,7 +17,6 @@ import {
   type RetryableEsClientError,
 } from './catch_retryable_es_client_errors';
 import { isWriteBlockException, isIndexNotFoundException } from './es_errors';
-import { WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE } from './constants';
 import type { TargetIndexHadWriteBlock, RequestEntityTooLargeException, IndexNotFound } from '.';
 import type { BulkOperation } from '../model/create_batches';
 
@@ -65,7 +64,6 @@ export const bulkOverwriteTransformedDocuments =
         // system indices puts in place a hard control.
         index,
         require_alias: useAliasToPreventAutoCreate,
-        wait_for_active_shards: WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
         refresh,
         filter_path: ['items.*.error'],
         // we need to unwrap the existing BulkIndexOperationTuple's

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/calculate_exclude_filters.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/calculate_exclude_filters.test.ts
@@ -78,7 +78,8 @@ describe('calculateExcludeFilters', () => {
   });
 
   it('ignores and returns errors for hooks that take longer than timeout', async () => {
-    const hook1 = jest.fn().mockReturnValue(new Promise((r) => setTimeout(r, 40_000)));
+    let timer1: NodeJS.Timeout | undefined;
+    const hook1 = jest.fn().mockReturnValue(new Promise((r) => (timer1 = setTimeout(r, 40_000))));
     const hook2 = jest.fn().mockResolvedValue({ bool: { must: { term: { fieldB: 'abc' } } } });
 
     const task = calculateExcludeFilters({
@@ -98,5 +99,6 @@ describe('calculateExcludeFilters', () => {
     expect((result as Either.Right<any>).right.errorsByType.type1.toString()).toMatchInlineSnapshot(
       `"Error: excludeFromUpgrade hook timed out after 0.1 seconds."`
     );
+    timer1?.unref();
   });
 });

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.test.ts
@@ -69,7 +69,6 @@ describe('cloneIndex', () => {
         },
         "target": "my_target_index",
         "timeout": "300s",
-        "wait_for_active_shards": "all",
       }
     `);
   });

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.ts
@@ -21,12 +21,7 @@ import {
 } from './catch_retryable_es_client_errors';
 import type { IndexNotFound, AcknowledgeResponse, OperationNotSupported } from '.';
 import { type IndexNotGreenTimeout, waitForIndexStatus } from './wait_for_index_status';
-import {
-  DEFAULT_TIMEOUT,
-  INDEX_AUTO_EXPAND_REPLICAS,
-  INDEX_NUMBER_OF_SHARDS,
-  WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
-} from './constants';
+import { DEFAULT_TIMEOUT, INDEX_AUTO_EXPAND_REPLICAS, INDEX_NUMBER_OF_SHARDS } from './constants';
 import { isClusterShardLimitExceeded } from './es_errors';
 import type { ClusterShardLimitExceeded } from './create_index';
 
@@ -84,7 +79,6 @@ export const cloneIndex = ({
       .clone({
         index: source,
         target,
-        wait_for_active_shards: WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
         settings: {
           index: {
             // The source we're cloning from will have a write block set, so
@@ -157,11 +151,11 @@ export const cloneIndex = ({
         // If the cluster state was updated and all shards ackd we're done
         return TaskEither.right(res);
       } else {
-        // Otherwise, wait until the target index has a 'yellow' status.
+        // Otherwise, wait until the target index has a 'green' status.
         return pipe(
           waitForIndexStatus({ client, index: target, timeout, status: 'green' }),
           TaskEither.map((value) => {
-            /** When the index status is 'yellow' we know that all shards were started */
+            /** When the index status is 'green' we know that all shards were started */
             return { acknowledged: true, shardsAcknowledged: true };
           })
         );

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/constants.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/constants.ts
@@ -22,5 +22,3 @@ export const DEFAULT_TIMEOUT = '300s';
 export const INDEX_AUTO_EXPAND_REPLICAS = '0-1';
 /** ES rule of thumb: shards should be several GB to 10's of GB, so Kibana is unlikely to cross that limit */
 export const INDEX_NUMBER_OF_SHARDS = 1;
-/** Wait for all shards to be active before starting an operation */
-export const WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE = 'all';

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.test.ts
@@ -71,7 +71,6 @@ describe('createIndex', () => {
           },
         },
         "timeout": "300s",
-        "wait_for_active_shards": "all",
       }
     `);
   });
@@ -106,7 +105,6 @@ describe('createIndex', () => {
           },
         },
         "timeout": "300s",
-        "wait_for_active_shards": "all",
       }
     `);
   });

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.ts
@@ -20,12 +20,7 @@ import {
   catchRetryableEsClientErrors,
   type RetryableEsClientError,
 } from './catch_retryable_es_client_errors';
-import {
-  DEFAULT_TIMEOUT,
-  INDEX_AUTO_EXPAND_REPLICAS,
-  INDEX_NUMBER_OF_SHARDS,
-  WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
-} from './constants';
+import { DEFAULT_TIMEOUT, INDEX_AUTO_EXPAND_REPLICAS, INDEX_NUMBER_OF_SHARDS } from './constants';
 import { type IndexNotGreenTimeout, waitForIndexStatus } from './wait_for_index_status';
 import { isClusterShardLimitExceeded } from './es_errors';
 
@@ -108,9 +103,6 @@ export const createIndex = ({
     return client.indices
       .create({
         index: indexName,
-        // wait up to timeout until the following shards are available before
-        // creating the index: primary, replica (only on multi node clusters)
-        wait_for_active_shards: WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
         // Timeout for the cluster state to update and all shards to become
         // available. If the request doesn't complete within timeout,
         // acknowledged or shards_acknowledged would be false.

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/index.ts
@@ -12,12 +12,7 @@ import { right } from 'fp-ts/lib/Either';
 import type { RetryableEsClientError } from './catch_retryable_es_client_errors';
 import type { DocumentsTransformFailed } from '../core/migrate_raw_docs';
 
-export {
-  DEFAULT_TIMEOUT,
-  INDEX_AUTO_EXPAND_REPLICAS,
-  INDEX_NUMBER_OF_SHARDS,
-  WAIT_FOR_ALL_SHARDS_TO_BE_ACTIVE,
-} from './constants';
+export { DEFAULT_TIMEOUT, INDEX_AUTO_EXPAND_REPLICAS, INDEX_NUMBER_OF_SHARDS } from './constants';
 
 export type { RetryableEsClientError };
 

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/wait_for_index_status.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/wait_for_index_status.ts
@@ -59,12 +59,11 @@ export function waitForIndexStatus({
  *
  * A yellow index status means the index's primary shard was allocated but ES
  * wasn't able to allocate the replica. Thus a yellow index can be searched
- * and read from but indexing documents with `wait_for_active_shards='all'`
- * will fail.
+ * and read from but when indexing documents only the primary will be written.
  *
- * A green index status means the index's primary and replica shards has been
- * allocated so we can search, read and index documents with
- * `wait_for_active_shards='all'`.
+ * A green index status means the index's primary and replica shards have been
+ * allocated so we can search, read and index documents knowing the primary
+ * and replica should be written
  */
 export function waitForIndexStatus({
   client,


### PR DESCRIPTION
## Summary

Removes `wait_for_active_shards=all` from all saved object migration actions to make them compatible with serverless.

Fixes #167249
Fixes #167250
Fixes #167251
Fixes #188968

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
