### PR TITLE
[ML] Functional tests - stabilize model list tests

### DIFF
--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -477,8 +477,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.navigation.navigateToTrainedModels();
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/175443
-      describe.skip('with imported models', function () {
+      describe('with imported models', function () {
         before(async () => {
           await ml.navigation.navigateToTrainedModels();
         });

--- a/x-pack/test/functional/services/ml/trained_models_table.ts
+++ b/x-pack/test/functional/services/ml/trained_models_table.ts
@@ -23,7 +23,7 @@ export interface TrainedModelRowData {
 export type MlTrainedModelsTable = ProvidedType<typeof TrainedModelsTableProvider>;
 
 export function TrainedModelsTableProvider(
-  { getService }: FtrProviderContext,
+  { getPageObject, getService }: FtrProviderContext,
   mlCommonUI: MlCommonUI,
   trainedModelsActions: TrainedModelsActions
 ) {
@@ -31,6 +31,7 @@ export function TrainedModelsTableProvider(
   const retry = getService('retry');
   const find = getService('find');
   const browser = getService('browser');
+  const headerPage = getPageObject('header');
 
   return new (class ModelsTable {
     public async parseModelsTable() {
@@ -194,6 +195,7 @@ export function TrainedModelsTableProvider(
     }
 
     public async doesModelCollapsedActionsButtonExist(modelId: string): Promise<boolean> {
+      await headerPage.waitUntilLoadingHasFinished();
       return await testSubjects.exists(this.rowSelector(modelId, 'euiCollapsedItemActionsButton'));
     }
 


### PR DESCRIPTION
## Summary

This PR stabilizes the model list tests by adding a wait for global loading before checking the collapsed action button.

### Details

I was able to reproduce the original failure by running the test suite in my local browser with network speed throttled to 3G: after stopping a model deployment, the row actions change and during that time the global loading is active. Checking the collapsed action button too early (i.e. before global loading finished) returns a false positive and then the next step will try to click that button which in the mean time disappeared. Adding the wait for global loading before checking the collapsed actions button fixed for my local runs with throttling.

Closes #175443


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->