### PR TITLE
Fix bug in overdue task metric script

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.test.ts
@@ -151,7 +151,7 @@ describe('TaskManagerMetricsCollector', () => {
                   return;
                 }
 
-                if(taskStatus == 'idle') {
+                if(taskStatus.value == 'idle') {
                   emit((new Date().getTime() - runAt.value.getMillis()) / 1000);
                 } else {
                   def retryAt = doc['task.retryAt'];

--- a/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_metrics_collector.ts
@@ -110,7 +110,7 @@ export class TaskManagerMetricsCollector implements ITaskEventEmitter<TaskLifecy
                   return;
                 }
 
-                if(taskStatus == 'idle') {
+                if(taskStatus.value == 'idle') {
                   emit((new Date().getTime() - runAt.value.getMillis()) / 1000);
                 } else {
                   def retryAt = doc['task.retryAt'];


### PR DESCRIPTION
Fixing a bug from https://github.com/elastic/kibana/pull/192603 where tasks in idle wouldn't show up in overdue metrics.

## To verify
1. Set `xpack.task_manager.unsafe.exclude_task_types: ['actions:*']` in your kibana.yml
2. Startup Elasticsearch and Kibana
3. Create an always firing rule that logs a server log message
4. Observe the metrics endpoint `/api/task_manager/metrics` and that the overdue metrics overall, for actions and for server log increase over time because the task is skipped

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->