### PR TITLE
[Fleet] Fix deleting policies belonging to multiple space

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -1205,7 +1205,9 @@ class AgentPolicyService {
       });
     }
 
-    await soClient.delete(savedObjectType, id);
+    await soClient.delete(savedObjectType, id, {
+      force: true, // need to delete through multiple space
+    });
     await this.triggerAgentPolicyUpdatedEvent(esClient, 'deleted', id, {
       spaceId: soClient.getCurrentNamespace(),
     });

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -1369,7 +1369,10 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     const secretsToDelete: string[] = [];
     if (idsToDelete.length > 0) {
       const { statuses } = await soClient.bulkDelete(
-        idsToDelete.map((id) => ({ id, type: savedObjectType }))
+        idsToDelete.map((id) => ({ id, type: savedObjectType })),
+        {
+          force: true, // need to delete through multiple space
+        }
       );
 
       statuses.forEach(({ id, success, error }) => {

--- a/x-pack/test/fleet_api_integration/apis/space_awareness/change_space_agent_policies.ts
+++ b/x-pack/test/fleet_api_integration/apis/space_awareness/change_space_agent_policies.ts
@@ -194,5 +194,32 @@ export default function (providerContext: FtrProviderContext) {
         );
       });
     });
+
+    describe('DELETE /agent_policies/{id}', () => {
+      let policyRes: CreateAgentPolicyResponse;
+      before(async () => {
+        const _policyRes = await apiClient.createAgentPolicy();
+        policyRes = _policyRes;
+        await apiClient.createPackagePolicy(undefined, {
+          policy_ids: [policyRes.item.id],
+          name: `test-nginx-${Date.now()}`,
+          description: 'test',
+          package: {
+            name: 'nginx',
+            version: '1.20.0',
+          },
+          inputs: {},
+        });
+        await apiClient.putAgentPolicy(policyRes.item.id, {
+          name: `test-nginx-${Date.now()}`,
+          namespace: 'default',
+          description: 'tata',
+          space_ids: ['default', TEST_SPACE_1],
+        });
+      });
+      it('should allow to delete an agent policy through multiple spaces', async () => {
+        await apiClient.deleteAgentPolicy(policyRes.item.id);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Resolve #192838

Fixing deleting policies belonging to multiple spaces, when deleting a saved object through multiple space we need to use the `force: true` option that PR add this to the delete agent and package policies calls.

## Tests

I added an integration test to cover that scenario.

You can test this by enabling space awareness (feature flag + API call) then creating a policy in multple space you should be able to delete it.

<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->