### PR TITLE
Adding Security team privileges to the FIPS pipeline

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -34,5 +34,7 @@ spec:
       teams:
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ
+        kibana-security:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
## Summary

As part of the handoff of FIPS pipeline to the Security team, we should have management access to re-run the buildkite pipeline


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->