### PR TITLE
[Security Solution] Hide Rule Upgrade disabling behind Prebuilt Rule Customization FF

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -76,10 +76,13 @@ export interface UpgradePrebuiltRulesTableState {
    */
   loadingRules: RuleSignatureId[];
   /**
-  /**
    * The timestamp for when the rules were successfully fetched
    */
   lastUpdated: number;
+  /**
+   * Feature Flag to enable prebuilt rules customization
+   */
+  isPrebuiltRulesCustomizationEnabled: boolean;
 }
 
 export const PREBUILT_RULE_UPDATE_FLYOUT_ANCHOR = 'updatePrebuiltRulePreview';
@@ -315,6 +318,7 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
         isUpgradingSecurityPackages,
         loadingRules,
         lastUpdated: dataUpdatedAt,
+        isPrebuiltRulesCustomizationEnabled,
       },
       actions,
     };
@@ -331,6 +335,7 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     loadingRules,
     dataUpdatedAt,
     actions,
+    isPrebuiltRulesCustomizationEnabled,
   ]);
 
   return (

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -107,13 +107,16 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 const createUpgradeButtonColumn = (
   upgradeRules: UpgradePrebuiltRulesTableActions['upgradeRules'],
   loadingRules: RuleSignatureId[],
-  isDisabled: boolean
+  isDisabled: boolean,
+  isPrebuiltRulesCustomizationEnabled: boolean
 ): TableColumn => ({
   field: 'rule_id',
   name: <RulesTableEmptyColumnName name={i18n.UPDATE_RULE_BUTTON} />,
   render: (ruleId: RuleSignatureId, record) => {
     const isRuleUpgrading = loadingRules.includes(ruleId);
-    const isUpgradeButtonDisabled = isRuleUpgrading || isDisabled || record.hasUnresolvedConflicts;
+    const isDisabledByConflicts =
+      isPrebuiltRulesCustomizationEnabled && record.hasUnresolvedConflicts;
+    const isUpgradeButtonDisabled = isRuleUpgrading || isDisabled || isDisabledByConflicts;
     const spinner = (
       <EuiLoadingSpinner
         size="s"
@@ -141,7 +144,12 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
   const hasCRUDPermissions = hasUserCRUDPermission(canUserCRUD);
   const [showRelatedIntegrations] = useUiSetting$<boolean>(SHOW_RELATED_INTEGRATIONS_SETTING);
   const {
-    state: { loadingRules, isRefetching, isUpgradingSecurityPackages },
+    state: {
+      loadingRules,
+      isRefetching,
+      isUpgradingSecurityPackages,
+      isPrebuiltRulesCustomizationEnabled,
+    },
     actions: { upgradeRules },
   } = useUpgradePrebuiltRulesTableContext();
   const isDisabled = isRefetching || isUpgradingSecurityPackages;
@@ -173,9 +181,23 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
         width: '12%',
       },
       ...(hasCRUDPermissions
-        ? [createUpgradeButtonColumn(upgradeRules, loadingRules, isDisabled)]
+        ? [
+            createUpgradeButtonColumn(
+              upgradeRules,
+              loadingRules,
+              isDisabled,
+              isPrebuiltRulesCustomizationEnabled
+            ),
+          ]
         : []),
     ],
-    [hasCRUDPermissions, loadingRules, isDisabled, showRelatedIntegrations, upgradeRules]
+    [
+      hasCRUDPermissions,
+      loadingRules,
+      isDisabled,
+      showRelatedIntegrations,
+      upgradeRules,
+      isPrebuiltRulesCustomizationEnabled,
+    ]
   );
 };


### PR DESCRIPTION
## Summary

With the merge of https://github.com/elastic/kibana/pull/191721, new logic was introduce to disable the Upgrade rule button in the Rule Upgrade table for rules which have conflicts in any of their fields.

**This change should be hidden behind a FF.** Otherwise the UI upgrade flow might break for any users who might have customized the rule via API and generated conflicts.

