### PR TITLE
[Cloud Security] Fix GCP service account deployment copy-paste command

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
@@ -194,8 +194,8 @@ export const GcpCredentialsFormAgentless = ({
   )?.replace(TEMPLATE_URL_ACCOUNT_TYPE_ENV_VAR, accountType);
 
   const commandText = `gcloud config set project ${
-    isOrganization ? `<PROJECT_ID> && ORD_ID=<ORG_ID_VALUE>` : `<PROJECT_ID>`
-  } && ./deploy_service_account.sh`;
+    isOrganization ? `<PROJECT_ID> && ORG_ID=<ORG_ID_VALUE>` : `<PROJECT_ID>`
+  } ./deploy_service_account.sh`;
 
   return (
     <>


### PR DESCRIPTION
## Summary

installing CSPM GCP on agentless shows the user a command to copy-paste (and plug in values), the command was slightly off which ended up triggering the service account deployment for projects and not organizations.

![Screenshot 2024-09-15 at 17 42 12](https://github.com/user-attachments/assets/f311df2a-8969-4314-bad9-f2ca450a42e5)

1. `ORD_ID` → `ORG_ID`
2. `ORG_ID=... && ./script` → `ORG_ID=.. script.ts` - this is required to make the env variable available to the script 


lucky enough though, after testing the above changes, i ran into another issue on cloudbeat side, which prevented deployment all-together as `ORG_ID` was treated as a number instead of a string. see [here](https://github.com/elastic/cloudbeat/pull/2529)

- related https://github.com/elastic/cloudbeat/issues/2502

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->