### PR TITLE
Serverless release pipeline - adjust version key for QA

### DIFF
--- a/.buildkite/scripts/serverless/create_deploy_tag/info_sections/commit_info.ts
+++ b/.buildkite/scripts/serverless/create_deploy_tag/info_sections/commit_info.ts
@@ -36,7 +36,7 @@ export async function getCurrentQARelease() {
   // @ts-ignore
   const fileContent = Buffer.from(releasesFile.data.content, 'base64').toString('utf8');
 
-  const sha = fileContent.match(`qa: "([a-z0-9]+)"`)?.[1];
+  const sha = fileContent.match(`qa-ds-1: "([a-z0-9]+)"`)?.[1];
 
   if (!sha) {
     throw new Error('Could not find QA hash in current releases file');


### PR DESCRIPTION
## Summary

This PR adjusts the serverless release pipeline script to use the new key for QA when reading the version.yaml file.

Note that this is a quick fix to get the pipeline running again. Longer term, we could have multiple slices of QA, so we should think about how to prepare the script for that scenario.
