### PR TITLE
[EDR Workflows][MKI] Skip event_filters.cy.ts in MKI

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
@@ -17,7 +17,8 @@ import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
 import { login } from '../../tasks/login';
 import type { ReturnTypeFromChainable } from '../../types';
 
-describe('Event Filters', { tags: ['@ess', '@serverless'] }, () => {
+// Skipped in Serverless MKI due to interactions with internal indices
+describe('Event Filters', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
   const CONDITION_VALUE = 'valuesAutocompleteMatch';


### PR DESCRIPTION
Skip due to interactions with internal indices which is not supported in MKI

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->