### PR TITLE
[8.x] [Defend Workflows] Fix bug when event filter value cannot be changed without using {backspace} (#192196)

### DIFF
--- a/packages/kbn-securitysolution-autocomplete/src/field_value_match/index.tsx
+++ b/packages/kbn-securitysolution-autocomplete/src/field_value_match/index.tsx
@@ -168,10 +168,26 @@ export const AutocompleteFieldMatchComponent: React.FC<AutocompleteFieldMatchPro
         handleWarning(warning);
 
         if (!err) handleSpacesWarning(searchVal);
-        setSearchQuery(searchVal);
       }
+
+      if (searchVal) {
+        // Clear selected option when user types to allow user to modify value without {backspace}
+        onChange('');
+      }
+
+      // Update search query unconditionally to show correct suggestions even when input is cleared
+      setSearchQuery(searchVal);
     },
-    [handleError, handleSpacesWarning, isRequired, selectedField, touched, handleWarning, warning]
+    [
+      selectedField,
+      onChange,
+      isRequired,
+      touched,
+      handleError,
+      handleWarning,
+      warning,
+      handleSpacesWarning,
+    ]
   );
 
   const handleCreateOption = useCallback(

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { APP_EVENT_FILTERS_PATH } from '../../../../../common/constants';
+import type { ArtifactsFixtureType } from '../../fixtures/artifacts_page';
+import { getArtifactsListTestsData } from '../../fixtures/artifacts_page';
+import {
+  createArtifactList,
+  createPerPolicyArtifact,
+  removeAllArtifacts,
+} from '../../tasks/artifacts';
+import { loadPage } from '../../tasks/common';
+import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
+import { login } from '../../tasks/login';
+import type { ReturnTypeFromChainable } from '../../types';
+
+describe('Event Filters', { tags: ['@ess', '@serverless'] }, () => {
+  let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
+
+  const CONDITION_VALUE = 'valuesAutocompleteMatch';
+  const SUBMIT_BUTTON = 'EventFiltersListPage-flyout-submitButton';
+
+  before(() => {
+    indexEndpointHosts().then((indexEndpoints) => {
+      endpointData = indexEndpoints;
+    });
+  });
+
+  after(() => {
+    removeAllArtifacts();
+
+    endpointData?.cleanup();
+    endpointData = undefined;
+  });
+
+  beforeEach(() => {
+    removeAllArtifacts();
+  });
+
+  describe('when editing event filter value', () => {
+    let eventFiltersMock: ArtifactsFixtureType;
+    beforeEach(() => {
+      login();
+
+      eventFiltersMock = getArtifactsListTestsData().find(
+        ({ tabId }) => tabId === 'eventFilters'
+      ) as ArtifactsFixtureType;
+
+      createArtifactList(eventFiltersMock.createRequestBody.list_id);
+      createPerPolicyArtifact(eventFiltersMock.artifactName, eventFiltersMock.createRequestBody);
+
+      loadPage(APP_EVENT_FILTERS_PATH);
+
+      cy.getByTestSubj('EventFiltersListPage-card-header-actions-button').click();
+      cy.getByTestSubj('EventFiltersListPage-card-cardEditAction').click();
+      cy.getByTestSubj('EventFiltersListPage-flyout').should('exist');
+    });
+
+    it('should be able to modify after deleting value with {backspace}', () => {
+      cy.getByTestSubj(CONDITION_VALUE).type(' {backspace}.lnk{enter}');
+      cy.getByTestSubj(SUBMIT_BUTTON).click();
+
+      cy.getByTestSubj('EventFiltersListPage-flyout').should('not.exist');
+      cy.contains('notepad.exe.lnk');
+    });
+
+    it('should be able to modify without using {backspace}', () => {
+      cy.getByTestSubj(CONDITION_VALUE).type('.lnk{enter}');
+      cy.getByTestSubj(SUBMIT_BUTTON).click();
+
+      cy.getByTestSubj('EventFiltersListPage-flyout').should('not.exist');
+      cy.contains('notepad.exe.lnk');
+    });
+
+    it('should show suggestions when filter value is cleared', () => {
+      cy.getByTestSubj(CONDITION_VALUE).clear();
+      cy.getByTestSubj(CONDITION_VALUE).type('aaaaaaaaaaaaaa as custom input');
+      cy.get('button[role="option"]').should('have.length', 0);
+
+      cy.getByTestSubj(CONDITION_VALUE).find('input').clear();
+      cy.get('button[role="option"]').should('have.length.above', 1);
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/management/cypress/fixtures/artifacts_page.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/fixtures/artifacts_page.ts
@@ -17,7 +17,7 @@ interface FormEditingDescription {
   }>;
 }
 
-interface ArtifactsFixtureType {
+export interface ArtifactsFixtureType {
   title: string;
   pagePrefix: string;
   tabId: string;
@@ -275,10 +275,10 @@ export const getArtifactsListTestsData = (): ArtifactsFixtureType[] => [
       list_id: ENDPOINT_ARTIFACT_LISTS.eventFilters.id,
       entries: [
         {
-          field: 'agent.id',
+          field: 'process.name',
           operator: 'included',
           type: 'match',
-          value: 'mr agent',
+          value: 'notepad.exe',
         },
       ],
       os_types: ['windows'],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Defend Workflows] Fix bug when event filter value cannot be changed without using {backspace} (#192196)](https://github.com/elastic/kibana/pull/192196)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2024-09-13T16:59:44Z","message":"[Defend Workflows] Fix bug when event filter value cannot be changed without using {backspace} (#192196)\n\n## Summary\r\n\r\nThis PR does 2 things around editing the value field for an Event\r\nFilter.\r\n\r\n1. It fixes the issue when during editing an existing Event Filter you\r\ncannot update the value without pressing {backspace}, by clearing\r\nselection when user is typing: 5da28aa25404e6a2bdc8a2e9cfce2f6546976d07\r\nBefore:\r\n\r\n![before](https://github.com/user-attachments/assets/7355c788-a9fd-4ea5-81b3-89ae41db2ee7)\r\n➡️ \r\nAfter:\r\n\r\n![after](https://github.com/user-attachments/assets/aa928fa4-6203-4fad-8f9b-4e586ac4d562)\r\n\r\n2. Improves suggestions: before the change, suggestions were there\r\ninitially, but after they are narrowed down by typing, they won't be\r\ndisplayed again after the user clears the input field. Therefore\r\nf9d60cf223644a3072d1a60fe273586338247b96 sets the suggestion search\r\nquery unconditionally, helping with this issue.\r\nBefore:\r\n\r\n![before](https://github.com/user-attachments/assets/87ccfba6-5b9d-4976-a5af-13c3d56db373)\r\n➡️ \r\nAfter:\r\n\r\n![after](https://github.com/user-attachments/assets/c21a909c-4b45-470e-9e77-9edc269f07f7)\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b31d119e5532c362c44a134547f461fd7db56770","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:Defend Workflows"],"title":"[Defend Workflows] Fix bug when event filter value cannot be changed without using {backspace}","number":192196,"url":"https://github.com/elastic/kibana/pull/192196","mergeCommit":{"message":"[Defend Workflows] Fix bug when event filter value cannot be changed without using {backspace} (#192196)\n\n## Summary\r\n\r\nThis PR does 2 things around editing the value field for an Event\r\nFilter.\r\n\r\n1. It fixes the issue when during editing an existing Event Filter you\r\ncannot update the value without pressing {backspace}, by clearing\r\nselection when user is typing: 5da28aa25404e6a2bdc8a2e9cfce2f6546976d07\r\nBefore:\r\n\r\n![before](https://github.com/user-attachments/assets/7355c788-a9fd-4ea5-81b3-89ae41db2ee7)\r\n➡️ \r\nAfter:\r\n\r\n![after](https://github.com/user-attachments/assets/aa928fa4-6203-4fad-8f9b-4e586ac4d562)\r\n\r\n2. Improves suggestions: before the change, suggestions were there\r\ninitially, but after they are narrowed down by typing, they won't be\r\ndisplayed again after the user clears the input field. Therefore\r\nf9d60cf223644a3072d1a60fe273586338247b96 sets the suggestion search\r\nquery unconditionally, helping with this issue.\r\nBefore:\r\n\r\n![before](https://github.com/user-attachments/assets/87ccfba6-5b9d-4976-a5af-13c3d56db373)\r\n➡️ \r\nAfter:\r\n\r\n![after](https://github.com/user-attachments/assets/c21a909c-4b45-470e-9e77-9edc269f07f7)\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b31d119e5532c362c44a134547f461fd7db56770"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192196","number":192196,"mergeCommit":{"message":"[Defend Workflows] Fix bug when event filter value cannot be changed without using {backspace} (#192196)\n\n## Summary\r\n\r\nThis PR does 2 things around editing the value field for an Event\r\nFilter.\r\n\r\n1. It fixes the issue when during editing an existing Event Filter you\r\ncannot update the value without pressing {backspace}, by clearing\r\nselection when user is typing: 5da28aa25404e6a2bdc8a2e9cfce2f6546976d07\r\nBefore:\r\n\r\n![before](https://github.com/user-attachments/assets/7355c788-a9fd-4ea5-81b3-89ae41db2ee7)\r\n➡️ \r\nAfter:\r\n\r\n![after](https://github.com/user-attachments/assets/aa928fa4-6203-4fad-8f9b-4e586ac4d562)\r\n\r\n2. Improves suggestions: before the change, suggestions were there\r\ninitially, but after they are narrowed down by typing, they won't be\r\ndisplayed again after the user clears the input field. Therefore\r\nf9d60cf223644a3072d1a60fe273586338247b96 sets the suggestion search\r\nquery unconditionally, helping with this issue.\r\nBefore:\r\n\r\n![before](https://github.com/user-attachments/assets/87ccfba6-5b9d-4976-a5af-13c3d56db373)\r\n➡️ \r\nAfter:\r\n\r\n![after](https://github.com/user-attachments/assets/c21a909c-4b45-470e-9e77-9edc269f07f7)\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b31d119e5532c362c44a134547f461fd7db56770"}}]}] BACKPORT-->