### PR TITLE
[8.15] [ES|QL] Set drop null columns param correctly for partial results (#192666)

### DIFF
--- a/src/plugins/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/esql_async_search/esql_async_search_strategy.ts
@@ -78,7 +78,7 @@ export const esqlAsyncSearchStrategyProvider = (
             {
               method: 'GET',
               path: `/_query/async/${id}`,
-              querystring: { ...params },
+              querystring: { ...params, drop_null_columns: dropNullColumns },
             },
             { ...options.transport, signal: options.abortSignal, meta: true }
           )

--- a/test/functional/apps/discover/group6/_sidebar.ts
+++ b/test/functional/apps/discover/group6/_sidebar.ts
@@ -115,7 +115,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(options).to.have.length(6);
 
         expect(await PageObjects.unifiedFieldList.getSidebarAriaDescription()).to.be(
-          '82 available fields.'
+          '76 available fields. 6 empty fields.'
         );
 
         await testSubjects.click('typeFilter-number');
@@ -123,7 +123,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await retry.waitFor('updates', async () => {
           return (
             (await PageObjects.unifiedFieldList.getSidebarAriaDescription()) ===
-            '6 available fields.'
+            '4 available fields. 2 empty fields.'
           );
         });
       });
@@ -448,14 +448,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         expect(await PageObjects.unifiedFieldList.getSidebarAriaDescription()).to.be(
-          '82 available fields.'
+          '76 available fields. 6 empty fields.'
         );
 
         await PageObjects.unifiedFieldList.clickFieldListItemRemove('extension');
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
 
         expect(await PageObjects.unifiedFieldList.getSidebarAriaDescription()).to.be(
-          '82 available fields.'
+          '76 available fields. 6 empty fields.'
         );
 
         const testQuery = `from logstash-* | limit 10 | stats countB = count(bytes) by geo.dest | sort countB`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ES|QL] Set drop null columns param correctly for partial results (#192666)](https://github.com/elastic/kibana/pull/192666)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2024-09-16T08:44:55Z","message":"[ES|QL] Set drop null columns param correctly for partial results (#192666)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/192595\r\n\r\nWe were not setting the `drop_null_columns ` queryString for partial\r\nresults and as a result it was returning the empty columns only for the\r\ninitial request, resulting in the weirdness that is being described in\r\nthe issue.","sha":"708a96cca8f636347fb37669b13e5b61cd5015d1","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","backport:prev-major","Feature:ES|QL","Team:ESQL","v8.15.0","v8.16.0"],"number":192666,"url":"https://github.com/elastic/kibana/pull/192666","mergeCommit":{"message":"[ES|QL] Set drop null columns param correctly for partial results (#192666)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/192595\r\n\r\nWe were not setting the `drop_null_columns ` queryString for partial\r\nresults and as a result it was returning the empty columns only for the\r\ninitial request, resulting in the weirdness that is being described in\r\nthe issue.","sha":"708a96cca8f636347fb37669b13e5b61cd5015d1"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192666","number":192666,"mergeCommit":{"message":"[ES|QL] Set drop null columns param correctly for partial results (#192666)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/192595\r\n\r\nWe were not setting the `drop_null_columns ` queryString for partial\r\nresults and as a result it was returning the empty columns only for the\r\ninitial request, resulting in the weirdness that is being described in\r\nthe issue.","sha":"708a96cca8f636347fb37669b13e5b61cd5015d1"}},{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/192976","number":192976,"state":"OPEN"}]}] BACKPORT-->