### PR TITLE
[Fleet] Require AgentPolicies:All to add a fleet server

### DIFF
--- a/x-pack/plugins/fleet/common/authz.ts
+++ b/x-pack/plugins/fleet/common/authz.ts
@@ -117,7 +117,8 @@ export const calculateAuthz = ({
         allSettings: fleet.settings?.all ?? false,
         allAgentPolicies: fleet.agentPolicies?.all ?? false,
         addAgents: fleet.agents?.all ?? false,
-        addFleetServers: (fleet.agents?.all && fleet.settings?.all) ?? false,
+        addFleetServers:
+          (fleet.agents?.all && fleet.agentPolicies?.all && fleet.settings?.all) ?? false,
         // Setup is needed to access the Fleet UI
         setup:
           hasFleetAll ||

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/settings_page/fleet_server_hosts_section.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/settings_page/fleet_server_hosts_section.tsx
@@ -59,7 +59,7 @@ export const FleetServerHostsSection: React.FunctionComponent<FleetServerHostsSe
         fleetServerHosts={fleetServerHosts}
         deleteFleetServerHost={deleteFleetServerHost}
       />
-      {authz.fleet.allSettings && authz.fleet.allAgents ? (
+      {authz.fleet.addFleetServers ? (
         <>
           <EuiSpacer size="s" />
           <EuiButtonEmpty

--- a/x-pack/plugins/fleet/server/services/security/security.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/security.test.ts
@@ -886,4 +886,57 @@ describe('getAuthzFromRequest', () => {
       expect(res.fleet.readAgents).toBe(false);
     });
   });
+
+  describe('Fleet addFleetServer', () => {
+    beforeEach(() => {
+      mockSecurity.authz.mode.useRbacForRequest.mockReturnValue(true);
+    });
+    it('should authorize user with Fleet:Agents:All Fleet:AgentsPolicies:All Fleet:Settings:All', async () => {
+      checkPrivileges.mockResolvedValue({
+        privileges: {
+          kibana: [
+            {
+              resource: 'default',
+              privilege: 'api:fleet-agents-all',
+              authorized: true,
+            },
+            {
+              resource: 'default',
+              privilege: 'api:fleet-agent-policies-all',
+              authorized: true,
+            },
+            {
+              resource: 'default',
+              privilege: 'api:fleet-settings-all',
+              authorized: true,
+            },
+          ],
+          elasticsearch: {} as any,
+        },
+        hasAllRequested: true,
+        username: 'test',
+      });
+      const res = await getAuthzFromRequest({} as any);
+      expect(res.fleet.addFleetServers).toBe(true);
+    });
+
+    it('should not authorize user with only Fleet:Agents:All', async () => {
+      checkPrivileges.mockResolvedValue({
+        privileges: {
+          kibana: [
+            {
+              resource: 'default',
+              privilege: 'api:fleet-agents-all',
+              authorized: true,
+            },
+          ],
+          elasticsearch: {} as any,
+        },
+        hasAllRequested: true,
+        username: 'test',
+      });
+      const res = await getAuthzFromRequest({} as any);
+      expect(res.fleet.addFleetServers).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolve #187652

In the flow to add a fleet server, we may need to create a fleet server policy, this is why we should require the `AgentPolicies:All` to add a Fleet server. 

That PR address that, and add a unit test to compute that role.


## Manual tests 

You can after enabling subfeaturePrivileges experimental features and with a trial license create a role with access to Agents:all Settings:all and AgentPolicies:read and check you cannot add a fleet server

## UI Change

####  With Agents:all Settings:all and Without AgentPolicies:all

<img width="600" alt="Screenshot 2024-09-16 at 9 47 46 AM" src="https://github.com/user-attachments/assets/77bb069b-1b59-4e75-b1b5-7752ac4486c7">

####  With Agents:all Settings:all AgentPolicies:alll

<img width="600" alt="Screenshot 2024-09-16 at 9 48 02 AM" src="https://github.com/user-attachments/assets/28bad2df-ad06-45a2-89e3-2de6b87f49d8">




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->