### PR TITLE
[8.x] [EDR Workflows][MKI] Skip event_filters.cy.ts in MKI (#192969)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
@@ -17,7 +17,8 @@ import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
 import { login } from '../../tasks/login';
 import type { ReturnTypeFromChainable } from '../../types';
 
-describe('Event Filters', { tags: ['@ess', '@serverless'] }, () => {
+// Skipped in Serverless MKI due to interactions with internal indices
+describe('Event Filters', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
   const CONDITION_VALUE = 'valuesAutocompleteMatch';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[EDR Workflows][MKI] Skip event_filters.cy.ts in MKI (#192969)](https://github.com/elastic/kibana/pull/192969)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2024-09-16T09:51:49Z","message":"[EDR Workflows][MKI] Skip event_filters.cy.ts in MKI (#192969)\n\nSkip due to interactions with internal indices which is not supported in\r\nMKI","sha":"2b12950e71f6cc7a616eeec1e787e76f3009575c","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","v8.16.0"],"number":192969,"url":"https://github.com/elastic/kibana/pull/192969","mergeCommit":{"message":"[EDR Workflows][MKI] Skip event_filters.cy.ts in MKI (#192969)\n\nSkip due to interactions with internal indices which is not supported in\r\nMKI","sha":"2b12950e71f6cc7a616eeec1e787e76f3009575c"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192969","number":192969,"mergeCommit":{"message":"[EDR Workflows][MKI] Skip event_filters.cy.ts in MKI (#192969)\n\nSkip due to interactions with internal indices which is not supported in\r\nMKI","sha":"2b12950e71f6cc7a616eeec1e787e76f3009575c"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->