### PR TITLE
hide kibana version in help menu on serverless

### DIFF
--- a/packages/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
+++ b/packages/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
@@ -86,7 +86,7 @@ const NoViewsTip = () => (
     content={
       <FormattedMessage
         id="contentManagement.contentEditor.viewsStats.noViewsTip"
-        defaultMessage="Views are counted every time someone opens a dashboard (after 11-2024)"
+        defaultMessage="Views are counted every time someone opens a dashboard"
       />
     }
   />

--- a/packages/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
+++ b/packages/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
@@ -86,7 +86,7 @@ const NoViewsTip = () => (
     content={
       <FormattedMessage
         id="contentManagement.contentEditor.viewsStats.noViewsTip"
-        defaultMessage="Views are counted everytime someone opens a dashboard (after version 8.16)"
+        defaultMessage="Views are counted every time someone opens a dashboard (after 11-2024)"
       />
     }
   />

--- a/packages/content-management/user_profiles/src/components/user_missing_tip.tsx
+++ b/packages/content-management/user_profiles/src/components/user_missing_tip.tsx
@@ -16,7 +16,7 @@ export const NoCreatorTip = (props: { iconType?: IconType }) => (
     content={
       <FormattedMessage
         id="contentManagement.userProfiles.noCreatorTip"
-        defaultMessage="Creators are assigned when objects are created (after 06-2024)"
+        defaultMessage="Creators are assigned when objects are created"
       />
     }
     {...props}
@@ -28,7 +28,7 @@ export const NoUpdaterTip = (props: { iconType?: string }) => (
     content={
       <FormattedMessage
         id="contentManagement.userProfiles.noUpdaterTip"
-        defaultMessage="Updated by is set when objects are updated (after 06-2024)"
+        defaultMessage="Updated by is set when objects are updated"
       />
     }
     {...props}

--- a/packages/content-management/user_profiles/src/components/user_missing_tip.tsx
+++ b/packages/content-management/user_profiles/src/components/user_missing_tip.tsx
@@ -16,7 +16,7 @@ export const NoCreatorTip = (props: { iconType?: IconType }) => (
     content={
       <FormattedMessage
         id="contentManagement.userProfiles.noCreatorTip"
-        defaultMessage="Creators are assigned when objects are created (after version 8.14)"
+        defaultMessage="Creators are assigned when objects are created (after 06-2024)"
       />
     }
     {...props}
@@ -28,7 +28,7 @@ export const NoUpdaterTip = (props: { iconType?: string }) => (
     content={
       <FormattedMessage
         id="contentManagement.userProfiles.noUpdaterTip"
-        defaultMessage="Updated by is set when objects are updated (after version 8.14)"
+        defaultMessage="Updated by is set when objects are updated (after 06-2024)"
       />
     }
     {...props}

--- a/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/chrome_service.tsx
@@ -422,6 +422,7 @@ export class ChromeService {
 
             return (
               <ProjectHeader
+                isServerless={this.isServerless}
                 application={application}
                 globalHelpExtensionMenuLinks$={globalHelpExtensionMenuLinks$}
                 actionMenu$={application.currentActionMenu$}
@@ -452,6 +453,7 @@ export class ChromeService {
 
         return (
           <Header
+            isServerless={this.isServerless}
             loadingCount$={http.getLoadingCount$()}
             application={application}
             headerBanner$={headerBanner$.pipe(takeUntil(this.stop$))}

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.test.tsx
@@ -96,6 +96,7 @@ describe('Header', () => {
         breadcrumbsAppendExtension$={breadcrumbsAppendExtension$}
         headerBanner$={headerBanner$}
         helpMenuLinks$={of([])}
+        isServerless={false}
       />
     );
     expect(component.find('EuiHeader').exists()).toBeTruthy();

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header.tsx
@@ -77,6 +77,7 @@ export interface HeaderProps {
   loadingCount$: ReturnType<HttpStart['getLoadingCount$']>;
   onIsLockedUpdate: OnIsLockedUpdate;
   customBranding$: Observable<CustomBranding>;
+  isServerless: boolean;
 }
 
 export function Header({
@@ -90,6 +91,7 @@ export function Header({
   breadcrumbsAppendExtension$,
   globalHelpExtensionMenuLinks$,
   customBranding$,
+  isServerless,
   ...observables
 }: HeaderProps) {
   const [isNavOpen, setIsNavOpen] = useState(false);
@@ -152,6 +154,7 @@ export function Header({
                     <HeaderNavControls navControls$={observables.navControlsExtension$} />
                   </EuiHideFor>,
                   <HeaderHelpMenu
+                    isServerless={isServerless}
                     globalHelpExtensionMenuLinks$={globalHelpExtensionMenuLinks$}
                     helpExtension$={observables.helpExtension$}
                     helpSupportUrl$={observables.helpSupportUrl$}

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React from 'react';
+import React, { type ComponentProps } from 'react';
 import { BehaviorSubject, of } from 'rxjs';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { applicationServiceMock } from '@kbn/core-application-browser-mocks';
@@ -16,22 +16,32 @@ import { docLinksServiceMock } from '@kbn/core-doc-links-browser-mocks';
 import { HeaderHelpMenu } from './header_help_menu';
 
 describe('HeaderHelpMenu', () => {
-  test('it only renders the default content', () => {
-    const application = applicationServiceMock.createInternalStartContract();
-    const helpExtension$ = new BehaviorSubject(undefined);
-    const helpSupportUrl$ = new BehaviorSubject('');
+  const application = applicationServiceMock.createInternalStartContract();
 
+  const defaultComponentProps: Pick<
+    ComponentProps<typeof HeaderHelpMenu>,
+    | 'kibanaVersion'
+    | 'docLinks'
+    | 'navigateToUrl'
+    | 'defaultContentLinks$'
+    | 'helpExtension$'
+    | 'helpSupportUrl$'
+    | 'kibanaDocLink'
+    | 'isServerless'
+  > = {
+    navigateToUrl: application.navigateToUrl,
+    kibanaVersion: 'version',
+    docLinks: docLinksServiceMock.createStartContract(),
+    defaultContentLinks$: of([]),
+    helpExtension$: new BehaviorSubject(undefined),
+    helpSupportUrl$: new BehaviorSubject(''),
+    kibanaDocLink: '',
+    isServerless: false,
+  };
+
+  test('it only renders the default content', () => {
     const component = mountWithIntl(
-      <HeaderHelpMenu
-        navigateToUrl={application.navigateToUrl}
-        globalHelpExtensionMenuLinks$={of([])}
-        helpExtension$={helpExtension$}
-        helpSupportUrl$={helpSupportUrl$}
-        kibanaVersion={'version'}
-        kibanaDocLink={''}
-        docLinks={docLinksServiceMock.createStartContract()}
-        defaultContentLinks$={of([])}
-      />
+      <HeaderHelpMenu {...defaultComponentProps} globalHelpExtensionMenuLinks$={of([])} />
     );
 
     expect(component.find('EuiButtonEmpty').length).toBe(1); // only the toggle view on/off button
@@ -48,14 +58,22 @@ describe('HeaderHelpMenu', () => {
     ]);
   });
 
-  test('it renders the global custom content + the default content', () => {
-    const application = applicationServiceMock.createInternalStartContract();
-    const helpExtension$ = new BehaviorSubject(undefined);
-    const helpSupportUrl$ = new BehaviorSubject('');
-
+  test("it doesn't render the version details when the prop isServerless is true", () => {
     const component = mountWithIntl(
       <HeaderHelpMenu
-        navigateToUrl={application.navigateToUrl}
+        {...defaultComponentProps}
+        isServerless={true}
+        globalHelpExtensionMenuLinks$={of([])}
+      />
+    );
+
+    expect(component.find('[data-test-subj="kbnVersionString"]').exists()).toBeFalsy();
+  });
+
+  test('it renders the global custom content + the default content', () => {
+    const component = mountWithIntl(
+      <HeaderHelpMenu
+        {...defaultComponentProps}
         globalHelpExtensionMenuLinks$={of([
           {
             linkType: 'custom',
@@ -71,12 +89,6 @@ describe('HeaderHelpMenu', () => {
             priority: 100,
           },
         ])}
-        helpExtension$={helpExtension$}
-        helpSupportUrl$={helpSupportUrl$}
-        kibanaVersion={'version'}
-        kibanaDocLink={''}
-        docLinks={docLinksServiceMock.createStartContract()}
-        defaultContentLinks$={of([])}
       />
     );
 

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_help_menu.tsx
@@ -81,6 +81,7 @@ interface Props {
   kibanaVersion: string;
   kibanaDocLink: string;
   docLinks: DocLinksStart;
+  isServerless: boolean;
 }
 
 interface State {
@@ -174,13 +175,19 @@ export class HeaderHelpMenu extends Component<Props, State> {
                 />
               </h2>
             </EuiFlexItem>
-            <EuiFlexItem grow={false} className="chrHeaderHelpMenu__version">
-              <FormattedMessage
-                id="core.ui.chrome.headerGlobalNav.helpMenuVersion"
-                defaultMessage="v {version}"
-                values={{ version: kibanaVersion }}
-              />
-            </EuiFlexItem>
+            {!this.props.isServerless && (
+              <EuiFlexItem
+                grow={false}
+                className="chrHeaderHelpMenu__version"
+                data-test-subj="kbnVersionString"
+              >
+                <FormattedMessage
+                  id="core.ui.chrome.headerGlobalNav.helpMenuVersion"
+                  defaultMessage="v {version}"
+                  values={{ version: kibanaVersion }}
+                />
+              </EuiFlexItem>
+            )}
           </EuiFlexGroup>
         </EuiPopoverTitle>
 

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.test.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.test.tsx
@@ -38,6 +38,7 @@ describe('Header', () => {
     isSideNavCollapsed$: Rx.of(false),
     prependBasePath: (str) => `hello/world/${str}`,
     toggleSideNav: jest.fn(),
+    isServerless: false,
   };
 
   it('renders', async () => {

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
@@ -33,7 +33,7 @@ import { MountPoint } from '@kbn/core-mount-utils-browser';
 import { i18n } from '@kbn/i18n';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { Router } from '@kbn/shared-ux-router';
-import React, { useCallback } from 'react';
+import React, { useCallback, type ComponentProps } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { debounceTime, Observable } from 'rxjs';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
@@ -111,7 +111,7 @@ const headerStrings = {
   },
 };
 
-export interface Props {
+export interface Props extends Pick<ComponentProps<typeof HeaderHelpMenu>, 'isServerless'> {
   headerBanner$: Observable<ChromeUserBanner | undefined>;
   breadcrumbs$: Observable<ChromeBreadcrumb[]>;
   actionMenu$: Observable<MountPoint | undefined>;
@@ -227,6 +227,7 @@ export const ProjectHeader = ({
   docLinks,
   toggleSideNav,
   customBranding$,
+  isServerless,
   ...observables
 }: Props) => {
   const headerActionMenuMounter = useHeaderActionMenuMounter(observables.actionMenu$);
@@ -293,6 +294,7 @@ export const ProjectHeader = ({
 
               <EuiHeaderSectionItem>
                 <HeaderHelpMenu
+                  isServerless={isServerless}
                   globalHelpExtensionMenuLinks$={observables.globalHelpExtensionMenuLinks$}
                   helpExtension$={observables.helpExtension$}
                   helpSupportUrl$={observables.helpSupportUrl$}

--- a/src/plugins/newsfeed/public/components/flyout_list.tsx
+++ b/src/plugins/newsfeed/public/components/flyout_list.tsx
@@ -30,10 +30,12 @@ import { NewsfeedItem } from '../types';
 import { NewsEmptyPrompt } from './empty_news';
 import { NewsLoadingPrompt } from './loading_news';
 
-export const NewsfeedFlyout = (props: Partial<EuiFlyoutProps> & { showPlainSpinner: boolean }) => {
+export const NewsfeedFlyout = (
+  props: Partial<EuiFlyoutProps> & { showPlainSpinner: boolean; isServerless: boolean }
+) => {
   const { newsFetchResult, setFlyoutVisible } = useContext(NewsfeedContext);
   const closeFlyout = useCallback(() => setFlyoutVisible(false), [setFlyoutVisible]);
-  const { showPlainSpinner, ...rest } = props;
+  const { showPlainSpinner, isServerless, ...rest } = props;
   return (
     <EuiPortal>
       <EuiFlyout
@@ -90,7 +92,7 @@ export const NewsfeedFlyout = (props: Partial<EuiFlyoutProps> & { showPlainSpinn
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              {newsFetchResult ? (
+              {newsFetchResult && !isServerless ? (
                 <EuiText color="subdued" size="s">
                   <p>
                     <FormattedMessage

--- a/src/plugins/newsfeed/public/components/newsfeed_header_nav_button.tsx
+++ b/src/plugins/newsfeed/public/components/newsfeed_header_nav_button.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef, ComponentProps } from 'react';
 import { EuiHeaderSectionItemButton, EuiIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { Observable } from 'rxjs';
@@ -23,12 +23,12 @@ export interface INewsfeedContext {
 
 export const NewsfeedContext = React.createContext({} as INewsfeedContext);
 
-export interface Props {
+export interface Props extends Pick<ComponentProps<typeof NewsfeedFlyout>, 'isServerless'> {
   newsfeedApi: NewsfeedApi;
   hasCustomBranding$: Observable<boolean>;
 }
 
-export const NewsfeedNavButton = ({ newsfeedApi, hasCustomBranding$ }: Props) => {
+export const NewsfeedNavButton = ({ newsfeedApi, hasCustomBranding$, isServerless }: Props) => {
   const [flyoutVisible, setFlyoutVisible] = useState<boolean>(false);
   const [newsFetchResult, setNewsFetchResult] = useState<FetchResult | null | void>(null);
   const hasCustomBranding = useObservable(hasCustomBranding$, false);
@@ -78,6 +78,7 @@ export const NewsfeedNavButton = ({ newsfeedApi, hasCustomBranding$ }: Props) =>
         </EuiHeaderSectionItemButton>
         {flyoutVisible ? (
           <NewsfeedFlyout
+            isServerless={isServerless}
             focusTrapProps={{ shards: [buttonRef] }}
             showPlainSpinner={hasCustomBranding}
           />

--- a/src/plugins/newsfeed/public/plugin.tsx
+++ b/src/plugins/newsfeed/public/plugin.tsx
@@ -24,11 +24,13 @@ export type NewsfeedPublicPluginStart = ReturnType<NewsfeedPublicPlugin['start']
 export class NewsfeedPublicPlugin
   implements Plugin<NewsfeedPublicPluginSetup, NewsfeedPublicPluginStart>
 {
+  private readonly isServerless: boolean;
   private readonly kibanaVersion: string;
   private readonly config: NewsfeedPluginBrowserConfig;
   private readonly stop$ = new Rx.ReplaySubject<void>(1);
 
   constructor(initializerContext: PluginInitializerContext<NewsfeedPluginBrowserConfig>) {
+    this.isServerless = initializerContext.env.packageInfo.buildFlavor === 'serverless';
     this.kibanaVersion = initializerContext.env.packageInfo.version;
     const config = initializerContext.config.get();
     this.config = Object.freeze({
@@ -89,7 +91,11 @@ export class NewsfeedPublicPlugin
     const hasCustomBranding$ = core.customBranding.hasCustomBranding$;
     ReactDOM.render(
       <KibanaRenderContextProvider {...core}>
-        <NewsfeedNavButton newsfeedApi={api} hasCustomBranding$={hasCustomBranding$} />
+        <NewsfeedNavButton
+          newsfeedApi={api}
+          hasCustomBranding$={hasCustomBranding$}
+          isServerless={this.isServerless}
+        />
       </KibanaRenderContextProvider>,
       targetDomElement
     );


### PR DESCRIPTION
## Summary

Closes #175909 and then some.

This PR introduces changes that hides the kibana version number from being displayed to the user in serverless, where it makes sense the version number is entirely hidden in other cases, where the version number denotes the availability of specific feature the month of release is replaced with the version number.

**P.S.**
it's worth noting there are other usages of the kibana version number, but they aren't displayed rather used as values for either link params or function invocations.


### How to test;

- Start up an ES serverless project of your choice; like so ` yarn es serverless --projectType oblt --license trial`
- Start up an accomapnying kibana project that mirrors the ES project you started choose, for our example we'd run; `yarn serverless-oblt`
- Verify that the help menu no longer shows the version number in a serverless project.
- Verify the version number is also still displayed in stateful kibana

<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->

### Visuals

#### stateful
<img width="1492" alt="Screenshot 2024-09-18 at 17 52 19" src="https://github.com/user-attachments/assets/9c2d83b3-0b3b-4a2a-a0df-246de58abfaf">

#### serverless
<img width="1493" alt="Screenshot 2024-09-18 at 18 01 31" src="https://github.com/user-attachments/assets/83740070-e2ec-4b3c-953b-a4e5c3121375">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->