### PR TITLE
[Search][Onboarding] Use new index details page

### DIFF
--- a/x-pack/plugins/search_indices/public/components/start/create_index_code.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index_code.tsx
@@ -45,21 +45,23 @@ export const CreateIndexCodeView = ({ createIndexForm }: CreateIndexCodeViewProp
   return (
     <EuiFlexGroup direction="column" data-test-subj="createIndexCodeView">
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-        <EuiFlexItem>
+        <EuiFlexItem css={{ maxWidth: '300px' }}>
           <LanguageSelector
             options={LanguageOptions}
             selectedLanguage={selectedLanguage}
             onSelectLanguage={(value) => setSelectedLanguage(value)}
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <TryInConsoleButton
-            request={SelectedCodeExamples.sense.createIndex(codeParams)}
-            application={application}
-            sharePlugin={share}
-            consolePlugin={consolePlugin}
-          />
-        </EuiFlexItem>
+        {selectedLanguage === 'curl' && (
+          <EuiFlexItem grow={false}>
+            <TryInConsoleButton
+              request={SelectedCodeExamples.sense.createIndex(codeParams)}
+              application={application}
+              sharePlugin={share}
+              consolePlugin={consolePlugin}
+            />
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
       {selectedCodeExample.installCommand && (
         <CodeSample

--- a/x-pack/plugins/search_indices/public/components/start/hooks/utils.ts
+++ b/x-pack/plugins/search_indices/public/components/start/hooks/utils.ts
@@ -7,11 +7,10 @@
 
 import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
 
-// TODO: we should define a locator for this and use that instead
-const INDEX_DETAILS_PATH = '/app/management/data/index_management/indices/index_details';
+const INDEX_DETAILS_PATH = '/app/elasticsearch/indices/index_details';
 
 function getIndexDetailsPath(http: HttpSetup, indexName: string) {
-  return http.basePath.prepend(`${INDEX_DETAILS_PATH}?indexName=${indexName}`);
+  return http.basePath.prepend(`${INDEX_DETAILS_PATH}/${encodeURIComponent(indexName)}`);
 }
 
 export const navigateToIndexDetails = (

--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -20,9 +20,7 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
     },
     async expectToBeOnIndexDetailsPage() {
       await retry.tryForTime(60 * 1000, async () => {
-        expect(await browser.getCurrentUrl()).contain(
-          '/app/management/data/index_management/indices/index_details'
-        );
+        expect(await browser.getCurrentUrl()).contain('/app/elasticsearch/indices/index_details');
       });
     },
     async expectToBeOnIndexListPage() {


### PR DESCRIPTION
## Summary

- Updated the empty state redirect to use the new index details page
- Updated the empty state to only show "Run in Console" when cURL is the selected coding language.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->