### PR TITLE
[ResponseOps] Add user-error tags to action logs

### DIFF
--- a/x-pack/plugins/actions/server/lib/action_executor.test.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.test.ts
@@ -1245,7 +1245,7 @@ describe('Action Executor', () => {
       );
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
-        tags: ['test', '1', 'action-run-failed'],
+        tags: ['test', '1', 'action-run-failed', 'framework-error'],
       });
     });
 
@@ -1274,7 +1274,7 @@ describe('Action Executor', () => {
       );
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
-        tags: ['test', '1', 'action-run-failed'],
+        tags: ['test', '1', 'action-run-failed', 'user-error'],
       });
     });
 

--- a/x-pack/plugins/actions/server/lib/action_executor.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.ts
@@ -575,7 +575,7 @@ export class ActionExecutor {
             event.error.message = actionErrorToMessage(result);
             if (result.error) {
               logger.error(result.error, {
-                tags: [actionTypeId, actionId, 'action-run-failed'],
+                tags: [actionTypeId, actionId, 'action-run-failed', `${result.errorSource}-error`],
                 error: { stack_trace: result.error.stack },
               });
             }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/192715

## Summary

Adds user-error and framework-error tags to the action error logs


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->