### PR TITLE
[Fleet] Fix bulk GET agent policies permissions

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -191,6 +191,11 @@ export const bulkGetAgentPoliciesHandler: FleetRequestHandler<
     const fleetContext = await context.fleet;
     const soClient = fleetContext.internalSoClient;
     const { full: withPackagePolicies = false, ignoreMissing = false, ids } = request.body;
+    if (!fleetContext.authz.fleet.readAgentPolicies && withPackagePolicies) {
+      throw new FleetUnauthorizedError(
+        'full query parameter require agent policies read permissions'
+      );
+    }
     let items = await agentPolicyService.getByIDs(soClient, ids, {
       withPackagePolicies,
       ignoreMissing,

--- a/x-pack/plugins/fleet/server/routes/agent_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/index.ts
@@ -61,8 +61,9 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
   router.versioned
     .post({
       path: AGENT_POLICY_API_ROUTES.BULK_GET_PATTERN,
-      fleetAuthz: {
-        fleet: { readAgentPolicies: true },
+      fleetAuthz: (authz) => {
+        //  Allow to retrieve agent policies metadata (no full) for user with only read agents permissions
+        return authz.fleet.readAgentPolicies || authz.fleet.readAgents;
       },
     })
     .addVersion(

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/privileges.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/privileges.ts
@@ -49,6 +49,46 @@ const READ_SCENARIOS = [
   },
 ];
 
+const READ_SCENARIOS_FULL_POLICIES = [
+  {
+    user: testUsers.fleet_all_only,
+    statusCode: 200,
+  },
+  {
+    user: testUsers.fleet_read_only,
+    statusCode: 200,
+  },
+  {
+    user: testUsers.fleet_agent_policies_read_only,
+    statusCode: 200,
+  },
+  {
+    user: testUsers.fleet_agent_policies_all_only,
+    statusCode: 200,
+  },
+  {
+    // Expect minimal access
+    user: testUsers.fleet_agents_read_only,
+    statusCode: 403,
+  },
+  {
+    user: testUsers.fleet_no_access,
+    statusCode: 403,
+  },
+  {
+    user: testUsers.fleet_minimal_all_only,
+    statusCode: 403,
+  },
+  {
+    user: testUsers.fleet_minimal_read_only,
+    statusCode: 403,
+  },
+  {
+    user: testUsers.fleet_settings_read_only,
+    statusCode: 403,
+  },
+];
+
 const ALL_SCENARIOS = [
   {
     user: testUsers.fleet_all_only,
@@ -103,8 +143,30 @@ export default function (providerContext: FtrProviderContext) {
     },
     {
       method: 'GET',
+      path: '/api/fleet/agent_policies?full=true',
+      scenarios: READ_SCENARIOS_FULL_POLICIES,
+    },
+    {
+      method: 'GET',
       path: '/api/fleet/agent_policies/policy-test-privileges-1',
       scenarios: READ_SCENARIOS,
+    },
+    {
+      method: 'POST',
+      path: '/api/fleet/agent_policies/_bulk_get',
+      scenarios: READ_SCENARIOS,
+      send: {
+        ids: ['policy-test-privileges-1'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/fleet/agent_policies/_bulk_get',
+      scenarios: READ_SCENARIOS_FULL_POLICIES,
+      send: {
+        ids: ['policy-test-privileges-1'],
+        full: true,
+      },
     },
     {
       method: 'POST',


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/191957 

In https://github.com/elastic/kibana/pull/191661 we switched to fetch all agent policies to use the bulk GET api for agent policies.

That API was not allowed for user with agent read permissions, that PR fix that by allowing it, that API return a sanitized agent policy version just the name and description and no package policies if the user do not have the `AgentPolicies:Read` permissions

## Test

I added unit test to cover those scenarios.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->