### PR TITLE
[Search][Onboarding] Add telemetry for Start Page code view

### DIFF
--- a/x-pack/plugins/search_indices/public/analytics/constants.ts
+++ b/x-pack/plugins/search_indices/public/analytics/constants.ts
@@ -10,4 +10,7 @@ export enum AnalyticsEvents {
   startPageShowCodeClick = 'start_page_show_code',
   startPageShowCreateIndexUIClick = 'start_page_show_create_index_ui',
   startCreateIndexClick = 'start_create_index',
+  startCreateIndexLanguageSelect = 'start_code_lang_select',
+  startCreateIndexCodeCopyInstall = 'start_code_copy_install',
+  startCreateIndexCodeCopy = 'start_code_copy',
 }

--- a/x-pack/plugins/search_indices/public/components/start/code_sample.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/code_sample.tsx
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+// Disabled so we can track the on copy event by adding an onClick to a div
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 
 import React from 'react';
 import {
@@ -19,9 +21,22 @@ export interface CodeSampleProps {
   title: string;
   language: string;
   code: string;
+  onCodeCopyClick?: React.MouseEventHandler<HTMLElement>;
 }
 
-export const CodeSample = ({ title, language, code }: CodeSampleProps) => {
+export const CodeSample = ({ title, language, code, onCodeCopyClick }: CodeSampleProps) => {
+  const onCodeClick = React.useCallback(
+    (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+      if (onCodeCopyClick === undefined) return;
+      if (e.target instanceof HTMLElement) {
+        if (e.target.dataset?.testSubj === 'euiCodeBlockCopy') {
+          onCodeCopyClick(e);
+        }
+      }
+    },
+    [onCodeCopyClick]
+  );
+
   return (
     <EuiFlexItem>
       <EuiText size="s">
@@ -30,15 +45,17 @@ export const CodeSample = ({ title, language, code }: CodeSampleProps) => {
       <EuiSpacer size="s" />
       <EuiThemeProvider colorMode="dark">
         <EuiPanel color="subdued" paddingSize="none" hasShadow={false}>
-          <EuiCodeBlock
-            language={language}
-            fontSize="m"
-            paddingSize="m"
-            isCopyable
-            transparentBackground
-          >
-            {code}
-          </EuiCodeBlock>
+          <div onClick={onCodeClick}>
+            <EuiCodeBlock
+              language={language}
+              fontSize="m"
+              paddingSize="m"
+              isCopyable
+              transparentBackground
+            >
+              {code}
+            </EuiCodeBlock>
+          </div>
         </EuiPanel>
       </EuiThemeProvider>
     </EuiFlexItem>


### PR DESCRIPTION
## Summary

Added telemetry tracking events for the start page code view. Specifically tracking when user selects a language and copies the example code snippets.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->