### PR TITLE
Improves Endpoint exceptions API content

### DIFF
--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list/create_endpoint_list.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list/create_endpoint_list.schema.yaml
@@ -8,8 +8,8 @@ paths:
       x-labels: [serverless, ess]
       x-codegen-enabled: true
       operationId: CreateEndpointList
-      summary: Creates an endpoint list
-      description: Creates an endpoint list or does nothing if the list already exists
+      summary: Create an endpoint exception list
+      description: Create an endpoint exception list, which groups endpoint exception list items. If an endpoint exception list already exists, an empty response is returned.
       responses:
         200:
           description: Successful response

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list_item/create_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/create_endpoint_list_item/create_endpoint_list_item.schema.yaml
@@ -8,7 +8,8 @@ paths:
       x-labels: [serverless, ess]
       x-codegen-enabled: true
       operationId: CreateEndpointListItem
-      summary: Creates an endpoint list item
+      summary: Create an endpoint exception list item
+      description: Create an endpoint exception list item, and associate it with the endpoint exception list.
       requestBody:
         description: Exception list item's properties
         required: true

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/delete_endpoint_list_item/delete_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/delete_endpoint_list_item/delete_endpoint_list_item.schema.yaml
@@ -8,7 +8,8 @@ paths:
       x-labels: [serverless, ess]
       x-codegen-enabled: true
       operationId: DeleteEndpointListItem
-      summary: Deletes an endpoint list item
+      summary: Delete an endpoint exception list item
+      description: Delete an endpoint exception list item using the `id` or `item_id` field.
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/find_endpoint_list_item/find_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/find_endpoint_list_item/find_endpoint_list_item.schema.yaml
@@ -8,7 +8,8 @@ paths:
       x-labels: [serverless, ess]
       x-codegen-enabled: true
       operationId: FindEndpointListItems
-      summary: Finds endpoint list items
+      summary: Get endpoint exception list items
+      description: Get a list of all endpoint exception list items.
       parameters:
         - name: filter
           in: query

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/read_endpoint_list_item/read_endpoint_list_item.schema.yaml
@@ -8,7 +8,8 @@ paths:
       x-labels: [serverless, ess]
       x-codegen-enabled: true
       operationId: ReadEndpointListItem
-      summary: Reads an endpoint list item
+      summary: Get an endpoint exception list item
+      description: Get the details of an endpoint exception list item using the `id` or `item_id` field.
       parameters:
         - name: id
           in: query

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/api/update_endpoint_list_item/update_endpoint_list_item.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/api/update_endpoint_list_item/update_endpoint_list_item.schema.yaml
@@ -8,7 +8,8 @@ paths:
       x-labels: [serverless, ess]
       x-codegen-enabled: true
       operationId: UpdateEndpointListItem
-      summary: Updates an endpoint list item
+      summary: Update an endpoint exception list item
+      description: Update an endpoint exception list item using the `id` or `item_id` field.
       requestBody:
         description: Exception list item's properties
         required: true

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -13,7 +13,10 @@ servers:
 paths:
   /api/endpoint_list:
     post:
-      description: Creates an endpoint list or does nothing if the list already exists
+      description: >-
+        Create an endpoint exception list, which groups endpoint exception list
+        items. If an endpoint exception list already exists, an empty response
+        is returned.
       operationId: CreateEndpointList
       responses:
         '200':
@@ -48,9 +51,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Creates an endpoint list
+      summary: Create an endpoint exception list
   /api/endpoint_list/items:
     delete:
+      description: >-
+        Delete an endpoint exception list item using the `id` or `item_id`
+        field.
       operationId: DeleteEndpointListItem
       parameters:
         - description: Either `id` or `item_id` must be specified
@@ -104,8 +110,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Deletes an endpoint list item
+      summary: Delete an endpoint exception list item
     get:
+      description: >-
+        Get the details of an endpoint exception list item using the `id` or
+        `item_id` field.
       operationId: ReadEndpointListItem
       parameters:
         - description: Either `id` or `item_id` must be specified
@@ -161,8 +170,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Reads an endpoint list item
+      summary: Get an endpoint exception list item
     post:
+      description: >-
+        Create an endpoint exception list item, and associate it with the
+        endpoint exception list.
       operationId: CreateEndpointListItem
       requestBody:
         content:
@@ -237,8 +249,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Creates an endpoint list item
+      summary: Create an endpoint exception list item
     put:
+      description: >-
+        Update an endpoint exception list item using the `id` or `item_id`
+        field.
       operationId: UpdateEndpointListItem
       requestBody:
         content:
@@ -318,9 +333,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Updates an endpoint list item
+      summary: Update an endpoint exception list item
   /api/endpoint_list/items/_find:
     get:
+      description: Get a list of all endpoint exception list items.
       operationId: FindEndpointListItems
       parameters:
         - description: >
@@ -422,7 +438,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Finds endpoint list items
+      summary: Get endpoint exception list items
 components:
   schemas:
     EndpointList:

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -13,7 +13,10 @@ servers:
 paths:
   /api/endpoint_list:
     post:
-      description: Creates an endpoint list or does nothing if the list already exists
+      description: >-
+        Create an endpoint exception list, which groups endpoint exception list
+        items. If an endpoint exception list already exists, an empty response
+        is returned.
       operationId: CreateEndpointList
       responses:
         '200':
@@ -48,9 +51,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Creates an endpoint list
+      summary: Create an endpoint exception list
   /api/endpoint_list/items:
     delete:
+      description: >-
+        Delete an endpoint exception list item using the `id` or `item_id`
+        field.
       operationId: DeleteEndpointListItem
       parameters:
         - description: Either `id` or `item_id` must be specified
@@ -104,8 +110,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Deletes an endpoint list item
+      summary: Delete an endpoint exception list item
     get:
+      description: >-
+        Get the details of an endpoint exception list item using the `id` or
+        `item_id` field.
       operationId: ReadEndpointListItem
       parameters:
         - description: Either `id` or `item_id` must be specified
@@ -161,8 +170,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Reads an endpoint list item
+      summary: Get an endpoint exception list item
     post:
+      description: >-
+        Create an endpoint exception list item, and associate it with the
+        endpoint exception list.
       operationId: CreateEndpointListItem
       requestBody:
         content:
@@ -237,8 +249,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Creates an endpoint list item
+      summary: Create an endpoint exception list item
     put:
+      description: >-
+        Update an endpoint exception list item using the `id` or `item_id`
+        field.
       operationId: UpdateEndpointListItem
       requestBody:
         content:
@@ -318,9 +333,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Updates an endpoint list item
+      summary: Update an endpoint exception list item
   /api/endpoint_list/items/_find:
     get:
+      description: Get a list of all endpoint exception list items.
       operationId: FindEndpointListItems
       parameters:
         - description: >
@@ -422,7 +438,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/SiemErrorResponse'
           description: Internal server error
-      summary: Finds endpoint list items
+      summary: Get endpoint exception list items
 components:
   schemas:
     EndpointList:

--- a/x-pack/test/api_integration/services/security_solution_endpoint_exceptions_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_endpoint_exceptions_api.gen.ts
@@ -31,7 +31,7 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
 
   return {
     /**
-     * Creates an endpoint list or does nothing if the list already exists
+     * Create an endpoint exception list, which groups endpoint exception list items. If an endpoint exception list already exists, an empty response is returned.
      */
     createEndpointList() {
       return supertest
@@ -40,6 +40,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(ELASTIC_HTTP_VERSION_HEADER, '2023-10-31')
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
+    /**
+     * Create an endpoint exception list item, and associate it with the endpoint exception list.
+     */
     createEndpointListItem(props: CreateEndpointListItemProps) {
       return supertest
         .post('/api/endpoint_list/items')
@@ -48,6 +51,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .send(props.body as object);
     },
+    /**
+     * Delete an endpoint exception list item using the `id` or `item_id` field.
+     */
     deleteEndpointListItem(props: DeleteEndpointListItemProps) {
       return supertest
         .delete('/api/endpoint_list/items')
@@ -56,6 +62,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get a list of all endpoint exception list items.
+     */
     findEndpointListItems(props: FindEndpointListItemsProps) {
       return supertest
         .get('/api/endpoint_list/items/_find')
@@ -64,6 +73,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Get the details of an endpoint exception list item using the `id` or `item_id` field.
+     */
     readEndpointListItem(props: ReadEndpointListItemProps) {
       return supertest
         .get('/api/endpoint_list/items')
@@ -72,6 +84,9 @@ export function SecuritySolutionApiProvider({ getService }: FtrProviderContext) 
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
         .query(props.query);
     },
+    /**
+     * Update an endpoint exception list item using the `id` or `item_id` field.
+     */
     updateEndpointListItem(props: UpdateEndpointListItemProps) {
       return supertest
         .put('/api/endpoint_list/items')


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/security-docs-internal/issues/34 by improving the Endpoint exceptions API docs content. Adds missing and improves existing operation summaries and operation descriptions to adhere to our [OAS standards](https://elasticco.atlassian.net/wiki/spaces/DOC/pages/450494532/API+reference+docs).