### PR TITLE
chore(rca): show full name in notes and store profile id in model

### DIFF
--- a/x-pack/plugins/observability_solution/investigate_app/public/hooks/query_key_factory.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/public/hooks/query_key_factory.ts
@@ -9,6 +9,8 @@
 
 export const investigationKeys = {
   all: ['investigations'] as const,
+  userProfiles: (profileIds: Set<string>) =>
+    [...investigationKeys.all, 'userProfiles', ...profileIds] as const,
   tags: () => [...investigationKeys.all, 'tags'] as const,
   stats: () => [...investigationKeys.all, 'stats'] as const,
   lists: () => [...investigationKeys.all, 'list'] as const,

--- a/x-pack/plugins/observability_solution/investigate_app/public/hooks/use_fetch_user_profiles.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/hooks/use_fetch_user_profiles.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { UserProfile } from '@kbn/security-plugin/common';
+import { useQuery } from '@tanstack/react-query';
+import { Dictionary, keyBy } from 'lodash';
+import { investigationKeys } from './query_key_factory';
+import { useKibana } from './use_kibana';
+
+export interface Params {
+  profileIds: Set<string>;
+}
+
+export interface Response {
+  isInitialLoading: boolean;
+  isLoading: boolean;
+  isRefetching: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  data: Dictionary<UserProfile> | undefined;
+}
+
+export function useFetchUserProfiles({ profileIds }: Params) {
+  const {
+    core: {
+      notifications: { toasts },
+      userProfile,
+    },
+  } = useKibana();
+
+  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data } = useQuery({
+    queryKey: investigationKeys.userProfiles(profileIds),
+    queryFn: async () => {
+      const userProfiles = await userProfile.bulkGet({ uids: profileIds });
+      return keyBy(userProfiles, 'uid');
+    },
+    enabled: profileIds.size > 0,
+    retry: false,
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    onError: (error: Error) => {
+      toasts.addError(error, {
+        title: i18n.translate('xpack.investigateApp.useFetchUserProfiles.errorTitle', {
+          defaultMessage: 'Something went wrong while fetching user profiles',
+        }),
+      });
+    },
+  });
+
+  return {
+    data,
+    isInitialLoading,
+    isLoading,
+    isRefetching,
+    isSuccess,
+    isError,
+  };
+}

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_notes/investigation_notes.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_notes/investigation_notes.tsx
@@ -18,6 +18,7 @@ import { i18n } from '@kbn/i18n';
 import { InvestigationNoteResponse } from '@kbn/investigation-shared';
 import { AuthenticatedUser } from '@kbn/security-plugin/common';
 import React, { useState } from 'react';
+import { useFetchUserProfiles } from '../../../../hooks/use_fetch_user_profiles';
 import { useTheme } from '../../../../hooks/use_theme';
 import { useInvestigation } from '../../contexts/investigation_context';
 import { Note } from './note';
@@ -30,8 +31,11 @@ export interface Props {
 export function InvestigationNotes({ user }: Props) {
   const theme = useTheme();
   const { investigation, addNote, isAddingNote } = useInvestigation();
-  const [noteInput, setNoteInput] = useState('');
+  const { data: userProfiles, isLoading: isLoadingUserProfiles } = useFetchUserProfiles({
+    profileIds: new Set(investigation?.notes.map((note) => note.createdBy) ?? []),
+  });
 
+  const [noteInput, setNoteInput] = useState('');
   const onAddNote = async (content: string) => {
     await addNote(content);
     setNoteInput('');
@@ -59,7 +63,9 @@ export function InvestigationNotes({ user }: Props) {
               <Note
                 key={currNote.id}
                 note={currNote}
-                disabled={currNote.createdBy !== user.username}
+                userProfile={userProfiles?.[currNote.createdBy]}
+                userProfileLoading={isLoadingUserProfiles}
+                isOwner={currNote.createdBy === user.profile_uid}
               />
             );
           })}

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_notes/investigation_notes.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_notes/investigation_notes.tsx
@@ -32,7 +32,7 @@ export function InvestigationNotes({ user }: Props) {
   const theme = useTheme();
   const { investigation, addNote, isAddingNote } = useInvestigation();
   const { data: userProfiles, isLoading: isLoadingUserProfiles } = useFetchUserProfiles({
-    profileIds: new Set(investigation?.notes.map((note) => note.createdBy) ?? []),
+    profileIds: new Set(investigation?.notes.map((note) => note.createdBy)),
   });
 
   const [noteInput, setNoteInput] = useState('');

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/list/components/investigation_list.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/list/components/investigation_list.tsx
@@ -15,7 +15,6 @@ import {
   EuiLink,
   EuiLoadingSpinner,
   EuiText,
-  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { InvestigationResponse } from '@kbn/investigation-shared/src/rest_specs/investigation';
@@ -24,12 +23,12 @@ import React, { useState } from 'react';
 import { paths } from '../../../../common/paths';
 import { InvestigationStatusBadge } from '../../../components/investigation_status_badge/investigation_status_badge';
 import { useFetchInvestigationList } from '../../../hooks/use_fetch_investigation_list';
+import { useFetchUserProfiles } from '../../../hooks/use_fetch_user_profiles';
 import { useKibana } from '../../../hooks/use_kibana';
 import { InvestigationListActions } from './investigation_list_actions';
 import { InvestigationStats } from './investigation_stats';
 import { InvestigationsError } from './investigations_error';
 import { SearchBar } from './search_bar/search_bar';
-import { useFetchUserProfiles } from '../../../hooks/use_fetch_user_profiles';
 
 export function InvestigationList() {
   const {
@@ -88,12 +87,7 @@ export function InvestigationList() {
         return isUserProfilesLoading ? (
           <EuiLoadingSpinner size="m" />
         ) : (
-          <EuiToolTip
-            position="top"
-            content={
-              userProfiles?.[value]?.user.full_name ?? userProfiles?.[value]?.user.username ?? value
-            }
-          >
+          <EuiFlexGroup gutterSize="s" direction="row">
             <EuiAvatar
               name={
                 userProfiles?.[value]?.user.full_name ??
@@ -102,7 +96,12 @@ export function InvestigationList() {
               }
               size="s"
             />
-          </EuiToolTip>
+            <EuiText size="s">
+              {userProfiles?.[value]?.user.full_name ??
+                userProfiles?.[value]?.user.username ??
+                value}
+            </EuiText>
+          </EuiFlexGroup>
         );
       },
     },

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/list/components/investigation_list.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/list/components/investigation_list.tsx
@@ -6,6 +6,7 @@
  */
 import {
   Criteria,
+  EuiAvatar,
   EuiBadge,
   EuiBasicTable,
   EuiBasicTableColumn,
@@ -14,6 +15,7 @@ import {
   EuiLink,
   EuiLoadingSpinner,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { InvestigationResponse } from '@kbn/investigation-shared/src/rest_specs/investigation';
@@ -27,6 +29,7 @@ import { InvestigationListActions } from './investigation_list_actions';
 import { InvestigationStats } from './investigation_stats';
 import { InvestigationsError } from './investigations_error';
 import { SearchBar } from './search_bar/search_bar';
+import { useFetchUserProfiles } from '../../../hooks/use_fetch_user_profiles';
 
 export function InvestigationList() {
   const {
@@ -49,6 +52,10 @@ export function InvestigationList() {
     perPage: pageSize,
     search,
     filter: toFilter(status, tags),
+  });
+
+  const { data: userProfiles, isLoading: isUserProfilesLoading } = useFetchUserProfiles({
+    profileIds: new Set(data?.results.map((i) => i.createdBy)),
   });
 
   const investigations = data?.results ?? [];
@@ -77,6 +84,27 @@ export function InvestigationList() {
         defaultMessage: 'Created by',
       }),
       truncateText: true,
+      render: (value: InvestigationResponse['createdBy']) => {
+        return isUserProfilesLoading ? (
+          <EuiLoadingSpinner size="m" />
+        ) : (
+          <EuiToolTip
+            position="top"
+            content={
+              userProfiles?.[value]?.user.full_name ?? userProfiles?.[value]?.user.username ?? value
+            }
+          >
+            <EuiAvatar
+              name={
+                userProfiles?.[value]?.user.full_name ??
+                userProfiles?.[value]?.user.username ??
+                value
+              }
+              size="s"
+            />
+          </EuiToolTip>
+        );
+      },
     },
     {
       field: 'tags',

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/create_investigation.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/create_investigation.ts
@@ -23,7 +23,7 @@ export async function createInvestigation(
     ...params,
     updatedAt: now,
     createdAt: now,
-    createdBy: user.username,
+    createdBy: user.profile_uid!,
     status: 'triage',
     notes: [],
     items: [],

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/create_investigation_item.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/create_investigation_item.ts
@@ -23,7 +23,7 @@ export async function createInvestigationItem(
   const now = Date.now();
   const investigationItem = {
     id: v4(),
-    createdBy: user.username,
+    createdBy: user.profile_uid!,
     createdAt: now,
     updatedAt: now,
     ...params,

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/create_investigation_note.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/create_investigation_note.ts
@@ -24,7 +24,7 @@ export async function createInvestigationNote(
   const investigationNote = {
     id: v4(),
     content: params.content,
-    createdBy: user.username,
+    createdBy: user.profile_uid!,
     updatedAt: now,
     createdAt: now,
   };

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/delete_investigation_item.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/delete_investigation_item.ts
@@ -19,7 +19,7 @@ export async function deleteInvestigationItem(
     throw new Error('Note not found');
   }
 
-  if (item.createdBy !== user.username) {
+  if (item.createdBy !== user.profile_uid) {
     throw new Error('User does not have permission to delete note');
   }
 

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/delete_investigation_note.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/delete_investigation_note.ts
@@ -19,7 +19,7 @@ export async function deleteInvestigationNote(
     throw new Error('Note not found');
   }
 
-  if (note.createdBy !== user.username) {
+  if (note.createdBy !== user.profile_uid) {
     throw new Error('User does not have permission to delete note');
   }
 

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/update_investigation_item.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/update_investigation_item.ts
@@ -25,7 +25,7 @@ export async function updateInvestigationItem(
     throw new Error('Cannot change item type');
   }
 
-  if (item.createdBy !== user.username) {
+  if (item.createdBy !== user.profile_uid) {
     throw new Error('User does not have permission to update item');
   }
 

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/update_investigation_note.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/update_investigation_note.ts
@@ -21,7 +21,7 @@ export async function updateInvestigationNote(
     throw new Error('Note not found');
   }
 
-  if (note.createdBy !== user.username) {
+  if (note.createdBy !== user.profile_uid) {
     throw new Error('User does not have permission to update note');
   }
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/193210

## Summary

This PR changes the model for the createdBy in the note and investigation models. We are now storing the profile_id instead of the username. We then fetch the user profiles from the profile ids, and display the full name in the notes and the avatar in the listing view.

List | Notes
-- | --
![image](https://github.com/user-attachments/assets/f0b05784-2efb-4a1f-af9b-9486c4946136) | ![image](https://github.com/user-attachments/assets/ab100979-504d-45c9-9f0d-3f7065f26acb)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->