### PR TITLE
[ci] Run codeql alerts after analyze matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,7 @@ jobs:
   alert:
     name: Alert
     runs-on: ubuntu-latest
+    needs: analyze
     if: github.repository == 'elastic/kibana' # Hack: Do not run on forks
     steps:
     - name: Checkout kibana-operations

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,11 @@ jobs:
         category: "/language:${{matrix.language}}"
         ref: ${{ env.CHECKOUT_REF }}
         sha: ${{ env.CHECKOUT_SHA }}
-
+  alert:
+    name: Alert
+    runs-on: ubuntu-latest
+    if: github.repository == 'elastic/kibana' # Hack: Do not run on forks
+    steps:
     - name: Checkout kibana-operations
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:


### PR DESCRIPTION
Instead of alerting as each branch finishes, this waits for the entire analyze run before sending out alerts.  