### PR TITLE
[Fleet] Handle missing permissions when creating standalone agent API keys 

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_standalone.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_standalone.tsx
@@ -35,7 +35,8 @@ export const InstallElasticAgentStandalonePageStep: React.FC<InstallAgentPagePro
   const [commandCopied, setCommandCopied] = useState(false);
   const [policyCopied, setPolicyCopied] = useState(false);
 
-  const { yaml, onCreateApiKey, apiKey, downloadYaml } = useFetchFullPolicy(agentPolicy);
+  const { yaml, onCreateApiKey, isCreatingApiKey, apiKey, downloadYaml } =
+    useFetchFullPolicy(agentPolicy);
 
   if (!agentPolicy) {
     return (
@@ -60,6 +61,7 @@ export const InstallElasticAgentStandalonePageStep: React.FC<InstallAgentPagePro
       downloadYaml,
       apiKey,
       onCreateApiKey,
+      isCreatingApiKey,
       isComplete: policyCopied,
       onCopy: () => setPolicyCopied(true),
     }),

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/hooks.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/hooks.tsx
@@ -210,12 +210,15 @@ export function useGetCreateApiKey() {
   const core = useStartServices();
 
   const [apiKey, setApiKey] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
   const onCreateApiKey = useCallback(async () => {
     try {
+      setIsLoading(true);
       const res = await sendCreateStandaloneAgentAPIKey({
         name: crypto.randomBytes(16).toString('hex'),
       });
-      const newApiKey = `${res.data?.item.id}:${res.data?.item.api_key}`;
+
+      const newApiKey = `${res.item.id}:${res.item.api_key}`;
       setApiKey(newApiKey);
     } catch (err) {
       core.notifications.toasts.addError(err, {
@@ -224,9 +227,11 @@ export function useGetCreateApiKey() {
         }),
       });
     }
+    setIsLoading(false);
   }, [core.notifications.toasts]);
   return {
     apiKey,
+    isLoading,
     onCreateApiKey,
   };
 }
@@ -235,7 +240,7 @@ export function useFetchFullPolicy(agentPolicy: AgentPolicy | undefined, isK8s?:
   const core = useStartServices();
   const [yaml, setYaml] = useState<any | undefined>('');
   const [fullAgentPolicy, setFullAgentPolicy] = useState<FullAgentPolicy | undefined>();
-  const { apiKey, onCreateApiKey } = useGetCreateApiKey();
+  const { apiKey, isLoading: isCreatingApiKey, onCreateApiKey } = useGetCreateApiKey();
 
   useEffect(() => {
     async function fetchFullPolicy() {
@@ -302,6 +307,7 @@ export function useFetchFullPolicy(agentPolicy: AgentPolicy | undefined, isK8s?:
     yaml,
     onCreateApiKey,
     fullAgentPolicy,
+    isCreatingApiKey,
     apiKey,
     downloadYaml,
   };

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
@@ -54,7 +54,10 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
   isK8s,
   cloudSecurityIntegration,
 }) => {
-  const { yaml, onCreateApiKey, apiKey, downloadYaml } = useFetchFullPolicy(selectedPolicy, isK8s);
+  const { yaml, onCreateApiKey, isCreatingApiKey, apiKey, downloadYaml } = useFetchFullPolicy(
+    selectedPolicy,
+    isK8s
+  );
 
   const agentVersion = useAgentVersion();
 
@@ -88,6 +91,7 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
         downloadYaml,
         apiKey,
         onCreateApiKey,
+        isCreatingApiKey,
       })
     );
 
@@ -116,6 +120,7 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
     downloadYaml,
     apiKey,
     onCreateApiKey,
+    isCreatingApiKey,
     cloudSecurityIntegration,
     mode,
     setMode,

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/configure_standalone_agent_step.tsx
@@ -34,6 +34,7 @@ export const ConfigureStandaloneAgentStep = ({
   downloadYaml,
   apiKey,
   onCreateApiKey,
+  isCreatingApiKey,
   isComplete,
   onCopy,
 }: {
@@ -43,6 +44,7 @@ export const ConfigureStandaloneAgentStep = ({
   downloadYaml: () => void;
   apiKey: string | undefined;
   onCreateApiKey: () => void;
+  isCreatingApiKey: boolean;
   isComplete?: boolean;
   onCopy?: () => void;
 }): EuiContainedStepProps => {
@@ -167,7 +169,7 @@ export const ConfigureStandaloneAgentStep = ({
             <EuiSpacer size="s" />
             <EuiFlexGroup gutterSize="m">
               <EuiFlexItem grow={false}>
-                <EuiButton onClick={onCreateApiKey}>
+                <EuiButton onClick={onCreateApiKey} isLoading={isCreatingApiKey}>
                   <FormattedMessage
                     id="xpack.fleet.agentEnrollment.createApiKeyButton"
                     defaultMessage="Create API key"

--- a/x-pack/plugins/fleet/public/hooks/use_request/standalone_agent_api_key.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_request/standalone_agent_api_key.ts
@@ -12,10 +12,10 @@ import type {
 
 import { API_VERSIONS, CREATE_STANDALONE_AGENT_API_KEY_ROUTE } from '../../../common/constants';
 
-import { sendRequest } from './use_request';
+import { sendRequestForRq } from './use_request';
 
 export function sendCreateStandaloneAgentAPIKey(body: PostStandaloneAgentAPIKeyRequest['body']) {
-  return sendRequest<PostStandaloneAgentAPIKeyResponse>({
+  return sendRequestForRq<PostStandaloneAgentAPIKeyResponse>({
     method: 'post',
     path: CREATE_STANDALONE_AGENT_API_KEY_ROUTE,
     version: API_VERSIONS.internal.v1,

--- a/x-pack/plugins/fleet/server/routes/standalone_agent_api_key/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/standalone_agent_api_key/handler.ts
@@ -9,18 +9,38 @@ import type { TypeOf } from '@kbn/config-schema';
 
 import { createStandaloneAgentApiKey } from '../../services/api_keys';
 import type { FleetRequestHandler, PostStandaloneAgentAPIKeyRequestSchema } from '../../types';
+import {
+  INDEX_PRIVILEGES,
+  canCreateStandaloneAgentApiKey,
+} from '../../services/api_keys/create_standalone_agent_api_key';
+import { FleetUnauthorizedError, defaultFleetErrorHandler } from '../../errors';
 
 export const createStandaloneAgentApiKeyHandler: FleetRequestHandler<
   undefined,
   undefined,
   TypeOf<typeof PostStandaloneAgentAPIKeyRequestSchema.body>
 > = async (context, request, response) => {
-  const coreContext = await context.core;
-  const esClient = coreContext.elasticsearch.client.asCurrentUser;
-  const key = await createStandaloneAgentApiKey(esClient, request.body.name);
-  return response.ok({
-    body: {
-      item: key,
-    },
-  });
+  try {
+    const coreContext = await context.core;
+    const esClient = coreContext.elasticsearch.client.asCurrentUser;
+    const canCreate = await canCreateStandaloneAgentApiKey(esClient);
+
+    if (!canCreate) {
+      throw new FleetUnauthorizedError(
+        `Missing permissions to create standalone API key, You need ${INDEX_PRIVILEGES.privileges.join(
+          ', '
+        )} for indices ${INDEX_PRIVILEGES.names.join(', ')}`
+      );
+    }
+
+    const key = await createStandaloneAgentApiKey(esClient, request.body.name);
+
+    return response.ok({
+      body: {
+        item: key,
+      },
+    });
+  } catch (error) {
+    return defaultFleetErrorHandler({ error, response });
+  }
 };

--- a/x-pack/plugins/fleet/server/routes/standalone_agent_api_key/index.ts
+++ b/x-pack/plugins/fleet/server/routes/standalone_agent_api_key/index.ts
@@ -21,7 +21,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       path: CREATE_STANDALONE_AGENT_API_KEY_ROUTE,
       access: 'internal',
       fleetAuthz: {
-        fleet: { all: true },
+        fleet: { addAgents: true },
       },
     })
     .addVersion(

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/create_standalone_api_key.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/create_standalone_api_key.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+
+import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { skipIfNoDockerRegistry } from '../../helpers';
+import { SpaceTestApiClient } from '../space_awareness/api_helper';
+import { expectToRejectWithError } from '../space_awareness/helpers';
+import { setupTestUsers, testUsers } from '../test_users';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const supertest = getService('supertest');
+
+  describe('create standalone api key', function () {
+    skipIfNoDockerRegistry(providerContext);
+
+    before(async () => {
+      await setupTestUsers(getService('security'));
+    });
+
+    describe('POST /internal/fleet/create_standalone_agent_api_key', () => {
+      it('should work with a user with the correct permissions', async () => {
+        const apiClient = new SpaceTestApiClient(supertest);
+        const res = await apiClient.postStandaloneApiKey('test');
+        expect(res.item.name).to.eql('standalone_agent-test');
+      });
+      it('should return a 403 if the user cannot create the api key', async () => {
+        const apiClient = new SpaceTestApiClient(supertestWithoutAuth, {
+          username: testUsers.fleet_all_int_all.username,
+          password: testUsers.fleet_all_int_all.password,
+        });
+        await expectToRejectWithError(
+          () => apiClient.postStandaloneApiKey('tata'),
+          /403 Forbidden Missing permissions to create standalone API key/
+        );
+      });
+    });
+  });
+}

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/index.js
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/index.js
@@ -12,5 +12,6 @@ export default function loadTests({ loadTestFile }) {
     loadTestFile(require.resolve('./agent_policy_datastream_permissions'));
     loadTestFile(require.resolve('./privileges'));
     loadTestFile(require.resolve('./agent_policy_root_integrations'));
+    loadTestFile(require.resolve('./create_standalone_api_key'));
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -554,4 +554,19 @@ export class SpaceTestApiClient {
 
     return res;
   }
+
+  async postStandaloneApiKey(name: string, spaceId?: string) {
+    const { body: res, statusCode } = await this.supertest
+      .post(`${this.getBaseUrl(spaceId)}/internal/fleet/create_standalone_agent_api_key`)
+      .auth(this.auth.username, this.auth.password)
+      .set('kbn-xsrf', 'xxxx')
+      .set('elastic-api-version', '1')
+      .send({ name });
+
+    if (statusCode !== 200) {
+      throw new Error(`${statusCode} ${res?.error} ${res.message}`);
+    }
+
+    return res;
+  }
 }


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/189150

We were not handling errors when creating standalone agent API keys in the Fleet UI.

That PR address that by:
* handling the error in the UI
* verifying in the API that user has the correct permissions and if not throw a 403 with an actionable error message.
* Add missing API integration test to that API

## UI Changes

<img width="790" alt="Screenshot 2024-09-17 at 2 50 25 PM" src="https://github.com/user-attachments/assets/d1f3cf7e-add9-4e9e-9d13-ca7b1e903952">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->