### PR TITLE
[Detection Engine] Limit the scope of an exceptions integration test

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/rule_exceptions_execution.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/exceptions/workflows/basic_license_essentials_tier/rule_exceptions_execution.ts
@@ -148,7 +148,7 @@ export default ({ getService }: FtrProviderContext) => {
             },
           ],
         ]);
-        const alertsOpen = await getOpenAlerts(supertest, log, es, createdRule);
+        const alertsOpen = await getAlertsByIds(supertest, log, [createdRule.id]);
         expect(alertsOpen.hits.hits.length).toEqual(0);
       });
 


### PR DESCRIPTION
## Summary

The hope here is that this fixes some flakiness in the test, by restricting the alerts being asserted upon to only those created within the test (via filtering on the created rule's ID). Surrounding tests do this, and it seems likely that the failure
(https://github.com/elastic/kibana/issues/181887) was caused by a previous test's alerts being present during this test.
