### PR TITLE
[data plugin] Remove fieldFormats reexport 

### DIFF
--- a/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_color.test.ts
+++ b/src/plugins/chart_expressions/expression_partition_vis/public/utils/layers/get_color.test.ts
@@ -11,9 +11,8 @@ import type { PaletteOutput, PaletteDefinition } from '@kbn/coloring';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import { byDataColorPaletteMap, SimplifiedArrayNode } from './get_color';
 import type { SeriesLayer } from '@kbn/coloring';
-import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
-import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import { getColor } from './get_color';
 import { createMockVisData, createMockBucketColumns, createMockPieParams } from '../../mocks';
 import { generateFormatters } from '../formatters';
@@ -108,7 +107,6 @@ describe('getColor', () => {
   const buckets = createMockBucketColumns();
   const visParams = createMockPieParams();
   const colors = ['color1', 'color2', 'color3', 'color4'];
-  const dataMock = dataPluginMock.createStartContract();
   interface RangeProps {
     gte: number;
     lt: number;
@@ -118,13 +116,13 @@ describe('getColor', () => {
   const distinctSeries = getDistinctSeries(visData.rows, buckets);
   const dataLength = { columnsLength: buckets.length, rowsLength: visData.rows.length };
 
-  dataMock.fieldFormats = {
+  const fieldFormats = {
     deserialize: jest.fn(() => ({
       convert: jest.fn((s: RangeProps) => {
         return `≥ ${s.gte} and < ${s.lt}`;
       }),
     })),
-  } as unknown as DataPublicPluginStart['fieldFormats'];
+  } as unknown as FieldFormatsStart;
 
   const getPaletteRegistry = () => {
     const mockPalette1: jest.Mocked<PaletteDefinition> = {
@@ -180,7 +178,7 @@ describe('getColor', () => {
       { getColor: () => undefined },
       false,
       false,
-      dataMock.fieldFormats,
+      fieldFormats,
       visData.columns[0],
       formatters
     );
@@ -215,7 +213,7 @@ describe('getColor', () => {
       { getColor: () => undefined },
       false,
       false,
-      dataMock.fieldFormats,
+      fieldFormats,
       visData.columns[0],
       formatters
     );
@@ -249,7 +247,7 @@ describe('getColor', () => {
       { getColor: () => undefined },
       false,
       false,
-      dataMock.fieldFormats,
+      fieldFormats,
       visData.columns[0],
       formatters
     );
@@ -313,7 +311,7 @@ describe('getColor', () => {
       { getColor: () => undefined },
       false,
       false,
-      dataMock.fieldFormats,
+      fieldFormats,
       column,
       formatters
     );
@@ -354,7 +352,7 @@ describe('getColor', () => {
       undefined,
       true,
       false,
-      dataMock.fieldFormats,
+      fieldFormats,
       visData.columns[0],
       formatters
     );
@@ -399,7 +397,7 @@ describe('getColor', () => {
       undefined,
       true,
       false,
-      dataMock.fieldFormats,
+      fieldFormats,
       visData.columns[0],
       formatters
     );

--- a/src/plugins/dashboard/kibana.jsonc
+++ b/src/plugins/dashboard/kibana.jsonc
@@ -9,6 +9,7 @@
     "browser": true,
     "requiredPlugins": [
       "data",
+      "fieldFormats",
       "dataViews",
       "dataViewEditor",
       "embeddable",

--- a/src/plugins/dashboard/public/dashboard_actions/export_csv_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/export_csv_action.tsx
@@ -48,7 +48,7 @@ export class ExportCSVAction implements Action<ExportContext> {
 
   constructor() {
     ({
-      data: { fieldFormats: this.fieldFormats },
+      fieldFormats: this.fieldFormats,
       settings: { uiSettings: this.uiSettings },
     } = pluginServices.getServices());
   }

--- a/src/plugins/dashboard/public/services/data/types.ts
+++ b/src/plugins/dashboard/public/services/data/types.ts
@@ -11,7 +11,6 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 
 export interface DashboardDataService {
   dataViews: DataPublicPluginStart['dataViews'];
-  fieldFormats: DataPublicPluginStart['fieldFormats'];
   query: DataPublicPluginStart['query'];
   search: DataPublicPluginStart['search'];
 }

--- a/src/plugins/dashboard/public/services/types.ts
+++ b/src/plugins/dashboard/public/services/types.ts
@@ -11,6 +11,7 @@ import { PluginInitializerContext } from '@kbn/core/public';
 import { KibanaPluginServiceParams } from '@kbn/presentation-util-plugin/public';
 import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
 import { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
+import { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 
 import { DashboardStartDependencies } from '../plugin';
 import { DashboardAnalyticsService } from './analytics/types';
@@ -61,6 +62,7 @@ export interface DashboardServices {
   coreContext: DashboardCoreContextService;
   dashboardCapabilities: DashboardCapabilitiesService;
   data: DashboardDataService;
+  fieldFormats: FieldFormatsStart;
   dataViewEditor: DashboardDataViewEditorService; // this service is used only for the no data state
   documentationLinks: DashboardDocumentationLinksService;
   embeddable: DashboardEmbeddableService;

--- a/src/plugins/data/public/mocks.ts
+++ b/src/plugins/data/public/mocks.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { fieldFormatsServiceMock } from '@kbn/field-formats-plugin/public/mocks';
 import { createDatatableUtilitiesMock } from '../common/mocks';
 import { DataPlugin } from '.';
 import { searchServiceMock } from './search/mocks';
@@ -38,7 +37,6 @@ const createStartContract = (): Start => {
     },
     datatableUtilities: createDatatableUtilitiesMock(),
     search: searchServiceMock.createStartContract(),
-    fieldFormats: fieldFormatsServiceMock.createStartContract(),
     query: queryStartMock,
     dataViews,
     /**

--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -104,7 +104,7 @@ export class DataPublicPlugin
       getTableViewDescription(() => ({
         uiActions: startServices().plugins.uiActions,
         uiSettings: startServices().core.uiSettings,
-        fieldFormats: startServices().self.fieldFormats,
+        fieldFormats: startServices().plugins.fieldFormats,
         isFilterable: startServices().self.datatableUtilities.isFilterable,
       }))
     );

--- a/src/plugins/data/public/types.ts
+++ b/src/plugins/data/public/types.ts
@@ -99,10 +99,6 @@ export interface DataPublicPluginStart {
    */
   search: ISearchStart;
   /**
-   * @deprecated Use fieldFormats plugin instead
-   */
-  fieldFormats: FieldFormatsStart;
-  /**
    * query service
    * {@link QueryStart}
    */

--- a/src/plugins/data/server/mocks.ts
+++ b/src/plugins/data/server/mocks.ts
@@ -9,10 +9,6 @@
 
 import { coreMock } from '@kbn/core/server/mocks';
 import {
-  createFieldFormatsSetupMock,
-  createFieldFormatsStartMock,
-} from '@kbn/field-formats-plugin/server/mocks';
-import {
   createSearchSetupMock,
   createSearchStartMock,
   createSearchRequestHandlerContext,
@@ -23,20 +19,12 @@ import { createDatatableUtilitiesMock } from './datatable_utilities/mock';
 function createSetupContract() {
   return {
     search: createSearchSetupMock(),
-    /**
-     * @deprecated - use directly from "fieldFormats" plugin instead
-     */
-    fieldFormats: createFieldFormatsSetupMock(),
   };
 }
 
 function createStartContract() {
   return {
     search: createSearchStartMock(),
-    /**
-     * @deprecated - use directly from "fieldFormats" plugin instead
-     */
-    fieldFormats: createFieldFormatsStartMock(),
     indexPatterns: createIndexPatternsStartMock(),
     datatableUtilities: createDatatableUtilitiesMock(),
   };

--- a/src/plugins/data/server/plugin.ts
+++ b/src/plugins/data/server/plugin.ts
@@ -26,20 +26,11 @@ import { QuerySetup } from './query';
 export interface DataPluginSetup {
   search: ISearchSetup;
   query: QuerySetup;
-  /**
-   * @deprecated - use "fieldFormats" plugin directly instead
-   */
-  fieldFormats: FieldFormatsSetup;
 }
 
 export interface DataPluginStart {
   search: ISearchStart;
-  /**
-   * @deprecated - use "fieldFormats" plugin directly instead
-   */
-  fieldFormats: FieldFormatsStart;
   indexPatterns: DataViewsServerPluginStart;
-
   /**
    * Datatable type utility functions.
    */
@@ -85,7 +76,7 @@ export class DataServerPlugin
 
   public setup(
     core: CoreSetup<DataPluginStartDependencies, DataPluginStart>,
-    { bfetch, expressions, usageCollection, fieldFormats }: DataPluginSetupDependencies
+    { bfetch, expressions, usageCollection }: DataPluginSetupDependencies
   ) {
     this.scriptsService.setup(core);
     const querySetup = this.queryService.setup(core);
@@ -102,7 +93,6 @@ export class DataServerPlugin
     return {
       search: searchSetup,
       query: querySetup,
-      fieldFormats,
     };
   }
 
@@ -121,7 +111,6 @@ export class DataServerPlugin
     return {
       datatableUtilities,
       search,
-      fieldFormats,
       indexPatterns: dataViews,
     };
   }

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/choropleth_map.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_expanded_row/choropleth_map.tsx
@@ -100,10 +100,7 @@ interface Props {
 
 export const ChoroplethMap: FC<Props> = ({ stats, suggestion }) => {
   const {
-    services: {
-      data: { fieldFormats },
-      maps: mapsService,
-    },
+    services: { fieldFormats, maps: mapsService },
   } = useDataVisualizerKibana();
 
   const { fieldName, isTopValuesSampled, topValues, sampleCount } = stats;

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_row/distinct_values.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_row/distinct_values.tsx
@@ -21,9 +21,7 @@ interface Props extends FieldDataRowProps {
 export const DistinctValues = ({ showIcon, config }: Props) => {
   const { stats, type } = config;
   const {
-    services: {
-      data: { fieldFormats },
-    },
+    services: { fieldFormats },
   } = useDataVisualizerKibana();
 
   const cardinality = stats?.cardinality;

--- a/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_row/document_stats.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/stats_table/components/field_data_row/document_stats.tsx
@@ -23,9 +23,7 @@ interface Props extends FieldDataRowProps {
 export const DocumentStat = ({ config, showIcon, totalCount }: Props) => {
   const { stats, type } = config;
   const {
-    services: {
-      data: { fieldFormats },
-    },
+    services: { fieldFormats },
   } = useDataVisualizerKibana();
 
   if (stats === undefined) return null;

--- a/x-pack/plugins/data_visualizer/public/application/common/components/top_values/top_values.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/common/components/top_values/top_values.tsx
@@ -65,9 +65,7 @@ export const TopValues: FC<Props> = ({
   showSampledValues = false,
 }) => {
   const {
-    services: {
-      data: { fieldFormats },
-    },
+    services: { fieldFormats },
   } = useDataVisualizerKibana();
 
   if (stats === undefined || !stats.topValues) return null;

--- a/x-pack/plugins/data_visualizer/public/application/data_drift/charts/default_value_formatter.ts
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/charts/default_value_formatter.ts
@@ -20,9 +20,7 @@ export const getFieldFormatType = (type: string) => {
 };
 export const useFieldFormatter = (fieldType: FIELD_FORMAT_IDS) => {
   const {
-    services: {
-      data: { fieldFormats },
-    },
+    services: { fieldFormats },
   } = useDataVisualizerKibana();
 
   const fieldFormatter = useMemo(() => {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_data_visualizer_esql_data.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_data_visualizer_esql_data.tsx
@@ -83,7 +83,7 @@ export const useESQLDataVisualizerData = (
 ) => {
   const [lastRefresh, setLastRefresh] = useState(0);
   const { services } = useDataVisualizerKibana();
-  const { uiSettings, executionContext, data } = services;
+  const { uiSettings, executionContext, fieldFormats } = services;
 
   const parentExecutionContext = useObservable(executionContext?.context$);
 
@@ -430,7 +430,7 @@ export const useESQLDataVisualizerData = (
           ...field,
           ...fieldData,
           loading: fieldData?.existsInDocs ?? true,
-          fieldFormat: data.fieldFormats.deserialize({ id: field.secondaryType }),
+          fieldFormat: fieldFormats.deserialize({ id: field.secondaryType }),
           aggregatable: true,
           deletable: false,
           type: getFieldType(field) as SupportedFieldType,
@@ -503,7 +503,7 @@ export const useESQLDataVisualizerData = (
           secondaryType: getFieldType(field) as SupportedFieldType,
           loading: fieldData?.existsInDocs ?? true,
           deletable: false,
-          fieldFormat: data.fieldFormats.deserialize({ id: field.secondaryType }),
+          fieldFormat: fieldFormats.deserialize({ id: field.secondaryType }),
         };
 
         // Map the field type from the Kibana index pattern to the field type

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/ranges.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/ranges/ranges.test.tsx
@@ -59,7 +59,7 @@ const unifiedSearchPluginMockValue = unifiedSearchPluginMock.createStartContract
 const fieldFormatsPluginMockValue = fieldFormatsServiceMock.createStartContract();
 const dataViewsPluginMockValue = dataViewPluginMocks.createStartContract();
 // need to overwrite the formatter field first
-dataPluginMockValue.fieldFormats.deserialize = jest.fn().mockImplementation(({ id, params }) => {
+fieldFormatsPluginMockValue.deserialize = jest.fn().mockImplementation(({ id, params }) => {
   return {
     convert: ({ gte, lt }: { gte: string; lt: string }) => {
       if (params?.id === 'custom') {


### PR DESCRIPTION
## Summary

Removing data plugin's deprecated reexport of the field formats plugin.

Resume after https://github.com/elastic/kibana/issues/167437 is compete
