### PR TITLE
[8.15] [Infra] Add observability feature id to host request (#192898)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/host/get_hosts_alerts_count.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/host/get_hosts_alerts_count.ts
@@ -6,6 +6,7 @@
  */
 
 import { kqlQuery, termQuery, termsQuery } from '@kbn/observability-plugin/server';
+import { observabilityFeatureId } from '@kbn/observability-shared-plugin/common';
 import {
   ALERT_RULE_PRODUCER,
   ALERT_STATUS,
@@ -48,7 +49,7 @@ export async function getHostsAlertsCount({
     query: {
       bool: {
         filter: [
-          ...termQuery(ALERT_RULE_PRODUCER, INFRA_ALERT_FEATURE_ID),
+          ...termsQuery(ALERT_RULE_PRODUCER, INFRA_ALERT_FEATURE_ID, observabilityFeatureId),
           ...termQuery(ALERT_STATUS, ALERT_STATUS_ACTIVE),
           ...termsQuery(BUCKET_KEY, ...hostNamesShortList),
           ...rangeQuery,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Infra] Add observability feature id to host request (#192898)](https://github.com/elastic/kibana/pull/192898)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gonçalo Rica Pais da Silva","email":"goncalo.rica@elastic.co"},"sourceCommit":{"committedDate":"2024-09-17T14:17:30Z","message":"[Infra] Add observability feature id to host request (#192898)\n\n## Summary\r\n\r\nFixes the Hosts view for serverless by enabling the `observability`\r\nfeature id for the `/api/metrics/infra/{assetType}` request.\r\n\r\nCloses #191078 \r\n\r\n## How to test\r\n\r\n- Go to Infrastructure -> Hosts\r\n- Go to Alerts & Rules, Infrastructure Rules and create a new Inventory\r\nRule, something like alert on cpu usage above certain %.\r\n- Allow the rule/alert to run\r\n- Go back to Infrastructure -> Hosts view\r\n- Hosts table should have a column with alert icons now visible for all\r\nhosts with alerts active on them.\r\n\r\nThis should be tested against serverless + stateful versions of the\r\nObservability product.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/8e0b36e0-30e6-4176-8190-592b3aaf2732\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"30622923f6aacfbf5f97838a2a8751e9dbc81812","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-infra_services","v8.15.0","v8.16.0"],"number":192898,"url":"https://github.com/elastic/kibana/pull/192898","mergeCommit":{"message":"[Infra] Add observability feature id to host request (#192898)\n\n## Summary\r\n\r\nFixes the Hosts view for serverless by enabling the `observability`\r\nfeature id for the `/api/metrics/infra/{assetType}` request.\r\n\r\nCloses #191078 \r\n\r\n## How to test\r\n\r\n- Go to Infrastructure -> Hosts\r\n- Go to Alerts & Rules, Infrastructure Rules and create a new Inventory\r\nRule, something like alert on cpu usage above certain %.\r\n- Allow the rule/alert to run\r\n- Go back to Infrastructure -> Hosts view\r\n- Hosts table should have a column with alert icons now visible for all\r\nhosts with alerts active on them.\r\n\r\nThis should be tested against serverless + stateful versions of the\r\nObservability product.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/8e0b36e0-30e6-4176-8190-592b3aaf2732\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"30622923f6aacfbf5f97838a2a8751e9dbc81812"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192898","number":192898,"mergeCommit":{"message":"[Infra] Add observability feature id to host request (#192898)\n\n## Summary\r\n\r\nFixes the Hosts view for serverless by enabling the `observability`\r\nfeature id for the `/api/metrics/infra/{assetType}` request.\r\n\r\nCloses #191078 \r\n\r\n## How to test\r\n\r\n- Go to Infrastructure -> Hosts\r\n- Go to Alerts & Rules, Infrastructure Rules and create a new Inventory\r\nRule, something like alert on cpu usage above certain %.\r\n- Allow the rule/alert to run\r\n- Go back to Infrastructure -> Hosts view\r\n- Hosts table should have a column with alert icons now visible for all\r\nhosts with alerts active on them.\r\n\r\nThis should be tested against serverless + stateful versions of the\r\nObservability product.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/8e0b36e0-30e6-4176-8190-592b3aaf2732\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"30622923f6aacfbf5f97838a2a8751e9dbc81812"}},{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/193176","number":193176,"state":"MERGED","mergeCommit":{"sha":"13a392a54f80e14fbf7400cc9af175b6eb1aec71","message":"[8.x] [Infra] Add observability feature id to host request (#192898) (#193176)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Infra] Add observability feature id to host request\n(#192898)](https://github.com/elastic/kibana/pull/192898)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Gonçalo Rica Pais da\nSilva\",\"email\":\"goncalo.rica@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-09-17T14:17:30Z\",\"message\":\"[Infra]\nAdd observability feature id to host request (#192898)\\n\\n##\nSummary\\r\\n\\r\\nFixes the Hosts view for serverless by enabling the\n`observability`\\r\\nfeature id for the `/api/metrics/infra/{assetType}`\nrequest.\\r\\n\\r\\nCloses #191078 \\r\\n\\r\\n## How to test\\r\\n\\r\\n- Go to\nInfrastructure -> Hosts\\r\\n- Go to Alerts & Rules, Infrastructure Rules\nand create a new Inventory\\r\\nRule, something like alert on cpu usage\nabove certain %.\\r\\n- Allow the rule/alert to run\\r\\n- Go back to\nInfrastructure -> Hosts view\\r\\n- Hosts table should have a column with\nalert icons now visible for all\\r\\nhosts with alerts active on\nthem.\\r\\n\\r\\nThis should be tested against serverless + stateful\nversions of the\\r\\nObservability\nproduct.\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/8e0b36e0-30e6-4176-8190-592b3aaf2732\\r\\n\\r\\nCo-authored-by:\nElastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"30622923f6aacfbf5f97838a2a8751e9dbc81812\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.16.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:prev-minor\",\"ci:project-deploy-observability\",\"Team:obs-ux-infra_services\",\"v8.15.0\",\"v8.16.0\"],\"title\":\"[Infra]\nAdd observability feature id to host\nrequest\",\"number\":192898,\"url\":\"https://github.com/elastic/kibana/pull/192898\",\"mergeCommit\":{\"message\":\"[Infra]\nAdd observability feature id to host request (#192898)\\n\\n##\nSummary\\r\\n\\r\\nFixes the Hosts view for serverless by enabling the\n`observability`\\r\\nfeature id for the `/api/metrics/infra/{assetType}`\nrequest.\\r\\n\\r\\nCloses #191078 \\r\\n\\r\\n## How to test\\r\\n\\r\\n- Go to\nInfrastructure -> Hosts\\r\\n- Go to Alerts & Rules, Infrastructure Rules\nand create a new Inventory\\r\\nRule, something like alert on cpu usage\nabove certain %.\\r\\n- Allow the rule/alert to run\\r\\n- Go back to\nInfrastructure -> Hosts view\\r\\n- Hosts table should have a column with\nalert icons now visible for all\\r\\nhosts with alerts active on\nthem.\\r\\n\\r\\nThis should be tested against serverless + stateful\nversions of the\\r\\nObservability\nproduct.\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/8e0b36e0-30e6-4176-8190-592b3aaf2732\\r\\n\\r\\nCo-authored-by:\nElastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"30622923f6aacfbf5f97838a2a8751e9dbc81812\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.15\",\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/192898\",\"number\":192898,\"mergeCommit\":{\"message\":\"[Infra]\nAdd observability feature id to host request (#192898)\\n\\n##\nSummary\\r\\n\\r\\nFixes the Hosts view for serverless by enabling the\n`observability`\\r\\nfeature id for the `/api/metrics/infra/{assetType}`\nrequest.\\r\\n\\r\\nCloses #191078 \\r\\n\\r\\n## How to test\\r\\n\\r\\n- Go to\nInfrastructure -> Hosts\\r\\n- Go to Alerts & Rules, Infrastructure Rules\nand create a new Inventory\\r\\nRule, something like alert on cpu usage\nabove certain %.\\r\\n- Allow the rule/alert to run\\r\\n- Go back to\nInfrastructure -> Hosts view\\r\\n- Hosts table should have a column with\nalert icons now visible for all\\r\\nhosts with alerts active on\nthem.\\r\\n\\r\\nThis should be tested against serverless + stateful\nversions of the\\r\\nObservability\nproduct.\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/8e0b36e0-30e6-4176-8190-592b3aaf2732\\r\\n\\r\\nCo-authored-by:\nElastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"30622923f6aacfbf5f97838a2a8751e9dbc81812\"}},{\"branch\":\"8.15\",\"label\":\"v8.15.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.x\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v8.16.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Gonçalo Rica Pais da Silva <goncalo.rica@elastic.co>"}}]}] BACKPORT-->