### PR TITLE
Add debug logging for flaky session tests

### DIFF
--- a/x-pack/test/security_api_integration/tests/session_concurrent_limit/global_limit.ts
+++ b/x-pack/test/security_api_integration/tests/session_concurrent_limit/global_limit.ts
@@ -146,9 +146,9 @@ export default function ({ getService }: FtrProviderContext) {
 
     beforeEach(async () => {
       await security.testUser.setRoles(['kibana_admin']);
-      await addESDebugLoggingSettings();
       await es.indices.refresh({ index: '.kibana_security_session*' });
       await es.cluster.health({ index: '.kibana_security_session*', wait_for_status: 'green' });
+      await addESDebugLoggingSettings();
       await supertest
         .post('/api/security/session/_invalidate')
         .set('kbn-xsrf', 'xxx')

--- a/x-pack/test/security_api_integration/tests/session_concurrent_limit/global_limit.ts
+++ b/x-pack/test/security_api_integration/tests/session_concurrent_limit/global_limit.ts
@@ -17,6 +17,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertestWithoutAuth');
+  const esSupertest = getService('esSupertest');
   const es = getService('es');
   const security = getService('security');
   const config = getService('config');
@@ -116,6 +117,15 @@ export default function ({ getService }: FtrProviderContext) {
       .expect(200);
   }
 
+  async function addESDebugLoggingSettings() {
+    const addLogging = {
+      persistent: {
+        'logger.org.elasticsearch.xpack.security.authc': 'debug',
+      },
+    };
+    await esSupertest.put('/_cluster/settings').send(addLogging).expect(200);
+  }
+
   describe('Session Global Concurrent Limit', () => {
     before(async function () {
       this.timeout(120000);
@@ -136,6 +146,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     beforeEach(async () => {
       await security.testUser.setRoles(['kibana_admin']);
+      await addESDebugLoggingSettings();
       await es.indices.refresh({ index: '.kibana_security_session*' });
       await es.cluster.health({ index: '.kibana_security_session*', wait_for_status: 'green' });
       await supertest


### PR DESCRIPTION
## Summary

Add settings to the ES Test cluster to enable debug logs so that if this test fails in the future, we will have more logs to investigate the issue. 


__Related:__ https://github.com/elastic/kibana/issues/152260

<!--ONMERGE {"backportTargets":["7.17","8.15","8.x"]} ONMERGE-->