### PR TITLE
[ci] skip FTRs that fail on chrome 129

### DIFF
--- a/test/functional/apps/dashboard/group1/url_field_formatter.ts
+++ b/test/functional/apps/dashboard/group1/url_field_formatter.ts
@@ -37,7 +37,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     expect(currentUrl).to.equal(fieldUrl);
   };
 
-  describe('Changing field formatter to Url', () => {
+  // Fails in chrome 129+: https://github.com/elastic/kibana-operations/issues/199
+  describe.skip('Changing field formatter to Url', () => {
     before(async function () {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader', 'animals']);
       await kibanaServer.savedObjects.cleanStandardList();

--- a/test/functional/apps/dashboard/group5/embed_mode.ts
+++ b/test/functional/apps/dashboard/group5/embed_mode.ts
@@ -57,7 +57,7 @@ export default function ({
       await browser.setWindowSize(1300, 900);
     });
 
-    // Fails in with chrome 128+ https://github.com/elastic/kibana/issues/163207
+    // Fails in chrome 128+ https://github.com/elastic/kibana-operations/issues/199
     describe.skip('default URL params', () => {
       it('hides the chrome', async () => {
         const globalNavShown = await globalNav.exists();
@@ -92,7 +92,7 @@ export default function ({
       });
     });
 
-    // Fails in with chrome 128+ https://github.com/elastic/kibana/issues/163207
+    // Fails in chrome 128+ https://github.com/elastic/kibana-operations/issues/199
     describe.skip('non-default URL params', () => {
       it('shows or hides elements based on URL params', async () => {
         const currentUrl = await browser.getCurrentUrl();

--- a/test/functional/apps/discover/group6/_time_field_column.ts
+++ b/test/functional/apps/discover/group6/_time_field_column.ts
@@ -308,7 +308,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             });
           });
 
-          it('should render selected columns correctly', async () => {
+          // Fails in chrome 129+: https://github.com/elastic/kibana-operations/issues/199
+          it.skip('should render selected columns correctly', async () => {
             await discover.selectTextBaseLang();
 
             await checkSelectedColumns({

--- a/x-pack/test/functional/apps/lens/group6/workspace_size.ts
+++ b/x-pack/test/functional/apps/lens/group6/workspace_size.ts
@@ -268,14 +268,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await assertWorkspaceDimensions('600px', '375px');
     });
 
-    // Fails in chrome 128+
+    // Fails in chrome 128+: https://github.com/elastic/kibana-operations/issues/199
     it.skip('gauge size (absolute pixels) - major arc', async () => {
       await lens.openVisualOptions();
       await lens.setGaugeShape('Major arc');
       await assertWorkspaceDimensions('600px', '430px');
     });
 
-    it('gauge size (absolute pixels) - circle', async () => {
+    // Fails in chrome 129+: https://github.com/elastic/kibana-operations/issues/199
+    it.skip('gauge size (absolute pixels) - circle', async () => {
       await lens.openVisualOptions();
       await lens.setGaugeShape('Circle');
       await assertWorkspaceDimensions('600px', '430px');


### PR DESCRIPTION
## Summary
`google-chrome-stable` is now on version 129. Another set of tests started to fail when running against a VM with unpinned chrome version: https://buildkite.com/elastic/kibana-pull-request/builds/235162

This PR skips another 3 tests and adjusts all messages to point to the central issue.

Relates to: https://github.com/elastic/kibana-operations/issues/199 - follow up to: https://github.com/elastic/kibana/pull/192830

<!--ONMERGE {"backportTargets":["7.17","8.15","8.x"]} ONMERGE-->