### PR TITLE
[Console] Add remote_indices to autocomplete overrides

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/json/overrides/security.put_role.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/overrides/security.put_role.json
@@ -10,6 +10,15 @@
           "query": ""
         }
       ],
+      "remote_indices": [
+        {
+          "clusters": [],
+          "field_security": {},
+          "names": [],
+          "privileges": [],
+          "query": ""
+        }
+      ],
       "run_as": [],
       "metadata": {}
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/188608 by adding "remote_indices" to the Create or update roles API. I'm not adding `remote_cluster` because it's not documented, and I don't know yet if it's on purpose or not. As `remote_indices` was also missing from the Elasticsearch specification, I opened  https://github.com/elastic/elasticsearch-specification/pull/2915 too.

## Screenshots

<img width="561" alt="Screenshot 2024-09-19 at 14 07 07" src="https://github.com/user-attachments/assets/172a4c54-335c-43f7-a899-5b84bb4fd2da">

<img width="591" alt="Screenshot 2024-09-19 at 14 07 33" src="https://github.com/user-attachments/assets/e57c20c3-6acf-4ede-8f79-e388f90e4104">

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->