### PR TITLE
[8.x] [ResponseOps][Cases] Fix a bug with cases telemetry where data from other spaces are not included (#193166)

### DIFF
--- a/x-pack/plugins/cases/server/telemetry/collect_telemetry_data.ts
+++ b/x-pack/plugins/cases/server/telemetry/collect_telemetry_data.ts
@@ -11,7 +11,7 @@ import { getCasesSystemActionData } from './queries/case_system_action';
 import { getUserCommentsTelemetryData } from './queries/comments';
 import { getConfigurationTelemetryData } from './queries/configuration';
 import { getConnectorsTelemetryData } from './queries/connectors';
-import { getPushedTelemetryData } from './queries/pushes';
+import { getPushedTelemetryData } from './queries/push';
 import { getUserActionsTelemetryData } from './queries/user_actions';
 import type { CasesTelemetry, CollectTelemetryDataParams } from './types';
 

--- a/x-pack/plugins/cases/server/telemetry/queries/alerts.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/alerts.test.ts
@@ -7,12 +7,15 @@
 
 import { loggingSystemMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
 import { getAlertsTelemetryData } from './alerts';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('alerts', () => {
   const logger = loggingSystemMock.createLogger();
 
   describe('getAlertsTelemetryData', () => {
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
     savedObjectsClient.find.mockResolvedValue({
       total: 5,
       saved_objects: [],
@@ -35,7 +38,10 @@ describe('alerts', () => {
     });
 
     it('it returns the correct res', async () => {
-      const res = await getAlertsTelemetryData({ savedObjectsClient, logger });
+      const res = await getAlertsTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           total: 5,
@@ -48,7 +54,7 @@ describe('alerts', () => {
     });
 
     it('should call find with correct arguments', async () => {
-      await getAlertsTelemetryData({ savedObjectsClient, logger });
+      await getAlertsTelemetryData({ savedObjectsClient: telemetrySavedObjectsClient, logger });
       expect(savedObjectsClient.find).toBeCalledWith({
         aggs: {
           counts: {
@@ -117,6 +123,7 @@ describe('alerts', () => {
         page: 0,
         perPage: 0,
         type: 'cases-comments',
+        namespaces: ['*'],
       });
     });
   });

--- a/x-pack/plugins/cases/server/telemetry/queries/case_system_action.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/case_system_action.test.ts
@@ -7,12 +7,14 @@
 
 import { loggingSystemMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
 import { getCasesSystemActionData } from './case_system_action';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('casesSystemAction', () => {
   const logger = loggingSystemMock.createLogger();
 
   describe('getCasesSystemActionData', () => {
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
 
     beforeEach(() => {
       jest.clearAllMocks();
@@ -26,7 +28,10 @@ describe('casesSystemAction', () => {
     });
 
     it('calculates the metrics correctly', async () => {
-      const res = await getCasesSystemActionData({ savedObjectsClient, logger });
+      const res = await getCasesSystemActionData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({ totalCasesCreated: 4, totalRules: 2 });
     });
 
@@ -38,8 +43,49 @@ describe('casesSystemAction', () => {
         page: 1,
       });
 
-      const res = await getCasesSystemActionData({ savedObjectsClient, logger });
+      const res = await getCasesSystemActionData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
+
       expect(res).toEqual({ totalCasesCreated: 0, totalRules: 0 });
+    });
+
+    it('should call find with correct arguments', async () => {
+      savedObjectsClient.find.mockResolvedValue({
+        total: 1,
+        saved_objects: [],
+        per_page: 1,
+        page: 1,
+      });
+
+      await getCasesSystemActionData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
+
+      expect(savedObjectsClient.find.mock.calls[0][0]).toMatchInlineSnapshot(`
+        Object {
+          "aggs": Object {
+            "counterSum": Object {
+              "sum": Object {
+                "field": "cases-rules.attributes.counter",
+              },
+            },
+            "totalRules": Object {
+              "cardinality": Object {
+                "field": "cases-rules.attributes.rules.id",
+              },
+            },
+          },
+          "namespaces": Array [
+            "*",
+          ],
+          "page": 1,
+          "perPage": 1,
+          "type": "cases-rules",
+        }
+      `);
     });
   });
 });

--- a/x-pack/plugins/cases/server/telemetry/queries/case_system_action.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/case_system_action.ts
@@ -26,6 +26,7 @@ export const getCasesSystemActionData = async ({
         cardinality: { field: `${CASE_RULES_SAVED_OBJECT}.attributes.rules.id` },
       },
     },
+    namespaces: ['*'],
   });
 
   return {

--- a/x-pack/plugins/cases/server/telemetry/queries/cases.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/cases.test.ts
@@ -15,6 +15,7 @@ import type {
   FileAttachmentAggregationResults,
 } from '../types';
 import { getCasesTelemetryData } from './cases';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 const MOCK_FIND_TOTAL = 5;
 const SOLUTION_TOTAL = 1;
@@ -23,6 +24,7 @@ describe('getCasesTelemetryData', () => {
   describe('getCasesTelemetryData', () => {
     const logger = loggingSystemMock.createLogger();
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
 
     const mockFind = (aggs: object, so: SavedObjectsFindResponse['saved_objects'] = []) => {
       savedObjectsClient.find.mockResolvedValueOnce({
@@ -322,7 +324,10 @@ describe('getCasesTelemetryData', () => {
         };
       };
 
-      const res = await getCasesTelemetryData({ savedObjectsClient, logger });
+      const res = await getCasesTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
 
       const allAttachmentsTotal = 5;
       const allAttachmentsAverage = allAttachmentsTotal / MOCK_FIND_TOTAL;
@@ -406,7 +411,7 @@ describe('getCasesTelemetryData', () => {
     it('should call find with correct arguments', async () => {
       mockResponse();
 
-      await getCasesTelemetryData({ savedObjectsClient, logger });
+      await getCasesTelemetryData({ savedObjectsClient: telemetrySavedObjectsClient, logger });
 
       expect(savedObjectsClient.find.mock.calls[0][0]).toMatchInlineSnapshot(`
         Object {
@@ -660,6 +665,9 @@ describe('getCasesTelemetryData', () => {
               },
             },
           },
+          "namespaces": Array [
+            "*",
+          ],
           "page": 0,
           "perPage": 0,
           "type": "cases",
@@ -974,6 +982,9 @@ describe('getCasesTelemetryData', () => {
               },
             },
           },
+          "namespaces": Array [
+            "*",
+          ],
           "page": 0,
           "perPage": 0,
           "type": "cases-comments",
@@ -1023,6 +1034,7 @@ describe('getCasesTelemetryData', () => {
         page: 0,
         perPage: 0,
         type: 'cases-comments',
+        namespaces: ['*'],
       });
 
       expect(savedObjectsClient.find.mock.calls[3][0]).toEqual({
@@ -1068,6 +1080,7 @@ describe('getCasesTelemetryData', () => {
         page: 0,
         perPage: 0,
         type: 'cases-user-actions',
+        namespaces: ['*'],
       });
 
       for (const [index, sortField] of ['created_at', 'updated_at', 'closed_at'].entries()) {
@@ -1079,6 +1092,7 @@ describe('getCasesTelemetryData', () => {
           sortField,
           sortOrder: 'desc',
           type: 'cases',
+          namespaces: ['*'],
         });
       }
 
@@ -1172,6 +1186,9 @@ describe('getCasesTelemetryData', () => {
             "function": "is",
             "type": "function",
           },
+          "namespaces": Array [
+            "*",
+          ],
           "page": 0,
           "perPage": 0,
           "type": "file",

--- a/x-pack/plugins/cases/server/telemetry/queries/comments.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/comments.test.ts
@@ -7,11 +7,14 @@
 
 import { loggingSystemMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
 import { getUserCommentsTelemetryData } from './comments';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('comments', () => {
   describe('getUserCommentsTelemetryData', () => {
     const logger = loggingSystemMock.createLogger();
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
     savedObjectsClient.find.mockResolvedValue({
       total: 5,
       saved_objects: [],
@@ -34,7 +37,10 @@ describe('comments', () => {
     });
 
     it('it returns the correct res', async () => {
-      const res = await getUserCommentsTelemetryData({ savedObjectsClient, logger });
+      const res = await getUserCommentsTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           total: 5,
@@ -47,7 +53,10 @@ describe('comments', () => {
     });
 
     it('should call find with correct arguments', async () => {
-      await getUserCommentsTelemetryData({ savedObjectsClient, logger });
+      await getUserCommentsTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(savedObjectsClient.find).toBeCalledWith({
         aggs: {
           counts: {
@@ -116,6 +125,7 @@ describe('comments', () => {
         page: 0,
         perPage: 0,
         type: 'cases-comments',
+        namespaces: ['*'],
       });
     });
   });

--- a/x-pack/plugins/cases/server/telemetry/queries/configuration.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/configuration.test.ts
@@ -8,11 +8,14 @@
 import { loggingSystemMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
 import { CustomFieldTypes } from '../../../common/types/domain';
 import { getConfigurationTelemetryData } from './configuration';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('configuration', () => {
   describe('getConfigurationTelemetryData', () => {
     const logger = loggingSystemMock.createLogger();
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
     savedObjectsClient.find.mockResolvedValue({
       total: 5,
       saved_objects: [],
@@ -66,7 +69,10 @@ describe('configuration', () => {
     });
 
     it('it returns the correct res', async () => {
-      const res = await getConfigurationTelemetryData({ savedObjectsClient, logger });
+      const res = await getConfigurationTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           closure: {
@@ -82,7 +88,10 @@ describe('configuration', () => {
     });
 
     it('should call find with correct arguments', async () => {
-      await getConfigurationTelemetryData({ savedObjectsClient, logger });
+      await getConfigurationTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(savedObjectsClient.find).toBeCalledWith({
         aggs: {
           closureType: {
@@ -95,6 +104,7 @@ describe('configuration', () => {
         page: 1,
         perPage: 5,
         type: 'cases-configure',
+        namespaces: ['*'],
       });
     });
 
@@ -135,7 +145,10 @@ describe('configuration', () => {
         },
       });
 
-      const res = await getConfigurationTelemetryData({ savedObjectsClient, logger });
+      const res = await getConfigurationTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           closure: {
@@ -205,7 +218,10 @@ describe('configuration', () => {
         },
       });
 
-      const res = await getConfigurationTelemetryData({ savedObjectsClient, logger });
+      const res = await getConfigurationTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           closure: {

--- a/x-pack/plugins/cases/server/telemetry/queries/configuration.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/configuration.ts
@@ -28,6 +28,7 @@ export const getConfigurationTelemetryData = async ({
     page: 1,
     perPage: 5,
     type: CASE_CONFIGURE_SAVED_OBJECT,
+    namespaces: ['*'],
     aggs: {
       closureType: {
         terms: { field: `${CASE_CONFIGURE_SAVED_OBJECT}.attributes.closure_type` },

--- a/x-pack/plugins/cases/server/telemetry/queries/connectors.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/connectors.test.ts
@@ -7,11 +7,13 @@
 
 import { savedObjectsRepositoryMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { getConnectorsTelemetryData } from './connectors';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('getConnectorsTelemetryData', () => {
   describe('getConnectorsTelemetryData', () => {
     const logger = loggingSystemMock.createLogger();
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
 
     const mockFind = (aggs: Record<string, unknown>) => {
       savedObjectsClient.find.mockResolvedValueOnce({
@@ -42,7 +44,10 @@ describe('getConnectorsTelemetryData', () => {
     it('it returns the correct res', async () => {
       mockResponse();
 
-      const res = await getConnectorsTelemetryData({ savedObjectsClient, logger });
+      const res = await getConnectorsTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           all: {
@@ -71,7 +76,7 @@ describe('getConnectorsTelemetryData', () => {
     it('should call find with correct arguments', async () => {
       mockResponse();
 
-      await getConnectorsTelemetryData({ savedObjectsClient, logger });
+      await getConnectorsTelemetryData({ savedObjectsClient: telemetrySavedObjectsClient, logger });
 
       expect(savedObjectsClient.find.mock.calls[0][0]).toEqual({
         aggs: {
@@ -101,6 +106,7 @@ describe('getConnectorsTelemetryData', () => {
         page: 0,
         perPage: 0,
         type: 'cases-user-actions',
+        namespaces: ['*'],
       });
 
       expect(savedObjectsClient.find.mock.calls[1][0]).toEqual({
@@ -151,6 +157,7 @@ describe('getConnectorsTelemetryData', () => {
         page: 0,
         perPage: 0,
         type: 'cases-user-actions',
+        namespaces: ['*'],
       });
 
       for (const [index, connector] of [
@@ -205,6 +212,7 @@ describe('getConnectorsTelemetryData', () => {
           page: 0,
           perPage: 0,
           type: 'cases-user-actions',
+          namespaces: ['*'],
         });
       }
     });

--- a/x-pack/plugins/cases/server/telemetry/queries/connectors.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/connectors.ts
@@ -37,6 +37,7 @@ export const getConnectorsTelemetryData = async ({
       perPage: 0,
       filter,
       type: CASE_USER_ACTION_SAVED_OBJECT,
+      namespaces: ['*'],
       aggs: {
         ...aggs,
       },

--- a/x-pack/plugins/cases/server/telemetry/queries/push.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/push.test.ts
@@ -6,12 +6,15 @@
  */
 
 import { savedObjectsRepositoryMock, loggingSystemMock } from '@kbn/core/server/mocks';
-import { getPushedTelemetryData } from './pushes';
+import { getPushedTelemetryData } from './push';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
-describe('pushes', () => {
+describe('push', () => {
   describe('getPushedTelemetryData', () => {
     const logger = loggingSystemMock.createLogger();
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
     savedObjectsClient.find.mockResolvedValue({
       total: 5,
       saved_objects: [],
@@ -27,7 +30,10 @@ describe('pushes', () => {
     });
 
     it('it returns the correct res', async () => {
-      const res = await getPushedTelemetryData({ savedObjectsClient, logger });
+      const res = await getPushedTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           maxOnACase: 1,
@@ -37,7 +43,7 @@ describe('pushes', () => {
     });
 
     it('should call find with correct arguments', async () => {
-      await getPushedTelemetryData({ savedObjectsClient, logger });
+      await getPushedTelemetryData({ savedObjectsClient: telemetrySavedObjectsClient, logger });
       expect(savedObjectsClient.find).toBeCalledWith({
         aggs: {
           references: {
@@ -86,6 +92,7 @@ describe('pushes', () => {
         page: 0,
         perPage: 0,
         type: 'cases-user-actions',
+        namespaces: ['*'],
       });
     });
   });

--- a/x-pack/plugins/cases/server/telemetry/queries/push.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/push.ts
@@ -29,6 +29,7 @@ export const getPushedTelemetryData = async ({
     perPage: 0,
     filter: pushFilter,
     type: CASE_USER_ACTION_SAVED_OBJECT,
+    namespaces: ['*'],
     aggs: { ...getMaxBucketOnCaseAggregationQuery(CASE_USER_ACTION_SAVED_OBJECT) },
   });
 

--- a/x-pack/plugins/cases/server/telemetry/queries/user_actions.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/user_actions.test.ts
@@ -7,11 +7,14 @@
 
 import { savedObjectsRepositoryMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { getUserActionsTelemetryData } from './user_actions';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('user_actions', () => {
   describe('getUserActionsTelemetryData', () => {
     const logger = loggingSystemMock.createLogger();
     const savedObjectsClient = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
     savedObjectsClient.find.mockResolvedValue({
       total: 5,
       saved_objects: [],
@@ -34,7 +37,10 @@ describe('user_actions', () => {
     });
 
     it('it returns the correct res', async () => {
-      const res = await getUserActionsTelemetryData({ savedObjectsClient, logger });
+      const res = await getUserActionsTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(res).toEqual({
         all: {
           total: 5,
@@ -47,7 +53,10 @@ describe('user_actions', () => {
     });
 
     it('should call find with correct arguments', async () => {
-      await getUserActionsTelemetryData({ savedObjectsClient, logger });
+      await getUserActionsTelemetryData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        logger,
+      });
       expect(savedObjectsClient.find).toBeCalledWith({
         aggs: {
           counts: {
@@ -101,6 +110,7 @@ describe('user_actions', () => {
         page: 0,
         perPage: 0,
         type: 'cases-user-actions',
+        namespaces: ['*'],
       });
     });
   });

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
@@ -29,6 +29,7 @@ import {
   getReferencesAggregationQuery,
   getSolutionValues,
 } from './utils';
+import { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 describe('utils', () => {
   describe('getSolutionValues', () => {
@@ -1017,7 +1018,12 @@ describe('utils', () => {
     });
 
     it('returns the correct counts and max data', async () => {
-      const res = await getCountsAndMaxData({ savedObjectsClient, savedObjectType: 'test' });
+      const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
+      const res = await getCountsAndMaxData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        savedObjectType: 'test',
+      });
       expect(res).toEqual({
         all: {
           total: 5,
@@ -1030,6 +1036,7 @@ describe('utils', () => {
     });
 
     it('returns zero data if the response aggregation is not as expected', async () => {
+      const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
       savedObjectsClient.find.mockResolvedValue({
         total: 5,
         saved_objects: [],
@@ -1037,7 +1044,10 @@ describe('utils', () => {
         page: 1,
       });
 
-      const res = await getCountsAndMaxData({ savedObjectsClient, savedObjectType: 'test' });
+      const res = await getCountsAndMaxData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        savedObjectType: 'test',
+      });
       expect(res).toEqual({
         all: {
           total: 5,
@@ -1050,7 +1060,13 @@ describe('utils', () => {
     });
 
     it('should call find with correct arguments', async () => {
-      await getCountsAndMaxData({ savedObjectsClient, savedObjectType: 'test' });
+      const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsClient);
+
+      await getCountsAndMaxData({
+        savedObjectsClient: telemetrySavedObjectsClient,
+        savedObjectType: 'test',
+      });
+
       expect(savedObjectsClient.find).toBeCalledWith({
         aggs: {
           counts: {
@@ -1104,6 +1120,7 @@ describe('utils', () => {
         page: 0,
         perPage: 0,
         type: 'test',
+        namespaces: ['*'],
       });
     });
   });

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.ts
@@ -7,7 +7,6 @@
 
 import { get } from 'lodash';
 import type { KueryNode } from '@kbn/es-query';
-import type { ISavedObjectsRepository } from '@kbn/core/server';
 import {
   CASE_COMMENT_SAVED_OBJECT,
   CASE_SAVED_OBJECT,
@@ -32,6 +31,7 @@ import type {
 import { buildFilter } from '../../client/utils';
 import type { Owner } from '../../../common/constants/types';
 import type { ConfigurationPersistedAttributes } from '../../common/types/configure';
+import type { TelemetrySavedObjectsClient } from '../telemetry_saved_objects_client';
 
 export const getCountsAggregationQuery = (savedObjectType: string) => ({
   counts: {
@@ -126,7 +126,7 @@ export const getCountsAndMaxData = async ({
   savedObjectType,
   filter,
 }: {
-  savedObjectsClient: ISavedObjectsRepository;
+  savedObjectsClient: TelemetrySavedObjectsClient;
   savedObjectType: string;
   filter?: KueryNode;
 }) => {
@@ -138,6 +138,7 @@ export const getCountsAndMaxData = async ({
     perPage: 0,
     filter,
     type: savedObjectType,
+    namespaces: ['*'],
     aggs: {
       ...getCountsAggregationQuery(savedObjectType),
       ...getMaxBucketOnCaseAggregationQuery(savedObjectType),

--- a/x-pack/plugins/cases/server/telemetry/telemetry_saved_objects_client.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/telemetry_saved_objects_client.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TelemetrySavedObjectsClient } from './telemetry_saved_objects_client';
+import { savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
+
+describe('TelemetrySavedObjectsClient', () => {
+  it("find requests are extended with `namespaces:['*']`", async () => {
+    const savedObjectsRepository = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsRepository);
+
+    await telemetrySavedObjectsClient.find({ type: 'my-test-type' });
+    expect(savedObjectsRepository.find).toBeCalledWith({ type: 'my-test-type', namespaces: ['*'] });
+  });
+
+  it("allow callers to overwrite the `namespaces:['*']`", async () => {
+    const savedObjectsRepository = savedObjectsRepositoryMock.create();
+    const telemetrySavedObjectsClient = new TelemetrySavedObjectsClient(savedObjectsRepository);
+
+    await telemetrySavedObjectsClient.find({ type: 'my-test-type', namespaces: ['some_space'] });
+    expect(savedObjectsRepository.find).toBeCalledWith({
+      type: 'my-test-type',
+      namespaces: ['some_space'],
+    });
+  });
+});

--- a/x-pack/plugins/cases/server/telemetry/telemetry_saved_objects_client.ts
+++ b/x-pack/plugins/cases/server/telemetry/telemetry_saved_objects_client.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsFindOptions, SavedObjectsFindResponse } from '@kbn/core/server';
+import { SavedObjectsClient } from '@kbn/core/server';
+
+/**
+ * Extends the SavedObjectsClient to fit the telemetry fetching requirements (i.e.: find objects from all namespaces by default)
+ */
+export class TelemetrySavedObjectsClient extends SavedObjectsClient {
+  /**
+   * Find the SavedObjects matching the search query in all the Spaces by default
+   * @param options
+   */
+  async find<T = unknown, A = unknown>(
+    options: SavedObjectsFindOptions
+  ): Promise<SavedObjectsFindResponse<T, A>> {
+    return super.find({ namespaces: ['*'], ...options });
+  }
+}

--- a/x-pack/plugins/cases/server/telemetry/types.ts
+++ b/x-pack/plugins/cases/server/telemetry/types.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import type { ISavedObjectsRepository, Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
 import type { MakeSchemaFrom } from '@kbn/usage-collection-plugin/server';
 import type { Owner } from '../../common/constants/types';
+import type { TelemetrySavedObjectsClient } from './telemetry_saved_objects_client';
 
 export type BucketKeyString = Omit<Bucket, 'key'> & { key: string };
 
@@ -35,7 +36,7 @@ export interface ReferencesAggregation {
 }
 
 export interface CollectTelemetryDataParams {
-  savedObjectsClient: ISavedObjectsRepository;
+  savedObjectsClient: TelemetrySavedObjectsClient;
   logger: Logger;
 }
 

--- a/x-pack/test/cases_api_integration/common/lib/api/index.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/index.ts
@@ -61,6 +61,8 @@ export * from './user_profiles';
 export * from './omit';
 export * from './configuration';
 export * from './files';
+export * from './telemetry';
+
 export { getSpaceUrlPrefix } from './helpers';
 
 function toArray<T>(input: T | T[]): T[] {

--- a/x-pack/test/cases_api_integration/common/lib/api/telemetry.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/telemetry.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type SuperTest from 'supertest';
+import {
+  ELASTIC_HTTP_VERSION_HEADER,
+  X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
+} from '@kbn/core-http-common';
+import { CasesTelemetry } from '@kbn/cases-plugin/server/telemetry/types';
+import { CASES_TELEMETRY_TASK_NAME } from '@kbn/cases-plugin/common/constants';
+
+interface CasesTelemetryPayload {
+  stats: { stack_stats: { kibana: { plugins: { cases: CasesTelemetry } } } };
+}
+
+export const getTelemetry = async (supertest: SuperTest.Agent): Promise<CasesTelemetryPayload> => {
+  const { body } = await supertest
+    .post('/internal/telemetry/clusters/_stats')
+    .set('kbn-xsrf', 'xxx')
+    .set(ELASTIC_HTTP_VERSION_HEADER, '2')
+    .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+    .send({ unencrypted: true, refreshCache: true })
+    .expect(200);
+
+  return body[0];
+};
+
+export const runTelemetryTask = async (supertest: SuperTest.Agent) => {
+  await supertest
+    .post('/api/cases_fixture/telemetry/run_soon')
+    .set('kbn-xsrf', 'xxx')
+    .send({ taskId: CASES_TELEMETRY_TASK_NAME })
+    .expect(200);
+};

--- a/x-pack/test/cases_api_integration/common/plugins/cases/kibana.jsonc
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/kibana.jsonc
@@ -11,6 +11,7 @@
       "features",
       "cases",
       "files",
+      "taskManager"
     ],
     "optionalPlugins": [
       "security",

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/plugin.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/plugin.ts
@@ -12,6 +12,7 @@ import { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { CasesServerStart, CasesServerSetup } from '@kbn/cases-plugin/server';
 import { FilesSetup } from '@kbn/files-plugin/server';
 import { PluginStartContract as ActionsPluginsStart } from '@kbn/actions-plugin/server/plugin';
+import { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { getPersistableStateAttachment } from './attachments/persistable_state';
 import { getExternalReferenceAttachment } from './attachments/external_reference';
 import { registerRoutes } from './routes';
@@ -28,6 +29,7 @@ export interface FixtureStartDeps {
   security?: SecurityPluginStart;
   spaces?: SpacesPluginStart;
   cases: CasesServerStart;
+  taskManager: TaskManagerStartContract;
 }
 
 export class FixturePlugin implements Plugin<void, void, FixtureSetupDeps, FixtureStartDeps> {

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/routes.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/routes.ts
@@ -15,6 +15,7 @@ import type {
 } from '@kbn/cases-plugin/server/attachment_framework/types';
 import { BulkCreateCasesRequest, CasesPatchRequest } from '@kbn/cases-plugin/common/types/api';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
+import { CASES_TELEMETRY_TASK_NAME } from '@kbn/cases-plugin/common/constants';
 import type { FixtureStartDeps } from './plugin';
 
 const hashParts = (parts: string[]): string => {
@@ -175,6 +176,34 @@ export const registerRoutes = (core: CoreSetup<FixtureStartDeps>, logger: Logger
         }
 
         throw err;
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: '/api/cases_fixture/telemetry/run_soon',
+      validate: {
+        body: schema.object({
+          taskId: schema.string({
+            validate: (telemetryTaskId: string) => {
+              if (CASES_TELEMETRY_TASK_NAME === telemetryTaskId) {
+                return;
+              }
+
+              return 'invalid telemetry task id';
+            },
+          }),
+        }),
+      },
+    },
+    async (context, req, res) => {
+      const { taskId } = req.body;
+      try {
+        const [_, { taskManager }] = await core.getStartServices();
+        return res.ok({ body: await taskManager.runSoon(taskId) });
+      } catch (err) {
+        return res.ok({ body: { id: taskId, error: `${err}` } });
       }
     }
   );

--- a/x-pack/test/cases_api_integration/common/plugins/cases/tsconfig.json
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/tsconfig.json
@@ -18,6 +18,7 @@
     "@kbn/features-plugin",
     "@kbn/spaces-plugin",
     "@kbn/security-plugin",
+    "@kbn/task-manager-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/index.ts
@@ -70,6 +70,11 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
      */
     loadTestFile(require.resolve('./cases/bulk_create_cases'));
 
+    /**
+     * Telemetry
+     */
+    loadTestFile(require.resolve('./telemetry'));
+
     // NOTE: Migrations are not included because they can inadvertently remove the .kibana indices which removes the users and spaces
     // which causes errors in any tests after them that relies on those
   });

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/telemetry.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/telemetry.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { getPostCaseRequest } from '../../../common/lib/mock';
+import {
+  deleteAllCaseItems,
+  createCase,
+  getTelemetry,
+  runTelemetryTask,
+} from '../../../common/lib/api';
+import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { superUser } from '../../../common/lib/authentication/users';
+
+// eslint-disable-next-line import/no-default-export
+export default ({ getService }: FtrProviderContext): void => {
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const retry = getService('retry');
+
+  describe('Cases telemetry', () => {
+    before(async () => {
+      await deleteAllCaseItems(es);
+    });
+
+    afterEach(async () => {
+      await deleteAllCaseItems(es);
+    });
+
+    it('should count cases from all spaces', async () => {
+      await createCase(supertest, getPostCaseRequest(), 200, {
+        user: superUser,
+        space: 'space1',
+      });
+
+      await createCase(supertest, getPostCaseRequest(), 200, {
+        user: superUser,
+        space: 'space2',
+      });
+
+      await runTelemetryTask(supertest);
+
+      await retry.try(async () => {
+        const res = await getTelemetry(supertest);
+        expect(res.stats.stack_stats.kibana.plugins.cases.cases.all.total).toBe(2);
+      });
+    });
+  });
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps][Cases] Fix a bug with cases telemetry where data from other spaces are not included (#193166)](https://github.com/elastic/kibana/pull/193166)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2024-09-19T12:06:30Z","message":"[ResponseOps][Cases] Fix a bug with cases telemetry where data from other spaces are not included (#193166)\n\n## Summary\r\n\r\nThe Find SO API supports the `namespaces` parameter where you can define\r\nthe spaces that the SO client should search for. If you omit the\r\n`namespaces` parameter, the SO client will use the active space. This PR\r\ncreates a wrapper around the SO client to add the `namespaces: ['*']` to\r\nall Find SO usages to count telemetry on all spaces.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6b372b7b45913a0171958a7795b4663ea865d137","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","v9.0.0","Feature:Cases","v8.16.0","v8.15.2"],"number":193166,"url":"https://github.com/elastic/kibana/pull/193166","mergeCommit":{"message":"[ResponseOps][Cases] Fix a bug with cases telemetry where data from other spaces are not included (#193166)\n\n## Summary\r\n\r\nThe Find SO API supports the `namespaces` parameter where you can define\r\nthe spaces that the SO client should search for. If you omit the\r\n`namespaces` parameter, the SO client will use the active space. This PR\r\ncreates a wrapper around the SO client to add the `namespaces: ['*']` to\r\nall Find SO usages to count telemetry on all spaces.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6b372b7b45913a0171958a7795b4663ea865d137"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","8.15"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193166","number":193166,"mergeCommit":{"message":"[ResponseOps][Cases] Fix a bug with cases telemetry where data from other spaces are not included (#193166)\n\n## Summary\r\n\r\nThe Find SO API supports the `namespaces` parameter where you can define\r\nthe spaces that the SO client should search for. If you omit the\r\n`namespaces` parameter, the SO client will use the active space. This PR\r\ncreates a wrapper around the SO client to add the `namespaces: ['*']` to\r\nall Find SO usages to count telemetry on all spaces.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6b372b7b45913a0171958a7795b4663ea865d137"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.15","label":"v8.15.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->