### PR TITLE
[fix] regenerate and add missing openapi-generated files

### DIFF
--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -131,7 +131,7 @@ paths:
                   type: string
               required:
                 - note
-        description: 'The note to add or update, along with additional metadata.'
+        description: The note to add or update, along with additional metadata.
         required: true
       responses:
         '200':
@@ -185,7 +185,7 @@ paths:
               required:
                 - eventId
                 - timelineId
-        description: 'The pinned event to add or update, along with additional metadata.'
+        description: The pinned event to add or update, along with additional metadata.
         required: true
       responses:
         '200':
@@ -321,7 +321,7 @@ paths:
                 - timelineId
                 - version
                 - timeline
-        description: 'The Timeline updates, along with the Timeline ID and version.'
+        description: The Timeline updates, along with the Timeline ID and version.
         required: true
       responses:
         '200':

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -131,7 +131,7 @@ paths:
                   type: string
               required:
                 - note
-        description: 'The note to add or update, along with additional metadata.'
+        description: The note to add or update, along with additional metadata.
         required: true
       responses:
         '200':
@@ -185,7 +185,7 @@ paths:
               required:
                 - eventId
                 - timelineId
-        description: 'The pinned event to add or update, along with additional metadata.'
+        description: The pinned event to add or update, along with additional metadata.
         required: true
       responses:
         '200':
@@ -321,7 +321,7 @@ paths:
                 - timelineId
                 - version
                 - timeline
-        description: 'The Timeline updates, along with the Timeline ID and version.'
+        description: The Timeline updates, along with the Timeline ID and version.
         required: true
       responses:
         '200':


### PR DESCRIPTION
## Summary
Main seems to be broken because of a check. These are probably regenerated with a different shape since the js-yaml update: #190678 

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->