### PR TITLE
[Security Solution][Notes] - fix column width on events table on host, user and network pages

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.tsx
@@ -12,6 +12,7 @@ import { EuiCheckbox } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import { dataTableActions } from '@kbn/securitysolution-data-table';
 import type { TableId } from '@kbn/securitysolution-data-table';
+import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 import type { CustomBulkAction } from '../../../../common/types';
 import { RowRendererValues } from '../../../../common/api/timeline';
 import { StatefulEventsViewer } from '../events_viewer';
@@ -73,7 +74,13 @@ const EventsQueryTabBodyComponent: React.FC<EventsQueryTabBodyComponentProps> = 
   const { globalFullScreen } = useGlobalFullScreen();
   const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
   const isEnterprisePlus = useLicense().isEnterprise();
-  const ACTION_BUTTON_COUNT = isEnterprisePlus ? 5 : 4;
+  let ACTION_BUTTON_COUNT = isEnterprisePlus ? 6 : 5;
+  const securitySolutionNotesEnabled = useIsExperimentalFeatureEnabled(
+    'securitySolutionNotesEnabled'
+  );
+  if (!securitySolutionNotesEnabled) {
+    ACTION_BUTTON_COUNT--;
+  }
   const leadingControlColumns = useMemo(
     () => getDefaultControlColumn(ACTION_BUTTON_COUNT),
     [ACTION_BUTTON_COUNT]


### PR DESCRIPTION
## Summary

This PR fixes a small bug on the events table on the Explore host, user and network pages.
As can be seen in the screenshot below, the actions column width is not correct when the `securitySolutionNotesEnabled` feature flag is enabled in `main` (we're missing the session view icon)
![Screenshot 2024-09-19 at 12 39 54 PM](https://github.com/user-attachments/assets/830c5799-2e38-4d5f-bfde-71bddd4a077d)

This branch increases the width to make room for the notes button when the `securitySolutionNotesEnabled` feature flag is enabled
![Screenshot 2024-09-19 at 12 37 08 PM](https://github.com/user-attachments/assets/9186b913-2a95-453a-a3cf-ca2c60de5d60)

And this is the normal width when the feature flag is not enabled
![Screenshot 2024-09-19 at 12 38 05 PM](https://github.com/user-attachments/assets/359fbd78-f236-4486-b923-0cb1efd4a88d)

https://github.com/elastic/kibana/issues/193088


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->