### PR TITLE
[Security Solution][Rules Management] Fix importing rules with connectors from one space to another

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -115,32 +115,31 @@ export const importRulesRoute = (router: SecuritySolutionPluginRouter, config: C
           const [duplicateIdErrors, parsedObjectsWithoutDuplicateErrors] =
             getTupleDuplicateErrorsAndUniqueRules(rules, request.query.overwrite);
 
-          const migratedParsedObjectsWithoutDuplicateErrors = await migrateLegacyActionsIds(
-            parsedObjectsWithoutDuplicateErrors,
-            actionSOClient,
-            actionsClient
-          );
-
           // import actions-connectors
           const {
             successCount: actionConnectorSuccessCount,
             success: actionConnectorSuccess,
             warnings: actionConnectorWarnings,
             errors: actionConnectorErrors,
-            rulesWithMigratedActions,
           } = await importRuleActionConnectors({
             actionConnectors,
             actionsClient,
             actionsImporter,
-            rules: migratedParsedObjectsWithoutDuplicateErrors,
+            rules: parsedObjectsWithoutDuplicateErrors,
             overwrite: request.query.overwrite_action_connectors,
           });
+
+          const migratedParsedObjectsWithoutDuplicateErrors = await migrateLegacyActionsIds(
+            parsedObjectsWithoutDuplicateErrors,
+            actionSOClient,
+            actionsClient
+          );
 
           // rulesWithMigratedActions: Is returned only in case connectors were exported from different namespace and the
           // original rules actions' ids were replaced with new destinationIds
           const parsedRules = actionConnectorErrors.length
             ? []
-            : rulesWithMigratedActions || migratedParsedObjectsWithoutDuplicateErrors;
+            : migratedParsedObjectsWithoutDuplicateErrors;
 
           const chunkParseObjects = chunk(CHUNK_PARSED_OBJECT_SIZE, parsedRules);
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/action_connectors/import_rule_action_connectors.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/action_connectors/import_rule_action_connectors.ts
@@ -11,7 +11,6 @@ import type { SavedObject } from '@kbn/core-saved-objects-server';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { ConnectorWithExtraFindData } from '@kbn/actions-plugin/server/application/connector/types';
 
-import type { RuleToImport } from '../../../../../../../common/api/detection_engine/rule_management';
 import type { WarningSchema } from '../../../../../../../common/api/detection_engine';
 import {
   checkIfActionsHaveMissingConnectors,
@@ -20,7 +19,6 @@ import {
   handleActionsHaveNoConnectors,
   mapSOErrorToRuleError,
   returnErroredImportResult,
-  updateRuleActionsWithMigratedResults,
 } from './utils';
 import type { ImportRuleActionConnectorsParams, ImportRuleActionConnectorsResult } from './types';
 
@@ -75,27 +73,18 @@ export const importRuleActionConnectors = async ({
     }
 
     const readStream = Readable.from(actionConnectorsToImport);
-    const { success, successCount, successResults, warnings, errors }: SavedObjectsImportResponse =
+    const { success, successCount, warnings, errors }: SavedObjectsImportResponse =
       await actionsImporter.import({
         readStream,
         overwrite,
         createNewCopies: false,
       });
-    /*
-      // When a connector is exported from one namespace and imported to another, it does not result in an error, but instead a new object is created with
-      // new destination id and id will have the old  origin id, so in order to be able to use the newly generated Connectors id, this util is used to swap the old id with the
-      // new destination Id
-      */
-    let rulesWithMigratedActions: Array<RuleToImport | Error> | undefined;
-    if (successResults?.some((res) => res.destinationId))
-      rulesWithMigratedActions = updateRuleActionsWithMigratedResults(rules, successResults);
 
     return {
       success,
       successCount,
       errors: errors ? mapSOErrorToRuleError(errors) : [],
       warnings: (warnings as WarningSchema[]) || [],
-      rulesWithMigratedActions,
     };
   } catch (error) {
     return returnErroredImportResult(error);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/action_connectors/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/action_connectors/types.ts
@@ -23,7 +23,6 @@ export interface ImportRuleActionConnectorsParams {
   actionConnectors: SavedObject[];
   actionsClient: ActionsClient;
   actionsImporter: ISavedObjectsImporter;
-  rules: Array<RuleToImport | Error>;
   overwrite: boolean;
 }
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/action_connectors/utils/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/action_connectors/utils/index.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 import { pick } from 'lodash';
-import type {
-  SavedObjectsImportFailure,
-  SavedObjectsImportSuccess,
-} from '@kbn/core-saved-objects-common';
+import type { SavedObjectsImportFailure } from '@kbn/core-saved-objects-common';
 import type { SavedObject } from '@kbn/core-saved-objects-server';
 import type { ActionsClient } from '@kbn/actions-plugin/server';
 import type { BulkError } from '../../../../../routes/utils';
@@ -130,44 +127,4 @@ export const checkIfActionsHaveMissingConnectors = (
     return handleActionsHaveNoConnectors(missingActionConnector, missingActionRules);
   }
   return null;
-};
-
-export const mapActionIdToNewDestinationId = (
-  connectorsImportResult: SavedObjectsImportSuccess[]
-) => {
-  return connectorsImportResult.reduce(
-    (acc: { [actionId: string]: string }, { destinationId, id }) => {
-      acc[id] = destinationId || id;
-      return acc;
-    },
-    {}
-  );
-};
-
-export const swapNonDefaultSpaceIdWithDestinationId = (
-  rule: RuleToImport,
-  actionIdDestinationIdLookup: { [actionId: string]: string }
-) => {
-  return rule.actions?.map((action) => {
-    const destinationId = actionIdDestinationIdLookup[action.id];
-    return { ...action, id: destinationId };
-  });
-};
-/*
-// When a connector is exported from one namespace and imported to another, it does not result in an error, but instead a new object is created with
-// new destination id and id will have the old  origin id, so in order to be able to use the newly generated Connectors id, this util is used to swap the old id with the
-// new destination Id
-*/
-export const updateRuleActionsWithMigratedResults = (
-  rules: Array<RuleToImport | Error>,
-  connectorsImportResult: SavedObjectsImportSuccess[]
-): Array<RuleToImport | Error> => {
-  const actionIdDestinationIdLookup = mapActionIdToNewDestinationId(connectorsImportResult);
-  return rules.map((rule) => {
-    if (rule instanceof Error) return rule;
-    return {
-      ...rule,
-      actions: swapNonDefaultSpaceIdWithDestinationId(rule, actionIdDestinationIdLookup),
-    };
-  });
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules_utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/import_rules_utils.ts
@@ -31,12 +31,11 @@ export interface RuleExceptionsPromiseFromStreams {
  * @param ruleChunks {array} - rules being imported
  * @param rulesResponseAcc {array} - the accumulation of success and
  * error messages gathered through the rules import logic
- * @param mlAuthz {object}
  * @param overwriteRules {boolean} - whether to overwrite existing rules
  * with imported rules if their rule_id matches
  * @param detectionRulesClient {object}
- * @param existingLists {object} - all exception lists referenced by
- * rules that were found to exist
+ * @param allowMissingConnectorSecrets {boolean}
+ * @param savedObjecsClient {object}
  * @returns {Promise} an array of error and success messages from import
  */
 export const importRules = async ({


### PR DESCRIPTION
## Summary

Fixes a bug where importing a rule fails **with a connector** into a space where (1) the connector already exists, and (2) the existing connector was exported and re-imported from another space. The import logic in this scenario effectively tries to convert the action ID on the rule import twice. The second conversion attempt tries to use the old action ID to look up the correct new action ID in a map, however, in this test scenario the action ID has already been updated by legacy SO ID migration logic and there is no map entry with the new ID as a key. The result is that the second attempt sets the action ID to `undefined`, resulting in an import failure.
![image](https://github.com/user-attachments/assets/77075af2-0b8d-4d8c-a6f3-030f952cedad)

### Repro Steps
0. Download the export file below and change the extension back to `.ndjson` from `.json` (github does not allow `.ndjson` files
[rules_export.json](https://github.com/user-attachments/files/17065272/rules_export.json)
1. Import the rule and connector into a space (`default` is fine)
2. Create a new space
3. Import the rule and connector into the new space
4. Import the rule and connector into the new space _again_, but check the `Overwrite existing connectors with conflicting action "id"` box. Observe the failure.

Integration test forthcoming
