### PR TITLE
Fix dev container repo path, add limitations docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,6 @@ ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 ENV HOME=/home/vscode
 ENV NVM_DIR=${HOME}/nvm
 ENV NVM_VERSION=v0.39.1
-ENV KBN_DIR=/workspaces/kibana
 ENV OPENSSL_PATH=${HOME}/openssl
 # Only specific versions are FIPS certified.
 ENV OPENSSL_VERSION='3.0.8'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,6 +49,7 @@ WORKDIR ${KBN_DIR}
 # Node and NVM setup
 COPY .node-version /tmp/
 
+# Mac will have permissions issues if Node and NVM are installed as root
 USER vscode
 
 RUN mkdir -p $NVM_DIR && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,16 @@
     9230,
     9231
   ],
-  "postStartCommand": "/workspaces/kibana/.devcontainer/scripts/post_start.sh",
+  "onCreateCommand": "echo $LOCAL_WORKSPACE_FOLDER && echo $LOCAL_WORKSPACE_FOLDER_BASENAME && echo $CONTAINER_WORKSPACE_FOLDER && echo $CONTAINER_WORKSPACE_FOLDER_BASENAME",
+  "postStartCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/post_start.sh",
   "remoteUser": "vscode",
+  "containerEnv": {
+    "KBN_DIR": "${containerWorkspaceFolder}",
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+    "LOCAL_WORKSPACE_FOLDER_BASENAME": "${localWorkspaceFolderBasename}",
+    "CONTAINER_WORKSPACE_FOLDER": "${containerWorkspaceFolder}",
+    "CONTAINER_WORKSPACE_FOLDER_BASENAME": "${containerWorkspaceFolderBasename}"
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,15 +23,10 @@
     9230,
     9231
   ],
-  "onCreateCommand": "echo $LOCAL_WORKSPACE_FOLDER && echo $LOCAL_WORKSPACE_FOLDER_BASENAME && echo $CONTAINER_WORKSPACE_FOLDER && echo $CONTAINER_WORKSPACE_FOLDER_BASENAME",
   "postStartCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/post_start.sh",
   "remoteUser": "vscode",
   "containerEnv": {
-    "KBN_DIR": "${containerWorkspaceFolder}",
-    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
-    "LOCAL_WORKSPACE_FOLDER_BASENAME": "${localWorkspaceFolderBasename}",
-    "CONTAINER_WORKSPACE_FOLDER": "${containerWorkspaceFolder}",
-    "CONTAINER_WORKSPACE_FOLDER_BASENAME": "${containerWorkspaceFolderBasename}"
+    "KBN_DIR": "${containerWorkspaceFolder}"
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/dev_docs/getting_started/setting_up_a_development_env.mdx
+++ b/dev_docs/getting_started/setting_up_a_development_env.mdx
@@ -109,6 +109,7 @@ Kibana also supports using a [dev container](https://containers.dev/) which can 
 1. You should see the Kibana repo and your terminal will be inside the container. You can develop as normal now, including running `yarn es` from inside the container.
 
 ### Customizing the Dev Container
+
 Installing any extra extensions or making adjustments to the OS environment inside the container will not have an effect on your local OS or VS Code installation. Editing the `devcontainer.json` or `.devcontainer/Dockerfile` should be reserved for changes to all dev environments.
 
 ### FIPS Mode
@@ -116,4 +117,9 @@ Installing any extra extensions or making adjustments to the OS environment insi
 The dev container is pre-configured to run Kibana in FIPS mode if needed. Simply change the `.env` file to `FIPS=1` and reopen your terminal. There should be a log message in your terminal which indicates `FIPS mode enabled`.
 
 ### Troubleshooting
+
 - Sometimes when rebuilding the container, there will be an error message that it failed. Usually hitting retry will fix this, and is only related to VS Code trying to reconnect to the container too quickly.
+
+### Limitations
+
+- Git worktrees are not supported when using the repo from the Local Filesystem. [VSCode issue](https://github.com/microsoft/vscode/issues/68038) for tracking, and a possible workaround though it is untested.


### PR DESCRIPTION
## Summary

- Fixes an issue where the container would not be setup or start properly if the repo wasn't name `kibana`
- Adds limitations section to docs 
