### PR TITLE
[Security Solution] [Attack discovery] Includes the `user.target.name` field in the default Anonymization allow list to improve Attack discoveries

### DIFF
--- a/x-pack/plugins/elastic_assistant/common/anonymization/index.ts
+++ b/x-pack/plugins/elastic_assistant/common/anonymization/index.ts
@@ -107,6 +107,7 @@ export const DEFAULT_ALLOW = [
   'user.name',
   'user.risk.calculated_level',
   'user.risk.calculated_score_norm',
+  'user.target.name',
 ];
 
 /** By default, these fields will be anonymized */
@@ -114,6 +115,7 @@ export const DEFAULT_ALLOW_REPLACEMENT = [
   'host.ip', // not a default allow field, but anonymized by default
   'host.name',
   'user.name',
+  'user.target.name',
 ];
 
 export const getDefaultAnonymizationFields = (spaceId: string) => {


### PR DESCRIPTION
## [Security Solution] [Attack discovery] Includes the `user.target.name` field in the default Anonymization allow list to improve Attack discoveries

### Summary

This PR implements <https://github.com/elastic/kibana/issues/193350> by adding the `user.target.name` field to the default Anonymization allow list.

The `user.target.name` field will be allowed and anonymized by default.

The _Background_ section below describes the purpose of this field, and how it improves Attack discoveries.

### Background

In the Elastic Common Schema (ECS), the `user.target.name` field represents the targeted user of an action taken. It is a member of the [Field sets that can be nested under User](https://www.elastic.co/guide/en/ecs/current/ecs-user.html#ecs-user-nestings).

Some detection rules make a distinction between the user taking action, and another account that's the _target_ of that action.

For example, in the [User Added to Privileged Group](https://www.elastic.co/guide/en/security/current/user-added-to-privileged-group.html) detection rule:

- The `user.name` field in the alert identifies the account taking action; in this example the user _adding_ a member to the `Administrators` group
- The `user.target.name` field in the alert specifies the account that's the _target_ of the action; in this example it's the account _being added to_ the `Administrators` group

Including the `user.target.name` field in the default Anonymization settings  improves Attack discoveries, because it enables the model to distinguish between the user taking action and the target of that action when the `user.target.name` field is available, as illustrated by the _Before_ and _After_ images below:

**Before**

![before](https://github.com/user-attachments/assets/440d25ee-0d91-4c2a-8763-ae6ee2d6a572)

**After**

![after](https://github.com/user-attachments/assets/d241be88-1cb1-4e13-a9ae-6328407c26ee)

### Desk testing

1) Start a new (development) instance of Elasticsearch:

```sh
yarn es snapshot -E path.data=/Users/$USERNAME/data-2024-09-19a
```

2) Start a local (development) instance of Kibana:

```
yarn start --no-base-path
````

3) Login to Kibana as the `elastic` user

4) Navigate to Stack Management > License management

5) Click Start trial

6) Navigate to Stack Management > AI Assistants

7) Click `Manage Settings` for the security assistant

8) Click Anonymization

9) Enter `user.target.name` in the search field

**Expected results**

- The `user.target.name` field is `Allowed`
- The `user.target.name` field is `Anonymized`

as illustrated by the screenshot below:

![anonymization_settings](https://github.com/user-attachments/assets/625dda96-d77a-416f-b78b-d4ef57fd4890)


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->