### PR TITLE
[Fleet] Repro backing index is overlaping with backing index

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/index.js
+++ b/x-pack/test/fleet_api_integration/apis/epm/index.js
@@ -12,6 +12,7 @@ export default function loadTests({ loadTestFile, getService }) {
     before(async () => {
       await setupTestUsers(getService('security'));
     });
+    loadTestFile(require.resolve('./test_upgrade_tsdb'));
     loadTestFile(require.resolve('./delete'));
     loadTestFile(require.resolve('./list'));
     loadTestFile(require.resolve('./setup'));

--- a/x-pack/test/fleet_api_integration/apis/epm/test_upgrade_tsdb.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/test_upgrade_tsdb.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
+import { skipIfNoDockerRegistry } from '../../helpers';
+
+export default function (providerContext: FtrProviderContext) {
+  const { getService } = providerContext;
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const fleetAndAgents = getService('fleetAndAgents');
+
+  const deletePackage = async (name: string, version: string) => {
+    await supertest.delete(`/api/fleet/epm/packages/${name}/${version}`).set('kbn-xsrf', 'xxxx');
+  };
+
+  async function writeDoc() {
+    await es.index({
+      index: 'metrics-no_tsdb_to_tsdb.test-default',
+      refresh: true,
+      body: {
+        data_stream: {
+          dataset: 'no_tsdb_to_tsdb.test',
+          namespace: 'default',
+          type: 'metrics',
+        },
+        '@timestamp': new Date().toISOString(),
+        some_field: 'test',
+        some_metric_field: 1,
+      },
+    });
+  }
+
+  async function rollover() {
+    await es.transport.request<any>(
+      {
+        method: 'POST',
+        path: `/metrics-no_tsdb_to_tsdb.test-default/_rollover`,
+      },
+      { meta: true }
+    );
+  }
+
+  describe('throw with is overlapping with backing index when upgrading after a rollback', () => {
+    skipIfNoDockerRegistry(providerContext);
+    before(async function () {
+      await es.transport
+        .request<any>(
+          {
+            method: 'DELETE',
+            path: `/_data_stream/metrics-no_tsdb_to_tsdb.test-default`,
+          },
+          { meta: true }
+        )
+        .catch((err) => {
+          // handle not existing
+        });
+    });
+
+    it('work', async () => {
+      // #### Install package no TSDB
+      await supertest
+        .post(`/api/fleet/epm/packages/no_tsdb_to_tsdb/0.1.0`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+
+      // Create data stream
+      await writeDoc();
+
+      // #### Install package with TSDB
+      await supertest
+        .post(`/api/fleet/epm/packages/no_tsdb_to_tsdb/0.2.0`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+      // Simulate rollover on upgrade
+      await rollover();
+
+      // #### Rollback to a no TSDB version
+      await supertest
+        .post(`/api/fleet/epm/packages/no_tsdb_to_tsdb/0.1.0`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+      // Simulate rollover after rollback, ILM policies, ...
+      await rollover();
+
+      // #### Try to upgrade again
+      // Install package with TSDB
+      await supertest
+        .post(`/api/fleet/epm/packages/no_tsdb_to_tsdb/0.2.0`)
+        .set('kbn-xsrf', 'xxxx')
+        .send({ force: true })
+        .expect(200);
+
+      // Simulate rollover on upgrade it should throw
+      let errMsg: any;
+      await rollover().catch((err) => {
+        errMsg = err.message;
+      });
+
+      expect(errMsg).to.match(
+        /illegal_argument_exception: backing index.*is overlapping with backing index/g
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Reproduction for the following error when upgrading an integration after a rollback
```
\t\tillegal_argument_exception: backing index [.ds-metrics-no_tsdb_to_tsdb.test-default-2024.09.20-000002] with range [2024-09-19T22:49:57.000Z TO 2024-09-20T01:19:57.000Z] is overlapping with backing index [.ds-metrics-no_tsdb_to_tsdb.test-default-2024.09.20-000005] with range [2024-09-19T22:50:04.000Z TO 2024-09-20T01:20:04.000Z]
```

When the upgrade to TSDB for a datastream do not succeed and we rollback to a non TDSB version, the following upgrades are not working 


## Details on the failing scenario

1. we install the package this create the datastream `metrics-no_tsdb_to_tsdb.test-default` without tsdb  => this create a backing index 0001
2. We upgrade, update `metrics-no_tsdb_to_tsdb.test-default` datastream to TSDB => this create a timeseries backing index 0002
2.  we rollback thepckage, update `metrics-no_tsdb_to_tsdb.test-` and rollover without tsb => this create backing indices `0003`, `0004` without timeseries
4. We try to upgrade again `metrics-no_tsdb_to_tsdb.test-default` datastream to TSDB => this fail with 
```
backing index [.ds-metrics-no_tsdb_to_tsdb.test-default-2024.09.20-000002] with range [2024-09-19T22:49:57.000Z TO 2024-09-20T01:19:57.000Z] is overlapping with backing index [.ds-metrics-no_tsdb_to_tsdb.test-default-2024.09.20-000005] with range [2024-09-19T22:50:04.000Z TO 2024-09-20T01:20:04.000Z]
```

@martijnvg your name seems associated to a lot of TSDB in elasticsearch, maybe you can help me understand (or redirect me to someone who can) the behaviour here, and if either there is a bug in how the upgrade is handled in elasticsearch, or if there is something in Fleet we can do to avoid that, thanks a lot
  
