### PR TITLE
[SPACETIME] [🚧 DRAFT🚧][WIP] Alerts generation in sythtrace

### DIFF
--- a/packages/kbn-apm-synthtrace-client/index.ts
+++ b/packages/kbn-apm-synthtrace-client/index.ts
@@ -37,3 +37,4 @@ export type { ESDocumentWithOperation, SynthtraceESAction, SynthtraceGenerator }
 export { log, type LogDocument, LONG_FIELD_NAME } from './src/lib/logs';
 export { type AssetDocument } from './src/lib/assets';
 export { syntheticsMonitor, type SyntheticsMonitorDocument } from './src/lib/synthetics';
+export { alert, type AlertEntityDocument } from './src/lib/alerts';

--- a/packages/kbn-apm-synthtrace-client/src/lib/alerts/index.ts
+++ b/packages/kbn-apm-synthtrace-client/src/lib/alerts/index.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/* eslint-disable max-classes-per-file */
+import { Entity, Fields } from '../entity';
+import { Serializable } from '../serializable';
+
+interface AlertDocument extends Fields {
+  'kibana.alert.reason'?: string;
+  'kibana.alert.evaluation.threshold'?: number[];
+  'kibana.alert.rule.category'?: string;
+  'kibana.alert.rule.consumer'?: string;
+  'kibana.alert.rule.execution.uuid'?: string;
+  'kibana.alert.rule.name'?: string;
+  'kibana.alert.rule.producer'?: string;
+  'kibana.alert.rule.revision'?: number;
+  'kibana.alert.rule.uuid'?: string;
+  'kibana.space_ids'?: string[];
+  'event.action'?: string;
+  'event.kind'?: string;
+  'kibana.alert.rule.execution.timestamp'?: number;
+  'kibana.alert.action_group'?: string;
+  'kibana.alert.flapping'?: boolean;
+  'kibana.alert.flapping_history'?: string;
+  'kibana.alert.instance.id'?: string;
+  'kibana.alert.maintenance_window_ids'?: string;
+  'kibana.alert.status'?: string;
+  'kibana.alert.uuid'?: string;
+  'kibana.alert.workflow_status'?: string;
+  'kibana.alert.duration.us'?: number;
+  tags?: string[];
+}
+
+export interface AlertInfraDocument extends AlertDocument {
+  'kibana.alert.evaluation.values'?: number[];
+  'cloud.availability_zone'?: string;
+  'cloud.instance.id'?: string;
+  'cloud.instance.name'?: string;
+  'cloud.provider'?: string;
+  'cloud.machine.type'?: string;
+  'cloud.project.id'?: string;
+  'cloud.region'?: string;
+  'host.hostname'?: string;
+  'host.os.platform'?: string;
+  'host.ip'?: string;
+  'host.name'?: string;
+  'host.architecture'?: string;
+  'kibana.alert.start'?: number | string;
+  'kibana.alert.time_range': {
+    gte: number | string;
+    lte?: number | string;
+  };
+}
+
+export interface AlertApmDocument extends AlertDocument {
+  'processor.event'?: string;
+  'kibana.alert.evaluation.value'?: number;
+  'agent.name'?: string;
+  labels?: { custom_labels?: string[] };
+  'service.environment'?: string;
+  'service.name'?: string;
+  'transaction.type'?: string;
+}
+
+export type AlertEntityDocument = AlertInfraDocument | AlertApmDocument;
+
+class AlertInfra extends Serializable<AlertInfraDocument> {}
+class AlertApm extends Serializable<AlertApmDocument> {}
+
+class Alert extends Entity<AlertDocument> {
+  host({ hostName, from, to }: { hostName: string; from: string; to: string }) {
+    return new AlertInfra({
+      ...this.fields,
+      // 'kibana.alert.evaluation.values': [0.92],
+      // 'cloud.availability_zone': 'us-west-1',
+      // 'cloud.instance.id': 'instance-id',
+      // 'cloud.instance.name': 'instance-name',
+      // 'cloud.provider': 'aws',
+      // 'cloud.machine.type': 't2.micro',
+      // 'cloud.project.id': 'project-id',
+      // 'cloud.region': 'us-west-1',
+      // 'host.hostname': hostName,
+      // 'host.os.platform': 'linux',
+      // 'host.ip': 'sjsjsjj',
+      'host.name': hostName,
+      'kibana.alert.start': from,
+      'kibana.alert.time_range': {
+        gte: from,
+        lte: to,
+      },
+      // 'host.architecture': 'x86_64',
+    });
+  }
+
+  apm(serviceName: string) {
+    return new AlertApm({
+      ...this.fields,
+      'processor.event': 'transaction',
+      'kibana.alert.evaluation.value': 0.5,
+      'agent.name': 'nodejs',
+      labels: { custom_labels: ['label1', 'label2'] },
+      'service.environment': 'production',
+      'service.name': serviceName,
+      'transaction.type': 'type',
+    });
+  }
+}
+
+export function alert({
+  category,
+  consumer,
+  producer,
+}: {
+  category: string;
+  consumer: string;
+  producer: string;
+}) {
+  return new Alert({
+    'kibana.alert.reason': 'CPU usage is 91.5% in the last 1 min for host. Alert when above 50%.',
+    'kibana.alert.evaluation.threshold': [50],
+    'kibana.alert.rule.category': category,
+    'kibana.alert.rule.consumer': consumer,
+    'kibana.alert.rule.name': 'Inventory threshold',
+    'kibana.alert.rule.producer': producer,
+    // 'kibana.alert.rule.revision': 0,
+    // 'kibana.space_ids': ['default'],
+    // 'event.action': 'active',
+    // 'event.kind': 'signal',
+    // 'kibana.alert.rule.execution.timestamp': timestamp,
+    // 'kibana.alert.action_group': 'metrics.inventory_threshold.fired',
+    // 'kibana.alert.instance.id': 'instance',
+    // 'kibana.alert.maintenance_window_ids': 'window',
+    'kibana.alert.status': 'active',
+    'kibana.alert.uuid': 'ef596789-5be3-45ad-91b4-e6b463ae06e2',
+    // 'kibana.alert.workflow_status': 'workflow',
+    // 'kibana.alert.duration.us': 1000,
+    tags: [],
+  });
+}

--- a/packages/kbn-apm-synthtrace/index.ts
+++ b/packages/kbn-apm-synthtrace/index.ts
@@ -17,6 +17,7 @@ export { MonitoringSynthtraceEsClient } from './src/lib/monitoring/monitoring_sy
 export { LogsSynthtraceEsClient } from './src/lib/logs/logs_synthtrace_es_client';
 export { AssetsSynthtraceEsClient } from './src/lib/assets/assets_synthtrace_es_client';
 export { SyntheticsSynthtraceEsClient } from './src/lib/synthetics/synthetics_synthtrace_es_client';
+export { AlertsSynthtraceEsClient } from './src/lib/alerts/alerts_sythtrace_es_client';
 export {
   addObserverVersionTransform,
   deleteSummaryFieldTransform,

--- a/packages/kbn-apm-synthtrace/src/cli/scenario.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/scenario.ts
@@ -13,6 +13,7 @@ import {
   InfraSynthtraceEsClient,
   LogsSynthtraceEsClient,
   SyntheticsSynthtraceEsClient,
+  AlertsSynthtraceEsClient,
 } from '../..';
 import { AssetsSynthtraceEsClient } from '../lib/assets/assets_synthtrace_es_client';
 import { Logger } from '../lib/utils/create_logger';
@@ -25,6 +26,7 @@ interface EsClients {
   infraEsClient: InfraSynthtraceEsClient;
   assetsEsClient: AssetsSynthtraceEsClient;
   syntheticsEsClient: SyntheticsSynthtraceEsClient;
+  alertsEsClient: AlertsSynthtraceEsClient;
 }
 
 type Generate<TFields> = (options: {

--- a/packages/kbn-apm-synthtrace/src/cli/utils/bootstrap.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/bootstrap.ts
@@ -16,6 +16,7 @@ import { getServiceUrls } from './get_service_urls';
 import { RunOptions } from './parse_run_cli_flags';
 import { getAssetsEsClient } from './get_assets_es_client';
 import { getSyntheticsEsClient } from './get_synthetics_es_client';
+import { getAlertsEsClient } from './get_alerts_es_client';
 
 export async function bootstrap(runOptions: RunOptions) {
   const logger = createLogger(runOptions.logLevel);
@@ -69,12 +70,19 @@ export async function bootstrap(runOptions: RunOptions) {
     concurrency: runOptions.concurrency,
   });
 
+  const alertsEsClient = getAlertsEsClient({
+    target: esUrl,
+    logger,
+    concurrency: runOptions.concurrency,
+  });
+
   if (runOptions.clean) {
     await apmEsClient.clean();
     await logsEsClient.clean();
     await infraEsClient.clean();
     await assetsEsClient.clean();
     await syntheticsEsClient.clean();
+    await alertsEsClient.clean();
   }
 
   return {
@@ -84,6 +92,7 @@ export async function bootstrap(runOptions: RunOptions) {
     infraEsClient,
     assetsEsClient,
     syntheticsEsClient,
+    alertsEsClient,
     version,
     kibanaUrl,
     esUrl,

--- a/packages/kbn-apm-synthtrace/src/cli/utils/get_alerts_es_client.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/get_alerts_es_client.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import { AlertsSynthtraceEsClient } from '../../lib/alerts/alerts_sythtrace_es_client';
+import { Logger } from '../../lib/utils/create_logger';
+import { RunOptions } from './parse_run_cli_flags';
+import { getEsClientTlsSettings } from './ssl';
+
+export function getAlertsEsClient({
+  target,
+  logger,
+  concurrency,
+}: Pick<RunOptions, 'concurrency'> & {
+  target: string;
+  logger: Logger;
+}) {
+  const client = new Client({
+    node: target,
+    tls: getEsClientTlsSettings(target),
+  });
+
+  return new AlertsSynthtraceEsClient({
+    client,
+    logger,
+    concurrency,
+    refreshAfterIndex: true,
+  });
+}

--- a/packages/kbn-apm-synthtrace/src/cli/utils/synthtrace_worker.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/synthtrace_worker.ts
@@ -20,6 +20,7 @@ import { getLogsEsClient } from './get_logs_es_client';
 import { getInfraEsClient } from './get_infra_es_client';
 import { getAssetsEsClient } from './get_assets_es_client';
 import { getSyntheticsEsClient } from './get_synthetics_es_client';
+import { getAlertsEsClient } from './get_alerts_es_client';
 
 export interface WorkerData {
   bucketFrom: Date;
@@ -65,6 +66,12 @@ async function start() {
     logger,
   });
 
+  const alertsEsClient = getAlertsEsClient({
+    concurrency: runOptions.concurrency,
+    target: esUrl,
+    logger,
+  });
+
   const file = runOptions.file;
 
   const scenario = await logger.perf('get_scenario', () => getScenario({ file, logger }));
@@ -80,6 +87,7 @@ async function start() {
       infraEsClient,
       assetsEsClient,
       syntheticsEsClient,
+      alertsEsClient,
     });
   }
 
@@ -88,7 +96,14 @@ async function start() {
   const generatorsAndClients = logger.perf('generate_scenario', () =>
     generate({
       range: timerange(bucketFrom, bucketTo),
-      clients: { logsEsClient, apmEsClient, infraEsClient, assetsEsClient, syntheticsEsClient },
+      clients: {
+        logsEsClient,
+        apmEsClient,
+        infraEsClient,
+        assetsEsClient,
+        syntheticsEsClient,
+        alertsEsClient,
+      },
     })
   );
 

--- a/packages/kbn-apm-synthtrace/src/lib/alerts/alerts_sythtrace_es_client.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/alerts/alerts_sythtrace_es_client.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import { ESDocumentWithOperation, AlertEntityDocument } from '@kbn/apm-synthtrace-client';
+import { pipeline, Readable, Transform } from 'stream';
+import { SynthtraceEsClient, SynthtraceEsClientOptions } from '../shared/base_client';
+import { getDedotTransform } from '../shared/get_dedot_transform';
+import { getSerializeTransform } from '../shared/get_serialize_transform';
+import { Logger } from '../utils/create_logger';
+
+export type AlertsSynthtraceEsClientOptions = Omit<SynthtraceEsClientOptions, 'pipeline'>;
+
+export class AlertsSynthtraceEsClient extends SynthtraceEsClient<AlertEntityDocument> {
+  constructor(options: { client: Client; logger: Logger } & AlertsSynthtraceEsClientOptions) {
+    super({
+      ...options,
+      pipeline: alertsPipeline(),
+    });
+    this.dataStreams = ['alerts-observability.apm*', 'alerts-observability.metrics*'];
+  }
+}
+
+function alertsPipeline() {
+  return (base: Readable) => {
+    return pipeline(
+      base,
+      getSerializeTransform(),
+      getRoutingTransform(),
+      getDedotTransform(),
+      (err: unknown) => {
+        if (err) {
+          throw err;
+        }
+      }
+    );
+  };
+}
+
+function getRoutingTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ESDocumentWithOperation<AlertEntityDocument>, encoding, callback) {
+      const alertProducer = document['kibana.alert.rule.producer'];
+      if (alertProducer === 'apm') {
+        document._index = 'alerts-observability.apm.alerts-default';
+      } else if (alertProducer === 'infrastructure') {
+        document._index = 'alerts-observability.metrics.alerts-default';
+      } else {
+        throw new Error('Cannot determine index for event');
+      }
+
+      callback(null, document);
+    },
+  });
+}

--- a/packages/kbn-apm-synthtrace/src/scenarios/infra_host_with_alerts.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/infra_host_with_alerts.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  InfraDocument,
+  infra,
+  AlertEntityDocument,
+  alert,
+  timerange,
+} from '@kbn/apm-synthtrace-client';
+import { times } from 'lodash';
+import { Scenario } from '../cli/scenario';
+import { withClient } from '../lib/utils/with_client';
+
+const scenario: Scenario<InfraDocument | AlertEntityDocument> = async ({
+  logger,
+  scenarioOpts = { numHosts: 2 },
+}) => {
+  return {
+    generate: ({ clients: { infraEsClient, alertsEsClient } }) => {
+      const from = '2024-09-19T15:17:26.764Z';
+      const to = '2024-09-19T15:32:26.764Z';
+      const range = timerange(from, to);
+      const { numHosts } = scenarioOpts;
+      const hostList = times(numHosts).map((index) => infra.host(`host-${index}`));
+      const hosts = range
+        .interval('30s')
+        .rate(1)
+        .generator((timestamp) => {
+          return hostList.flatMap((host) => [
+            host.cpu({ cpuTotalValue: 0.9 }).timestamp(timestamp),
+            host.memory().timestamp(timestamp),
+            host.network().timestamp(timestamp),
+            host.load().timestamp(timestamp),
+            host.filesystem().timestamp(timestamp),
+            host.diskio().timestamp(timestamp),
+          ]);
+        });
+
+      const alertsList = times(numHosts).map(() =>
+        alert({
+          producer: 'infrastructure',
+          consumer: 'infrastructure',
+          category: 'Inventory',
+        })
+      );
+
+      const alerts = range
+        .interval('30s')
+        .rate(1)
+        .generator((timestamp) => {
+          return alertsList.flatMap((hostAlert, index) => [
+            hostAlert.host({ hostName: `host-${index}`, from, to }).timestamp(timestamp),
+          ]);
+        });
+
+      return [
+        withClient(
+          infraEsClient,
+          logger.perf('generating_infra_hosts', () => hosts)
+        ),
+        withClient(
+          alertsEsClient,
+          logger.perf('generating_alerts', () => alerts)
+        ),
+      ];
+    },
+  };
+};
+
+export default scenario;


### PR DESCRIPTION
[🚧 WIP] [Spacetime](https://github.com/elastic/kibana/issues/192571)

### In this PR

Created Alerts synthtrace client and scenario to add alerts for hosts

#### What worked so far

Documents are created and can be found when searching `GET alerts-observability.metrics.alerts-default/_search`

#### What doesn't work

- The document exist but nothing is showing in the UI
- Documents are not cleaned when using `--clean` tag

I suspect for the documents that something is missing regarding time rages

