### PR TITLE
Stricter byte size validation

### DIFF
--- a/packages/kbn-config-schema/src/byte_size_value/index.test.ts
+++ b/packages/kbn-config-schema/src/byte_size_value/index.test.ts
@@ -36,8 +36,37 @@ describe('parsing units', () => {
     expect(ByteSizeValue.parse('1Mb').getValueInBytes()).toBe(1024 * 1024);
   });
 
+  test('parses the max safe integer', () => {
+    expect(ByteSizeValue.parse('9007199254740991').getValueInBytes()).toBe(9007199254740991);
+    expect(ByteSizeValue.parse('9007199254740991b').getValueInBytes()).toBe(9007199254740991);
+  });
+
   test('throws an error when unsupported unit specified', () => {
     expect(() => ByteSizeValue.parse('1tb')).toThrowErrorMatchingInlineSnapshot(
+      `"Failed to parse value as byte value. Value must be either number of bytes, or follow the format <count>[b|kb|mb|gb] (e.g., '1024kb', '200mb', '1gb'), where the number is a safe positive integer."`
+    );
+  });
+
+  test('throws an error when unsafe integer', () => {
+    expect(() => ByteSizeValue.parse('9007199254740992')).toThrowErrorMatchingInlineSnapshot(
+      `"Value in bytes is expected to be a safe positive integer."`
+    );
+  });
+
+  test('throws an error on unusually long input', () => {
+    expect(() => ByteSizeValue.parse('19007199254740991kb')).toThrowErrorMatchingInlineSnapshot(
+      `"Value in bytes is expected to be a safe positive integer."`
+    );
+  });
+
+  test('throws when string does not start with a digit', () => {
+    expect(() => ByteSizeValue.parse(' 1kb')).toThrowErrorMatchingInlineSnapshot(
+      `"Failed to parse value as byte value. Value must be either number of bytes, or follow the format <count>[b|kb|mb|gb] (e.g., '1024kb', '200mb', '1gb'), where the number is a safe positive integer."`
+    );
+  });
+
+  test('throws when string does not end with a digit or unit', () => {
+    expect(() => ByteSizeValue.parse('1kb ')).toThrowErrorMatchingInlineSnapshot(
       `"Failed to parse value as byte value. Value must be either number of bytes, or follow the format <count>[b|kb|mb|gb] (e.g., '1024kb', '200mb', '1gb'), where the number is a safe positive integer."`
     );
   });

--- a/packages/kbn-config-schema/src/byte_size_value/index.ts
+++ b/packages/kbn-config-schema/src/byte_size_value/index.ts
@@ -23,7 +23,11 @@ function renderUnit(value: number, unit: string) {
 
 export class ByteSizeValue {
   public static parse(text: string): ByteSizeValue {
-    const match = /([1-9][0-9]*)(b|kb|mb|gb)/i.exec(text);
+    if (text.length > 18) {
+      // Exit early on large input where <count> uses more than 16 digits and is therefore larger than Number.MAX_SAFE_INTEGER
+      throw new Error('Value in bytes is expected to be a safe positive integer.');
+    }
+    const match = /(^[1-9]\d*)(b|kb|mb|gb)$/i.exec(text);
     if (!match) {
       const number = Number(text);
       if (typeof number !== 'number' || isNaN(number)) {


### PR DESCRIPTION
## Summary

This makes byte size validation stricter by ensuring that the string starts and ends with valid values so it won't match on e.g. `a1234b` or `1234ba`.

This has a slight chance to fail validation on an existing kibana.yml if users had a typo that we previously ignored. As such it would be safer to not backport to 8.x

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
