### PR TITLE
[8.15] [ci] skip tests that fail on chrome 128+ (#192830)

### DIFF
--- a/test/functional/apps/dashboard/group5/embed_mode.ts
+++ b/test/functional/apps/dashboard/group5/embed_mode.ts
@@ -56,7 +56,8 @@ export default function ({
       await browser.setWindowSize(1300, 900);
     });
 
-    describe('default URL params', () => {
+    // Fails in with chrome 128+ https://github.com/elastic/kibana/issues/163207
+    describe.skip('default URL params', () => {
       it('hides the chrome', async () => {
         const globalNavShown = await globalNav.exists();
         expect(globalNavShown).to.be(true);
@@ -90,7 +91,8 @@ export default function ({
       });
     });
 
-    describe('non-default URL params', () => {
+    // Fails in with chrome 128+ https://github.com/elastic/kibana/issues/163207
+    describe.skip('non-default URL params', () => {
       it('shows or hides elements based on URL params', async () => {
         const currentUrl = await browser.getCurrentUrl();
         const newUrl = [currentUrl].concat(urlParamExtensions).join('&');

--- a/test/functional/apps/kibana_overview/_analytics.ts
+++ b/test/functional/apps/kibana_overview/_analytics.ts
@@ -16,7 +16,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['common', 'header']);
 
-  describe('overview page - Analytics apps', function describeIndexTests() {
+  // Fails in chrome 128+: See https://github.com/elastic/kibana/issues/192509
+  describe.skip('overview page - Analytics apps', function describeIndexTests() {
     before(async () => {
       await esArchiver.load('test/functional/fixtures/es_archiver/logstash_functional');
       await kibanaServer.importExport.load(

--- a/x-pack/test/functional/apps/lens/group6/workspace_size.ts
+++ b/x-pack/test/functional/apps/lens/group6/workspace_size.ts
@@ -276,7 +276,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await assertWorkspaceDimensions('600px', '375px');
     });
 
-    it('gauge size (absolute pixels) - major arc', async () => {
+    // Fails in chrome 128+
+    it.skip('gauge size (absolute pixels) - major arc', async () => {
       await retry.try(async () => {
         await PageObjects.lens.switchToVisualization(GaugeShapes.ARC, 'arc');
       });

--- a/x-pack/test/functional/apps/maps/group1/documents_source/search_hits.js
+++ b/x-pack/test/functional/apps/maps/group1/documents_source/search_hits.js
@@ -113,7 +113,8 @@ export default function ({ getPageObjects, getService }) {
         expect(hits).to.equal('2');
       });
 
-      it('should apply layer query to fit to bounds', async () => {
+      // Fails in chrome 128+: https://github.com/elastic/kibana/issues/175378
+      it.skip('should apply layer query to fit to bounds', async () => {
         // Set view to other side of world so no matching results
         await PageObjects.maps.setView(-15, -100, 6);
         await PageObjects.maps.clickFitToBounds('logstash');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[ci] skip tests that fail on chrome 128+ (#192830)](https://github.com/elastic/kibana/pull/192830)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2024-09-16T13:18:49Z","message":"[ci] skip tests that fail on chrome 128+ (#192830)\n\n## Summary\r\nCurrently `google-chrome-stable` is pinned to `v127.x.x` as with\r\n`v128.x.x` we get a few FTR breakages (some of them on visual\r\ninaccuracies, some other).\r\n\r\nWe'd like to unpin chrome, and move on to 128, and start fixing these\r\ntest failures. So we're skipping the failures temporarily, bumping\r\nchrome to 128, then allow for unskipping and fixing these.","sha":"f4587149987aa21ec9345e887bc7121d75792ea5","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:all-open","v8.16.0"],"number":192830,"url":"https://github.com/elastic/kibana/pull/192830","mergeCommit":{"message":"[ci] skip tests that fail on chrome 128+ (#192830)\n\n## Summary\r\nCurrently `google-chrome-stable` is pinned to `v127.x.x` as with\r\n`v128.x.x` we get a few FTR breakages (some of them on visual\r\ninaccuracies, some other).\r\n\r\nWe'd like to unpin chrome, and move on to 128, and start fixing these\r\ntest failures. So we're skipping the failures temporarily, bumping\r\nchrome to 128, then allow for unskipping and fixing these.","sha":"f4587149987aa21ec9345e887bc7121d75792ea5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192830","number":192830,"mergeCommit":{"message":"[ci] skip tests that fail on chrome 128+ (#192830)\n\n## Summary\r\nCurrently `google-chrome-stable` is pinned to `v127.x.x` as with\r\n`v128.x.x` we get a few FTR breakages (some of them on visual\r\ninaccuracies, some other).\r\n\r\nWe'd like to unpin chrome, and move on to 128, and start fixing these\r\ntest failures. So we're skipping the failures temporarily, bumping\r\nchrome to 128, then allow for unskipping and fixing these.","sha":"f4587149987aa21ec9345e887bc7121d75792ea5"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/193012","number":193012,"state":"MERGED","mergeCommit":{"sha":"612e5780f66598d54d6af5dc7b4b21c294beea39","message":"[8.x] [ci] skip tests that fail on chrome 128+ (#192830) (#193012)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[ci] skip tests that fail on chrome 128+\n(#192830)](https://github.com/elastic/kibana/pull/192830)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Alex\nSzabo\",\"email\":\"alex.szabo@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-09-16T13:18:49Z\",\"message\":\"[ci]\nskip tests that fail on chrome 128+ (#192830)\\n\\n## Summary\\r\\nCurrently\n`google-chrome-stable` is pinned to `v127.x.x` as with\\r\\n`v128.x.x` we\nget a few FTR breakages (some of them on visual\\r\\ninaccuracies, some\nother).\\r\\n\\r\\nWe'd like to unpin chrome, and move on to 128, and start\nfixing these\\r\\ntest failures. So we're skipping the failures\ntemporarily, bumping\\r\\nchrome to 128, then allow for unskipping and\nfixing\nthese.\",\"sha\":\"f4587149987aa21ec9345e887bc7121d75792ea5\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.16.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:all-open\"],\"title\":\"[ci]\nskip tests that fail on chrome\n128+\",\"number\":192830,\"url\":\"https://github.com/elastic/kibana/pull/192830\",\"mergeCommit\":{\"message\":\"[ci]\nskip tests that fail on chrome 128+ (#192830)\\n\\n## Summary\\r\\nCurrently\n`google-chrome-stable` is pinned to `v127.x.x` as with\\r\\n`v128.x.x` we\nget a few FTR breakages (some of them on visual\\r\\ninaccuracies, some\nother).\\r\\n\\r\\nWe'd like to unpin chrome, and move on to 128, and start\nfixing these\\r\\ntest failures. So we're skipping the failures\ntemporarily, bumping\\r\\nchrome to 128, then allow for unskipping and\nfixing\nthese.\",\"sha\":\"f4587149987aa21ec9345e887bc7121d75792ea5\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/192830\",\"number\":192830,\"mergeCommit\":{\"message\":\"[ci]\nskip tests that fail on chrome 128+ (#192830)\\n\\n## Summary\\r\\nCurrently\n`google-chrome-stable` is pinned to `v127.x.x` as with\\r\\n`v128.x.x` we\nget a few FTR breakages (some of them on visual\\r\\ninaccuracies, some\nother).\\r\\n\\r\\nWe'd like to unpin chrome, and move on to 128, and start\nfixing these\\r\\ntest failures. So we're skipping the failures\ntemporarily, bumping\\r\\nchrome to 128, then allow for unskipping and\nfixing these.\",\"sha\":\"f4587149987aa21ec9345e887bc7121d75792ea5\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}}]}] BACKPORT-->