### PR TITLE
[Inventory][ECO] API error handler

### DIFF
--- a/x-pack/plugins/observability_solution/inventory/public/hooks/use_inventory_abortable_async.ts
+++ b/x-pack/plugins/observability_solution/inventory/public/hooks/use_inventory_abortable_async.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useAbortableAsync } from '@kbn/observability-utils/hooks/use_abortable_async';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from './use_kibana';
+
+export function useInventoryAbortableAsync<T>(...args: Parameters<typeof useAbortableAsync<T>>) {
+  const {
+    core: { notifications },
+  } = useKibana();
+  const response = useAbortableAsync(...args);
+
+  if (response.error) {
+    notifications.toasts.addDanger({
+      title: i18n.translate('xpack.inventory.apiCall.error.title', {
+        defaultMessage: `Error while fetching resource`,
+      }),
+      text: response.error.message,
+    });
+  }
+
+  return response;
+}

--- a/x-pack/plugins/observability_solution/inventory/public/hooks/use_inventory_abortable_async.ts
+++ b/x-pack/plugins/observability_solution/inventory/public/hooks/use_inventory_abortable_async.ts
@@ -6,7 +6,11 @@
  */
 import { useAbortableAsync } from '@kbn/observability-utils/hooks/use_abortable_async';
 import { i18n } from '@kbn/i18n';
+import { IHttpFetchError, ResponseErrorBody } from '@kbn/core-http-browser';
 import { useKibana } from './use_kibana';
+
+const getDetailsFromErrorResponse = (error: IHttpFetchError<ResponseErrorBody>) =>
+  error.body?.message ?? error.response?.statusText;
 
 export function useInventoryAbortableAsync<T>(...args: Parameters<typeof useAbortableAsync<T>>) {
   const {
@@ -15,11 +19,16 @@ export function useInventoryAbortableAsync<T>(...args: Parameters<typeof useAbor
   const response = useAbortableAsync(...args);
 
   if (response.error) {
+    const errorMessage =
+      'response' in response.error
+        ? getDetailsFromErrorResponse(response.error as IHttpFetchError<ResponseErrorBody>)
+        : response.error.message;
+
     notifications.toasts.addDanger({
       title: i18n.translate('xpack.inventory.apiCall.error.title', {
         defaultMessage: `Error while fetching resource`,
       }),
-      text: response.error.message,
+      text: errorMessage,
     });
   }
 

--- a/x-pack/plugins/observability_solution/inventory/public/pages/inventory_page/index.tsx
+++ b/x-pack/plugins/observability_solution/inventory/public/pages/inventory_page/index.tsx
@@ -4,13 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
-import { useAbortableAsync } from '@kbn/observability-utils/hooks/use_abortable_async';
 import { EuiDataGridSorting } from '@elastic/eui';
+import React from 'react';
 import { EntitiesGrid } from '../../components/entities_grid';
-import { useKibana } from '../../hooks/use_kibana';
+import { useInventoryAbortableAsync } from '../../hooks/use_inventory_abortable_async';
 import { useInventoryParams } from '../../hooks/use_inventory_params';
 import { useInventoryRouter } from '../../hooks/use_inventory_router';
+import { useKibana } from '../../hooks/use_kibana';
 
 export function InventoryPage() {
   const {
@@ -20,7 +20,7 @@ export function InventoryPage() {
   const { sortDirection, sortField, pageIndex } = query;
   const inventoryRoute = useInventoryRouter();
 
-  const { value = { entities: [] }, loading } = useAbortableAsync(
+  const { value = { entities: [] }, loading } = useInventoryAbortableAsync(
     ({ signal }) => {
       return inventoryAPIClient.fetch('GET /internal/inventory/entities', {
         params: {

--- a/x-pack/plugins/observability_solution/inventory/tsconfig.json
+++ b/x-pack/plugins/observability_solution/inventory/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/es-types",
     "@kbn/entities-schema",
     "@kbn/i18n-react",
-    "@kbn/io-ts-utils"
+    "@kbn/io-ts-utils",
+    "@kbn/core-http-browser"
   ]
 }


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/193547

<img width="1158" alt="Screenshot 2024-09-20 at 14 14 12" src="https://github.com/user-attachments/assets/bf41320b-b7b6-4a08-901e-943488c19fde">



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->