### PR TITLE
[ES|QL] Disable field statistics panel in Dashboard if ES|QL is disabled

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
@@ -38,13 +38,14 @@ import {
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { dynamic } from '@kbn/shared-ux-utility';
 import { isDefined } from '@kbn/ml-is-defined';
-import { EuiFlexItem } from '@elastic/eui';
+import { EuiCallOut, EuiEmptyPrompt, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ActionExecutionContext } from '@kbn/ui-actions-plugin/public';
 import type { Filter } from '@kbn/es-query';
 import { FilterStateStore } from '@kbn/es-query';
-import { getESQLAdHocDataview } from '@kbn/esql-utils';
+import { ENABLE_ESQL, getESQLAdHocDataview } from '@kbn/esql-utils';
 import { ACTION_GLOBAL_APPLY_FILTER } from '@kbn/unified-search-plugin/public';
+import { FormattedMessage } from '@kbn/i18n-react';
 import type { DataVisualizerTableState } from '../../../../../common/types';
 import type { DataVisualizerPluginStart } from '../../../../plugin';
 import type { FieldStatisticsTableEmbeddableState } from '../grid_embeddable/types';
@@ -153,20 +154,19 @@ export const getFieldStatsChartEmbeddableFactory = (
         serializeFieldStatsChartState,
         onFieldStatsTableDestroy,
         resetData$,
-      } = initializeFieldStatsControls(state);
+      } = initializeFieldStatsControls(state, deps.uiSettings);
       const { onError, dataLoading, blockingError } = dataLoadingApi;
 
-      const defaultDataViewId = await deps.data.dataViews.getDefaultId();
-      const validDataViewId: string =
-        isDefined(state.dataViewId) && state.dataViewId !== ''
-          ? state.dataViewId
-          : defaultDataViewId ?? '';
-      let initialDataView: DataView[] | undefined;
+      const validDataViewId: string | undefined =
+        isDefined(state.dataViewId) && state.dataViewId !== '' ? state.dataViewId : undefined;
+      let initialDataView: DataView | undefined;
       try {
         const dataView = isESQLQuery(state.query)
           ? await getESQLAdHocDataview(state.query.esql, deps.data.dataViews)
-          : await deps.data.dataViews.get(validDataViewId);
-        initialDataView = [dataView];
+          : validDataViewId
+          ? await deps.data.dataViews.get(validDataViewId)
+          : undefined;
+        initialDataView = dataView;
       } catch (error) {
         // Only need to publish blocking error if viewtype is data view, and no data view found
         if (state.viewType === FieldStatsInitializerViewType.DATA_VIEW) {
@@ -174,7 +174,9 @@ export const getFieldStatsChartEmbeddableFactory = (
         }
       }
 
-      const dataViews$ = new BehaviorSubject<DataView[] | undefined>(initialDataView);
+      const dataViews$ = new BehaviorSubject<DataView[] | undefined>(
+        initialDataView ? [initialDataView] : undefined
+      );
 
       const subscriptions = new Subscription();
       if (fieldStatsControlsApi.dataViewId$) {
@@ -182,10 +184,10 @@ export const getFieldStatsChartEmbeddableFactory = (
           fieldStatsControlsApi.dataViewId$
             .pipe(
               skip(1),
-              skipWhile((dataViewId) => !dataViewId && !defaultDataViewId),
+              skipWhile((dataViewId) => !dataViewId),
               switchMap(async (dataViewId) => {
                 try {
-                  return await deps.data.dataViews.get(dataViewId ?? defaultDataViewId);
+                  return await deps.data.dataViews.get(dataViewId);
                 } catch (error) {
                   return undefined;
                 }
@@ -324,6 +326,8 @@ export const getFieldStatsChartEmbeddableFactory = (
               api.viewType$,
               api.showDistributions$
             );
+          const isEsqlEnabled = deps.uiSettings.get(ENABLE_ESQL);
+
           const lastReloadRequestTime = useObservable(reload$, Date.now());
 
           const isEsqlMode = viewType === FieldStatsInitializerViewType.ESQL;
@@ -361,6 +365,47 @@ export const getFieldStatsChartEmbeddableFactory = (
               onFieldStatsTableDestroy();
             };
           }, []);
+
+          if (viewType === FieldStatsInitializerViewType.DATA_VIEW && !dataViews) {
+            return (
+              <EuiEmptyPrompt
+                color="primary"
+                title={
+                  <h3>
+                    <FormattedMessage
+                      id="xpack.dashboard.fieldStats.noDataViewSelected"
+                      defaultMessage="No data view selected"
+                    />
+                  </h3>
+                }
+                body={
+                  <p>
+                    <FormattedMessage
+                      id="xpack.dashboard.fieldStats.noDataViewSelectedDescription"
+                      defaultMessage="Pick a data view to view field statistics."
+                    />
+                  </p>
+                }
+              />
+            );
+          }
+
+          if (isEsqlMode && !isEsqlEnabled) {
+            return (
+              <EuiCallOut
+                title={
+                  <h3>
+                    <FormattedMessage
+                      id="xpack.dashboard.fieldStats.noDataViewSelected"
+                      defaultMessage="ES|QL is disabled"
+                    />
+                  </h3>
+                }
+                color="warning"
+                iconType="alert"
+              />
+            );
+          }
 
           return (
             <EuiFlexItem css={statsTableCss} data-test-subj="dashboardFieldStatsEmbeddedContent">

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
@@ -373,7 +373,7 @@ export const getFieldStatsChartEmbeddableFactory = (
                 title={
                   <h3>
                     <FormattedMessage
-                      id="xpack.dashboard.fieldStats.noDataViewSelected"
+                      id="xpack.dataVisualizer.dashboard.fieldStats.noDataViewSelected"
                       defaultMessage="No data view selected"
                     />
                   </h3>
@@ -381,7 +381,7 @@ export const getFieldStatsChartEmbeddableFactory = (
                 body={
                   <p>
                     <FormattedMessage
-                      id="xpack.dashboard.fieldStats.noDataViewSelectedDescription"
+                      id="xpack.dataVisualizer.dashboard.fieldStats.noDataViewSelectedDescription"
                       defaultMessage="Pick a data view to view field statistics."
                     />
                   </p>
@@ -396,7 +396,7 @@ export const getFieldStatsChartEmbeddableFactory = (
                 title={
                   <h3>
                     <FormattedMessage
-                      id="xpack.dashboard.fieldStats.noDataViewSelected"
+                      id="xpack.dataVisualizer.fieldStats.noDataViewSelected"
                       defaultMessage="ES|QL is disabled"
                     />
                   </h3>

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_factory.tsx
@@ -392,18 +392,20 @@ export const getFieldStatsChartEmbeddableFactory = (
 
           if (isEsqlMode && !isEsqlEnabled) {
             return (
-              <EuiCallOut
-                title={
-                  <h3>
-                    <FormattedMessage
-                      id="xpack.dataVisualizer.fieldStats.noDataViewSelected"
-                      defaultMessage="ES|QL is disabled"
-                    />
-                  </h3>
-                }
-                color="warning"
-                iconType="alert"
-              />
+              <EuiFlexItem css={statsTableCss} data-test-subj="dashboardFieldStatsEmbeddedContent">
+                <EuiCallOut
+                  title={
+                    <h3>
+                      <FormattedMessage
+                        id="xpack.dataVisualizer.fieldStats.noDataViewSelected"
+                        defaultMessage="ES|QL is disabled"
+                      />
+                    </h3>
+                  }
+                  color="warning"
+                  iconType="alert"
+                />
+              </EuiFlexItem>
             );
           }
 

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_initializer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/field_stats_initializer.tsx
@@ -223,6 +223,7 @@ export const FieldStatisticsInitializer: FC<FieldStatsInitializerProps> = ({
                   defaultMessage: 'Data view',
                 }
               )}
+              css={css({ padding: euiThemeVars.euiSizeM })}
             >
               <IndexPatternSelect
                 autoFocus={!dataViewId}

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/initialize_field_stats_controls.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/initialize_field_stats_controls.ts
@@ -15,13 +15,22 @@ import type { AggregateQuery } from '@kbn/es-query';
 import type { StateComparators } from '@kbn/presentation-publishing';
 import { BehaviorSubject } from 'rxjs';
 import fastIsEqual from 'fast-deep-equal';
+import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { FieldStatsInitializerViewType } from '../grid_embeddable/types';
 import type { FieldStatsInitialState } from '../grid_embeddable/types';
 import type { FieldStatsControlsApi } from './types';
 
-export const initializeFieldStatsControls = (rawState: FieldStatsInitialState) => {
+export const initializeFieldStatsControls = (
+  rawState: FieldStatsInitialState,
+  uiSettings: IUiSettingsClient
+) => {
+  const isEsqlEnabled = uiSettings.get(ENABLE_ESQL);
+  const defaultType = isEsqlEnabled
+    ? FieldStatsInitializerViewType.ESQL
+    : FieldStatsInitializerViewType.DATA_VIEW;
   const viewType$ = new BehaviorSubject<FieldStatsInitializerViewType | undefined>(
-    rawState.viewType ?? FieldStatsInitializerViewType.ESQL
+    rawState.viewType ?? defaultType
   );
   const dataViewId$ = new BehaviorSubject<string | undefined>(rawState.dataViewId);
   const query$ = new BehaviorSubject<AggregateQuery | undefined>(rawState.query);

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/ui_actions/create_field_stats_table.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/ui_actions/create_field_stats_table.tsx
@@ -17,6 +17,7 @@ import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { isDefined } from '@kbn/ml-is-defined';
 import { COMMON_VISUALIZATION_GROUPING } from '@kbn/visualizations-plugin/public';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { FIELD_STATS_EMBEDDABLE_TYPE } from '../embeddables/field_stats/constants';
 import type { DataVisualizerStartDependencies } from '../../common/types/data_visualizer_plugin';
 import type {
@@ -139,22 +140,31 @@ export function createAddFieldStatsTableAction(
       i18n.translate('xpack.dataVisualizer.fieldStatistics.displayName', {
         defaultMessage: 'Field statistics',
       }),
+    disabled: !coreStart.uiSettings.get(ENABLE_ESQL),
     async isCompatible(context: EmbeddableApiContext) {
-      return Boolean(await parentApiIsCompatible(context.embeddable));
+      return (
+        Boolean(await parentApiIsCompatible(context.embeddable)) &&
+        coreStart.uiSettings.get(ENABLE_ESQL)
+      );
     },
     async execute(context) {
       const presentationContainerParent = await parentApiIsCompatible(context.embeddable);
       if (!presentationContainerParent) throw new IncompatibleActionError();
 
+      const isEsqlEnabled = coreStart.uiSettings.get(ENABLE_ESQL);
       try {
         const defaultIndexPattern = await pluginStart.data.dataViews.getDefault();
-        const defaultInitialState: FieldStatsInitialState = {
-          viewType: FieldStatsInitializerViewType.ESQL,
-          query: {
-            // Initial default query
-            esql: `from ${defaultIndexPattern?.getIndexPattern()} | limit 10`,
-          },
-        };
+        const defaultInitialState: FieldStatsInitialState = isEsqlEnabled
+          ? {
+              viewType: FieldStatsInitializerViewType.ESQL,
+              query: {
+                // Initial default query
+                esql: `from ${defaultIndexPattern?.getIndexPattern()} | limit 10`,
+              },
+            }
+          : {
+              viewType: FieldStatsInitializerViewType.DATA_VIEW,
+            };
         const embeddable = await presentationContainerParent.addNewPanel<
           object,
           FieldStatisticsTableEmbeddableApi

--- a/x-pack/plugins/data_visualizer/tsconfig.json
+++ b/x-pack/plugins/data_visualizer/tsconfig.json
@@ -88,7 +88,8 @@
     "@kbn/core-lifecycle-browser",
     "@kbn/presentation-containers",
     "@kbn/react-kibana-mount",
-    "@kbn/visualizations-plugin"
+    "@kbn/visualizations-plugin",
+    "@kbn/core-ui-settings-browser"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

This PR disables the field statistics panel in Dashboard if ES|QL is disabled. In addition, it adds a bit of safety check for panels that have already been added.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->