### PR TITLE
feat(rca): add header details

### DIFF
--- a/x-pack/plugins/observability_solution/investigate_app/public/components/investigation_tag/investigation_tag.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/components/investigation_tag/investigation_tag.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexItem, EuiBadge } from '@elastic/eui';
+import React from 'react';
+
+interface Props {
+  tag: string;
+}
+
+export function InvestigationTag({ tag }: Props) {
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiBadge color="hollow">{tag}</EuiBadge>
+    </EuiFlexItem>
+  );
+}

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/alert_details_button.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/alert_details_button.tsx
@@ -22,9 +22,7 @@ export function AlertDetailsButton() {
   const { investigation } = useInvestigation();
 
   const alertOriginInvestigation = alertOriginSchema.safeParse(investigation?.origin);
-  const alertId = alertOriginInvestigation.success
-    ? alertOriginInvestigation.data.id
-    : '2ad3ff76-43ef-4b3d-b97a-baa2bfd21853';
+  const alertId = alertOriginInvestigation.success ? alertOriginInvestigation.data.id : undefined;
   const { data: alertDetails } = useFetchAlert({ id: alertId });
 
   if (!alertDetails) {

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/alert_details_button.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/alert_details_button.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { alertOriginSchema } from '@kbn/investigation-shared';
+import { ALERT_RULE_CATEGORY } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
+import React from 'react';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { useInvestigation } from '../../contexts/investigation_context';
+import { useFetchAlert } from '../../hooks/use_fetch_alert';
+
+export function AlertDetailsButton() {
+  const {
+    core: {
+      http: { basePath },
+    },
+  } = useKibana();
+  const { investigation } = useInvestigation();
+
+  const alertOriginInvestigation = alertOriginSchema.safeParse(investigation?.origin);
+  const alertId = alertOriginInvestigation.success
+    ? alertOriginInvestigation.data.id
+    : '2ad3ff76-43ef-4b3d-b97a-baa2bfd21853';
+  const { data: alertDetails } = useFetchAlert({ id: alertId });
+
+  if (!alertDetails) {
+    return null;
+  }
+  return (
+    <EuiButtonEmpty
+      data-test-subj="investigationDetailsAlertLink"
+      iconType="arrowLeft"
+      size="xs"
+      href={basePath.prepend(`/app/observability/alerts/${alertId}`)}
+    >
+      <EuiText size="s">{`[Alert] ${alertDetails?.[ALERT_RULE_CATEGORY]} breached`}</EuiText>
+    </EuiButtonEmpty>
+  );
+}

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
@@ -5,40 +5,24 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiText } from '@elastic/eui';
-import { alertOriginSchema } from '@kbn/investigation-shared';
-import { ALERT_RULE_CATEGORY } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
-import { useKibana } from '../../../../hooks/use_kibana';
 import { useInvestigation } from '../../contexts/investigation_context';
-import { useFetchAlert } from '../../hooks/use_fetch_alert';
+import { AlertDetailsButton } from './alert_details_button';
 
 export function InvestigationHeader() {
-  const {
-    core: {
-      http: { basePath },
-    },
-  } = useKibana();
-
   const { investigation } = useInvestigation();
 
-  const alertOriginInvestigation = alertOriginSchema.safeParse(investigation?.origin);
-  const alertId = alertOriginInvestigation.success ? alertOriginInvestigation.data.id : undefined;
-  const { data: alertDetails } = useFetchAlert({ id: alertId });
+  if (!investigation) {
+    return null;
+  }
 
   return (
-    <>
-      {alertDetails && (
-        <EuiButtonEmpty
-          data-test-subj="investigationDetailsAlertLink"
-          iconType="arrowLeft"
-          size="xs"
-          href={basePath.prepend(`/app/observability/alerts/${alertId}`)}
-        >
-          <EuiText size="s">{`[Alert] ${alertDetails?.[ALERT_RULE_CATEGORY]} breached`}</EuiText>
-        </EuiButtonEmpty>
-      )}
-      {investigation && <div>{investigation.title}</div>}
-    </>
+    <EuiFlexGroup direction="column" gutterSize="m" alignItems="flexStart">
+      <EuiFlexItem>
+        <AlertDetailsButton />
+      </EuiFlexItem>
+      <EuiFlexItem>{investigation.title}</EuiFlexItem>
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
@@ -35,13 +35,15 @@ export function InvestigationHeader() {
           <InvestigationStatusBadge status={investigation.status} />
         </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup responsive={false} wrap gutterSize="s">
-            {investigation.tags.map((tag) => (
-              <InvestigationTag key={tag} tag={tag} />
-            ))}
-          </EuiFlexGroup>
-        </EuiFlexItem>
+        {investigation.tags.length > 0 && (
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup responsive={false} wrap gutterSize="s">
+              {investigation.tags.map((tag) => (
+                <InvestigationTag key={tag} tag={tag} />
+              ))}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        )}
 
         <EuiFlexItem grow={false}>
           <EuiText size="s">

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
@@ -30,7 +30,7 @@ export function InvestigationHeader() {
 
       <EuiFlexItem>{investigation.title}</EuiFlexItem>
 
-      <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
+      <EuiFlexGroup direction="row" gutterSize="m" alignItems="center" wrap responsive={false}>
         <EuiFlexItem grow={false}>
           <InvestigationStatusBadge status={investigation.status} />
         </EuiFlexItem>

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { formatDistance } from 'date-fns';
+import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
+import { InvestigationStatusBadge } from '../../../../components/investigation_status_badge/investigation_status_badge';
+import { InvestigationTag } from '../../../../components/investigation_tag/investigation_tag';
 import { useInvestigation } from '../../contexts/investigation_context';
 import { AlertDetailsButton } from './alert_details_button';
-import { InvestigationTag } from '../../../../components/investigation_tag/investigation_tag';
-import { InvestigationStatusBadge } from '../../../../components/investigation_status_badge/investigation_status_badge';
 
 export function InvestigationHeader() {
   const { investigation } = useInvestigation();
@@ -24,21 +27,39 @@ export function InvestigationHeader() {
       <EuiFlexItem>
         <AlertDetailsButton />
       </EuiFlexItem>
-      <EuiFlexGroup direction="column" gutterSize="s" alignItems="flexStart">
-        <EuiFlexItem>{investigation.title}</EuiFlexItem>
 
-        <EuiFlexGroup direction="row" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <InvestigationStatusBadge status={investigation.status} />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup responsive={false} wrap gutterSize="s">
-              {investigation.tags.map((tag) => (
-                <InvestigationTag key={tag} tag={tag} />
-              ))}
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+      <EuiFlexItem>{investigation.title}</EuiFlexItem>
+
+      <EuiFlexGroup direction="row" gutterSize="m" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <InvestigationStatusBadge status={investigation.status} />
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup responsive={false} wrap gutterSize="s">
+            {investigation.tags.map((tag) => (
+              <InvestigationTag key={tag} tag={tag} />
+            ))}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <FormattedMessage
+              id="xpack.investigateApp.investigationHeader.startedLabel"
+              defaultMessage="Started: {timeAgo}"
+              values={{
+                timeAgo: (
+                  <strong>
+                    {formatDistance(new Date(investigation.createdAt), new Date(), {
+                      addSuffix: true,
+                    })}
+                  </strong>
+                ),
+              }}
+            />
+          </EuiText>
+        </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
@@ -9,9 +9,9 @@ import { EuiButtonEmpty, EuiText } from '@elastic/eui';
 import { alertOriginSchema } from '@kbn/investigation-shared';
 import { ALERT_RULE_CATEGORY } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
 import React from 'react';
-import { useFetchAlert } from '../../../../hooks/use_get_alert_details';
 import { useKibana } from '../../../../hooks/use_kibana';
 import { useInvestigation } from '../../contexts/investigation_context';
+import { useFetchAlert } from '../../hooks/use_fetch_alert';
 
 export function InvestigationHeader() {
   const {

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/components/investigation_header/investigation_header.tsx
@@ -9,6 +9,8 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
 import { useInvestigation } from '../../contexts/investigation_context';
 import { AlertDetailsButton } from './alert_details_button';
+import { InvestigationTag } from '../../../../components/investigation_tag/investigation_tag';
+import { InvestigationStatusBadge } from '../../../../components/investigation_status_badge/investigation_status_badge';
 
 export function InvestigationHeader() {
   const { investigation } = useInvestigation();
@@ -22,7 +24,22 @@ export function InvestigationHeader() {
       <EuiFlexItem>
         <AlertDetailsButton />
       </EuiFlexItem>
-      <EuiFlexItem>{investigation.title}</EuiFlexItem>
+      <EuiFlexGroup direction="column" gutterSize="s" alignItems="flexStart">
+        <EuiFlexItem>{investigation.title}</EuiFlexItem>
+
+        <EuiFlexGroup direction="row" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <InvestigationStatusBadge status={investigation.status} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup responsive={false} wrap gutterSize="s">
+              {investigation.tags.map((tag) => (
+                <InvestigationTag key={tag} tag={tag} />
+              ))}
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexGroup>
     </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/details/hooks/use_fetch_alert.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/details/hooks/use_fetch_alert.tsx
@@ -7,7 +7,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { BASE_RAC_ALERTS_API_PATH, EcsFieldsResponse } from '@kbn/rule-registry-plugin/common';
-import { useKibana } from './use_kibana';
+import { useKibana } from '../../../hooks/use_kibana';
 
 export interface AlertParams {
   id?: string;

--- a/x-pack/plugins/observability_solution/investigate_app/public/pages/list/components/investigation_list.tsx
+++ b/x-pack/plugins/observability_solution/investigate_app/public/pages/list/components/investigation_list.tsx
@@ -7,11 +7,9 @@
 import {
   Criteria,
   EuiAvatar,
-  EuiBadge,
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiFlexGroup,
-  EuiFlexItem,
   EuiLink,
   EuiLoadingSpinner,
   EuiText,
@@ -22,6 +20,7 @@ import moment from 'moment';
 import React, { useState } from 'react';
 import { paths } from '../../../../common/paths';
 import { InvestigationStatusBadge } from '../../../components/investigation_status_badge/investigation_status_badge';
+import { InvestigationTag } from '../../../components/investigation_tag/investigation_tag';
 import { useFetchInvestigationList } from '../../../hooks/use_fetch_investigation_list';
 import { useFetchUserProfiles } from '../../../hooks/use_fetch_user_profiles';
 import { useKibana } from '../../../hooks/use_kibana';
@@ -114,9 +113,7 @@ export function InvestigationList() {
         return (
           <EuiFlexGroup wrap gutterSize="xs">
             {value.map((tag) => (
-              <EuiFlexItem key={tag} grow={false}>
-                <EuiBadge color="hollow">{tag}</EuiBadge>
-              </EuiFlexItem>
+              <InvestigationTag key={tag} tag={tag} />
             ))}
           </EuiFlexGroup>
         );

--- a/x-pack/plugins/observability_solution/investigate_app/server/services/delete_investigation_item.ts
+++ b/x-pack/plugins/observability_solution/investigate_app/server/services/delete_investigation_item.ts
@@ -16,11 +16,11 @@ export async function deleteInvestigationItem(
   const investigation = await repository.findById(investigationId);
   const item = investigation.items.find((currItem) => currItem.id === itemId);
   if (!item) {
-    throw new Error('Note not found');
+    throw new Error('Item not found');
   }
 
   if (item.createdBy !== user.profile_uid) {
-    throw new Error('User does not have permission to delete note');
+    throw new Error('User does not have permission to delete item');
   }
 
   investigation.items = investigation.items.filter((currItem) => currItem.id !== itemId);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/188584

## Summary

This PR adds the status and tags badges in the header as well as the relative created at date.


Details | Screenshot
-- | --
With tags | ![image](https://github.com/user-attachments/assets/31d2fe7d-8a45-41b7-ac36-85d49f5832d5)
Without tags | ![image](https://github.com/user-attachments/assets/78e69787-9496-43d9-9a97-472d7108d2f5)
Responsive | ![image](https://github.com/user-attachments/assets/ff555f42-39aa-4bdc-977b-16ab17854932)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->