### PR TITLE
[Fleet] allow optional statusCode and error in generic error response schema

### DIFF
--- a/x-pack/plugins/fleet/server/routes/schema/errors.ts
+++ b/x-pack/plugins/fleet/server/routes/schema/errors.ts
@@ -10,8 +10,8 @@ import { schema } from '@kbn/config-schema';
 export const genericErrorResponse = () =>
   schema.object(
     {
-      statusCode: schema.number(),
-      error: schema.string(),
+      statusCode: schema.maybe(schema.number()),
+      error: schema.maybe(schema.string()),
       message: schema.string(),
     },
     {


### PR DESCRIPTION
Relates https://github.com/elastic/kibana/issues/184685
Make statusCode and error optional in genericErrorResponse, sometimes it seems to be missing.

Saw this screenshot in another issue: 
![image](https://github.com/user-attachments/assets/f2cdf0a4-9067-4c36-a98f-65dc302a4e55)
