### PR TITLE
[8.15] [ci] skip FTR that fails on chrome 129

### DIFF
--- a/test/functional/apps/context/_context_navigation.ts
+++ b/test/functional/apps/context/_context_navigation.ts
@@ -110,7 +110,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
     });
 
-    it('should go back via breadcrumbs with updated state after a goBack browser', async function () {
+    // Fails in chrome 128+: https://github.com/elastic/kibana-operations/issues/199
+    it.skip('should go back via breadcrumbs with updated state after a goBack browser', async function () {
       await dataGrid.clickRowToggle({ rowIndex: 0 });
       const rowActions = await dataGrid.getRowActions({ rowIndex: 0 });
       await rowActions[1].click();

--- a/x-pack/test_serverless/functional/test_suites/common/context/_context_navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/context/_context_navigation.ts
@@ -126,7 +126,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
     });
 
-    it('should go back via breadcrumbs with updated state after a goBack browser', async function () {
+    // Fails in chrome 128+: https://github.com/elastic/kibana-operations/issues/199
+    it.skip('should go back via breadcrumbs with updated state after a goBack browser', async function () {
       await dataGrid.clickRowToggle({ rowIndex: 0 });
       const rowActions = await dataGrid.getRowActions({ rowIndex: 0 });
       await rowActions[1].click();

--- a/x-pack/test_serverless/functional/test_suites/common/context/_context_navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/context/_context_navigation.ts
@@ -126,8 +126,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       );
     });
 
-    // Fails in chrome 128+: https://github.com/elastic/kibana-operations/issues/199
-    it.skip('should go back via breadcrumbs with updated state after a goBack browser', async function () {
+    it('should go back via breadcrumbs with updated state after a goBack browser', async function () {
       await dataGrid.clickRowToggle({ rowIndex: 0 });
       const rowActions = await dataGrid.getRowActions({ rowIndex: 0 });
       await rowActions[1].click();


### PR DESCRIPTION
## Summary
There's one more test that fails on 8.15 + chrome 128/129

See this issue for the failure: https://github.com/elastic/kibana/issues/193550

Relates to: https://github.com/elastic/kibana-operations/issues/199