### PR TITLE
[Controls] Debounce time slider selections to improve performance (#193227)

### DIFF
--- a/src/plugins/presentation_panel/public/panel_actions/customize_panel_action/custom_time_range_badge.tsx
+++ b/src/plugins/presentation_panel/public/panel_actions/customize_panel_action/custom_time_range_badge.tsx
@@ -22,6 +22,16 @@ import { customizePanelAction } from '../panel_actions';
 
 export const CUSTOM_TIME_RANGE_BADGE = 'CUSTOM_TIME_RANGE_BADGE';
 
+function debounce(fn: Function, delay: number) {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (...args: any[]) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      fn.apply(this, args);
+    }, delay);
+  };
+}
+
 export class CustomTimeRangeBadge
   implements Action<EmbeddableApiContext>, FrequentCompatibilityChangeAction<EmbeddableApiContext>
 {
@@ -64,8 +74,12 @@ export class CustomTimeRangeBadge
     onChange: (isCompatible: boolean, action: CustomTimeRangeBadge) => void
   ) {
     if (!apiPublishesTimeRange(embeddable)) return;
+  const debouncedOnChange = debounce((isCompatible: boolean) => {
+      onChange(isCompatible, this);
+    }, 300);
+
     return embeddable.timeRange$.subscribe((timeRange) => {
-      onChange(Boolean(timeRange), this);
+      debouncedOnChange(Boolean(timeRange));
     });
   }
 


### PR DESCRIPTION
Fixes #193227

### Summary:
This PR addresses the performance issue described in issue #193227, where dragging the pins on a time slider caused excessive requests, leading to laggy and jittery behavior.

### Changes:
- Implemented a custom debounce function that only affects drag events on the time slider, ensuring that requests are debounced while the user is dragging.
- No debouncing was applied to the play, next, and previous buttons to maintain responsiveness for those actions.

### Steps to reproduce the issue:
1. Add a time slider control to a sample dashboard with multiple panels.
2. Drag the pins on the time slider and notice performance improvements.

### Expected behavior:
- The UI should be smoother when dragging, with fewer requests sent during drag events.
- Other interactions (e.g., play, next, previous) should remain unaffected.

