### PR TITLE
[8.x] [Search][Onboarding] Add telemetry for Start Page code view (#193099)

### DIFF
--- a/x-pack/plugins/search_indices/public/analytics/constants.ts
+++ b/x-pack/plugins/search_indices/public/analytics/constants.ts
@@ -10,4 +10,7 @@ export enum AnalyticsEvents {
   startPageShowCodeClick = 'start_page_show_code',
   startPageShowCreateIndexUIClick = 'start_page_show_create_index_ui',
   startCreateIndexClick = 'start_create_index',
+  startCreateIndexLanguageSelect = 'start_code_lang_select',
+  startCreateIndexCodeCopyInstall = 'start_code_copy_install',
+  startCreateIndexCodeCopy = 'start_code_copy',
 }

--- a/x-pack/plugins/search_indices/public/components/start/code_sample.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/code_sample.tsx
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+// Disabled so we can track the on copy event by adding an onClick to a div
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 
 import React from 'react';
 import {
@@ -19,9 +21,22 @@ export interface CodeSampleProps {
   title: string;
   language: string;
   code: string;
+  onCodeCopyClick?: React.MouseEventHandler<HTMLElement>;
 }
 
-export const CodeSample = ({ title, language, code }: CodeSampleProps) => {
+export const CodeSample = ({ title, language, code, onCodeCopyClick }: CodeSampleProps) => {
+  const onCodeClick = React.useCallback(
+    (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+      if (onCodeCopyClick === undefined) return;
+      if (e.target instanceof HTMLElement) {
+        if (e.target.dataset?.testSubj === 'euiCodeBlockCopy') {
+          onCodeCopyClick(e);
+        }
+      }
+    },
+    [onCodeCopyClick]
+  );
+
   return (
     <EuiFlexItem>
       <EuiText size="s">
@@ -30,15 +45,17 @@ export const CodeSample = ({ title, language, code }: CodeSampleProps) => {
       <EuiSpacer size="s" />
       <EuiThemeProvider colorMode="dark">
         <EuiPanel color="subdued" paddingSize="none" hasShadow={false}>
-          <EuiCodeBlock
-            language={language}
-            fontSize="m"
-            paddingSize="m"
-            isCopyable
-            transparentBackground
-          >
-            {code}
-          </EuiCodeBlock>
+          <div onClick={onCodeClick}>
+            <EuiCodeBlock
+              language={language}
+              fontSize="m"
+              paddingSize="m"
+              isCopyable
+              transparentBackground
+            >
+              {code}
+            </EuiCodeBlock>
+          </div>
         </EuiPanel>
       </EuiThemeProvider>
     </EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Search][Onboarding] Add telemetry for Start Page code view (#193099)](https://github.com/elastic/kibana/pull/193099)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2024-09-17T18:17:34Z","message":"[Search][Onboarding] Add telemetry for Start Page code view (#193099)\n\n## Summary\r\n\r\nAdded telemetry tracking events for the start page code view.\r\nSpecifically tracking when user selects a language and copies the\r\nexample code snippets.","sha":"f01f68e05918195cbf47e46f9bce6d0e938a3290","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:prev-minor"],"number":193099,"url":"https://github.com/elastic/kibana/pull/193099","mergeCommit":{"message":"[Search][Onboarding] Add telemetry for Start Page code view (#193099)\n\n## Summary\r\n\r\nAdded telemetry tracking events for the start page code view.\r\nSpecifically tracking when user selects a language and copies the\r\nexample code snippets.","sha":"f01f68e05918195cbf47e46f9bce6d0e938a3290"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193099","number":193099,"mergeCommit":{"message":"[Search][Onboarding] Add telemetry for Start Page code view (#193099)\n\n## Summary\r\n\r\nAdded telemetry tracking events for the start page code view.\r\nSpecifically tracking when user selects a language and copies the\r\nexample code snippets.","sha":"f01f68e05918195cbf47e46f9bce6d0e938a3290"}}]}] BACKPORT-->