### PR TITLE
[Security Solution] [Attack discovery] Use common replacements function

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant-common/impl/data_anonymization/helpers/index.test.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/data_anonymization/helpers/index.test.ts
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import { isAllowed, isAnonymized, isDenied, getIsDataAnonymizable } from '.';
+import {
+  isAllowed,
+  isAnonymized,
+  isDenied,
+  getIsDataAnonymizable,
+  replaceAnonymizedValuesWithOriginalValues,
+} from '.';
 
 const anonymizationFields = [
   { id: 'fieldName1', field: 'fieldName1', allowed: true, anonymized: false },
@@ -89,6 +95,43 @@ describe('helpers', () => {
 
     it('returns false when allowReplacementSet is empty', () => {
       expect(isAnonymized({ anonymizationFields: [], field: 'user.name' })).toBe(false);
+    });
+  });
+
+  describe('replaceAnonymizedValuesWithOriginalValues', () => {
+    const replacements = {
+      '3541b730-1dce-4937-b63f-0d618ea1cc5f': 'not-an-administrator',
+      'b222e892-431e-4e4f-9295-2ba92ef9d12d': 'domain-controller',
+    };
+
+    it('replaces anonymized values with original values', () => {
+      const messageContent =
+        'User {{ user.name 3541b730-1dce-4937-b63f-0d618ea1cc5f }} added a member to the Administrators group on host {{ host.name b222e892-431e-4e4f-9295-2ba92ef9d12d }}';
+
+      const result = replaceAnonymizedValuesWithOriginalValues({ messageContent, replacements });
+
+      expect(result).toEqual(
+        'User {{ user.name not-an-administrator }} added a member to the Administrators group on host {{ host.name domain-controller }}'
+      );
+    });
+
+    it('returns the original messageContent if no replacements are found', () => {
+      const messageContent = 'There are no replacements applicable to this message';
+
+      const result = replaceAnonymizedValuesWithOriginalValues({ messageContent, replacements });
+
+      expect(result).toEqual(messageContent);
+    });
+
+    it('replaces multiple occurrences of the same replacement key', () => {
+      const messageContent =
+        'User {{ user.name 3541b730-1dce-4937-b63f-0d618ea1cc5f }} added a member to the Administrators group on host {{ host.name b222e892-431e-4e4f-9295-2ba92ef9d12d }}, which is unusual because {{ user.name 3541b730-1dce-4937-b63f-0d618ea1cc5f }} is not a member of the Administrators group.';
+
+      const result = replaceAnonymizedValuesWithOriginalValues({ messageContent, replacements });
+
+      expect(result).toEqual(
+        'User {{ user.name not-an-administrator }} added a member to the Administrators group on host {{ host.name domain-controller }}, which is unusual because {{ user.name not-an-administrator }} is not a member of the Administrators group.'
+      );
     });
   });
 });

--- a/x-pack/packages/kbn-elastic-assistant-common/impl/data_anonymization/helpers/index.ts
+++ b/x-pack/packages/kbn-elastic-assistant-common/impl/data_anonymization/helpers/index.ts
@@ -42,12 +42,11 @@ export const replaceAnonymizedValuesWithOriginalValues = ({
   messageContent: string;
   replacements: Replacements;
 }): string =>
-  replacements != null
-    ? Object.keys(replacements).reduce((acc, key) => {
-        const value = replacements[key];
-        return acc.replaceAll(key, value);
-      }, messageContent)
-    : messageContent;
+  Object.keys(replacements).reduce((acc, key) => {
+    const value = replacements[key];
+
+    return acc.replaceAll(key, value);
+  }, messageContent);
 
 export const replaceOriginalValuesWithUuidValues = ({
   messageContent,

--- a/x-pack/plugins/security_solution/public/attack_discovery/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { replaceAnonymizedValuesWithOriginalValues } from '@kbn/elastic-assistant-common';
 import type { AttackDiscovery, Replacements } from '@kbn/elastic-assistant-common';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -34,21 +35,19 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
 
   const summaryMarkdownWithReplacements = useMemo(
     () =>
-      Object.entries<string>(replacements ?? {}).reduce((acc, [key, value]) => {
-        const regex = new RegExp(key, 'g');
-
-        return acc.replace(regex, value);
-      }, summaryMarkdown),
+      replaceAnonymizedValuesWithOriginalValues({
+        messageContent: summaryMarkdown,
+        replacements: replacements ?? {},
+      }),
     [replacements, summaryMarkdown]
   );
 
   const detailsMarkdownWithReplacements = useMemo(
     () =>
-      Object.entries<string>(replacements ?? {}).reduce((acc, [key, value]) => {
-        const regex = new RegExp(key, 'g');
-
-        return acc.replace(regex, value);
-      }, detailsMarkdown),
+      replaceAnonymizedValuesWithOriginalValues({
+        messageContent: detailsMarkdown,
+        replacements: replacements ?? {},
+      }),
     [detailsMarkdown, replacements]
   );
 


### PR DESCRIPTION
### [Security Solution] [Attack discovery] Use common replacements function

This PR is a follow-up to <https://github.com/elastic/kibana/pull/193428>, to make use of the common function for replacing anonymized values with original values


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->